### PR TITLE
Add GPU support to Cook

### DIFF
--- a/scheduler/docs/configuration.asc
+++ b/scheduler/docs/configuration.asc
@@ -98,6 +98,14 @@ We'll look at the configurable options in turn:
   This sets the role that Cook will connect to Mesos with. Default: `*`
   You can omit this property unless you've enabled security features in Mesos. The value should be in authorized list for the current `:principal` in `register_frameworks` Action in Mesos Authorization file. See http://mesos.apache.org/documentation/latest/authorization/ for details.
 
+`:enable-gpu-support`::
+  This enables GPU support for Cook.
+  It is a boolean value, with default value `false`.
+  This property will only work with Mesos 1.0 and above, since that's when GPU support was added.
+  If you enable this on an earlier version of Mesos, Cook will fail to start and print the error in the log.
+  If you enable this and your cluster doesn't have any GPU machines, Cook will accept GPU jobs, but they'll never be scheduled.
+  See https://github.com/apache/mesos/blob/master/docs/gpu-support.md for details on configuring the agents, installing external NVidia dependencies, and configuring Docker/GPU integration.
+
 [[auth_config]]
 ==== Authorization Configuration
 

--- a/scheduler/docs/scheduler-rest-api.asc
+++ b/scheduler/docs/scheduler-rest-api.asc
@@ -75,6 +75,7 @@ The request body is list of job maps with each entry containing a map of the fol
 |`max_runtime` | long | the maximum running time of the job in milliseconds. An instance that runs for more than max_runtime will be killed and job will be retried.
 |`cpus` | double | number of requested cpus.
 |`mem` | double | MB of requested memory.
+|`gpus` | integer | Number of requested GPUs. Must be a whole number and support must be enabled in the config.
 |`ports` | integer | Number of ports that should be opened for the job.
 |`uris` | list of URI objects | A list of URIs that will be fetched into the container before launch.
 |`env` | JSON map | A map of environment variables to be provided to the job.
@@ -155,6 +156,7 @@ The response body contains the following:
 |`uuid` | the job UUID
 |`cpus` | the number of CPUs requested
 |`mem` | the amount of memory requested
+|`gpus` | the number of GPUs requested
 |`framework_id` | the Mesos framework ID of cook
 |`status` |  the status of the job
 |`instances` | a list of job instance maps (see <<instance_maps>>)

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -42,7 +42,8 @@
                  [org.clojure/data.priority-map "0.0.5"]
                  [swiss-arrows "1.0.0"]
                  [riddley "0.1.10"]
-                 [com.netflix.fenzo/fenzo-core "0.8.2"
+                 [org.apache.mesos/mesos "1.0.1"]
+                 [com.netflix.fenzo/fenzo-core "0.9.4-SNAPSHOT"
                   :exclusions [org.apache.mesos/mesos
                                com.fasterxml.jackson.core/jackson-core
                                org.slf4j/slf4j-api
@@ -56,6 +57,7 @@
                  [com.draines/postal "1.11.0"
                   :exclusions [commons-codec]]
                  [prismatic/plumbing "0.1.1"]
+                 [log4j "1.2.17"]
                  [instaparse "1.4.0"]
                  [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
                  [clj-pid "0.1.1"]
@@ -84,7 +86,7 @@
 
                  ;;External system integrations
                  [me.raynes/conch "0.5.2"]
-                 [wyegelwe/mesomatic "0.28.0-r0-SNAPSHOT"]
+                 [spootnik/mesomatic "1.0.1-r0"]
                  [org.clojure/tools.nrepl "0.2.3"]
 
                  ;;Ring
@@ -134,6 +136,7 @@
 
    :dev
    {:dependencies [[clj-http-fake "1.0.1"]
+                   [org.mockito/mockito-core "1.10.19"]
                    [org.clojure/test.check "0.6.1"]]
     :jvm-opts ["-Xms2G"
                "-XX:-OmitStackTraceInFastThrow"

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -61,11 +61,12 @@
     (resolve var-sym)))
 
 (def raw-scheduler-routes
-  {:scheduler (fnk [mesos-datomic framework-id mesos-pending-jobs-atom [:settings task-constraints]]
+  {:scheduler (fnk [mesos-datomic framework-id mesos-pending-jobs-atom [:settings task-constraints mesos-gpu-enabled]]
                    ((lazy-load-var 'cook.mesos.api/handler)
                     mesos-datomic
                     framework-id
                     task-constraints
+                    mesos-gpu-enabled
                     (fn [] @mesos-pending-jobs-atom)))
    :view (fnk [scheduler]
               scheduler)})
@@ -77,7 +78,7 @@
                       (route/not-found "<h1>Not a valid route</h1>")))})
 
 (def mesos-scheduler
-  {:mesos-scheduler (fnk [[:settings mesos-master mesos-master-hosts mesos-leader-path mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset task-constraints riemann dru-scale] mesos-datomic mesos-datomic-mult curator-framework mesos-pending-jobs-atom]
+  {:mesos-scheduler (fnk [[:settings mesos-master mesos-master-hosts mesos-leader-path mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset task-constraints riemann dru-scale mesos-gpu-enabled] mesos-datomic mesos-datomic-mult curator-framework mesos-pending-jobs-atom]
                          (try
                            (Class/forName "org.apache.mesos.Scheduler")
                            ((lazy-load-var 'cook.mesos/start-mesos-scheduler)
@@ -99,7 +100,8 @@
                             (:host riemann)
                             (:port riemann)
                             mesos-pending-jobs-atom
-                            dru-scale)
+                            dru-scale
+                            mesos-gpu-enabled)
                            (catch ClassNotFoundException e
                              (log/warn e "Not loading mesos support...")
                              nil)))})
@@ -222,7 +224,7 @@
                              (log/info "Starting local ZK server")
                              (.start zookeeper-server)))
      :mesos mesos-scheduler
-     :mesos-pending-jobs-atom (fnk [] (atom []))
+     :mesos-pending-jobs-atom (fnk [] (atom {}))
      :curator-framework curator-framework}))
 
 (def simple-dns-name
@@ -321,6 +323,8 @@
                                               fenzo-floor-iterations-before-warn)
      :fenzo-floor-iterations-before-reset (fnk [[:config [:scheduler {fenzo-floor-iterations-before-reset 1000}]]]
                                                fenzo-floor-iterations-before-reset)
