### PR TITLE
scheduler: Handle task-error status updates from Mesos.

### DIFF
--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -225,7 +225,8 @@
                                    #{:task-finished} :instance.status/success
                                    #{:task-failed
                                      :task-killed
-                                     :task-lost} :instance.status/failed)
+                                     :task-lost
+                                     :task-error} :instance.status/failed)
                  prior-job-state (:job/state (d/entity db job))
                  progress (try 
                               (when (:data status)


### PR DESCRIPTION
This Mesos status means that the task was incorrectly specified in the
first place.  Cook wasn't handling it at all; we should consider the
task failed in this case.