### PR TITLE
Add GPU support to api & config file

### DIFF
--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -77,7 +77,7 @@
 
 (defn start-mesos-scheduler
   "Starts a leader elector that runs a mesos."
-  [mesos-master mesos-master-hosts curator-framework mesos-datomic-conn mesos-datomic-mult zk-prefix mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset task-constraints riemann-host riemann-port mesos-pending-jobs-atom dru-scale]
+  [mesos-master mesos-master-hosts curator-framework mesos-datomic-conn mesos-datomic-mult zk-prefix mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset task-constraints riemann-host riemann-port mesos-pending-jobs-atom dru-scale gpu-enabled?]
   (let [zk-framework-id (str zk-prefix "/framework-id")
         datomic-report-chan (async/chan (async/sliding-buffer 4096))
         mesos-heartbeat-chan (async/chan (async/buffer 4096))
@@ -98,7 +98,8 @@
                    fenzo-scaleback
                    fenzo-floor-iterations-before-warn
                    fenzo-floor-iterations-before-reset
-                   task-constraints)
+                   task-constraints
+                   gpu-enabled?)
         framework-id (when-let [bytes (curator/get-or-nil curator-framework zk-framework-id)]
                        (String. bytes))
         leader-selector (LeaderSelector.

--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -436,6 +436,9 @@
     :db/ident :resource.type/mem
     :resource.type/mesos-name :mem}
    {:db/id (d/tempid :db.part/user)
+    :db/ident :resource.type/gpus
+    :resource.type/mesos-name :gpus}
+   {:db/id (d/tempid :db.part/user)
     :db/ident :resource.type/uri}
    ;; Functions for database manipulation
    {:db/id (d/tempid :db.part/user)

--- a/scheduler/src/cook/mesos/share.clj
+++ b/scheduler/src/cook/mesos/share.clj
@@ -60,14 +60,14 @@
    \"default\" user. If there is NO \"default\" value for a specific type,
    return Double.MAX_VALUE."
   [db user]
-  (->> (util/get-all-resource-types db)
+  (->> [:cpus :mem]
        (map (fn [type] [type (get-share-by-type db type user)]))
        (into {})))
 
 (defn retract-share!
   [conn user]
   (let [db (db conn)]
-    (->> (util/get-all-resource-types db)
+    (->> [:cpus :mem]
          (map (fn [type]
                 [type (retract-share-by-type! conn type user)]))
          (into {}))))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -21,7 +21,7 @@
             [metrics.timers :as timers]))
 
 (defn get-all-resource-types
-  "Return a list of all supported resources types. Example, :cpus :mem ..."
+  "Return a list of all supported resources types. Example, :cpus :mem :gpus ..."
   [db]
   (->> (q '[:find ?ident
             :where
@@ -80,7 +80,7 @@
   (reduce (fn [m r]
             (let [resource (keyword (name (:resource/type r)))]
               (condp contains? resource
-                #{:cpus :mem} (assoc m resource (:resource/amount r))
+                #{:cpus :mem :gpus} (assoc m resource (:resource/amount r))
                 #{:uri} (update-in m [:uris] (fnil conj [])
                                    {:cache (:resource.uri/cache? r false)
                                     :executable (:resource.uri/executable? r false)


### PR DESCRIPTION
This PR adds GPUs to the Cook API, if they're enabled in the config file (by default, there is no behavior change). This should be mergeable separately from the actual GPU support, since the latter only affects the scheduler, while this change affects several aspects of the system.