+     :mesos-gpu-enabled (fnk [[:config [:mesos {enable-gpu-support false}]]]
+                             (boolean enable-gpu-support))
      :mesos-master (fnk [[:config [:mesos master]]]
                         master)
      :mesos-master-hosts (fnk [[:config [:mesos master {master-hosts nil}]]]

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -77,7 +77,7 @@
 
 (defn start-mesos-scheduler
   "Starts a leader elector that runs a mesos."
-  [mesos-master mesos-master-hosts curator-framework mesos-datomic-conn mesos-datomic-mult zk-prefix mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset task-constraints riemann-host riemann-port mesos-pending-jobs-atom dru-scale]
+  [mesos-master mesos-master-hosts curator-framework mesos-datomic-conn mesos-datomic-mult zk-prefix mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset task-constraints riemann-host riemann-port mesos-pending-jobs-atom dru-scale gpu-enabled?]
   (let [zk-framework-id (str zk-prefix "/framework-id")
         datomic-report-chan (async/chan (async/sliding-buffer 4096))
         mesos-heartbeat-chan (async/chan (async/buffer 4096))
@@ -98,7 +98,8 @@
                    fenzo-scaleback
                    fenzo-floor-iterations-before-warn
                    fenzo-floor-iterations-before-reset
-                   task-constraints)
+                   task-constraints
+                   gpu-enabled?)
         framework-id (when-let [bytes (curator/get-or-nil curator-framework zk-framework-id)]
                        (String. bytes))
         leader-selector (LeaderSelector.
@@ -123,6 +124,8 @@
                                                           {:role mesos-role})
                                                         (when mesos-principal
                                                           {:principal mesos-principal})
+                                                        (when gpu-enabled?
+                                                          {:capabilities [{:type :framework-capability-gpu-resources}]})
                                                         (when mesos-failover-timeout
                                                           {:failover-timeout mesos-failover-timeout})
                                                         (when framework-id

--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -441,6 +441,9 @@
     :db/ident :resource.type/mem
     :resource.type/mesos-name :mem}
    {:db/id (d/tempid :db.part/user)
+    :db/ident :resource.type/gpus
+    :resource.type/mesos-name :gpus}
+   {:db/id (d/tempid :db.part/user)
     :db/ident :resource.type/uri}
    ;; Functions for database manipulation
    {:db/id (d/tempid :db.part/user)

--- a/scheduler/src/cook/mesos/share.clj
+++ b/scheduler/src/cook/mesos/share.clj
@@ -36,8 +36,10 @@
                               [?r :resource/type ?t]
                               [?r :resource/amount ?a]]
                             db user type))]
-    @(d/transact conn
-               [[:db.fn/retractEntity resource]])))
+    (if resource
+      @(d/transact conn
+                   [[:db.fn/retractEntity resource]])
+      :default)))
 
 (defn- get-share-by-type
   [db type user]

--- a/scheduler/test/cook/test/mesos/dru.clj
+++ b/scheduler/test/cook/test/mesos/dru.clj
@@ -61,10 +61,10 @@
           db (d/db conn)
           running-task-ents (util/get-running-task-ents db)
           pending-job-ents [(d/entity db job3)]]
-      (let [_ (share/set-share! conn "default" :mem 25.0 :cpus 25.0)
+      (let [_ (share/set-share! conn "default" :mem 25.0 :cpus 25.0 :gpus 1.0)
             _ (share/set-share! conn "wzhao" :mem 10.0 :cpus 10.0)
             db (d/db conn)]
-        (is (= {"ljin" {:mem 25.0 :cpus 25.0} "wzhao" {:mem 10.0 :cpus 10.0} "sunil" {:mem 25.0 :cpus 25.0}}
+        (is (= {"ljin" {:mem 25.0 :cpus 25.0 :gpus 1.0} "wzhao" {:mem 10.0 :cpus 10.0 :gpus 1.0} "sunil" {:mem 25.0 :cpus 25.0 :gpus 1.0}}
                (dru/init-user->dru-divisors db running-task-ents pending-job-ents)))))))
 
 (deftest test-sorted-task-scored-task-pairs

--- a/scheduler/test/cook/test/mesos/rebalancer.clj
+++ b/scheduler/test/cook/test/mesos/rebalancer.clj
@@ -58,7 +58,7 @@
 
           tasks (shuffle [task-ent1 task-ent2 task-ent3 task-ent4
                            task-ent5 task-ent6 task-ent7 task-ent8])]
-      (let [_ (share/set-share! conn "default" :mem 25.0 :cpus 25.0)
+      (let [_ (share/set-share! conn "default" :mem 25.0 :cpus 25.0 :gpus 1.0)
             scored-task1 (dru/->ScoredTask task-ent1 0.4 10.0 10.0)
             scored-task2 (dru/->ScoredTask task-ent2 0.6 5.0 5.0)
             scored-task3 (dru/->ScoredTask task-ent3 1.6 15.0 25.0)
@@ -71,7 +71,7 @@
             running-tasks (util/get-running-task-ents db)
             pending-jobs []
             {:keys [task->scored-task user->sorted-running-task-ents]}
-            (rebalancer/init-state db running-tasks pending-jobs {})]
+            (rebalancer/init-state db running-tasks pending-jobs {} :normal)]
         (is (= [task-ent4 task-ent3 task-ent8 task-ent7
                 task-ent6 task-ent2 task-ent1 task-ent5]
                (keys task->scored-task)))
@@ -83,9 +83,9 @@
         (is (= [task-ent5 task-ent6 task-ent7 task-ent8]
                (seq (get user->sorted-running-task-ents "wzhao"))))))))
 
