### PR TITLE
Lock down /rawscheduler endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ pom.xml.asc
 .lein-plugins
 .lein-repl-history
 .nrepl-port
+.minimesos/
+minimesosFile

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ pom.xml.asc
 .nrepl-port
 .minimesos/
 minimesosFile
+.lein-env
+log/

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,129 @@
+# Setting up your Cook dev environment
+
+This document tells you how to set up a Cook dev environment from
+scratch on a Macintosh computer.
+
+Prerequisites
+=============
+
+Before beginning, you should already have working installations of MacPorts,
+Clojure, Leiningen, and Emacs (or your favorite text editor). Refer to
+those projects' getting started guides for information on how to set
+them up.
+
+You will need the latest Xcode and Xcode Command Line Tools packages from
+Apple. The Command Line Tools can no longer be installed through
+XCode. To get them, log in at https://developer.apple.com/, go to
+"Downloads," then scroll to click on "See more downloads" at the
+bottom. From there, download and install the "Command Line Tools"
+package that corresponds to your version of Xcode.
+
+This guide assumes you're using MacPorts. Homebrew will work
+similarly, though you may have to adjust a few paths to correspond to
+those that Homebrew uses.
+
+
+Installing Cook-specific Infrastructure
+========================================
+
+We need to install Datomic, Docker, and Mesos.
+
+
+Datomic
+-------
+
+Create an account at www.datomic.com. Download the "Datomic Pro
+Starter" package and unzip it somewhere.
+
+Install it into your local Maven repository with:
+
+```
+./bin/maven-install
+```
+
+
+Docker
+-----
+
+Install Docker from https://www.docker.com/products/docker#/mac .
+
+
+Vagrant
+-------
+Install Vagrant from https://www.vagrantup.com/downloads.html .
+
+
+
+
+Minimesos
+-----
+
+If you're using the Docker native Mac app beta, you can't use
+minimesos until 0.9.1 is released (scheduled for sometime in July
+2016.) Minimesos <= 0.9.0 has a bug that prevents it from working on
+the Docker 1.12 that comes with the Docker for Mac app.
+
+In the meantime, you can get Docker 1.11 on a Mac by installing the
+older "Docker Toolbox" app from
+https://www.docker.com/products/docker-toolbox .
+
+Then, install minimesos by following the instructions at
+http://minimesos.readthedocs.io/en/latest/ .
+
+
+Once minimesos is installed, you can download and run minimesos itself:
+
+
+```
+mkdir minimesos
+cd minimesos
+
+minimesos init
+minimesos up --num-agents 2
+```
+
+
+
+Big Mesos
+---------
+
+Even if you are using minimesos, you still have to build regular Mesos
+to get the `libmesos.dylib` library (called `libmesos.so` on Linux).
+
+
+```
+
+sudo port install wget git autoconf automake libtool subversion
+#
+# Or 'brew install ...' if you use homebrew instead of MacPorts.
+#
+# This will take a while if you don't already have these installed.
+
+
+git clone https://git-wip-us.apache.org/repos/asf/mesos.git
+cd mesos
+
+./bootstrap
+
+mkdir build && cd build
+
+# PYTHON= is a workaround for the Python bug
+# described at http://gwikis.blogspot.com/2015/08/building-mesos-0230-on-os-x-yosemite.html
+#
+# The --with-svn=/opt/local/ flag makes it use the MacPorts copy of Subversion rather
+# than the system copy, which does not include the dev headers and library.
+#
+
+PYTHON=/usr/bin/python ../configure --with-svn=/opt/local/
+
+# Add MacPorts libraries to the linker search path:
+LIBRARY_PATH=/opt/local/lib make
+
+
+```
+
+
+Command Line Usage
+==================
+
+1. Start

