### PR TITLE
Add running and queue endpoints

### DIFF
--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -76,10 +76,9 @@
 
 (defn start-mesos-scheduler
   "Starts a leader elector that runs a mesos."
-  [mesos-master mesos-master-hosts curator-framework mesos-datomic-conn mesos-datomic-mult zk-prefix mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms task-constraints riemann-host riemann-port]
+  [mesos-master mesos-master-hosts curator-framework mesos-datomic-conn mesos-datomic-mult zk-prefix mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms task-constraints riemann-host riemann-port mesos-pending-jobs-atom]
   (let [zk-framework-id (str zk-prefix "/framework-id")
         datomic-report-chan (async/chan (async/sliding-buffer 4096))
-        mesos-pending-jobs-atom (atom [])
         mesos-heartbeat-chan (async/chan (async/buffer 4096))
         {:keys [scheduler view-incubating-offers view-mature-offers]}
         (sched/create-datomic-scheduler

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -366,7 +366,34 @@
                           (::results ctx)))
       ring.middleware.json/wrap-json-params))
 
+(defn waiting-jobs
+  [mesos-pending-jobs-fn]
+  (-> (resource
+        :available-media-types ["application/json"]
+        :allowed-methods [:get]
+        :handle-ok (fn [ctx]
+                     (->> (mesos-pending-jobs-fn)
+                          (map d/touch)
+                          cheshire/generate-string)))
+      ring.middleware.json/wrap-json-params))
+
+(defn running-jobs
+  [conn]
+  (-> (resource
+        :available-media-types ["application/json"]
+        :allowed-methods [:get]
+        :handle-ok (fn [ctx]
+                     (->> (util/get-running-task-ents (db conn))
+                          (map d/touch)
+                          cheshire/generate-string)))
+      ring.middleware.json/wrap-json-params))
+
 (defn handler
-  [conn fid task-constraints]
-  (ANY "/rawscheduler" []
-       (job-resource conn fid task-constraints)))
+  [conn fid task-constraints mesos-pending-jobs-fn]
+  (routes
+    (ANY "/rawscheduler" []
+         (job-resource conn fid task-constraints))
+    (ANY "/queue" []
+         (waiting-jobs mesos-pending-jobs-fn))
+    (ANY "/running" []
+         (running-jobs conn))))


### PR DESCRIPTION
Add endpoints to inspect the running and waiting instances in cook. The waiting jobs are returned sorted.