### PR TITLE
Cleanup comments and add a standalone mesos example

### DIFF
--- a/scheduler/dev-config.edn
+++ b/scheduler/dev-config.edn
@@ -1,17 +1,27 @@
 {:port 12321
- ;; We'll set the user to vagrant, since that's the default for many Vagrant-based Mesos setups
+ ;; We'll set the user to vagrant, since that's the default for many 
+ ;  Vagrant-based Mesos setups
  :authorization {:one-user "vagrant"}
  :database {:datomic-uri "datomic:mem://cook-jobs"}
  :zookeeper {:local? true
-             ;:local-port 3291 ; Uncomment to change the default port
+             ;; Uncomment 'local-port' to change the default port
+             ;:local-port 3291
              }
  :scheduler {:offer-incubate-ms 15000
              :task-constraints {:timeout-hours 1
                                 :timeout-interval-minutes 1
                                 :memory-gb 48
                                 :cpus 6}}
- :mesos {:master "zk://localhost:2181/mesos" ; Assuming Mesos is configured to use Zookeeper and is running locally
-         :failover-timeout-ms nil ; When we close the instance of Cook, all its tasks are killed by Mesos
+ ;; Mesos Master can point to a zookeeper instance, or for testing,
+ ;  a standalone instance of Mesos.
+ ;  For Zookeeper, use  
+ ;     :master "zk://${host}:$port}/mesos"
+ ;  For a standalone intancee, use
+ ;     :master ${host}:{$port} e.g. ':master "localhost:5050"
+ :mesos {:master "localhost:5050"
+         ;; Setting failover-timeout-ms to nil will cause all tasks to be
+         ;  killed when we close this instance of Mesos
+         :failover-timeout-ms nil 
          :leader-path "/cook-scheduler"}
  :unhandled-exceptions {:log-level :error}
  :metrics {:jmx true}

--- a/scheduler/dev-config.edn
+++ b/scheduler/dev-config.edn
@@ -18,7 +18,7 @@
  ;;    :master "zk://${host}:$port}/mesos"
  ;; For a standalone intancee, use
  ;;    :master ${host}:{$port} e.g. ':master "localhost:5050"
- :mesos {:master "localhost:5050"
+ :mesos {:master "zk://localhost:2181/mesos"
          ;; Setting failover-timeout-ms to nil will cause all tasks to be
          ;; killed when we close this instance of Mesos
          :failover-timeout-ms nil 

--- a/scheduler/dev-config.edn
+++ b/scheduler/dev-config.edn
@@ -1,6 +1,6 @@
 {:port 12321
  ;; We'll set the user to vagrant, since that's the default for many 
- ;  Vagrant-based Mesos setups
+ ;; Vagrant-based Mesos setups
  :authorization {:one-user "vagrant"}
  :database {:datomic-uri "datomic:mem://cook-jobs"}
  :zookeeper {:local? true
@@ -13,14 +13,14 @@
                                 :memory-gb 48
                                 :cpus 6}}
  ;; Mesos Master can point to a zookeeper instance, or for testing,
- ;  a standalone instance of Mesos.
- ;  For Zookeeper, use  
- ;     :master "zk://${host}:$port}/mesos"
- ;  For a standalone intancee, use
- ;     :master ${host}:{$port} e.g. ':master "localhost:5050"
+ ;; a standalone instance of Mesos.
+ ;; For Zookeeper, use  
+ ;;    :master "zk://${host}:$port}/mesos"
+ ;; For a standalone intancee, use
+ ;;    :master ${host}:{$port} e.g. ':master "localhost:5050"
  :mesos {:master "localhost:5050"
          ;; Setting failover-timeout-ms to nil will cause all tasks to be
-         ;  killed when we close this instance of Mesos
+         ;; killed when we close this instance of Mesos
          :failover-timeout-ms nil 
          :leader-path "/cook-scheduler"}
  :unhandled-exceptions {:log-level :error}


### PR DESCRIPTION
I tried to standardize on a comment format 
     - comment starts above relevant line
     - no more than 80 chars on line
     - two semicolons at start, and one to follow. 