--- a/scheduler/dev-config.edn
+++ b/scheduler/dev-config.edn
@@ -1,6 +1,11 @@
 {:port 12321
  ;; We'll set the user to vagrant, since that's the default for many Vagrant-based Mesos setups
  :authorization {:one-user "vagrant"}
+
+ ;; These users have admin privileges -- they can view and modify other users' jobs.
+ :user-privileges {:admin #{"admin" "other-admin"}}
+
+
  :database {:datomic-uri "datomic:mem://cook-jobs"}
  :zookeeper {:local? true
              ;:local-port 3291 ; Uncomment to change the default port

--- a/scheduler/docs/configuration.asc
+++ b/scheduler/docs/configuration.asc
@@ -63,6 +63,17 @@ If need it to bind to another port, you can specify that with the `:local-port` 
   Cook currently supports a single-user development mode, HTTP Basic authentication, and Kerberos authentication.
   See <<auth_config>> for details.
 
+`:user-privileges`::
+
+  This key defines what privileges specified users have on the
+  system. Its value is a map. Keys of this map are the names of
+  privileges, and values are sets of users who have that privilege.
+  The only currently supported privilege is `:admin`. Admins can
+  modify any jobs on the system, while non-admins can only modify
+  their own jobs.
+  For example, to make Alice and Bob admins, add a line like:
+  `:user-privileges {:admin #{"alice" "bob"}}`
+
 [[mesos_config]]
 ==== Mesos Configuration
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -90,7 +90,8 @@
                  [liberator "0.13"]
 
                  ;;Databases
-                 [com.datomic/datomic-free "0.9.5206"
+                 [;;com.datomic/datomic-free "0.9.5206"
+                  com.datomic/datomic-pro "0.9.5385"
                   :exclusions [org.slf4j/slf4j-api
                                com.fasterxml.jackson.core/jackson-core
                                org.slf4j/jcl-over-slf4j

--- a/scheduler/src/cook/authorization.clj
+++ b/scheduler/src/cook/authorization.clj
@@ -1,0 +1,37 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.authorization
+  "Functions that determine whether a given user is allowed to perform a
+  certain action.
+
+  Note that this is a seperate concern than authentication, which is
+  determining whether a user is who they claim to be."
+  (:require [plumbing.core :refer (fnk defnk)]))
+
+
+(defn is-admin?
+  "Given a username and an app state ref, determines whether the user
+  has administrative privileges."
+  [app-state username]
+  
+  ;; Currently, we only support including a list of admins in the
+  ;; :user-privileges key in the app settings.
+  ;; 
+  ;; In the future, more complex schemes can be plugged in here,
+  ;; selected through the global app settings read from the config file.
+
+  (contains? (some-> @app-state :settings :user-privileges :admin) 
+             username))

--- a/scheduler/src/cook/basic_auth.clj
+++ b/scheduler/src/cook/basic_auth.clj
@@ -41,6 +41,7 @@
   (fn [req]
     (if-let [[user pass] (parse-auth-from-request req)]
       (do
+        (log/info "Allowing user:" user)
         (log/debug "Got http basic auth:" user pass)
         (h (assoc req :authorization/user user)))
       (-> (response "malformed or missing authorization header in basic auth")

--- a/scheduler/src/cook/basic_auth.clj
+++ b/scheduler/src/cook/basic_auth.clj
@@ -41,7 +41,7 @@
   (fn [req]
     (if-let [[user pass] (parse-auth-from-request req)]
       (do
-        (log/info "Allowing user:" user)
+        (log/info "Request from user:" user)
         (log/debug "Got http basic auth:" user pass)
         (h (assoc req :authorization/user user)))
       (-> (response "malformed or missing authorization header in basic auth")

--- a/scheduler/src/cook/basic_auth.clj
+++ b/scheduler/src/cook/basic_auth.clj
@@ -15,7 +15,8 @@
 ;;
 (ns cook.basic-auth
   (:require [clojure.tools.logging :as log]
-            [ring.util.response :refer (header status response)]))
+            [ring.util.response :refer (header status response)])
+  (:import org.apache.commons.codec.binary.Base64))
 
 (defn parse-auth-from-request
   "Given a request, extracts the HTTP basic auth username & password"

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -354,6 +354,7 @@
                                                host->combined-offers))))
         shutdown-rebalancer (chime-at (periodic/periodic-seq (time/now) rebalance-interval)
                                       (fn [now]
+                                        (log/debug "[shutdown-rebalancer] Connecting to db:" conn)
                                         (let [db (mt/db conn)
                                               params (-<>>
                                                       (d/pull db ["*"] :rebalancer/config)


### PR DESCRIPTION
This PR provides the functionality necessary to lock down the /rawscheduler endpoint, as detailled in my previous emails.

Ordinary users can only view their own jobs. Admins can view any job.

Admins are specified as a set of usernames in the config file.

Various modifications were also made to allow for easier interactive development at the REPL so that web handlers can be modified without having to restart the whole system from scratch, and more log messages were added to make it easier to inspect internal system state.