### PR TITLE
Fix the build, tests still broken

### DIFF
--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -504,7 +504,7 @@
                                                        :healthy false
                                                        :data (com.google.protobuf.ByteString/copyFrom (.getBytes (pr-str {:percent 85.0}) "UTF-8"))
                                                        :uuid (com.google.protobuf.ByteString/copyFrom (.getBytes "my-uuid" "UTF-8"))})
-        interpreted-status (sched/interpret-mesos-status mesos-status)]
+        interpreted-status (sched/interpret-task-status mesos-status)]
     (is (= (:progress interpreted-status) 85.0))
     (is (= (:task-id interpreted-status) "a07708d8-7ab6-404d-b136-a3e2cb2567e3"))
     (is (= (:task-state interpreted-status) :task-lost))

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -1,4 +1,4 @@
-(ns cook.test.mesos.task-test
+(ns cook.test.mesos.task
   (:use clojure.test)
   (:require [clojure.edn :as edn]
             [mesomatic.types :as mtypes]


### PR DESCRIPTION
This fixes the build to the point where the issues can be addressed. There are still these 2 issues: one from Mesosmatic, and the other is when `get-lingering-tasks` had a signature change.

```
ERROR in (test-task-info->mesos-message) (Reflector.java:271)
Uncaught exception, not in assertion.
expected: nil
  actual: java.lang.IllegalArgumentException: No matching field found: getAllPorts for class org.apache.mesos.Protos$Ports
 at clojure.lang.Reflector.getInstanceField (Reflector.java:271)
    clojure.lang.Reflector.invokeNoArgInstanceMember (Reflector.java:315)
    mesomatic.types$eval9375$fn__9376.invoke (types.clj:1054)
    clojure.lang.MultiFn.invoke (MultiFn.java:229)
    mesomatic.types$eval9415$fn__9416.invoke (types.clj:1079)
    clojure.lang.MultiFn.invoke (MultiFn.java:229)
    mesomatic.types$eval8682$fn__8683.invoke (types.clj:487)
    clojure.lang.MultiFn.invoke (MultiFn.java:229)
    mesomatic.types$eval9473$fn__9474.invoke (types.clj:1119)
    clojure.lang.MultiFn.invoke (MultiFn.java:229)
    cook.test.mesos.task$fn__25610.invokeStatic (task.clj:137)
```

```
ERROR in (test-get-lingering-tasks) (AFn.java:429)
expected: (= [task-id-2] (sched/get-lingering-tasks test-db now 120))
  actual: clojure.lang.ArityException: Wrong number of args (3) passed to: scheduler/get-lingering-tasks
```