-(deftest test-compute-pending-job-dru
+(deftest test-pending-normal-job-dru
   (testing "test1"
-    (let [datomic-uri "datomic:mem://test-compute-pending-job-dru"
+    (let [datomic-uri "datomic:mem://test-rebalancer/compute-pending-normal-job-dru"
           conn (schema/restore-fresh-database! datomic-uri)
           job1 (schema/create-dummy-job conn :name "job1" :user "ljin" :memory 10.0 :ncpus 10.0)
           job2 (schema/create-dummy-job conn :name "job2" :user "ljin" :memory 5.0  :ncpus 5.0)
@@ -118,15 +118,61 @@
           task-ent7 (d/entity (d/db conn) task7)
           task-ent8 (d/entity (d/db conn) task8)
 
-          _ (share/set-share! conn "default" :mem 25.0 :cpus 25.0)
+          _ (share/set-share! conn "default" :mem 25.0 :cpus 25.0 :gpus 1.0)
 
           db (d/db conn)
           running-tasks (util/get-running-task-ents db)
           pending-jobs (map #(d/entity db %) [job9 job10 job11])
-          state (rebalancer/init-state db running-tasks pending-jobs {})]
-      (is (= 1.92 (rebalancer/compute-pending-job-dru state (d/entity db job9))))
-      (is (= 0.8 (rebalancer/compute-pending-job-dru state (d/entity db job10))))
-      (is (= 2.6 (rebalancer/compute-pending-job-dru state (d/entity db job11)))))))
+          state (rebalancer/init-state db running-tasks pending-jobs {} :normal)]
+      (is (= 1.92 (rebalancer/compute-pending-normal-job-dru state (d/entity db job9))))
+      (is (= 0.8 (rebalancer/compute-pending-normal-job-dru state (d/entity db job10))))
+      (is (= 2.6 (rebalancer/compute-pending-normal-job-dru state (d/entity db job11)))))))
+
+(deftest test-pending-gpu-job-dru
+  (let [datomic-uri "datomic:mem://test-rebalancer/compute-pending-normal-job-dru"
+        conn (schema/restore-fresh-database! datomic-uri)
+        job1 (schema/create-dummy-job conn :name "job1" :user "ljin" :memory 10.0 :ncpus 10.0 :gpus 1.0)
+        job2 (schema/create-dummy-job conn :name "job2" :user "ljin" :memory 5.0  :ncpus 5.0 :gpus 1.0)
+        job3 (schema/create-dummy-job conn :name "job3" :user "ljin" :memory 15.0 :ncpus 25.0 :gpus 1.0)
+        job4 (schema/create-dummy-job conn :name "job4"  :user "ljin" :memory 25.0 :ucpus 15.0 :gpus 1.0)
+        job5 (schema/create-dummy-job conn :name "job5" :user "wzhao" :memory 8.0 :ncpus 8.0 :gpus 1.0)
+        job6 (schema/create-dummy-job conn :name "job6" :user "wzhao" :memory 10.0 :ncpus 10.0 :gpus 1.0)
+        job7 (schema/create-dummy-job conn :name "job7" :user "wzhao" :memory 10.0 :ncpus 10.0 :gpus 1.0)
+        job8 (schema/create-dummy-job conn :name "job8" :user "wzhao" :memory 10.0 :ncpus 10.0 :gpus 1.0)
+
+        job9 (schema/create-dummy-job conn :name "job9" :user "wzhao" :memory 10.0 :ncpus 10.0 :gpus 1.0)
+        job10 (schema/create-dummy-job conn :name "job10" :user "sunil" :memory 20.0 :ncpus 20.0 :gpus 1.0)
+        job11 (schema/create-dummy-job conn :name "job11" :user "ljin" :memory 10.0 :ucpus 10.0 :gpus 2.0)
+
+        task1 (schema/create-dummy-instance conn job1 :instance-status :instance.status/running)
+        task2 (schema/create-dummy-instance conn job2 :instance-status :instance.status/running)
+        task3 (schema/create-dummy-instance conn job3 :instance-status :instance.status/running)
+        task4 (schema/create-dummy-instance conn job4 :instance-status :instance.status/running)
+        task5 (schema/create-dummy-instance conn job5 :instance-status :instance.status/running)
+        task6 (schema/create-dummy-instance conn job6 :instance-status :instance.status/running)
+        task7 (schema/create-dummy-instance conn job7 :instance-status :instance.status/running)
+        task8 (schema/create-dummy-instance conn job8 :instance-status :instance.status/running)
+
+        task-ent1 (d/entity (d/db conn) task1)
+        task-ent2 (d/entity (d/db conn) task2)
+        task-ent3 (d/entity (d/db conn) task3)
+        task-ent4 (d/entity (d/db conn) task4)
+        task-ent5 (d/entity (d/db conn) task5)
+        task-ent6 (d/entity (d/db conn) task6)
+        task-ent7 (d/entity (d/db conn) task7)
+        task-ent8 (d/entity (d/db conn) task8)
+
+        _ (share/set-share! conn "default" :mem 25.0 :cpus 25.0 :gpus 1.0)
+
+        db (d/db conn)
+        running-tasks (util/get-running-task-ents db)
+        pending-jobs (map #(d/entity db %) [job9 job10 job11])
+        state (rebalancer/init-state db running-tasks pending-jobs {} :gpu)]
+    (is (= (rebalancer/compute-pending-gpu-job-dru state (d/entity db job2))
+           (rebalancer/compute-pending-gpu-job-dru state (d/entity db job6))))
+    (is (= 5.0 (rebalancer/compute-pending-gpu-job-dru state (d/entity db job9))))
+    (is (= 1.0 (rebalancer/compute-pending-gpu-job-dru state (d/entity db job10))))
+    (is (= 6.0 (rebalancer/compute-pending-gpu-job-dru state (d/entity db job11))))))
 
 (deftest test-compute-preemption-decision
   (testing "test1"
@@ -190,13 +236,13 @@
           task-ent7 (d/entity (d/db conn) task7)
           task-ent8 (d/entity (d/db conn) task8)
 
-          _ (share/set-share! conn "default" :mem 25.0 :cpus 25.0)
+          _ (share/set-share! conn "default" :mem 25.0 :cpus 25.0 :gpus 1.0)
 
           db (d/db conn)
           running-tasks (util/get-running-task-ents db)
           pending-jobs (map #(d/entity db %) [job9 job10 job11 job12 job13 job14])
           {:keys [task->scored-task user->sorted-running-task-ents user->dru-divisors]}
-          (rebalancer/init-state db running-tasks pending-jobs {})]
+          (rebalancer/init-state db running-tasks pending-jobs {} :normal)]
 
       (comment all-decisions-without-spare-resources
         {"hostA" [{:dru 1.12 :task [task-ent7] :mem 10.0 :cpus 10.0}]
@@ -204,45 +250,50 @@
                   {:dru 1.6 :task [task-ent4 task-ent3] :mem 40.0 :cpus 40.0}
                   {:dru 1.52 :task [task-ent4 task-ent3 task-ent8] :mem 50.0 :cpus 50.0}]})
 
-      (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 25.0 :cpus 15.0}
+      (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 25.0 :cpus 15.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
                                                    (d/entity db job9))))
 
