### PR TITLE
scheduler: Update Fenzo to newer version.

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -43,7 +43,7 @@
                  [swiss-arrows "1.0.0"]
                  [riddley "0.1.10"]
                  [org.apache.mesos/mesos "1.0.1"]
-                 [com.netflix.fenzo/fenzo-core "0.9.4-SNAPSHOT"
+                 [com.netflix.fenzo/fenzo-core "0.10.0"
                   :exclusions [org.apache.mesos/mesos
                                com.fasterxml.jackson.core/jackson-core
                                org.slf4j/slf4j-api


### PR DESCRIPTION
The previous version of this line was pointing to an ephemeral snapshot
release of Fenzo which is no longer available.