### PR TITLE
Create shim principal for access logs

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -43,7 +43,7 @@
            org.eclipse.jetty.security.UserAuthentication
            org.eclipse.jetty.security.DefaultUserIdentity
            javax.security.auth.Subject
-           javax.security.auth.kerberos.KerberosPrincipal)
+           java.security.Principal)
   (:gen-class))
 
 (defn wrap-no-cache
@@ -162,7 +162,13 @@
                             "kerberos"
                             (DefaultUserIdentity.
                               (Subject.)
-                              (KerberosPrincipal. (:authorization/user req))
+                              (reify Principal ; Shim principal to pass username along
+                                (equals [this another]
+                                  (= this another))
+                                (getName [this]
+                                  (:authorization/user req))
+                                (toString [this]
+                                  (str "Shim principal for user: " (:authorization/user req))))
                               (into-array String []))))
       (h req))))
 

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -371,10 +371,12 @@
   [schedule {{:keys [cpus mem]} :resources :as offer}]
   (log/debug "Matching offer " offer " to the schedule" schedule)
   (loop [[candidates & remaining-prefixes] (prefixes schedule)
+         resources-so-far {:mem 0 :cpus 0}
          prev []]
-    (let [required (util/sum-resources-of-jobs candidates)]
+    (let [required (merge-with + resources-so-far
+                               (select-keys [:mem :cpus] (util/job-ent->resources (last candidates))))]
       (if (and candidates (>= cpus (:cpus required)) (>= mem (:mem required)))
-        (recur remaining-prefixes candidates)
+        (recur remaining-prefixes required candidates)
         prev))))
 
 (meters/defmeter [cook-mesos scheduler scheduler-offer-declined])


### PR DESCRIPTION
Swap out the kerberos principal which was causing errors for non-kerberized auth environments (issue #123) and instead just pass in a shim principal.