-      (is (= {:hostname "hostB" :dru Double/MAX_VALUE :task nil :mem 15.0 :cpus 15.0}
+      (is (= {:hostname "hostB" :dru Double/MAX_VALUE :task nil :mem 15.0 :cpus 15.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {"hostB" {:mem 15.0 :cpus 15.0}}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
                                                    (d/entity db job9))))
 
-      (is (= {:hostname "hostA" :dru Double/MAX_VALUE :task nil :mem 20.0 :cpus 20.0}
+      (is (= {:hostname "hostA" :dru Double/MAX_VALUE :task nil :mem 20.0 :cpus 20.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {"hostA" {:mem 20.0 :cpus 20.0}
                                                              "hostB" {:mem 10.0 :cpus 10.0}}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
                                                    (d/entity db job9))))
 
-      (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 35.0 :cpus 25.0}
+      (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 35.0 :cpus 25.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {"hostA" {:mem 10.0 :cpus 10.0}
                                                              "hostB" {:mem 10.0 :cpus 10.0}}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.0 :safe-dru-threshold 1.0}
                                                    (d/entity db job9))))
 
-      (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 25.0 :cpus 15.0}
+      (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 25.0 :cpus 15.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
                                                    (d/entity db job10))))
 
@@ -250,7 +301,8 @@
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
                                                    (d/entity db job11))))
 
@@ -258,15 +310,17 @@
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.0 :safe-dru-threshold 1.0}
                                                    (d/entity db job12))))
 
-      (is (= {:hostname "hostA" :dru Double/MAX_VALUE :task nil :mem 40.0 :cpus 40.0}
+      (is (= {:hostname "hostA" :dru Double/MAX_VALUE :task nil :mem 40.0 :cpus 40.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {"hostA" {:mem 40.0 :cpus 40.0}}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
                                                    (d/entity db job12))))
 
@@ -274,16 +328,18 @@
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {"hostA" {:mem 35.0 :cpus 35.0}}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.0 :safe-dru-threshold 1.0}
                                                    (d/entity db job12))))
 
-      (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 55.0 :cpus 45.0}
+      (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 55.0 :cpus 45.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {"hostA" {:mem 35.0 :cpus 35.0}
                                                              "hostB" {:mem 30.0 :cpus 30.0}}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
                                                    (d/entity db job12))))
 
@@ -291,7 +347,8 @@
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
                                                    (d/entity db job13))))
 
@@ -299,7 +356,8 @@
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 2.0 :safe-dru-threshold 1.0}
                                                    (d/entity db job13))))
 
@@ -307,7 +365,8 @@
              (rebalancer/compute-preemption-decision (->State task->scored-task
                                                             user->sorted-running-task-ents
                                                             {}
-                                                            user->dru-divisors)
+                                                            user->dru-divisors
+                                                            rebalancer/compute-pending-normal-job-dru)
                                                    {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
                                                    (d/entity db job14)))))))
 (deftest test-next-state
@@ -362,7 +421,7 @@
                                              job8
                                              :instance-status :instance.status/running
                                              :hostname "hostB")
-          _ (share/set-share! conn "default" :mem 25.0 :cpus 25.0)
+          _ (share/set-share! conn "default" :mem 25.0 :cpus 25.0 :gpus 1.0)
           db (d/db conn)
 
           job-ent9 (d/entity db job9)
@@ -381,19 +440,19 @@
           running-task-ents (util/get-running-task-ents db)
           pending-job-ents (map #(d/entity db %) [job9 job10 job11 job12 job13 job14])
           host->spare-resources {"hostA" {:mem 50.0 :cpus 50.0}}
-          user->dru-divisors {"ljin" {:mem 25.0 :cpus 25.0} "wzhao" {:mem 25.0 :cpus 25.0} "sunil" {:mem 25.0 :cpus 25.0}}
-          state (rebalancer/init-state db running-task-ents pending-job-ents host->spare-resources)]
+          user->dru-divisors {"ljin" {:mem 25.0 :cpus 25.0 :gpus 1.0} "wzhao" {:mem 25.0 :cpus 25.0 :gpus 1.0} "sunil" {:mem 25.0 :cpus 25.0 :gpus 1.0}}
+          state (rebalancer/init-state db running-task-ents pending-job-ents host->spare-resources :normal)]
       (let [task-ent9 {:job/_instance job-ent9
                        :instance/hostname "hostB"
                        :instance/status :instance.status/running}
             user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent1 task-ent2 task-ent3 task-ent4])
                                                "wzhao" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent5 task-ent7 task-ent9])}
