### PR TITLE
scheduler: Don't try to preempt synthetic tasks.

### DIFF
--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -368,7 +368,13 @@
                    (dec remaining-preemption)
                    jobs-to-make-room-for
                    (conj pending-job-ents-to-run pending-job-ent)
-                   (into task-ents-to-preempt (:task preemption-decision)))
+                   (into task-ents-to-preempt
+                         ;; If a task has no id, it must be a synthetic task.
+                         ;; This means that on one iteration of (compute-next-state-and-preemption-decision),
+                         ;; the rebalancer decided to make room for a certain hypothetical task,
+                         ;; but on a subsequent iteration, it became clear that OTHER hypothetical tasks would be an even better outcome.
+                         ;; We shouldn't try to actually preempt tasks that were never scheduled.
+                         (filter :db/id (:task preemption-decision))))
             (recur state'
                    remaining-preemption
                    jobs-to-make-room-for


### PR DESCRIPTION
I noticed this while running simulation tests.

If the rebalancer "changes its mind" during a rebalance - adding a synthetic task and then subsequently removing that one in favor of other synthetic tasks - it will actually try to transact a preemption on the removed synthetic tasks.  Since these synthetic tasks don't have id's, that causes an error.    