### PR TITLE
Update the documentation 

### DIFF
--- a/scheduler/README.asc
+++ b/scheduler/README.asc
@@ -61,7 +61,11 @@ By default, you can use the Free edition of Datomic, which runs on a single mach
 Be sure to make backups!
 
 If you're running Cook in an enviroment with higher availability requirements, you can use Datomic Pro or Pro Starter.
-To use these, you'll need to install Datomic Pro locally, and then change the dependency in `project.clj` from `com.datomic/datomic-free` to `com.datomic/datomic-pro`.
+To use Datomic Pro instead of Datomic Free, 
+- Install Datomic Pro jars locally on the build host using `mvn install`. Datomic pro distribution provides a helper script called `bin/maven-install` that installs jar in local maven repository. (See http://aan.io/datomic-pro-and-leiningen/ for some helpful tips.)
+- Change the dependency in `project.clj` from `com.datomic/datomic-free` to `com.datomic/datomic-pro`.
+- Run `lein uberjar`
+ 
 We recommend not changing the version of Datomic, although moving to a version shouldn't cause any issues.
 
 If you'd like email notifications on critical exceptions, make sure that JavaMail will work on the server you've set up.

--- a/scheduler/docs/configuration.asc
+++ b/scheduler/docs/configuration.asc
@@ -80,7 +80,11 @@ We'll look at the configurable options in turn:
 
 `:principal`::
   This sets the principal that Cook will connect to Mesos with.
-  You can omit this property unless you've enabled security features with Mesos, in which case you should already know how to set this.
+  You can omit this property unless you've enabled security features with Mesos. The value here should match with authorized `principals` in `register_frameworks` Action in Mesos Authorization file. See http://mesos.apache.org/documentation/latest/authorization/ for details.
+
+`:role`::
+  This sets the role that Cook will connect to Mesos with. Default: `*`
+  You can omit this property unless you've enabled security features in Mesos. The value should be in authorized list for the current `:principal` in `register_frameworks` Action in Mesos Authorization file. See http://mesos.apache.org/documentation/latest/authorization/ for details.
 
 [[auth_config]]
 ==== Authorization Configuration


### PR DESCRIPTION
Two changes:
- Clarify on how to build cook with datomic pro
- Document the `:role` configuration option for connecting to mesos master with security/ACL enabled.