-            host->spare-resources' {"hostA" {:mem 50.0 :cpus 50.0} "hostB" {:mem 5.0 :cpus 5.0}}]
+            host->spare-resources' {"hostA" {:mem 50.0 :cpus 50.0} "hostB" {:mem 5.0 :cpus 5.0 :gpus 0.0}}]
         (let [{task->scored-task'' :task->scored-task
                user->sorted-running-task-ents'' :user->sorted-running-task-ents
                host->spare-resources'' :host->spare-resources
                user->dru-divisors'' :user->dru-divisors}
-              (rebalancer/next-state state job-ent9 {:hostname "hostB" :task [task-ent6 task-ent8] :mem 20.0 :cpus 20.0})]
+              (rebalancer/next-state state job-ent9 {:hostname "hostB" :task [task-ent6 task-ent8] :mem 20.0 :cpus 20.0 :gpus 0.0})]
           (is (= user->sorted-running-task-ents' user->sorted-running-task-ents''))
           (is (= host->spare-resources' host->spare-resources''))
           (is (= user->dru-divisors user->dru-divisors''))
@@ -414,7 +473,7 @@
             user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent1 task-ent3 task-ent4])
                                                "wzhao" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent5 task-ent6 task-ent8])
                                                "sunil" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent10])}
-            host->spare-resources' {"hostA" {:mem 50.0 :cpus 50.0}}]
+            host->spare-resources' {"hostA" {:mem 50.0 :cpus 50.0 :gpus 0.0}}]
         (let [{task->scored-task'' :task->scored-task
                user->sorted-running-task-ents'' :user->sorted-running-task-ents
                host->spare-resources'' :host->spare-resources
@@ -439,7 +498,7 @@
             user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent1 task-ent2 task-ent3 task-ent4])
                                                "wzhao" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent5 task-ent6 task-ent7 task-ent8])
                                                "sunil" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent12])}
-            host->spare-resources' {"hostA" {:mem 10.0 :cpus 10.0}}]
+            host->spare-resources' {"hostA" {:mem 10.0 :cpus 10.0 :gpus 0.0}}]
 
         (let [{task->scored-task'' :task->scored-task
                user->sorted-running-task-ents'' :user->sorted-running-task-ents
@@ -513,7 +572,7 @@
                                              job8
                                              :instance-status :instance.status/running
                                              :hostname "hostB")
-          _ (share/set-share! conn "default" :mem 25.0 :cpus 25.0)
+          _ (share/set-share! conn "default" :mem 25.0 :cpus 25.0 :gpus 1.0)
 
           db (d/db conn)
 
@@ -561,7 +620,7 @@
       (let [db (d/db conn)
             pending-job-ents (map #(d/entity db %) [job9 job10 job11 job12 job13
                                                     job14 job15 job16 job17 job18])
-            params {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.0}]
+            params {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.0 :category :normal}]
         (let [[pending-job-ents-to-run task-ents-to-preempt] (rebalancer/rebalance db pending-job-ents {} params)]
           (is (= (map #(d/entity db %) [job9 job10 job11])
                  pending-job-ents-to-run))
@@ -577,7 +636,7 @@
       (let [db (d/db conn)
             pending-job-ents (map #(d/entity db %) [job19 job20 job21 job22 job23
                                                     job24 job25 job26 job27 job28])
-            params {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.0}]
+            params {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.0 :category :normal}]
         (let [[pending-job-ents-to-run task-ents-to-preempt] (rebalancer/rebalance db pending-job-ents {} params)]
           (is (= (map #(d/entity db %) [job19 job20 job21 job22 job23
                                         job24 job25 job26])
@@ -588,7 +647,7 @@
       (let [db (d/db conn)
             pending-job-ents (map #(d/entity db %) [job19 job20 job21 job22 job23
                                                     job24 job25 job26 job27 job28])
-            params {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.0}]
+            params {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.0 :category :normal}]
         (let [[pending-job-ents-to-run task-ents-to-preempt] (rebalancer/rebalance db pending-job-ents {"hostB" {:cpus 25.0 :mem 25.0}} params)]
           (is (= (map #(d/entity db %) [job19 job20 job21 job22 job23
                                         job24 job25 job26])
@@ -600,7 +659,7 @@
             db (d/db conn)
             pending-job-ents (map #(d/entity db %) [job19 job20 job21 job22 job23
                                                     job24 job25 job26 job27 job28])
-            params {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.0}]
+            params {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.0 :category :normal}]
         (let [[pending-job-ents-to-run task-ents-to-preempt] (rebalancer/rebalance db pending-job-ents {} params)]
           (is (= (map #(d/entity db %) [job19 job20 job21 job22 job23
                                         job24 job25 job26 job27 job28])
@@ -621,7 +680,7 @@
           pending-job-gen  (gen/tuple pending-user-gen mem-gen cpus-gen)
           ]
       (let [conn (schema/restore-fresh-database! datomic-uri)
-            _ (share/set-share! conn "default" :mem 1024.0 :cpus Double/MAX_VALUE)
+            _ (share/set-share! conn "default" :mem 1024.0 :cpus Double/MAX_VALUE :gpus 1.0)
             running-tasks-sample-size 10240
             pending-jobs-sample-size 1024
 
@@ -638,6 +697,6 @@
             db (d/db conn)
 
             pending-job-ents (util/get-pending-job-ents db)
-            [pending-job-ents-to-run task-ents-to-preempt] (time (rebalancer/rebalance db pending-job-ents {} {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.5}))]))))
+            [pending-job-ents-to-run task-ents-to-preempt] (time (rebalancer/rebalance db pending-job-ents {} {:max-preemption 128 :safe-dru-threshold 1.0 :min-dru-diff 0.5 :category :normal}))]))))
 
 (comment (run-tests))

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -27,7 +27,8 @@
             [cook.mesos.util :as util]
             [cook.mesos.schema :as schem]
             [cook.test.mesos.schema :refer (restore-fresh-database! create-dummy-job create-dummy-instance)]
