### PR TITLE
REVIEW ONLY: Scheduler: Replace clj-mesos with mesomatic.

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -84,8 +84,7 @@
 
                  ;;External system integrations
                  [me.raynes/conch "0.5.2"]
-                 [twosigma/clj-mesos "0.22.4-SNAPSHOT"]
-                 [com.google.protobuf/protobuf-java "2.6.1"] ; used by clj-mesos
+                 [spootnik/mesomatic "0.28.0-r0"]
                  [org.clojure/tools.nrepl "0.2.3"]
 
                  ;;Ring

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (ns cook.mesos.rebalancer
-  (:require [clj-mesos.scheduler :as mesos]
+  (:require [mesomatic.scheduler :as mesos]
             [cook.mesos.scheduler :as sched]
             [cook.mesos.util :as util]
             [cook.mesos.dru :as dru]
@@ -357,7 +357,7 @@
           (catch Throwable e
             (log/warn e "Failed to transact preemption")))
         (when-let [task-id (:instance/task-id task-ent)]
-          (mesos/kill-task driver task-id))))))
+          (mesos/kill-task! driver {:value task-id}))))))
 
 (defn get-mesos-utilization
   [mesos-master-hosts]

--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -1,0 +1,174 @@
+(ns cook.mesos.task
+  (:require [plumbing.core :refer (map-vals)]
+            [clojure.tools.logging :as log])
+  (import com.netflix.fenzo.TaskAssignmentResult))
+
+
+(defn TaskAssignmentResult->task-info
+  "Organizes the info Fenzo has already told us about the task we need to run"
+  [^TaskAssignmentResult fenzo-result]
+  (merge (:task-info (.getRequest fenzo-result))
+         {:ports-assigned (.getAssignedPorts fenzo-result)}))
+
+
+(defmulti combine-like-resources
+  (fn [list] (-> list first :type)))
+
+(defmethod combine-like-resources :value-scalar [resources]
+  (->> resources (map :scalar) (apply +)))
+
+(defmethod combine-like-resources :value-ranges [resources]
+  (->> resources (map :ranges) (apply into)))
+
+(defn resources-by-role
+  "Given a set of offers, combine all the available resources into a comprehensible
+  and easily walkable data strucuture, grouped first by resource name e.g. mem, then
+  by role."
+  [offers]
+  (->> offers
+       (map :resources)
+       flatten
+       (group-by :name)
+       (map-vals (fn [resources]
+                   (->> resources
+                        (group-by :role)
+                        (map-vals combine-like-resources))))))
+
+(defn range-contains?
+  "true iff val is contained by a mesos-style range e.g. {:begin 1 :end 10}"
+  [val mesos-range]
+  (and (<= (:begin mesos-range) val)
+       (>= (:end mesos-range) val)))
+
+(defn role-containing-port
+  "in: {\"*\" [{:begin 201 :end 202}] \"cook\" [{:begin 203 :end 204}]}, 201
+  ;; out \"*\""
+  [available-ports port]
+  (->> available-ports
+       seq
+       (filter #(some (partial range-contains? port) (val %)))
+       ffirst))
+
+(defn take-ports
+  "Given a set of available resources (in the format returned by resources-by-role),
+  returns a vector of mesos messages that will reserve the specified ports.
+  Note: unlike with scalar-resources, available-resources don't need to be
+  changed by this function, because Fenzo has already provided us with
+  specific ports to use for every task."
+  [available-resources ports-needed]
+  (mapv (fn [port]
+          {:name "ports"
+           :type :value-ranges
+           :role (role-containing-port available-resources port)
+           :ranges [{:begin port :end port}]})
+        ports-needed))
+
+(defn add-ports-to-task-info
+  "Given a set of tasks and offers that were matched together by Fenzo,
+   assigns the specific ports requested by role to each task.
+   Returns the input tasks, decorated with :ports-resource-messages"
+  [available-resources tasks]
+  (let [available-ports (available-resources "ports")]
+    (map (fn [task]
+           (let [ports (:ports-assigned task)
+                 port-env-vars (into {} (map-indexed (fn [i p] [(str "PORT" i) (str p)])
+                                                     ports))]
+             (-> task
+                 (assoc :ports-resource-messages (take-ports available-ports ports))
+                 (update-in [:command :environment] merge port-env-vars))))
+         tasks)))
+
+(defn take-resources
+  "Given a set of available resources (in the format returned by resources-by-role),
+  take the specified amount of the specified resource from the pool.
+  Return {:remaining-resources (the pool after resources were taken)
+          :mesos-messages (the Mesos messages that are necessary to reserve the resources)
+          :amount-still-needed (the amount still needed to satisfy amount... if it's not 0, something went wrong)}"
+  [available-resources resource-name amount]
+  (let [avail (available-resources resource-name)
+        ;; to be polite to other frameworks, take from role-specific pool first.
+        sorted-roles (sort-by #(= "*" %) (keys avail))
+        init-state {:remaining-resources avail
+                    :mesos-messages []
+                    :amount-still-needed amount}]
+    (reduce (fn [{:keys [remaining-resources mesos-messages amount-still-needed]
+                  :as state} role-name]
+              (let [amount-avail (or (remaining-resources role-name) 0)
+                    amount-to-take (min amount-still-needed amount-avail)]
+                (if (pos? amount-to-take)
+                  {:remaining-resources
+                   (assoc remaining-resources role-name (- amount-avail amount-to-take))
+                   :mesos-messages
+                   (conj mesos-messages {:name resource-name
+                                         :type :value-scalar
+                                         :role role-name
+                                         :scalar amount-to-take})
+                   :amount-still-needed (- amount-still-needed amount-to-take)}
+                  state)))
+            init-state
+            sorted-roles)))
+
+(defn take-all-scalar-resources-for-task
+  [resources task]
+  (reduce
+   (fn [{:keys [remaining-resources mesos-messages]} [resource-keyword amount]]
+     (let [resource-name (name resource-keyword)
+           adjustment (take-resources remaining-resources resource-name amount)]
+       {:remaining-resources (assoc remaining-resources resource-name (:remaining-resources adjustment))
+        :mesos-messages (into mesos-messages (:mesos-messages adjustment))}))
+   {:remaining-resources resources
+    :mesos-messages []}
+   (-> task :resources vec)))
+
+(defn add-scalar-resources-to-task-infos
+  "Given a set of tasks and offers that were matched together by Fenzo,
+   assigns the specific scalar resource requirements by role to each task.
+   Returns the input tasks, decorated with :scalar-resource-messages"
+  [available-resources tasks]
+  (:handled-tasks
+   (reduce (fn [{:keys [remaining-resources handled-tasks]} task]
+             (let [adjustment (take-all-scalar-resources-for-task remaining-resources task)
+                   new-task (assoc task :scalar-resource-messages (:mesos-messages adjustment))]
+               {:remaining-resources (:remaining-resources adjustment)
+                :handled-tasks (conj handled-tasks new-task)}))
+           {:remaining-resources available-resources
+            :handled-tasks []}
+           tasks)))
+
+(defn map->mesos-kv
+  "Converts a normal clojure map to a format sometimes employed in mesos messages.
+  e.g. {:foo :bar}  ->  [{:key :foo :value :bar}]"
+  [m key-name]
+  (mapv (fn [kv] {key-name (key kv) :value (val kv)})
+        (vec m)))
+
+(defn task-info->mesos-message
+  "Given a clojure data structure (based on Cook's internal data format for jobs),
+  which has already been decorated with everything we need to know about
+  a task, return a Mesos message that will actually launch that task"
+  [t]
+  {:name (:name t)
+   :slave-id (:slave-id t)
+   :task-id {:value (:task-id t)}
+   :resources (into (:scalar-resource-messages t)
+                    (:ports-resource-messages t))
+
+   :labels {:labels (map->mesos-kv (:labels t) :key)}
+   :command (update (:command t)
+                    :environment
+                    (fn [env] {:variables (map->mesos-kv env :name)}))
+   :data (com.google.protobuf.ByteString/copyFrom (:data t))})
+
+(defn compile-mesos-messages
+  "Given Mesos offers and Fenzo TaskAssignmentResults,
+   Returns a vector of Mesos messages that can start the tasks
+   suggested by the TaskAssignmentResults"
+  [offers task-assignments]
+  (let [slave-id (-> offers first :slave-id)
+        combined-resource-pool (resources-by-role offers)]
+    (->> task-assignments
+         (map TaskAssignmentResult->task-info)
+         (add-scalar-resources-to-task-infos combined-resource-pool)
+         (add-ports-to-task-info combined-resource-pool)
+         (map #(assoc % :slave-id slave-id))
+         (map task-info->mesos-message))))

--- a/scheduler/test/cook/test/mesos.clj
+++ b/scheduler/test/cook/test/mesos.clj
@@ -77,8 +77,8 @@
 (defn make-offer
   [cpus mem]
   {:slave-id "mycoolslave"
-   :resources {:cpus cpus
-               :mem mem}})
+   :resources [{:name "cpus" :scalar cpus}
+               {:name "mem" :scalar mem}]})
 
 (deftest test-resource-matching
   ;; Should have at least one match

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -1,0 +1,177 @@
+(ns cook.test.mesos.task-test
+  (:use clojure.test)
+  (:require [clojure.edn :as edn]
+            [mesomatic.types :as mtypes]
+            [cook.mesos.task :as task]
+            [cook.mesos.scheduler :as sched]))
+
+(deftest test-resources-by-role
+  (let [
+        offers [{:resources [{:name "mem", :type :value-scalar, :scalar 100.0, :role "cook"}
+                             {:name "mem", :type :value-scalar, :scalar 50.0, :role "*"}
+                             {:name "cpus", :type :value-scalar, :scalar 6.0, :role "cook"}
+                             {:name "cpus", :type :value-scalar, :scalar 4.0, :role "*"}
+                             {:name "ports",
+                              :type :value-ranges,
+                              :ranges [{:begin 1000 :end 2000} {:begin 3000 :end 4000}],
+                              :role "cook"}
+                             {:name "ports",
+                              :type :value-ranges,
+                              :ranges [{:begin 5000 :end 6000} {:begin 7000 :end 8000}],
+                              :role "*"}]}
+                {:resources [{:name "mem", :type :value-scalar, :scalar 30.0, :role "cook"}
+                             {:name "mem", :type :value-scalar, :scalar 20.0, :role "*"}
+                             {:name "cpus", :type :value-scalar, :scalar 3.0, :role "cook"}
+                             {:name "cpus", :type :value-scalar, :scalar 2.0, :role "*"}
+                             {:name "ports",
+                              :type :value-ranges,
+                              :ranges [{:begin 11000 :end 12000} {:begin 13000 :end 14000}],
+                              :role "cook"}
+                             {:name "ports",
+                              :type :value-ranges,
+                              :ranges [{:begin 15000 :end 16000} {:begin 17000 :end 18000}],
+                              :role "*"}]
+                 }]
+        results (task/resources-by-role offers)]
+
+    (is (= (results "mem")
+           {"cook" 130.0, "*" 70.0}))
+
+    (is (= (results "cpus")
+           {"cook" 9.0, "*" 6.0}))
+
+    (is (= (results "ports")
+           {"cook" [{:begin 1000, :end 2000}
+                    {:begin 3000, :end 4000}
+                    {:begin 11000, :end 12000}
+                    {:begin 13000, :end 14000}],
+            "*" [{:begin 5000, :end 6000}
+                 {:begin 7000, :end 8000}
+                 {:begin 15000, :end 16000}
+                 {:begin 17000, :end 18000}]}))))
+
+(deftest test-take-resources
+  (let [resources {"mem" {"cook" 50.0 "*" 125.0}}
+        result (task/take-resources resources "mem" 75.0)]
+    (is (= (:amount-still-needed result) 0.0))
+    (is (= (:mesos-messages result) [
+                                     {:name "mem"
+                                      :type :value-scalar
+                                      :role "cook"
+                                      :scalar 50.0}
+                                     {:name "mem"
+                                      :type :value-scalar
+                                      :role "*"
+                                      :scalar 25.0}
+                                     ])
+        (is (= (:remaining-resources result) {"cook" 0.0 "*" 100.0})))))
+
+(deftest test-range-contains?
+  (let [r {:begin 100 :end 200}]
+    (is (true? (task/range-contains? 100 r)))
+    (is (true? (task/range-contains? 200 r)))
+    (is (false? (task/range-contains? 99 r)))
+    (is (false? (task/range-contains? 250 r)))))
+
+(deftest test-role-containing-port
+  (let [avail {"*" [{:begin 201 :end 202}] "cook" [{:begin 203 :end 204}]}]
+    (is (= (task/role-containing-port avail 201) "*"))
+    (is (= (task/role-containing-port avail 204) "cook"))
+    (is (nil? (task/role-containing-port avail 999)))))
+
+(deftest test-take-ports
+  (let [resources {"*" [{:begin 201 :end 202}] "cook" [{:begin 203 :end 204}]}
+        result (task/take-ports resources [201 203])]
+    (is (= result  [{:name "ports" :type :value-ranges :role "*" :ranges [{:begin 201 :end 201}]}
+                    {:name "ports" :type :value-ranges :role "cook" :ranges [{:begin 203 :end 203}]}]))))
+
+(deftest test-take-scalar-resources-for-task
+  (let [available {"cpus" {"cook" 8.0 "*" 6.0}
+                   "mem" {"cook" 800.0 "*" 700.0}}
+        task {:resources {:cpus 12 :mem 900}}
+        result (task/take-all-scalar-resources-for-task available task)]
+    (is (= (:remaining-resources result)
+           {"cpus" {"cook" 0.0 "*" 2.0}
+            "mem" {"cook" 0.0 "*" 600.0}}))
+    (is (= (:mesos-messages result)
+           [{:name "cpus", :type :value-scalar, :role "cook", :scalar 8.0}
+            {:name "cpus", :type :value-scalar, :role "*", :scalar 4.0}
+            {:name "mem", :type :value-scalar, :role "cook", :scalar 800.0}
+            {:name "mem", :type :value-scalar, :role "*", :scalar 100.0}]))))
+
+(deftest test-add-scalar-resources-to-task-infos
+  (let [available {"cpus" {"cook" 8.0 "*" 6.0}
+                   "mem" {"cook" 800.0 "*" 700.0}}
+        tasks [{:resources {:cpus 12 :mem 900}}]
+        results (task/add-scalar-resources-to-task-infos available tasks)]
+    (is (= (-> results first :scalar-resource-messages)
+           [{:name "cpus", :type :value-scalar, :role "cook", :scalar 8.0}
+            {:name "cpus", :type :value-scalar, :role "*", :scalar 4.0}
+            {:name "mem", :type :value-scalar, :role "cook", :scalar 800.0}
+            {:name "mem", :type :value-scalar, :role "*", :scalar 100.0}]))
+    (is (= (-> results first :resources)
+           (-> tasks first :resources)))))
+
+(deftest test-task-info->mesos-message
+  (let [task {:name "yaiqlzwhfm_andalucien_4425e656-2278-4f91-b1e4-9a2e942e6e82",
+              :task-id "4425e656-2278-4f91-b1e4-9a2e942e6e82",
+              :role "4425e656-2278-4f91-b1e4-9a2e942e6e82",
+              :slave-id {:value "foobar"},
+              :num-ports 0,
+              :resources {:mem 623.0
+                          :cpus 1.0
+                          :ports [{:begin 31000, :end 31002}]},
+              :scalar-resource-messages [{:name "mem", :type :value-scalar, :scalar 623.0, :role "cook"}
+                                        {:name "cpus", :type :value-scalar, :scalar 1.0, :role "cook"}]
+              :ports-resource-messages [{:name "ports" :type :value-ranges :role "cook" :ranges [{:begin 31000 :end 31002}]}]
+              :labels {"foo" "bar", "doo" "dar"},
+              :data (.getBytes (pr-str {:instance "5"}) "UTF-8"),
+              :command {:value "sleep 26; exit 0",
+                        :environment {"MYENV" "VAR"},
+                        :user "andalucien",
+                        :uris [{:value "http://www.yahoo.com"
+                                :executable true
+                                :cache true
+                                :extract true}]}}
+        ;; roundrip to and from Mesos protobuf to validate clojure data format
+        msg (->> task
+                 task/task-info->mesos-message
+                 (mtypes/->pb :TaskInfo)
+                 mtypes/pb->data)]
+
+    (is (= (:name msg) (:name task)))
+    (is (= (-> msg :slave-id :value) (-> task :slave-id :value)))
+    (is (= (-> msg :task-id :value) (:task-id task)))
+
+    ;; offers have the same resources structure as tasks so we can reuse (offer-resource-values)
+    (is (= (sched/offer-resource-scalar msg "mem") (-> task :resources :mem)))
+    (is (= (sched/offer-resource-scalar msg "cpus") (-> task :resources :cpus)))
+    (is (= (->> (sched/offer-resource-ranges msg "ports") first :begin)
+           (-> task :resources :ports first :begin)))
+    (is (= (->> (sched/offer-resource-ranges msg "ports") first :end)
+           (-> task :resources :ports first :end)))
+    (is (= (->> msg :resources (map :role))
+           (map :role (concat (:scalar-resource-messages task)
+                              (:ports-resource-messages task)))))
+
+    (is (= (:instance (edn/read-string (String. (.toByteArray (:data msg))))) "5"))
+
+    (is (= (->> msg :labels :labels (filter #(= (:key %) "foo")) first :value) "bar"))
+
+    (let [msg-cmd (:command msg)
+          task-cmd (:command task)
+          msg-uri (-> msg-cmd :uris first)
+          task-uri (-> task-cmd :uris first)]
+      (is (= (:value msg-cmd) (:value task-cmd)))
+      (is (= (:user msg-cmd) (:user task-cmd)))
+      (is (= (:value msg-uri) (:value task-uri)))
+      (is (= (:executable msg-uri) (:executable task-uri)))
+      (is (= (:cache msg-uri) (:cache task-uri)))
+      (is (= (:extract msg-uri) (:extract task-uri))))
+
+    ;; the following assertions don't use the roundtrip because Mesomatic currently
+    ;; has a bug and doesn't convert env var info back into clojure data.
+    ;; It's not a problem for Cook, except for the purposes of this unit test.
+    (let [msg-env (-> task task/task-info->mesos-message :command :environment)]
+      (is (= (-> msg-env :variables first :name) "MYENV"))
+      (is (= (-> msg-env :variables first :value) "VAR")))))


### PR DESCRIPTION
This change also enables us to properly support Mesos Roles.

At this time, it depends on a version of Mesomatic with this PR merged in:

pyr/mesomatic#23

Thus, it can't be used without a new version of Mesomatic (or forking Mesomatic); at this stage this PR is for code review purposes only & shouldn't be merged yet.