### PR TITLE
Elide some job params from db for better compression. Fixes #25

### DIFF
--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -90,7 +90,7 @@
                           :command command}
                          command)]
     ;; If the there is no value for key :job/name, the following name will contain a substring "null".
-    {:name (format "%s_%s_%s" (:job/name job-ent) (:job/user job-ent) task-id)
+    {:name (format "%s_%s_%s" (:job/name job-ent "cookjob") (:job/user job-ent) task-id)
      :task-id task-id
      :num-ports (count (:ports resources))
      :resources (select-keys resources [:mem :cpus])

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -105,6 +105,8 @@
   [task-ent]
   (get-in task-ent [:job/_instance :job/user]))
 
+(def ^:const default-job-priority 50)
+
 (defn same-user-task-comparator
   "Comparator to order same user's tasks"
   [task1 task2]
@@ -113,7 +115,7 @@
             ;; Use :db/id because they guarantee uniqueness for different entities
             ;; (:db/id task) is not sufficient because synthetic task entities don't have :db/id
             ;; This assumes there are at most one synthetic task for a job, otherwise uniqueness invariant will break
-            [(- (:job/priority (:job/_instance task) 50))
+            [(- (:job/priority (:job/_instance task) default-job-priority))
              (:instance/start-time task (java.util.Date. Long/MAX_VALUE))
              (:db/id task)
              (:db/id (:job/_instance task))])]


### PR DESCRIPTION
This should begin to reduce the amount of DB storage we use for default params, which could lead to better scan performance for some workloads.

Leif, as resident DB expert, what do you think about this style?