-            [datomic.api :as d :refer (q db)]))
+            [datomic.api :as d :refer (q db)])
+  (:import [org.mockito Mockito]))
 
 (def datomic-uri "datomic:mem://test-mesos-jobs")
 
@@ -55,12 +56,12 @@
     (testing "test1"
       (let [_ (share/set-share! conn "default" :mem 10.0 :cpus 10.0)
             db (d/db conn)]
-        (is (= [j2 j3 j6 j4 j8] (map :db/id (sched/sort-jobs-by-dru db db))))))
+        (is (= [j2 j3 j6 j4 j8] (map :db/id (:normal (sched/sort-jobs-by-dru db db)))))))
     (testing "test2"
         (let [_ (share/set-share! conn "default" :mem 10.0 :cpus 10.0)
               _ (share/set-share! conn "sunil" :mem 100.0 :cpus 100.0)
               db (d/db conn)]
-          (is (= [j8 j2 j3 j6 j4] (map :db/id (sched/sort-jobs-by-dru db db)))))))
+          (is (= [j8 j2 j3 j6 j4] (map :db/id (:normal (sched/sort-jobs-by-dru db db))))))))
 
   (let [uri "datomic:mem://test-sort-jobs-by-dru"
         conn (restore-fresh-database! uri)
@@ -85,7 +86,7 @@
 
         test-db (d/db conn)]
     (testing
-      (is (= [job-id-2 job-id-3 job-id-1 job-id-4] (map :db/id (sched/sort-jobs-by-dru test-db test-db)))))))
+      (is (= [job-id-2 job-id-3 job-id-1 job-id-4] (map :db/id (:normal (sched/sort-jobs-by-dru test-db test-db))))))))
 
 (d/delete-database "datomic:mem://preemption-testdb")
 (d/create-database "datomic:mem://preemption-testdb")
@@ -388,10 +389,8 @@
         offensive-jobs-ch (async/chan (count jobs))
         offensive-jobs #{job-entity-1 job-entity-2}]
     (is (= #{job-entity-3} (set (sched/filter-offensive-jobs constraints offensive-jobs-ch jobs))))
-    (println "check1")
     (let [received-offensive-jobs (async/<!! offensive-jobs-ch)]
       (is (= (set received-offensive-jobs) offensive-jobs))
-      (println "check2")
       (async/close! offensive-jobs-ch))))
 
 (deftest test-rank-jobs
@@ -417,7 +416,9 @@
         offensive-jobs #{job-entity-1 job-entity-2}
         offensive-jobs-ch (sched/make-offensive-job-stifler conn)
         offensive-job-filter (partial sched/filter-offensive-jobs constraints offensive-jobs-ch)]
-    (is (= #{job-entity-2} (set (sched/rank-jobs test-db test-db offensive-job-filter))))))
+    (is (= {:normal (list job-entity-2)
+            :gpu ()}
+           (sched/rank-jobs test-db test-db offensive-job-filter)))))
 
 (deftest test-get-lingering-tasks
   (let [uri "datomic:mem://test-lingering-tasks"
@@ -455,7 +456,7 @@
         check-count-of-pending-and-runnable-jobs
         (fn check-count-of-pending-and-runnable-jobs [expected-pending expected-runnable msg]
           (let [db (db conn)
-                pending-jobs (sched/rank-jobs db db identity)
+                pending-jobs (:normal (sched/rank-jobs db db identity))
                 runnable-jobs (filter (fn [job] (util/job-allowed-to-start? db job)) pending-jobs)]
             (is (= expected-pending (count pending-jobs)) (str "Didn't match pending job count in " msg))
             (is (= expected-runnable (count runnable-jobs)) (str "Didn't match runnable job count in " msg))))
@@ -486,7 +487,8 @@
                                      :resources [#mesomatic.types.Resource{:name "cpus", :type :value-scalar, :scalar 40.0, :ranges [], :set #{}, :role "*"}
                                                  #mesomatic.types.Resource{:name "mem", :type :value-scalar, :scalar 5000.0, :ranges [], :set #{}, :role "*"}
                                                  #mesomatic.types.Resource{:name "disk", :type :value-scalar, :scalar 6000.0, :ranges [], :set #{}, :role "*"}
-                                                 #mesomatic.types.Resource{:name "ports", :type :value-ranges, :scalar 0.0, :ranges [#mesomatic.types.ValueRange{:begin 31000, :end 32000}], :set #{}, :role "*"}],
+                                                 #mesomatic.types.Resource{:name "ports", :type :value-ranges, :scalar 0.0, :ranges [#mesomatic.types.ValueRange{:begin 31000, :end 32000}], :set #{}, :role "*"}
+                                                 #mesomatic.types.Resource{:name "gpus", :type :value-scalar :scalar 2.0 :role "*"}],
                                      :attributes [],
                                      :executor-ids []}
         adapter (sched/->VirtualMachineLeaseAdapter offer when)]
@@ -498,6 +500,7 @@
     (is (= (.getVMID adapter) "my-slave-id"))
     (is (= (.hostname adapter) "slave3"))
     (is (= (.memoryMB adapter) 5000.0))
+    (is (= (.getScalarValues adapter) {"gpus" 2.0 "cpus" 40.0 "disk" 6000.0 "mem" 5000.0 "ports" 0.0}))
     (is (= (-> adapter .portRanges first .getBeg) 31000))
     (is (= (-> adapter .portRanges first .getEnd) 32000))))
 
@@ -519,6 +522,111 @@
     (is (= (:task-state interpreted-status) :task-lost))
     (is (= (:reason interpreted-status) :reason-invalid-offers))))
 
