### PR TITLE
Infinite loop during lost job races

### DIFF
--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -209,10 +209,11 @@
                (handle-throughput-metrics complete-throughput-metrics
                                           job-resources
                                           instance-runtime))
-             (when (or (nil? instance)
+             ;; This code kills any task that "shouldn't" be running
+             (when (or (nil? instance) ; We could know nothing about the task, meaning a DB error happened and it's a waste to finish
                        (not= task-state :task-lost) ; killing an unknown task causes a TASK_LOST message. Break the cycle!
-                       (= prior-job-state :job.state/completed)
-                       (= prior-instance-status :instance.status/failed))
+                       (= prior-job-state :job.state/completed) ; The task is attached to a failed job, possibly due to instances running on multiple hosts
+                       (= prior-instance-status :instance.status/failed)) ; The kill-task message could've been glitched on the network
                (log/warn "Attempting to kill task" task-id
                          "as instance" instance "with" prior-job-state "and" prior-instance-status
                          "should've been put down already")

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -210,6 +210,7 @@
                                           job-resources
                                           instance-runtime))
              (when (or (nil? instance)
+                       (not= task-state :task-lost) ; killing an unknown task causes a TASK_LOST message. Break the cycle!
                        (= prior-job-state :job.state/completed)
                        (= prior-instance-status :instance.status/failed))
                (log/warn "Attempting to kill task" task-id


### PR DESCRIPTION
It seems that it's possible for reconciliation to cause Cook to keep recieving updates about an instance, and those updates will keep failing, which will kill due to consuming too many resources.

We must investigate under what circumstances we repeatedly try to transact an instance fail update that is repeatedly bailed out of by the transaction function _and_ triggers reconciliation or Mesos status updates (or maybe those are in response to a repeatedly generated `killTask`?).

```
2015-09-22 19:53:29,693 WARN  cook.mesos.scheduler [clojure-agent-send-off-pool-5] - Attempting to kill task 19b52a71-b837-4758-ac3d-41dae28e4050 as instance 17592186045465 with :job.state/completed and :instance.status/unknown should've been put down already
2015-09-22 19:53:29,706 WARN  cook.datomic [async-dispatch-23] - Retrying txn ([:instance/update-state 17592186045465 :instance.status/failed] [:db/add 17592186045465 :instance/end-time #inst "2015-09-22T19:49:23.169-00:00"]) attempt 10 of 10
2015-09-22 19:53:29,708 WARN  cook.datomic [async-dispatch-39] - Retrying txn ([:instance/update-state 17592186045465 :instance.status/failed] [:db/add 17592186045465 :instance/end-time #inst "2015-09-22T19:53:29.258-00:00"]) attempt 2 of 10
2015-09-22 19:53:29,708 WARN  cook.datomic [async-dispatch-41] - Retrying txn ([:instance/update-state 17592186045465 :instance.status/failed] [:db/add 17592186045465 :instance/end-time #inst "2015-09-22T19:53:29.222-00:00"]) attempt 2 of 10
2015-09-22 19:53:29,710 INFO  cook.mesos.scheduler [clojure-agent-send-off-pool-11] - Mesos status is:  {:task-id 19b52a71-b837-4758-ac3d-41dae28e4050, :state :task-lost, :message Reconciliation: Task is unknown, :timestamp 1.442951609695113E9, :source :source-master, :reason :reason-reconciliation}
2015-09-22 19:53:29,706 WARN  cook.datomic [async-dispatch-3] - Retrying txn ([:instance/update-state 17592186045465 :instance.status/failed] [:db/add 17592186045465 :instance/end-time #inst "2015-09-22T19:50:19.917-00:00"]) attempt 10 of 10
2015-09-22 19:53:29,714 WARN  cook.datomic [async-dispatch-43] - Retrying txn ([:instance/update-state 17592186045465 :instance.status/failed] [:db/add 17592186045465 :instance/end-time #inst "2015-09-22T19:53:29.714-00:00"]) attempt 1 of 10
```