### PR TITLE
draft of clone api

### DIFF
--- a/scheduler/docs/scheduler-rest-api.asc
+++ b/scheduler/docs/scheduler-rest-api.asc
@@ -230,4 +230,77 @@ The `DELETE` verb also accepts multiple job uuids, just like `GET`.
 curl -X DELETE -u: --negotiate "$scheduler_endpoint?job=$uuid"
 ----
 
+==== Update/Modify/Clone a Job
+
+In Cook, updating a job's parameters is the same as creating a new job and killing the old one.
+Let's look at some use cases for this API:
+
+Retry a job that's already used up its automatic retries::
+  To use the clone API, you must, at a minimum, specify the UUID of the job to clone (the `from_uuid`) and the UUID that the new copy will have (the `new_uuid`).
+  By doing this, you're not changing anything about the job's definition--instead, we're merely copying its entire descriptor, which will cause it to rerun as before.
+
+Retry a job while changing its resource requirements::
+  Sometimes, we'll submit a job or group of jobs, and but without enough memory or CPUs.
+  The clone API can be used to fix the old submissions: in addition to the UUIDs, you can include a `job` field, which takes precedence over the original job's descriptor.
+  For example, to copy a job and change it to use 8 CPUs, you could use the following JSON:
++
+[source,json]
+----
+{
+  "copies": [
+    {
+      "from_uuid": "cb1b6c69-76c1-4471-bfc8-9b6a94160d01",
+      "to_uuid": "681f9851-b078-4845-9102-af37f21b6a44",
+      "job": {
+         "cpus": 8
+      }
+    }
+  ]
+}
+----
+
+Change the priority of a running job::
+  If you submit a job with too low of a priority, it still may be able to run, but it's too low in the queue to run soon.
+  To adjust the job's priority higher, we'll use the clone API to make a copy with an updated priority.
+  For convenience in this sort of situation, the clone API allows you to specify a flag, `kill_original`, which will kill the from represented by `from_uuid` if it isn't already complete.
+  For example, let's see how to change an existing job's priority:
++
+[source,json]
+----
+{
+  "copies": [
+    {
+      "from_uuid": "cb1b6c69-76c1-4471-bfc8-9b6a94160d01",
+      "to_uuid": "681f9851-b078-4845-9102-af37f21b6a44",
+      "kill_original": true,
+      "job": {
+         "priority": 10
+      }
+    }
+  ]
+}
+----
+
+[TIP]
+====
+The clone API will always submit the new jobs as the user who invoked the clone API.
+This means that you can clone another user's job to run it as yourself.
+====
+
+.Possible response codes
+[options="header"]
+|====
+|Code | HTTP Meaning | Possible reason
+|201 | Created | Job has been successfully created.
+|400 | Malformed | This will be returned if the UUID is already used or the requst syntax is not correct.
+|401 | Not Authorized | Returned if authentication fails or user is not authorized to run jobs on the system.
+|422 | Unprocessable Entity | Returned if there is an error committing jobs to the Cook database.
+|====
+
+.Example Usage
+[source,bash]
+----
+TODO
+----
+
 © Two Sigma Open Source, LLC


### PR DESCRIPTION
We'd like to have a way to update a job's properties, as asked for in #50. However, to maintain immutability throughout the system, we'll add this "clone" API, to enable creating new jobs based on existing ones, and optionally simultaneously killing the existing one.