### PR TITLE
Add metrics-clojure-ring, move us back to mainline metrics-clojure

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -62,9 +62,10 @@
                  [cc.qbits/jet "0.5.4"]
 
                  ;;Metrics
-                 [dgrnbrg/metrics-clojure "2.6.1"
-                  :exclusions [io.netty/netty
-                               org.clojure/clojure]]
+                 [metrics-clojure "2.6.1"
+                  :exclusions [io.netty/netty org.clojure/clojure]]
+                 [metrics-clojure-ring "2.3.0"
+                  :exclusions [io.netty/netty org.clojure/clojure]]
                  [io.dropwizard.metrics/metrics-graphite "3.1.2"]
                  [com.aphyr/metrics3-riemann-reporter "0.4.0"]
                  [riemann-clojure-client "0.4.1"]

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -32,7 +32,8 @@
             [compojure.core :refer (GET POST routes context)]
             [compojure.route :as route]
             [plumbing.graph :as graph]
-            [cook.curator :as curator])
+            [cook.curator :as curator]
+            [metrics.ring.instrument] :refer (instrument))
   (:import org.apache.curator.retry.BoundedExponentialBackoffRetry
            org.apache.curator.framework.state.ConnectionStateListener
            org.apache.curator.framework.CuratorFrameworkFactory)
@@ -158,7 +159,8 @@
                                                        wrap-stacktrace-web
                                                        wrap-no-cache
                                                        wrap-params
-                                                       health-check-middleware)
+                                                       health-check-middleware
+                                                       instrument)
                                      :join? false
                                      :max-threads 200})]
                          (fn [] (.stop jetty))))


### PR DESCRIPTION
It appears that in purging the codebase of voom (5c44eff1a52339176f1b6692639effd4970b8a6f) we lost the automatic Ring metrics.

This adds them back, and additionally puts us back on the upstream published version of metrics-clojure, now that it's been published.