### PR TITLE
Add Fenzo for scheduling

### DIFF
--- a/scheduler/dev-config.edn
+++ b/scheduler/dev-config.edn
@@ -21,6 +21,4 @@
        :levels {"datomic.db" :warn
                 "datomic.peer" :warn
                 "datomic.kv-cluster" :warn
-                "cook.mesos.scheduler" :debug
-                "com.netflix.fenzo.TaskScheduler" :debug
                 :default :info}}}

--- a/scheduler/dev-config.edn
+++ b/scheduler/dev-config.edn
@@ -21,4 +21,6 @@
        :levels {"datomic.db" :warn
                 "datomic.peer" :warn
                 "datomic.kv-cluster" :warn
+                "cook.mesos.scheduler" :debug
+                "com.netflix.fenzo.TaskScheduler" :debug
                 :default :info}}}

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -31,10 +31,10 @@
                  [amalloy/ring-buffer "1.1"]
                  [lonocloud/synthread "1.0.4"]
                  [org.clojure/tools.namespace "0.2.4"]
-                 [org.clojure/core.cache "0.6.3"]
-                 [org.clojure/core.memoize "0.5.6"]
+                 [org.clojure/core.cache "0.6.4"]
+                 [org.clojure/core.memoize "0.5.8"]
                  [clj-time "0.9.0"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+                 [org.clojure/core.async "0.2.374"]
                  [prismatic/schema "0.2.1"
                   :exclusions [potemkin]]
                  [clojure-miniprofiler "0.4.0"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -42,6 +42,7 @@
                  [org.clojure/data.priority-map "0.0.5"]
                  [swiss-arrows "1.0.0"]
                  [riddley "0.1.10"]
+                 [com.netflix.fenzo/fenzo-core "0.7.10"]
 
                  ;;Logging
                  [org.clojure/tools.logging "0.2.6"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -42,7 +42,10 @@
                  [org.clojure/data.priority-map "0.0.5"]
                  [swiss-arrows "1.0.0"]
                  [riddley "0.1.10"]
-                 [com.netflix.fenzo/fenzo-core "0.7.10"]
+                 [com.netflix.fenzo/fenzo-core "0.8.2"
+                  :exclusions [org.apache.mesos/mesos
+                               org.slf4j/slf4j-api
+                               org.slf4j/slf4j-simple]]
 
                  ;;Logging
                  [org.clojure/tools.logging "0.2.6"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -16,7 +16,7 @@
 (defproject cook "1.0.1-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
 
                  ;;Data marshalling
                  [org.clojure/data.codec "0.1.0"]

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -252,6 +252,7 @@
                     end (:instance/end-time instance)
                     base {:task_id (:instance/task-id instance)
                           :hostname hostname
+                          :backfilled (:instance/backfilled? instance false)
                           :slave_id (:instance/slave-id instance)
                           :executor_id (:instance/executor-id instance)
                           :status (name (:instance/status instance))}

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -55,7 +55,7 @@
    :max-retries (s/both s/Int (s/pred pos? 'pos?))
    :max-runtime (s/both s/Int (s/pred pos? 'pos?))
    (s/optional-key :uris) [Uri]
-   (s/optional-key :ports) [(s/pred zero? 'zero)] ;;TODO add to docs the limited uri/port support
+   (s/optional-key :ports) (s/pred pos? 'pos?)
    (s/optional-key :env) {NonEmptyString s/Str}
    :cpus PosDouble
    :mem PosDouble
@@ -67,10 +67,8 @@
   [conn jobs :- [Job]]
   (doseq [{:keys [uuid command max-retries max-runtime priority cpus mem user name ports uris env]} jobs
           :let [id (d/tempid :db.part/user)
-                ports (mapv (fn [port]
-                              ;;TODO this schema might not work b/c all ports are zero
-                              [:db/add id :job/port port])
-                            ports)
+                ports (when (and ports (not (zero? ports)))
+                        [[:db/add id :job/port ports]])
                 uris (mapcat (fn [{:keys [value executable? cache? extract?]}]
                                (let [uri-id (d/tempid :db.part/user)
                                      optional-params {:resource.uri/executable? executable?
@@ -144,7 +142,7 @@
                   :priority (or priority util/default-job-priority)
                   :max-retries max_retries
                   :max-runtime (or max_runtime Long/MAX_VALUE)
-                  :ports (or ports [])
+                  :ports (or ports 0)
                   :cpus (double cpus)
                   :mem (double mem)}
                  (when uris
@@ -239,7 +237,7 @@
        :status (name (:job/state job))
        :uris (:uris resources)
        :env (util/job-ent->env job)
-       ;;TODO include ports
+       :ports (:job/port job 0)
        :instances
        (map (fn [instance]
               (let [hostname (:instance/hostname instance)

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -252,7 +252,9 @@
                     end (:instance/end-time instance)
                     base {:task_id (:instance/task-id instance)
                           :hostname hostname
+                          ;;TODO validate that these show up in API
                           :backfilled (:instance/backfilled? instance false)
+                          :preempted (:instance/preempted? instance false)
                           :slave_id (:instance/slave-id instance)
                           :executor_id (:instance/executor-id instance)
                           :status (name (:instance/status instance))}

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -55,7 +55,7 @@
    :max-retries (s/both s/Int (s/pred pos? 'pos?))
    :max-runtime (s/both s/Int (s/pred pos? 'pos?))
    (s/optional-key :uris) [Uri]
-   (s/optional-key :ports) (s/pred pos? 'pos?)
+   (s/optional-key :ports) (s/pred #(not (neg? %)) 'nonnegative?)
    (s/optional-key :env) {NonEmptyString s/Str}
    :cpus PosDouble
    :mem PosDouble

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -250,7 +250,6 @@
                     end (:instance/end-time instance)
                     base {:task_id (:instance/task-id instance)
                           :hostname hostname
-                          ;;TODO validate that these show up in API
                           :backfilled (:instance/backfilled? instance false)
                           :preempted (:instance/preempted? instance false)
                           :slave_id (:instance/slave-id instance)

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -334,7 +334,7 @@
     utilization))
 
 (defn start-rebalancer!
-  [{:keys [conn driver mesos-master pending-jobs-atom view-incubating-offers view-mature-offers]}]
+  [{:keys [conn driver mesos-master pending-jobs-atom view-incubating-offers]}]
   (let [rebalance-interval (time/minutes 5)
         observe-interval (time/seconds 5)
         observe-refreshness-threshold (time/seconds 30)
@@ -343,7 +343,6 @@
                                     (fn [now]
                                       (let [host->combined-offers
                                             (-<>> (view-incubating-offers)
-                                                  (sched/combine-offers)
                                                   (map (fn [v]
                                                          [(:hostname v) (assoc v :time-observed now)]))
                                                   (into {}))]

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -314,7 +314,7 @@
         (try
           @(d/transact
             conn
-            ;; Make :instance/status and :instance/preempted consistent to simplify the state machine.
+            ;; Make :instance/status and :instance/preempted? consistent to simplify the state machine.
             ;; We don't want to deal with {:instance/status :instance.stats/running, :instance/preempted? true}
             ;; all over the places.
             (let [job-eid (:db/id (:job/_instance task-ent))

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -224,10 +224,6 @@
         ;; This will preserve the ordering of task->scored-task
         host->scored-tasks (->> task->scored-task
                                 (vals)
-                                (map (fn [{:keys [task] :as scored-task}]
-                                       (if (:instance/backfilled? task)
-                                         (assoc scored-task :dru Double/MAX_VALUE)
-                                         scored-task)))
                                 (remove #(< (:dru %) safe-dru-threshold))
                                 (filter #(> (- (:dru %) pending-job-dru) min-dru-diff))
                                 (group-by (fn [{:keys [task]}]

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -224,6 +224,10 @@
         ;; This will preserve the ordering of task->scored-task
         host->scored-tasks (->> task->scored-task
                                 (vals)
+                                (map (fn [{:keys [task] :as scored-task}]
+                                       (if (:instance/backfilled? task)
+                                         (assoc scored-task :dru Double/MAX_VALUE)
+                                         scored-task)))
                                 (remove #(< (:dru %) safe-dru-threshold))
                                 (filter #(> (- (:dru %) pending-job-dru) min-dru-diff))
                                 (group-by (fn [{:keys [task]}]

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -810,7 +810,7 @@
         jobs (-<>> (concat running-task-ents pending-task-ents)
                    (group-by util/task-ent->user)
                    (map (fn [[user task-ents]]
-                          [user (into (sorted-set-by util/same-user-task-comparator) task-ents)]))
+                          [user (into (sorted-set-by (util/same-user-task-comparator false)) task-ents)]))
                    (into {})
                    (dru/init-task->scored-task <> user->dru-divisors)
                    (filter (fn [[task scored-task]]

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -366,7 +366,7 @@
    the offer.
 
    Returns a list of tasks that got matched to the offer"
-  [^TaskScheduler fenzo considerable offers db fid conn]
+  [^TaskScheduler fenzo considerable offers db fid]
   (log/debug "Matching" (count offers) "offers to" (count considerable) "jobs with fenzo")
   (let [t (System/currentTimeMillis)
         leases (mapv #(->VirtualMachineLeaseAdapter % t) offers)
@@ -511,7 +511,7 @@
                                           (job-allowed-to-start? db job)))
                                 (take num-considerable))
               _ (log/debug "We'll consider scheduling" (count considerable) "of those pending jobs (limited to " num-considerable " due to backdown)")
-              matches (match-offer-to-schedule fenzo considerable offers db fid conn)
+              matches (match-offer-to-schedule fenzo considerable offers db fid)
               matched-jobs (for [match matches
                                  ^TaskAssignmentResult task-result (:tasks match)
                                  :let [task-request (.getRequest task-result)]]

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -200,6 +200,8 @@
                                      (.getTime (:instance/start-time instance-ent)))
                  job-resources (util/job-ent->resources job-ent)]
              (when (#{:instance.status/success :instance.status/failed} instance-status)
+               ;;TODO what if these messages came through a reconciliation & there's no task-id in fenzo already?
+               ;;Maybe we need to suppress such an exception
                (log/debug "Unassigning task" task-id "from" (:instance/hostname instance-ent))
                (.. fenzo
                    (getTaskUnAssigner)

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -473,12 +473,12 @@
               ;; the pending-jobs atom is repopulated
               @(d/transact
                  conn
-                 (mapcat (fn [{:keys [offer] :as task-info}]
+                 (mapcat (fn [{:keys [offers] :as task-info}]
                            [[:job/allowed-to-start? (:job-id task-info)]
                             {:db/id (d/tempid :db.part/user)
                              :job/_instance (:job-id task-info)
                              :instance/task-id (:task-id task-info)
-                             :instance/hostname (:hostname offer)
+                             :instance/hostname (:hostname (first offers))
                              :instance/start-time (now)
                              ;; NB command executor uses the task-id
                              ;; as the executor-id

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -434,7 +434,6 @@
                      (:instance/backfilled? %)))
        (map :db/id)))
 
-;;TODO test this
 (defn process-matches-for-backfill
   "This computes some sets:
    
@@ -467,7 +466,6 @@
          :upgrade-backfill upgrade-backfill
          :backfill-jobs backfill-jobs
          :matched-head? matched-head?}))))
-;;TODO need to ensure that we exponentially converge to head of line blocking when we repeating come up with non-head solutions
 
 (defn handle-resource-offers!
   "Gets a list of offers from mesos. Decides what to do with them all--they should all

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -626,7 +626,7 @@
         max-considerable 1000]
     (async/thread
       (loop [num-considerable max-considerable]
-        ;;TODO make this cancelable
+        ;;TODO make this cancelable (if we want to be able to restart the server w/o restarting the JVM)
         (recur
           (try
             (let [offers (async/alt!!

--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -227,6 +227,12 @@
     :db/index true
     :db.alter/_attribute :db.part/db}])
 
+(def migration-port-is-a-count
+  "This was written on 10-20-2015"
+  [{:db/id :job/port
+    :db/cardinality :db.cardinality/one
+    :db.alter/_attribute :db.part/db}])
+
 (def rebalancer-configs
   [{:db/id (d/tempid :db.part/user)
     :db/ident :rebalancer/config}
@@ -409,4 +415,4 @@
                        []))}}])
 
 (def work-item-schema
-  [schema-attributes state-enums rebalancer-configs migration-add-index-to-job-state db-fns])
+  [schema-attributes state-enums rebalancer-configs migration-add-index-to-job-state migration-port-is-a-count db-fns])

--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -158,6 +158,12 @@
      :db/cardinality :db.cardinality/one
      :db.install/_attribute :db.part/db}
     {:db/id (d/tempid :db.part/db)
+     :db/ident :instance/backfilled?
+     :db/doc "If this is true, then this instance doesn't count towards making a job running, and it should be preempted first. It's okay to upgrade an instance to be non-backfilled after a while."
+     :db/valueType :db.type/boolean
+     :db/cardinality :db.cardinality/one
+     :db.install/_attribute :db.part/db}
+    {:db/id (d/tempid :db.part/db)
      :db/ident :instance/hostname
      :db/valueType :db.type/string
      :db/cardinality :db.cardinality/one
@@ -310,20 +316,20 @@
              - task succeeded => job completed
              - task failed, no other tasks, retries exceeded => job completed
              - task failed, no other tasks, retries remaining => job waiting
-             - task failed, other tasks running => job running"
+             - task failed, other tasks running => job running
+
+             Note that backfilled running instances are treated as if they don't exist."
     :db/fn #db/fn {:lang "clojure"
                    :params [db j]
                    :requires [[metatransaction.core :as mt]]
                    :code
                    (let [db (mt/filter-committed db)
                          job (d/entity db j)
-                         instance-states (mapv first (q '[:find ?state ?i
-                                                          :in $ ?j
-                                                          :where
-                                                          [?j :job/instance ?i]
-                                                          [?i :instance/status ?s]
-                                                          [?s :db/ident ?state]]
-                                                        db j))
+                         instance-states (mapcat (fn [instance]
+                                                   (when-not (and (= :instance.status/running (:instance/status instance))
+                                                                  (:instance/backfilled? instance))
+                                                     [(:instance/status instance)]))
+                                                 (:job/instance job))
                          any-success? (some #{:instance.status/success} instance-states)
                          any-running? (some #{:instance.status/running} instance-states)
                          all-failed? (every? #{:instance.status/failed} instance-states)

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -118,9 +118,8 @@
             ;; Use :db/id because they guarantee uniqueness for different entities
             ;; (:db/id task) is not sufficient because synthetic task entities don't have :db/id
             ;; This assumes there are at most one synthetic task for a job, otherwise uniqueness invariant will break
-            [(if (and consider-backfilled-jobs? (:instance/backfilled? task))
-               Integer/MAX_VALUE
-               (- (:job/priority (:job/_instance task) default-job-priority)))
+            [(and consider-backfilled-jobs? (:instance/backfilled? task)) ; true sorts higher than false
+             (- (:job/priority (:job/_instance task) default-job-priority))
              (:instance/start-time task (java.util.Date. Long/MAX_VALUE))
              (:db/id task)
              (:db/id (:job/_instance task))])]

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -118,7 +118,7 @@
             ;; Use :db/id because they guarantee uniqueness for different entities
             ;; (:db/id task) is not sufficient because synthetic task entities don't have :db/id
             ;; This assumes there are at most one synthetic task for a job, otherwise uniqueness invariant will break
-            [(and consider-backfilled-jobs? (:instance/backfilled? task)) ; true sorts higher than false
+            [(if (and consider-backfilled-jobs? (:instance/backfilled? task)) 1 0)
              (- (:job/priority (:job/_instance task) default-job-priority))
              (:instance/start-time task (java.util.Date. Long/MAX_VALUE))
              (:db/id task)

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -50,7 +50,7 @@
                                     :executable (:resource.uri/executable? r false)
                                     :value (:resource.uri/value r)
                                     :extract (:resource.uri/extract? r false)}))))
-          {:ports (:job/port job-ent)}
+          {:ports (:job/port job-ent 0)}
           (:job/resource job-ent)))
 
 (defn sum-resources-of-jobs

--- a/scheduler/test/cook/test/mesos/rebalancer.clj
+++ b/scheduler/test/cook/test/mesos/rebalancer.clj
@@ -386,8 +386,8 @@
       (let [task-ent9 {:job/_instance job-ent9
                        :instance/hostname "hostB"
                        :instance/status :instance.status/running}
-            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by util/same-user-task-comparator) [task-ent1 task-ent2 task-ent3 task-ent4])
-                                               "wzhao" (into (sorted-set-by util/same-user-task-comparator) [task-ent5 task-ent7 task-ent9])}
+            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator true)) [task-ent1 task-ent2 task-ent3 task-ent4])
+                                               "wzhao" (into (sorted-set-by (util/same-user-task-comparator true)) [task-ent5 task-ent7 task-ent9])}
             host->spare-resources' {"hostA" {:mem 50.0 :cpus 50.0} "hostB" {:mem 5.0 :cpus 5.0}}]
         (let [{task->scored-task'' :task->scored-task
                user->sorted-running-task-ents'' :user->sorted-running-task-ents
@@ -411,9 +411,9 @@
       (let [task-ent10 {:job/_instance job-ent10
                         :instance/hostname "hostA"
                         :instance/status :instance.status/running}
-            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by util/same-user-task-comparator) [task-ent1 task-ent3 task-ent4])
-                                               "wzhao" (into (sorted-set-by util/same-user-task-comparator) [task-ent5 task-ent6 task-ent8])
-                                               "sunil" (into (sorted-set-by util/same-user-task-comparator) [task-ent10])}
+            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator true)) [task-ent1 task-ent3 task-ent4])
+                                               "wzhao" (into (sorted-set-by (util/same-user-task-comparator true)) [task-ent5 task-ent6 task-ent8])
+                                               "sunil" (into (sorted-set-by (util/same-user-task-comparator true)) [task-ent10])}
             host->spare-resources' {"hostA" {:mem 50.0 :cpus 50.0}}]
         (let [{task->scored-task'' :task->scored-task
                user->sorted-running-task-ents'' :user->sorted-running-task-ents
@@ -436,9 +436,9 @@
       (let [task-ent12 {:job/_instance job-ent12
                         :instance/hostname "hostA"
                         :instance/status :instance.status/running}
-            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by util/same-user-task-comparator) [task-ent1 task-ent2 task-ent3 task-ent4])
-                                               "wzhao" (into (sorted-set-by util/same-user-task-comparator) [task-ent5 task-ent6 task-ent7 task-ent8])
-                                               "sunil" (into (sorted-set-by util/same-user-task-comparator) [task-ent12])}
+            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator true)) [task-ent1 task-ent2 task-ent3 task-ent4])
+                                               "wzhao" (into (sorted-set-by (util/same-user-task-comparator true)) [task-ent5 task-ent6 task-ent7 task-ent8])
+                                               "sunil" (into (sorted-set-by (util/same-user-task-comparator true)) [task-ent12])}
             host->spare-resources' {"hostA" {:mem 10.0 :cpus 10.0}}]
 
         (let [{task->scored-task'' :task->scored-task

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -226,6 +226,69 @@
         backfilled-ids (sched/ids-of-backfilled-instances (d/entity db-after jid'))]
     (is (= [tid2'] backfilled-ids))))
 
+(deftest test-process-matches-for-backfill
+  (letfn [(mock-job [& instances] ;;instances is a seq of booleans which denote the running instances that could be true or false
+            {:job/uuid (java.util.UUID/randomUUID)
+             :job/instance (for [backfill? instances]
+                             {:instance/status :instance.status/running
+                              :instance/backfilled? backfill?
+                              :db/id (java.util.UUID/randomUUID)})})]
+    (let [j1 (mock-job)
+          j2 (mock-job true)
+          j3 (mock-job false true true)
+          j4 (mock-job)
+          j5 (mock-job true)
+          j6 (mock-job false false)
+          j7 (mock-job false)]
+      (testing "Match nothing"
+        (let [result (sched/process-matches-for-backfill [j1 j4] j1 [])]
+          (is (zero? (count (:fully-processed result))))
+          (is (zero? (count (:upgrade-backfill result))))
+          (is (zero? (count (:backfill-jobs result))))
+          (is (not (:matched-head? result)))))
+      (testing "Match everything basic"
+        (let [result (sched/process-matches-for-backfill [j1 j4] j1 [j1 j4])]
+          (is (= 2 (count (:fully-processed result))))
+          (is (zero? (count (:upgrade-backfill result))))
+          (is (zero? (count (:backfill-jobs result))))
+          (is (:matched-head? result))))
+      (testing "Don't match head"
+        (let [result (sched/process-matches-for-backfill [j1 j4] j1 [j4])]
+          (is (zero? (count (:fully-processed result))))
+          (is (zero? (count (:upgrade-backfill result))))
+          (is (= 1 (count (:backfill-jobs result))))
+          (is (not (:matched-head? result)))))
+      (testing "Match the tail, but the head isn't considerable" ;;TODO is this even correct?
+        (let [result (sched/process-matches-for-backfill [j1 j4] j4 [j4])]
+          (is (zero? (count (:fully-processed result))))
+          (is (zero? (count (:upgrade-backfill result))))
+          (is (= 1 (count (:backfill-jobs result))))
+          (is (not (:matched-head? result)))))
+      (testing "Match the tail, and the head was backfilled"
+        (let [result (sched/process-matches-for-backfill [j2 j1 j4] j1 [j1 j4])]
+          (is (= 2 (count (:fully-processed result))))
+          (is (= 1 (count (:upgrade-backfill result))))
+          (is (zero? (count (:backfill-jobs result))))
+          (is (:matched-head? result))))
+      (testing "Match the tail, and the head was backfilled (multiple backfilled mixed in)"
+        (let [result (sched/process-matches-for-backfill [j2 j1 j3 j4] j1 [j1 j4])]
+          (is (= 2 (count (:fully-processed result))))
+          (is (= 3 (count (:upgrade-backfill result))))
+          (is (zero? (count (:backfill-jobs result))))
+          (is (:matched-head? result))))
+      (testing "Fail to match the head, but backfill several jobs"
+        (let [result (sched/process-matches-for-backfill [j1 j2 j3 j4 j5 j6 j7] j1 [j4 j6 j7])]
+          (is (zero? (count (:fully-processed result))))
+          (is (zero? (count (:upgrade-backfill result))))
+          (is (= 3 (count (:backfill-jobs result))))
+          (is (not (:matched-head? result)))))
+      (testing "Fail to match the head, but backfill several jobs"
+        (let [result (sched/process-matches-for-backfill [j1 j2 j3 j4 j5 j6 j7] j1 [j4 j6 j7])]
+          (is (zero? (count (:fully-processed result))))
+          (is (zero? (count (:upgrade-backfill result))))
+          (is (= 3 (count (:backfill-jobs result))))
+          (is (not (:matched-head? result))))))))
+
 (deftest test-get-user->used-resources
   (let [uri "datomic:mem://test-get-used-resources"
         conn (restore-fresh-database! uri)

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -434,6 +434,7 @@
   ;; Then we'll upgrade the jobs
   ;; Check here that they have the right properties (running, not ready to run)
   ;; Then shut it down
+
   (let [uri "datomic:mem://test-backfill-upgrade"
         conn (restore-fresh-database! uri)
         check-count-of-pending-and-runnable-jobs

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -178,9 +178,6 @@
     (is (= 1.0 (:cpus resources)))
     (is (= 1000.0 (:mem resources)))))
 
-(deftest test-prefixes
-  (is (= [[1] [1 2] [1 2 3] [1 2 3 4] [1 2 3 4 5]] (sched/prefixes [1 2 3 4 5]))))
-
 (deftest test-match-offer-to-schedule
   (let [schedule (map #(d/entity (db c) %) [j1 j2 j3 j4])] ; all 1gb 1 cpu
       (testing "Consume no schedule cases"

--- a/scheduler/test/cook/test/mesos/schema.clj
+++ b/scheduler/test/cook/test/mesos/schema.clj
@@ -71,13 +71,14 @@
 
 (defn create-dummy-instance
   "Return the entity id for the created instance."
-  [conn job & {:keys [job-state instance-status start-time hostname task-id progress]
+  [conn job & {:keys [job-state instance-status start-time hostname task-id progress backfilled?]
                :or  {job-state :job.state/running
                      instance-status :instance.status/unknown
                      start-time (java.util.Date.)
                      hostname "localhost"
                      task-id (str (str (java.util.UUID/randomUUID)))
-                     progress 0}}]
+                     backfilled? false
+                     progress 0} :as cfg}]
   (let [id (d/tempid :db.part/user)
         val @(d/transact conn [{:db/id job
                                 :job/state job-state}
@@ -85,6 +86,7 @@
                                 :job/_instance job
                                 :instance/hostname hostname
                                 :instance/progress progress
+                                :instance/backfilled? backfilled?
                                 :instance/status instance-status
                                 :instance/start-time start-time
                                 :instance/task-id task-id}])]


### PR DESCRIPTION
This adds Fenzo as the task placer. To take advantage of Fenzo, we want to provide it with many tasks to place every cycle. In order to guarantee that big tasks get scheduled and Fenzo sees a lot of tasks, we exponentially reduce the # of tasks that Fenzo sees every scheduling cycle as long as it doesn't schedule the head of the queue. Once the head is scheduled, we reset the # of jobs that Fenzo gets to consider.

When Fenzo starts a task out of order, it is flagged as "backfilled". A backfilled task is bumped to the highest priority for the preemption system. Once a backfilled task moves to the head of the queue, however, we upgrade it to be non-backfilled. The backfilled tasks don't actually make a job register as "running", since they could be killed at any time.