### PR TITLE
REVIEW ONLY: Replace clj-mesos with Mesomatic.

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -79,8 +79,7 @@
 
                  ;;External system integrations
                  [me.raynes/conch "0.5.2"]
-                 [twosigma/clj-mesos "0.22.4-SNAPSHOT"]
-                 [com.google.protobuf/protobuf-java "2.6.1"] ; used by clj-mesos
+                 [spootnik/mesomatic "0.28.0-r0"]
                  [org.clojure/tools.nrepl "0.2.3"]
 
                  ;;Ring

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -19,7 +19,8 @@
             [metatransaction.core :as mt :refer (db)]
             [metatransaction.utils :as dutils]
             [clojure.tools.logging :as log]
-            [clj-mesos.scheduler]
+            [mesomatic.scheduler]
+            [mesomatic.types]
             [metrics.counters :as counters]
             [cook.datomic :refer (transact-with-retries)]
             [cook.mesos.scheduler :as sched]
@@ -88,11 +89,12 @@
                      (curator/set-or-create
                       curator-framework
                       zk-framework-id
-                      (.getBytes framework-id "UTF-8")))
+                      (.getBytes (-> framework-id mesomatic.types/pb->data :value) "UTF-8")))
                    current-driver
                    mesos-pending-jobs-atom
                    mesos-heartbeat-chan
                    offer-incubate-time-ms
+                   mesos-role
                    fenzo-max-jobs-considered
                    fenzo-scaleback
                    fenzo-floor-iterations-before-warn
@@ -112,7 +114,7 @@
                               (let [normal-exit (atom true)
                                     shutdown-hooks (atom ())]
                                 (try
-                                  (let [driver (apply clj-mesos.scheduler/driver
+                                  (let [driver (apply mesomatic.scheduler/scheduler-driver
                                                       scheduler
                                                       (merge
                                                         {:user ""
@@ -129,7 +131,7 @@
                                                       mesos-master
                                                       (when mesos-principal
                                                         [{:principal mesos-principal}]))]
-                                    (clj-mesos.scheduler/start driver)
+                                    (mesomatic.scheduler/start! driver)
                                     (reset! current-driver driver)
                                     (if riemann-host
                                       (swap! shutdown-hooks conj (cook.mesos.monitor/riemann-reporter mesos-datomic-conn :riemann-host riemann-host :riemann-port riemann-port)))
@@ -148,7 +150,7 @@
                                       (swap! shutdown-hooks conj (fn []
                                                                    (kill-monitor)
                                                                    (async/untap mesos-datomic-mult datomic-report-chan))))
-                                    (clj-mesos.scheduler/join driver)
+                                    (mesomatic.scheduler/join! driver)
                                     (reset! current-driver nil))
                                   (catch Exception e
                                     (log/error e "Lost mesos leadership due to exception")
@@ -168,7 +170,7 @@
                               (when (#{ConnectionState/LOST ConnectionState/SUSPENDED} newState)
                                 (when-let [driver @current-driver]
                                   (log/warn "Forfeiting mesos leadership")
-                                  (clj-mesos.scheduler/stop driver true))))))]
+                                  (mesomatic.scheduler/stop! driver true))))))]
     (.setId leader-selector (str (java.net.InetAddress/getLocalHost) \- (java.util.UUID/randomUUID)))
     (.autoRequeue leader-selector)
     (.start leader-selector)

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (ns cook.mesos.rebalancer
-  (:require [clj-mesos.scheduler :as mesos]
+  (:require [mesomatic.scheduler :as mesos]
             [cook.mesos.scheduler :as sched]
             [cook.mesos.util :as util]
             [cook.mesos.dru :as dru]
@@ -358,7 +358,7 @@
           (catch Throwable e
             (log/warn e "Failed to transact preemption")))
         (when-let [task-id (:instance/task-id task-ent)]
-          (mesos/kill-task driver task-id))))))
+          (mesos/kill-task! driver {:value task-id}))))))
 
 (defn get-mesos-utilization
   [mesos-master-hosts]

--- a/scheduler/test/cook/test/mesos.clj
+++ b/scheduler/test/cook/test/mesos.clj
@@ -77,8 +77,8 @@
 (defn make-offer
   [cpus mem]
   {:slave-id "mycoolslave"
-   :resources {:cpus cpus
-               :mem mem}})
+   :resources [{:name "cpus" :scalar cpus}
+               {:name "mem" :scalar mem}]})
 
 (deftest test-resource-matching
   ;; Should have at least one match


### PR DESCRIPTION
This branch fully replaces clj-mesos with Mesomatic.

At this time, it depends on a version of Mesomatic with this PR merged in:

https://github.com/pyr/mesomatic/pull/23

Thus, it can't be used without a new version of Mesomatic (or forking Mesomatic); at this stage this PR is for code review purposes only & shouldn't be merged yet. 