### PR TITLE
Use unfiltered db when possible for query improvement

### DIFF
--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -50,12 +50,12 @@
     (testing "test1"
       (let [_ (share/set-share! conn "default" :mem 10.0 :cpus 10.0)
             db (d/db conn)]
-        (is (= [j2 j3 j6 j4 j8] (map :db/id (sched/sort-jobs-by-dru db))))))
+        (is (= [j2 j3 j6 j4 j8] (map :db/id (sched/sort-jobs-by-dru db db))))))
     (testing "test2"
         (let [_ (share/set-share! conn "default" :mem 10.0 :cpus 10.0)
               _ (share/set-share! conn "sunil" :mem 100.0 :cpus 100.0)
               db (d/db conn)]
-          (is (= [j8 j2 j3 j6 j4] (map :db/id (sched/sort-jobs-by-dru db)))))))
+          (is (= [j8 j2 j3 j6 j4] (map :db/id (sched/sort-jobs-by-dru db db)))))))
 
   (let [uri "datomic:mem://test-sort-jobs-by-dru"
         conn (restore-fresh-database! uri)
@@ -80,7 +80,7 @@
 
         test-db (d/db conn)]
     (testing
-      (is (= [job-id-2 job-id-3 job-id-1 job-id-4] (map :db/id (sched/sort-jobs-by-dru test-db)))))))
+      (is (= [job-id-2 job-id-3 job-id-1 job-id-4] (map :db/id (sched/sort-jobs-by-dru test-db test-db)))))))
 
 (d/delete-database "datomic:mem://preemption-testdb")
 (d/create-database "datomic:mem://preemption-testdb")
@@ -310,7 +310,7 @@
         offensive-jobs #{job-entity-1 job-entity-2}
         offensive-jobs-ch (sched/make-offensive-job-stifler conn)
         offensive-job-filter (partial sched/filter-offensive-jobs constraints offensive-jobs-ch)]
-    (is (= #{job-entity-2} (set (sched/rank-jobs test-db offensive-job-filter))))))
+    (is (= #{job-entity-2} (set (sched/rank-jobs test-db test-db offensive-job-filter))))))
 
 (deftest test-get-lingering-tasks
   (let [uri "datomic:mem://test-lingering-tasks"


### PR DESCRIPTION
This commit has the `sort-jobs-by-dru` use an unfiltered db when possible. Throughout most (all) of the code, we use a filtered datomic database which will remove datoms which have a metatransaction status of uncommitted. We do this so that jobs will only be considered valid once they have all been submitted so that we could avoid a case where we try to schedule a partial submission. Unfortunately, using a filtered database is not free, and in some cases can be costly. In the case of ranking jobs, it is very costly. The reason for the cost is that the filter must check every datom to see if it passes. Worse, if the datom doesn't have a metatransaction linked to it, it has to do a more expensive search to confirm that. If we can avoid using the filtered db where possible, both the initial poll for data gets fast as well as looking up additional attributes on the entity. 

As an aside, we should revisit the idea of metatransaction because it comes with such hefty performance consequences. 