### PR TITLE
Backfill broken

### DIFF
--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -552,9 +552,9 @@
       (meters/mark! upgraded-cpu (:cpus resources-upgraded))
       (meters/mark! upgraded-mem (:mem resources-upgraded)))
 
-    {:fully-processed (mapv :job/uuid jobs-fully-processed)
-     :upgrade-backfill tasks-ids-to-upgrade
-     :backfill-jobs (mapv :job/uuid jobs-to-backfill)
+    {:fully-processed (set (mapv :job/uuid jobs-fully-processed))
+     :upgrade-backfill (set tasks-ids-to-upgrade)
+     :backfill-jobs (set (mapv :job/uuid jobs-to-backfill))
      :matched-head? (matched? head-of-considerable)}))
 
 (defn handle-resource-offers!

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -239,7 +239,8 @@
                              {:instance/status :instance.status/running
                               :instance/backfilled? backfill?
                               :db/id (java.util.UUID/randomUUID)})})]
-    (let [j1 (mock-job)
+    (let [validate-format! #(is (every? set? (vals (select-keys % [:fully-processed :upgrade-backfill :backfill-jobs]))))
+          j1 (mock-job)
           j2 (mock-job true)
           j3 (mock-job false true true)
           j4 (mock-job)
@@ -248,48 +249,56 @@
           j7 (mock-job false)]
       (testing "Match nothing"
         (let [result (sched/process-matches-for-backfill [j1 j4] j1 [])]
+          (validate-format! result)
           (is (zero? (count (:fully-processed result))))
           (is (zero? (count (:upgrade-backfill result))))
           (is (zero? (count (:backfill-jobs result))))
           (is (not (:matched-head? result)))))
       (testing "Match everything basic"
         (let [result (sched/process-matches-for-backfill [j1 j4] j1 [j1 j4])]
+          (validate-format! result)
           (is (= 2 (count (:fully-processed result))))
           (is (zero? (count (:upgrade-backfill result))))
           (is (zero? (count (:backfill-jobs result))))
           (is (:matched-head? result))))
       (testing "Don't match head"
         (let [result (sched/process-matches-for-backfill [j1 j4] j1 [j4])]
+          (validate-format! result)
           (is (zero? (count (:fully-processed result))))
           (is (zero? (count (:upgrade-backfill result))))
           (is (= 1 (count (:backfill-jobs result))))
           (is (not (:matched-head? result)))))
       (testing "Match the tail, but the head isn't considerable"
         (let [result (sched/process-matches-for-backfill [j1 j4] j5 [j4])]
+          (validate-format! result)
           (is (zero? (count (:fully-processed result))))
           (is (zero? (count (:upgrade-backfill result))))
           (is (= 1 (count (:backfill-jobs result))))
           (is (not (:matched-head? result)))))
       (testing "Match the tail, and the head was backfilled"
         (let [result (sched/process-matches-for-backfill [j2 j1 j4] j1 [j1 j4])]
+          (validate-format! result)
           (is (= 2 (count (:fully-processed result))))
           (is (= 1 (count (:upgrade-backfill result))))
           (is (zero? (count (:backfill-jobs result))))
           (is (:matched-head? result))))
       (testing "Match the tail, and the head was backfilled (multiple backfilled mixed in)"
         (let [result (sched/process-matches-for-backfill [j2 j1 j3 j4] j1 [j1 j4])]
+          (validate-format! result)
           (is (= 2 (count (:fully-processed result))))
           (is (= 3 (count (:upgrade-backfill result))))
           (is (zero? (count (:backfill-jobs result))))
           (is (:matched-head? result))))
       (testing "Fail to match the head, but backfill several jobs"
         (let [result (sched/process-matches-for-backfill [j1 j2 j3 j4 j5 j6 j7] j1 [j4 j6 j7])]
+          (validate-format! result)
           (is (zero? (count (:fully-processed result))))
           (is (zero? (count (:upgrade-backfill result))))
           (is (= 3 (count (:backfill-jobs result))))
           (is (not (:matched-head? result)))))
       (testing "Fail to match the head, but backfill several jobs"
         (let [result (sched/process-matches-for-backfill [j1 j2 j3 j4 j5 j6 j7] j1 [j4 j6 j7])]
+          (validate-format! result)
           (is (zero? (count (:fully-processed result))))
           (is (zero? (count (:upgrade-backfill result))))
           (is (= 3 (count (:backfill-jobs result))))


### PR DESCRIPTION
[This commit](https://github.com/twosigma/Cook/commit/c356e3dcf1ef6942f72774c9954777ca07d59209) broke backfilling by changing the outputs from sets to vectors. Further down, `contains?` is used on these parameters.