### PR TITLE
scheduler: Fix error when recycling offer-stash.

### DIFF
--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -581,7 +581,7 @@
                                      lease leases]
                                  (:offer lease))
               offers-not-scheduled (clojure.set/intersection (set offers) (set offers-scheduled))
-              _ (reset! offer-stash @offer-stash)
+              _ (reset! offer-stash offers-scheduled)
               matched-jobs (for [match matches
                                  ^TaskAssignmentResult task-result (:tasks match)
                                  :let [task-request (.getRequest task-result)]]


### PR DESCRIPTION
offer-stash was initialized to nil and was only being reset! to its own
value, @offer-stash - meaning it could never acquire a value other than
nil.

Thus, attempting to put its value back on the channel in the exception
handling block would in turn raise an exception (can't put nil on
channel).  Since this exception was not handled, the thread would die,
and handle-resource-offers! would stop happening, resulting in no offers
to match until Cook was restarted.

I believe the var offers-scheduled contains what @offer-stash USED to
be reset! to, prior to commit a134d1f8776eb1b0627eb74a073bae125bf6d52a.