+(deftest test-gpu-constraint
+  (let [fid #mesomatic.types.FrameworkID{:value "my-framework-id"}
+        gpu-offer #mesomatic.types.Offer{:id #mesomatic.types.OfferID {:value "my-offer-id"}
+                                         :framework-id fid
+                                         :slave-id #mesomatic.types.SlaveID{:value "my-slave-id"},
+                                         :hostname "slave3",
+                                         :resources [#mesomatic.types.Resource{:name "cpus", :type :value-scalar, :scalar 40.0, :ranges [], :set #{}, :role "*"}
+                                                     #mesomatic.types.Resource{:name "mem", :type :value-scalar, :scalar 5000.0, :ranges [], :set #{}, :role "*"}
+                                                     #mesomatic.types.Resource{:name "disk", :type :value-scalar, :scalar 6000.0, :ranges [], :set #{}, :role "*"}
+                                                     #mesomatic.types.Resource{:name "ports", :type :value-ranges, :scalar 0.0, :ranges [#mesomatic.types.ValueRange{:begin 31000, :end 32000}], :set #{}, :role "*"}
+                                                     #mesomatic.types.Resource{:name "gpus", :type :value-scalar :scalar 2.0 :role "*"}],
+                                         :attributes [],
+                                         :executor-ids []}
+        non-gpu-offer #mesomatic.types.Offer{:id #mesomatic.types.OfferID {:value "my-offer-id"}
+                                             :framework-id fid
+                                             :slave-id #mesomatic.types.SlaveID{:value "my-slave-id"},
+                                             :hostname "slave3",
+                                             :resources [#mesomatic.types.Resource{:name "cpus", :type :value-scalar, :scalar 40.0, :ranges [], :set #{}, :role "*"}
+                                                         #mesomatic.types.Resource{:name "mem", :type :value-scalar, :scalar 5000.0, :ranges [], :set #{}, :role "*"}
+                                                         #mesomatic.types.Resource{:name "disk", :type :value-scalar, :scalar 6000.0, :ranges [], :set #{}, :role "*"}
+                                                         #mesomatic.types.Resource{:name "ports", :type :value-ranges, :scalar 0.0, :ranges [#mesomatic.types.ValueRange{:begin 31000, :end 32000}], :set #{}, :role "*"}],
+                                             :attributes [],
+                                             :executor-ids []}
+        uri "datomic:mem://test-gpu-constraint"
+        conn (restore-fresh-database! uri)
+        gpu-job-id (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        other-gpu-job-id (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        non-gpu-job-id (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 0.0)
+        db (db conn)
+        gpu-job (d/entity db gpu-job-id)
+        other-gpu-job (d/entity db other-gpu-job-id)
+        non-gpu-job (d/entity db non-gpu-job-id)
+        mock-gpu-assignment #(-> (Mockito/when (.getRequest (Mockito/mock com.netflix.fenzo.TaskAssignmentResult)))
+                                 (.thenReturn (sched/->TaskRequestAdapter other-gpu-job (sched/job->task-info db fid (:db/id other-gpu-job)) (atom nil)))
+                                 (.getMock))]
+    (doseq [[type gpu-lease] [["gpu avail"
+                               (reify com.netflix.fenzo.VirtualMachineCurrentState
+                                (getHostname [_] "test-host")
+                                (getRunningTasks [_] [])
+                                (getTasksCurrentlyAssigned [_] [])
+                                (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter gpu-offer 0)))]
+                              ["running gpu"
+                               (reify com.netflix.fenzo.VirtualMachineCurrentState
+                                (getHostname [_] "test-host")
+                                (getRunningTasks [_] [(sched/->TaskRequestAdapter other-gpu-job (sched/job->task-info db fid (:db/id other-gpu-job)) (atom nil))])
+                                (getTasksCurrentlyAssigned [_] [])
+                                (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter non-gpu-offer 0)))]
+                              ["gpu assigned"
+                               (reify com.netflix.fenzo.VirtualMachineCurrentState
+                                (getHostname [_] "test-host")
+                                (getRunningTasks [_] [])
+                                (getTasksCurrentlyAssigned [_] [(mock-gpu-assignment)])
+                                (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter non-gpu-offer 0)))]]]
+      (is (.isSuccessful
+            (.evaluate (sched/gpu-host-constraint gpu-job)
+                       (sched/->TaskRequestAdapter gpu-job (sched/job->task-info db fid (:db/id gpu-job)) (atom nil))
+                       gpu-lease
+                       nil))
+          (str "GPU task on GPU host with " type " should succeed"))
+      (is (not (.isSuccessful
+                 (.evaluate (sched/gpu-host-constraint non-gpu-job)
+                            (sched/->TaskRequestAdapter non-gpu-job (sched/job->task-info db fid (:db/id non-gpu-job)) (atom nil))
+                            gpu-lease
+                            nil)))
+          (str "GPU task on GPU host with " type " should fail") )
+      (is (not (.isSuccessful
+                 (.evaluate (sched/gpu-host-constraint gpu-job)
+                            (sched/->TaskRequestAdapter gpu-job (sched/job->task-info db fid (:db/id gpu-job)) (atom nil))
+                            (reify com.netflix.fenzo.VirtualMachineCurrentState
+                              (getHostname [_] "test-host")
+                              (getRunningTasks [_] [])
+                              (getTasksCurrentlyAssigned [_] [])
+                              (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter non-gpu-offer 0)))
+                            nil)))
+          "GPU task on non GPU host should fail")
+      (is (.isSuccessful
+          (.evaluate (sched/gpu-host-constraint non-gpu-job)
+                   (sched/->TaskRequestAdapter non-gpu-job (sched/job->task-info db fid (:db/id non-gpu-job)) (atom nil))
+                   (reify com.netflix.fenzo.VirtualMachineCurrentState
+                     (getHostname [_] "test-host")
+                     (getRunningTasks [_] [])
+                     (getTasksCurrentlyAssigned [_] [])
+                     (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter non-gpu-offer 0)))
+                   nil))
+        "non GPU task on non GPU host should succeed"))))
+
+(deftest test-gpu-share-prioritization
+  (let [uri "datomic:mem://test-gpu-shares"
+        conn (restore-fresh-database! uri)
+        ljin-1 (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        ljin-2 (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        ljin-3 (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        ljin-4 (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        wzhao-1 (create-dummy-job conn :user "wzhao" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        wzhao-2 (create-dummy-job conn :user "wzhao" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        _ (create-dummy-instance conn ljin-1)
+        _ (share/set-share! conn "default" :cpus 1.0 :mem 2.0 :gpus 1.0)]
+    (testing "test1"
+      (let [_ (share/set-share! conn "ljin" :gpus 2.0)
+            db (d/db conn)]
+        (is (= [ljin-2 wzhao-1 ljin-3 ljin-4 wzhao-2] (map :db/id (:gpu (sched/sort-jobs-by-dru db db)))))))
+    (testing "test2"
+        (let [_ (share/set-share! conn "ljin" :gpus 1.0)
+              db (d/db conn)]
+          (is (= [wzhao-1 wzhao-2 ljin-2 ljin-3 ljin-4] (map :db/id (:gpu (sched/sort-jobs-by-dru db db)))))))))
 
 (comment
   (run-tests))

--- a/scheduler/test/cook/test/mesos/schema.clj
+++ b/scheduler/test/cook/test/mesos/schema.clj
@@ -38,7 +38,7 @@
 
 (defn create-dummy-job
   "Return the entity id for the created dummy job."
-  [conn & {:keys [user uuid command ncpus memory name retry-count max-runtime priority job-state submit-time custom-executor?]
+  [conn & {:keys [user uuid command ncpus memory name retry-count max-runtime priority job-state submit-time custom-executor? gpus]
            :or {user (System/getProperty "user.name")
                 uuid (d/squuid)
                 command "dummy command"
@@ -65,6 +65,10 @@
                                   :resource/amount (double ncpus)}
                                  {:resource/type :resource.type/mem
                                   :resource/amount (double memory)}]}
+        job-info (if gpus
+                   (update-in job-info [:job/resource] conj {:resource/type :resource.type/gpus
+                                                             :resource/amount (double gpus)})
+                   job-info)
         val @(d/transact conn [(if (nil? custom-executor?)
                                  job-info
                                  (assoc job-info :job/custom-executor custom-executor?))])]

--- a/scheduler/test/cook/test/mesos/share.clj
+++ b/scheduler/test/cook/test/mesos/share.clj
@@ -27,17 +27,17 @@
     (share/set-share! conn "u1" :cpus 20.0 :mem 10.0)
     (share/set-share! conn "u1" :cpus 5.0)
     (share/set-share! conn "u2" :cpus 5.0  :mem 10.0)
-    (share/set-share! conn "default" :cpus 1.0 :mem 2.0)
+    (share/set-share! conn "default" :cpus 1.0 :mem 2.0 :gpus 1.0)
     (let [db (db conn)]
       (testing "set and query."
-        (is (= {:cpus 5.0 :mem 10.0} (share/get-share db "u2"))))
+        (is (= {:cpus 5.0 :mem 10.0 :gpus 1.0} (share/get-share db "u2"))))
       (testing "set and overide."
-        (is (= {:cpus 5.0 :mem 10.0} (share/get-share db "u1"))))
+        (is (= {:cpus 5.0 :mem 10.0 :gpus 1.0} (share/get-share db "u1"))))
       (testing "query default."
-        (is (= {:cpus 1.0 :mem 2.0} (share/get-share db "default"))))
+        (is (= {:cpus 1.0 :mem 2.0 :gpus 1.0} (share/get-share db "default"))))
       (testing "query unknown user."
         (is (= (share/get-share db "whoami") (share/get-share db "default"))))
       (testing "retract share"
         (share/retract-share! conn "u2")
         (let [db (mt/db conn)]
-          (is (= {:cpus 1.0 :mem 2.0} (share/get-share db "u2"))))))))
+          (is (= {:cpus 1.0 :mem 2.0 :gpus 1.0} (share/get-share db "u2"))))))))

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -88,7 +88,8 @@
 (deftest test-take-scalar-resources-for-task
   (let [available {"cpus" {"cook" 8.0 "*" 6.0}
                    "mem" {"cook" 800.0 "*" 700.0}}
-        task {:resources {:cpus 12 :mem 900}}
+        task {:task-request (reify com.netflix.fenzo.TaskRequest
+                                (getScalarRequests [_] {:cpus 12.0 :mem 900.0}))}
         result (task/take-all-scalar-resources-for-task available task)]
     (is (= (:remaining-resources result)
            {"cpus" {"cook" 0.0 "*" 2.0}
@@ -102,7 +103,8 @@
 (deftest test-add-scalar-resources-to-task-infos
   (let [available {"cpus" {"cook" 8.0 "*" 6.0}
                    "mem" {"cook" 800.0 "*" 700.0}}
-        tasks [{:resources {:cpus 12 :mem 900}}]
+        tasks [{:task-request (reify com.netflix.fenzo.TaskRequest
+                                (getScalarRequests [_] {:cpus 12.0 :mem 900.0}))}]
         results (task/add-scalar-resources-to-task-infos available tasks)]
     (is (= (-> results first :scalar-resource-messages)
            [{:name "cpus", :type :value-scalar, :role "cook", :scalar 8.0}


### PR DESCRIPTION
This adds support for:
- GPU resources on agents, which will only be accepted if enabled in the
  config file
- Scheduling GPU jobs on GPU machines and non-GPU jobs on non-GPU
  machines
- Uses DRU & preemption with GPUs as well, but they're considered
  independently
- Adds GPUs to the REST API
- If GPUs are enabled and the Mesos version doesn't support them, fails
  loudly