### PR TITLE
Support for Spark-2.0.1

### DIFF
--- a/spark/0001-Add-cook-support-for-spark-v2.0.1.patch
+++ b/spark/0001-Add-cook-support-for-spark-v2.0.1.patch
@@ -1,0 +1,686 @@
+From 395b510432893b4d83ec85dd8b5c6968655532d9 Mon Sep 17 00:00:00 2001
+From: Prasanna Gautam <prasannagautam@gmail.com>
+Date: Fri, 28 Oct 2016 14:45:28 -0700
+Subject: [PATCH] This updates Spark-2 to support Cook scheduler
+
+At high level, this keeps the behavior for cook support the same.
+You can connect to a cook cluster using
+cook://<username>@<cook host>
+similar to using mesos schema.
+
+Notable changes from the patch for 1.6.1:
+
+- The method signatures for doRequestTotalExecutors,doKillExecutors
+  changed to return Future, corresponding changes have also been changed
+- Moved the calculateTotalmemory method to CoarseCookSchedulerBackend
+  since it's not implemented in MesosBackend anymore
+---
+ core/pom.xml                                       |   5 +
+ .../main/scala/org/apache/spark/SparkContext.scala |   8 +
+ .../org/apache/spark/deploy/SparkSubmit.scala      |  10 +-
+ .../cluster/cook/CoarseCookSchedulerBackend.scala  | 316 +++++++++++++++++++++
+ .../cook/CoarseCookSchedulerBackendSuite.scala     | 243 ++++++++++++++++
+ 5 files changed, 578 insertions(+), 4 deletions(-)
+ create mode 100644 core/src/main/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackend.scala
+ create mode 100644 core/src/test/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackendSuite.scala
+
+diff --git a/core/pom.xml b/core/pom.xml
+index 2d19e5b..1f23523 100644
+--- a/core/pom.xml
++++ b/core/pom.xml
+@@ -40,6 +40,11 @@
+       <classifier>${avro.mapred.classifier}</classifier>
+     </dependency>
+     <dependency>
++      <groupId>com.twosigma</groupId>
++      <artifactId>cook.jobclient</artifactId>
++      <version>0.1.0</version>
++    </dependency>
++    <dependency>
+       <groupId>com.google.guava</groupId>
+       <artifactId>guava</artifactId>
+     </dependency>
+diff --git a/core/src/main/scala/org/apache/spark/SparkContext.scala b/core/src/main/scala/org/apache/spark/SparkContext.scala
+index e9f9d72..abfa65b 100644
+--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
++++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
+@@ -53,6 +53,7 @@ import org.apache.spark.rdd._
+ import org.apache.spark.rpc.RpcEndpointRef
+ import org.apache.spark.scheduler._
+ import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, StandaloneSchedulerBackend}
++import org.apache.spark.scheduler.cluster.cook.CoarseCookSchedulerBackend
+ import org.apache.spark.scheduler.cluster.mesos.{MesosCoarseGrainedSchedulerBackend, MesosFineGrainedSchedulerBackend}
+ import org.apache.spark.scheduler.local.LocalSchedulerBackend
+ import org.apache.spark.storage._
+@@ -2450,6 +2451,11 @@ object SparkContext extends Logging {
+         val backend = new LocalSchedulerBackend(sc.getConf, scheduler, 1)
+         scheduler.initialize(backend)
+         (backend, scheduler)
++      case COOK_REGEX(user, pass, url, port) =>
++            val scheduler = new TaskSchedulerImpl(sc)
++            val backend = new CoarseCookSchedulerBackend(scheduler, sc, url, port.toInt, user, pass)
++            scheduler.initialize(backend)
++            (backend, scheduler)
+ 
+       case LOCAL_N_REGEX(threads) =>
+         def localCpuCount: Int = Runtime.getRuntime.availableProcessors()
+@@ -2556,6 +2562,8 @@ private object SparkMasterRegex {
+   val SPARK_REGEX = """spark://(.*)""".r
+   // Regular expression for connection to Mesos cluster by mesos:// or mesos://zk:// url
+   val MESOS_REGEX = """mesos://(.*)""".r
++  // Regular expression for connection to Cook Scheduler
++  val COOK_REGEX = """cook://(?:(.*):(.*)@)?(.*):([0-9]+)""".r
+ }
+ 
+ /**
+diff --git a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+index 8061165..0619120 100644
+--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
++++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+@@ -70,7 +70,8 @@ object SparkSubmit {
+   private val STANDALONE = 2
+   private val MESOS = 4
+   private val LOCAL = 8
+-  private val ALL_CLUSTER_MGRS = YARN | STANDALONE | MESOS | LOCAL
++  private val COOK = 16
++  private val ALL_CLUSTER_MGRS = YARN | STANDALONE | MESOS | COOK | LOCAL
+ 
+   // Deploy modes
+   private val CLIENT = 1
+@@ -238,6 +239,7 @@ object SparkSubmit {
+       case m if m.startsWith("spark") => STANDALONE
+       case m if m.startsWith("mesos") => MESOS
+       case m if m.startsWith("local") => LOCAL
++      case m if m.startsWith("cook") => COOK
+       case _ =>
+         printErrorAndExit("Master must either be yarn or start with spark, mesos, local")
+         -1
+@@ -467,11 +469,11 @@ object SparkSubmit {
+       // Other options
+       OptionAssigner(args.executorCores, STANDALONE | YARN, ALL_DEPLOY_MODES,
+         sysProp = "spark.executor.cores"),
+-      OptionAssigner(args.executorMemory, STANDALONE | MESOS | YARN, ALL_DEPLOY_MODES,
++      OptionAssigner(args.executorMemory, STANDALONE | MESOS | YARN | COOK, ALL_DEPLOY_MODES,
+         sysProp = "spark.executor.memory"),
+-      OptionAssigner(args.totalExecutorCores, STANDALONE | MESOS, ALL_DEPLOY_MODES,
++      OptionAssigner(args.totalExecutorCores, STANDALONE | MESOS | COOK, ALL_DEPLOY_MODES,
+         sysProp = "spark.cores.max"),
+-      OptionAssigner(args.files, LOCAL | STANDALONE | MESOS, ALL_DEPLOY_MODES,
++      OptionAssigner(args.files, LOCAL | STANDALONE | MESOS | COOK, ALL_DEPLOY_MODES,
+         sysProp = "spark.files"),
+       OptionAssigner(args.jars, LOCAL, CLIENT, sysProp = "spark.jars"),
+       OptionAssigner(args.jars, STANDALONE | MESOS, ALL_DEPLOY_MODES, sysProp = "spark.jars"),
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackend.scala b/core/src/main/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackend.scala
+new file mode 100644
+index 0000000..a0f7000
+--- /dev/null
++++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackend.scala
+@@ -0,0 +1,316 @@
++/*
++ * Licensed to the Apache Software Foundation (ASF) under one or more
++ * contributor license agreements.  See the NOTICE file distributed with
++ * this work for additional information regarding copyright ownership.
++ * The ASF licenses this file to You under the Apache License, Version 2.0
++ * (the "License"); you may not use this file except in compliance with
++ * the License.  You may obtain a copy of the License at
++ *
++ *    http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package org.apache.spark.scheduler.cluster.cook
++
++import java.io.{BufferedWriter, FileWriter}
++import java.net.URI
++import java.nio.file.{Files, Paths}
++import scala.concurrent.ExecutionContext.Implicits.global
++import java.util.{UUID, List => JList}
++
++import scala.collection.JavaConverters._
++import scala.collection.mutable.HashMap
++import org.apache.mesos._
++import org.apache.mesos.Protos._
++import org.apache.spark.internal.Logging
++import org.apache.spark.SparkContext
++import org.apache.spark.scheduler.TaskSchedulerImpl
++import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
++import org.apache.spark.scheduler.cluster.mesos.MesosCoarseGrainedSchedulerBackend
++import com.twosigma.cook.jobclient.{FetchableURI, Job, JobClient, JobClientException, JobListener => CJobListener}
++import org.eclipse.jetty.util.MemoryUtils
++
++import scala.concurrent.Future
++import scala.util.{Failure, Success, Try}
++
++object CoarseCookSchedulerBackend {
++  def fetchUri(uri: String): String =
++    Option(URI.create(uri).getScheme).map(_.toLowerCase) match {
++      case Some("http") => s"curl $uri"
++      case None | Some("file") => s"cp $uri ."
++      case Some(x) => sys.error(s"$x not supported yet")
++    }
++}
++
++/**
++ * A SchedulerBackend that runs tasks using Cook, using "coarse-grained" tasks, where it holds
++ * onto Cook instances for the duration of the Spark job instead of relinquishing cores whenever
++ * a task is done. It launches Spark tasks within the coarse-grained Cook instances using the
++ * CoarseGrainedSchedulerBackend mechanism. This class is useful for lower and more predictable
++ * latency.
++ */
++private[spark] class CoarseCookSchedulerBackend(
++  scheduler: TaskSchedulerImpl,
++  sc: SparkContext,
++  cookHost: String,
++  cookPort: Int,
++  cookUser: String,
++  cookPassword: String
++) extends CoarseGrainedSchedulerBackend(scheduler, sc.env.rpcEnv) with Logging {
++  // Book-keeping for cores we have requested from cook
++  var totalCoresRequested = 0
++  var totalFailures = 0
++  val maxFailures = conf.getInt("spark.executor.failures", 5)
++
++  val maxCores = conf.getInt("spark.cores.max", 0)
++  val maxCoresPerJob = conf.getInt("spark.cook.cores.per.job.max", 5)
++
++  val priority = conf.getInt("spark.cook.priority", 75)
++
++  val executorUuidWriter: UUID => Unit =
++    conf.getOption("spark.cook.executoruuid.log").fold { _: UUID => () } { _file =>
++      def file(ct: Int) = s"${_file}.$ct"
++      def path(ct: Int) = Paths.get(file(ct))
++
++      // Here we roll existing logs
++      @annotation.tailrec
++      def findFirstFree(ct: Int = 0): Int =
++        if (Files.exists(path(ct))) {
++          findFirstFree(ct + 1)
++        } else {
++          ct
++        }
++
++      @annotation.tailrec
++      def rollin(ct: Int) {
++        if (ct > 0) {
++          Files.move(path(ct - 1), path(ct))
++          rollin(ct - 1)
++        }
++      }
++
++      rollin(findFirstFree())
++
++      { uuid: UUID =>
++        val bw = new BufferedWriter(new FileWriter(file(0), true))
++        bw.write(uuid.toString)
++        bw.newLine()
++        bw.close()
++      }
++    }
++
++  // TODO do we need to do something smarter about the security manager?
++  val mesosBackend =
++    new MesosCoarseGrainedSchedulerBackend(scheduler, sc, "", sc.env.securityManager)
++
++  val jobClient = {
++      val builder = new JobClient.Builder()
++          .setHost(cookHost)
++          .setPort(cookPort)
++          .setEndpoint("rawscheduler")
++          .setStatusUpdateInterval(1)
++          .setBatchRequestSize(10)
++      Option(cookUser) match {
++          case Some(user) => builder.setUsernameAuth(user, cookPassword)
++          case None => builder.setKerberosAuth()
++      }
++      builder.build()
++  }
++
++  var runningJobUUIDs = Set[UUID]()
++  var abortedJobIds = Set[UUID]()
++
++  // Set via dynamic-allocation when doRequestTotalExecutors is called to limit
++  // the number of jobs that the backend can create
++  private var jobLimit: Option[Int] = None
++
++  val jobListener = new CJobListener {
++    // These are called serially so don't need to worry about race conditions
++    def onStatusUpdate(job : Job) {
++      val uuid = job.getUUID
++      val isCompleted = job.getStatus == Job.Status.COMPLETED
++      val isAborted = abortedJobIds.contains(uuid)
++
++      if (isCompleted) {
++        totalCoresRequested -= job.getCpus().toInt
++        abortedJobIds = abortedJobIds - uuid
++        runningJobUUIDs = runningJobUUIDs - uuid
++
++        if (isAborted) { logInfo(s"Job $uuid has been successfuly aborted") }
++
++        if (!job.isSuccess && !isAborted) {
++          totalFailures += 1
++          logWarning(s"Job $uuid has died. Failure ($totalFailures/$maxFailures)")
++
++          if (totalFailures >= maxFailures) {
++            // TODO should we abort the outstanding tasks now?
++            logError(s"We have exceeded our maximum failures ($maxFailures)" +
++                       "and will not relaunch any more tasks")
++          } else {
++            requestRemainingCores
++          }
++        }
++      }
++    }
++  }
++
++  def createJob(numCores: Int): Job = { // should return Job
++    import CoarseCookSchedulerBackend.fetchUri
++
++    val jobId = UUID.randomUUID()
++
++    executorUuidWriter(jobId)
++    logInfo(s"Creating job with id: $jobId")
++
++    val slaveId = SlaveID.newBuilder().setValue(jobId.toString)
++
++    val fakeOffer = Offer.newBuilder()
++      .setId(OfferID.newBuilder().setValue("Cook-id"))
++      .setFrameworkId(FrameworkID.newBuilder().setValue("Cook"))
++      .setHostname("$(hostname)")
++      .setSlaveId(slaveId)
++      .build()
++
++    val taskId = mesosBackend.newMesosTaskId()
++    val commandInfo = mesosBackend.createCommand(fakeOffer, numCores, taskId)
++    val commandString = commandInfo.getValue
++    val environmentInfo = commandInfo.getEnvironment
++
++    // Note that it is critical to export these variables otherwise when
++    // we invoke the spark scripts, our values will not be picked up
++    val environment =
++      environmentInfo.getVariablesList.asScala
++      .map{ v => (v.getName, v.getValue) }.toMap +
++      ("SPARK_LOCAL_DIRS" -> "spark-temp")
++
++    val uris = commandInfo.getUrisList.asScala
++      .map{ uri => new FetchableURI.Builder()
++                       .setValue(uri.getValue)
++                       .setExtract(uri.getExtract)
++                       .setExecutable(uri.getExecutable)
++                       .build()
++       }
++    logDebug(s"command: $commandString")
++
++    val remoteHdfsConf = conf.get("spark.executor.cook.hdfs.conf.remote", "")
++    val remoteConfFetch = if (remoteHdfsConf.nonEmpty) {
++      val name = Paths.get(remoteHdfsConf).getFileName
++      Seq(
++        fetchUri(remoteHdfsConf),
++        "mkdir HADOOP_CONF_DIR",
++        s"tar --strip-components=1 -xvzf $name -C HADOOP_CONF_DIR",
++        // This must be absolute because we cd into the spark directory
++        s"export HADOOP_CONF_DIR=`pwd`/HADOOP_CONF_DIR",
++        "export HADOOP_CLASSPATH=$HADOOP_CONF_DIR"
++      )
++
++    } else Seq()
++
++    val cleanup = "if [ -z $KEEP_SPARK_LOCAL_DIRS ]; then rm -rf $SPARK_LOCAL_DIRS; echo deleted $SPARK_LOCAL_DIRS; fi"
++
++    val cmds = remoteConfFetch ++ environment ++ Seq(commandString, cleanup)
++
++    new Job.Builder()
++      .setUUID(jobId)
++      .setEnv(environment.asJava)
++      .setUris(uris.asJava)
++      .setCommand(cmds.mkString("; "))
++      .setMemory(calculateTotalMemory(sc))
++      .setCpus(numCores)
++      .setPriority(priority)
++      .build()
++  }
++
++  private val MEMORY_OVERHEAD_FRACTION = 0.10
++  private val MEMORY_OVERHEAD_MINIMUM = 384
++
++  def calculateTotalMemory(sc: SparkContext):Int = {
++    sc.conf.getInt("spark.mesos.executor.memoryOverhead",
++      math.max(MEMORY_OVERHEAD_FRACTION * sc.executorMemory, MEMORY_OVERHEAD_MINIMUM).toInt) +
++      sc.executorMemory
++  }
++
++  def createRemainingJobs(): List[Job] = {
++    @annotation.tailrec
++    def loop(coresRemaining: Int, jobs: List[Job]): List[Job] =
++      if (coresRemaining <= 0) {
++        jobs
++      } else if (coresRemaining <= maxCoresPerJob) {
++        createJob(coresRemaining) :: jobs
++      } else {
++        loop(coresRemaining - maxCoresPerJob, createJob(maxCoresPerJob) :: jobs)
++      }
++    loop(currentCoresLimit, List()).reverse
++  }
++
++  def requestRemainingCores() : Unit = {
++    val jobs = createRemainingJobs()
++
++    totalCoresRequested += jobs.map(_.getCpus.toInt).sum
++    runningJobUUIDs = runningJobUUIDs ++ jobs.map(_.getUUID)
++
++    if (!jobs.isEmpty) { jobClient.submit(jobs.asJava, jobListener) }
++  }
++
++  def currentCoresLimit(): Int =
++    jobLimit.map(_ * maxCoresPerJob).getOrElse(maxCores) - totalCoresRequested
++
++  override def doKillExecutors(executorIds: Seq[String]): Future[Boolean] =
++    Future {abortJobs(executorIds.map(x => UUID.fromString(x)).toList)}
++
++  override def doRequestTotalExecutors(requestedTotal: Int): Future[Boolean] = {
++    Future {
++      logInfo(s"Capping the total amount of executors to $requestedTotal")
++      jobLimit = Some(requestedTotal)
++      requestRemainingCores
++      true
++    }
++  }
++
++  // todo we should consider making this async, because if there are issues with cook it'll
++  // just block the spark shell completely. We can block if they submit something (we don't
++  // want to get into thread management issues)
++  override def start() {
++    super.start()
++    logInfo("Starting Cook Spark Scheduler")
++    requestRemainingCores()
++  }
++
++  private def abortJobs(uuids: List[UUID]) : Boolean = {
++    logInfo(s"Aborting jobs: $uuids")
++
++    Try(jobClient.abort(uuids.asJavaCollection)) match {
++      case Success(v) =>
++        abortedJobIds = abortedJobIds ++ uuids.toSet
++        true
++      case Failure(e) =>
++        logWarning(s"Failed to kill an executor ${e.getMessage}")
++        false
++    }
++  }
++
++  private[this] val minExecutorsNecessary =
++    math.ceil(maxCores.toDouble / maxCoresPerJob) * minRegisteredRatio
++
++  override def sufficientResourcesRegistered(): Boolean =
++    totalRegisteredExecutors.get >= minExecutorsNecessary
++
++  private[this] var lastIsReadyLog = 0L
++
++  override def isReady(): Boolean = {
++    val ret = super.isReady()
++    val cur = System.currentTimeMillis
++    if (!ret && cur - lastIsReadyLog > 5000) {
++      logInfo("Backend is not yet ready. Registered executors " +
++        s"[${totalRegisteredExecutors.get}] vs minimum necessary " +
++        s"to start [$minExecutorsNecessary]")
++      lastIsReadyLog = cur
++    }
++    ret
++  }
++}
+diff --git a/core/src/test/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackendSuite.scala b/core/src/test/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackendSuite.scala
+new file mode 100644
+index 0000000..ae7469f
+--- /dev/null
++++ b/core/src/test/scala/org/apache/spark/scheduler/cluster/cook/CoarseCookSchedulerBackendSuite.scala
+@@ -0,0 +1,243 @@
++/*
++ * Licensed to the Apache Software Foundation (ASF) under one or more
++ * contributor license agreements.  See the NOTICE file distributed with
++ * this work for additional information regarding copyright ownership.
++ * The ASF licenses this file to You under the Apache License, Version 2.0
++ * (the "License"); you may not use this file except in compliance with
++ * the License.  You may obtain a copy of the License at
++ *
++ *    http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package org.apache.spark.scheduler.cluster.cook
++
++import java.util
++import java.util.Collections
++import java.util.UUID
++import scala.collection.JavaConverters._
++import scala.util.{Failure, Success}
++import scala.concurrent.ExecutionContext.Implicits.global
++
++import org.apache.mesos.Protos.Value.Scalar
++import org.apache.mesos.Protos._
++import org.apache.mesos.{Protos, Scheduler, SchedulerDriver}
++import org.mockito.Matchers._
++import org.mockito.Mockito._
++import org.mockito.Matchers
++import org.scalatest.mock.MockitoSugar
++import org.scalatest.BeforeAndAfter
++
++import org.apache.spark.scheduler.TaskSchedulerImpl
++import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SecurityManager, SparkFunSuite}
++
++import org.apache.spark.scheduler.cluster.cook.CoarseCookSchedulerBackend
++
++import com.twosigma.cook.jobclient.{ JobClient, Job, JobClientException }
++
++class CoarseCookSchedulerBackendSuite extends SparkFunSuite
++    with LocalSparkContext
++    with MockitoSugar
++    with BeforeAndAfter {
++
++  private def createSchedulerBackend(taskScheduler: TaskSchedulerImpl): CoarseCookSchedulerBackend = {
++    val backend = new CoarseCookSchedulerBackend(
++      taskScheduler, sc, "127.0.0.1", 12321, "vagrant", "ignorePassword"
++    )
++    backend.start()
++    backend
++  }
++
++  private def getJobs(backend: CoarseCookSchedulerBackend): List[Job] = {
++    backend.jobClient.query(backend.runningJobUUIDs.asJavaCollection).asScala.values.toList
++  }
++
++  before {
++    val sparkConf = (new SparkConf)
++      .setMaster("local[*]")
++      .setAppName("test-cook-dynamic-alloc")
++      .setSparkHome("/path")
++
++    sparkConf.set("spark.executor.failures", "2")
++    sparkConf.set("spark.cook.priority", "50")
++    sparkConf.set("spark.cores.max", "3")
++    sparkConf.set("spark.cook.cores.per.job.max", "1")
++
++    sc = new SparkContext(sparkConf)
++  }
++
++  test("isReady") {
++    val taskScheduler = mock[TaskSchedulerImpl]
++    when(taskScheduler.sc).thenReturn(sc)
++
++    val backend = createSchedulerBackend(taskScheduler)
++
++    assert(backend.isReady())
++  }
++
++  test("initial executors on start-up") {
++    val taskScheduler = mock[TaskSchedulerImpl]
++    when(taskScheduler.sc).thenReturn(sc)
++
++    val backend = createSchedulerBackend(taskScheduler)
++
++    assert(backend.runningJobUUIDs.size == 3)
++    assert(backend.currentCoresLimit == 0)
++    assert(backend.abortedJobIds.isEmpty)
++  }
++
++  test("cook sets custom priority for jobs") {
++    val taskScheduler = mock[TaskSchedulerImpl]
++    when(taskScheduler.sc).thenReturn(sc)
++
++    val backend = createSchedulerBackend(taskScheduler)
++    var jobs = getJobs(backend)
++
++    assert(jobs(0).getPriority() == 50)
++    assert(jobs(1).getPriority() == 50)
++    assert(jobs(2).getPriority() == 50)
++  }
++
++  test("cook supports scaling executors up & down") {
++    val taskScheduler = mock[TaskSchedulerImpl]
++    when(taskScheduler.sc).thenReturn(sc)
++
++    val backend = createSchedulerBackend(taskScheduler)
++    var executorIds = backend.runningJobUUIDs.map(_.toString).toSeq
++
++    backend.doKillExecutors(executorIds)
++    assert(backend.abortedJobIds == backend.runningJobUUIDs)
++
++    var jobs = getJobs(backend)
++
++    // force job status update
++    for (job <- jobs) backend.jobListener.onStatusUpdate(job)
++
++    assert(backend.abortedJobIds.isEmpty)
++    assert(backend.runningJobUUIDs.size == 0)
++
++    backend.doRequestTotalExecutors(0).onComplete{
++      case Success(value) => assert(value)
++      case Failure(e) => e.printStackTrace()
++    }
++    assert(backend.totalFailures == 0)
++
++    backend.doRequestTotalExecutors(2).onComplete{
++      case Success(value) => assert(value)
++      case Failure(e) => e.printStackTrace();
++    }
++
++    assert(backend.totalFailures == 0)
++
++    assert(backend.runningJobUUIDs.size == 2)
++    assert(backend.currentCoresLimit == 0)
++
++    executorIds = backend.runningJobUUIDs.map(_.toString).toSeq
++    backend.doKillExecutors(executorIds)
++
++    backend.doRequestTotalExecutors(1).onComplete{
++      case Success(value) => assert(value)
++      case Failure(e) => e.printStackTrace()
++    }
++    assert(backend.totalFailures == 0)
++
++    jobs = getJobs(backend)
++
++    // force job status update
++    for (job <- jobs) backend.jobListener.onStatusUpdate(job)
++
++    assert(backend.currentCoresLimit == 1)
++    assert(backend.abortedJobIds.isEmpty)
++
++    backend.requestRemainingCores()
++
++    assert(backend.currentCoresLimit == 0)
++    assert(backend.runningJobUUIDs.size == 1)
++  }
++
++  test("cook requests new jobs when failure limit was not exceeded") {
++    val taskScheduler = mock[TaskSchedulerImpl]
++    when(taskScheduler.sc).thenReturn(sc)
++
++    val backend = createSchedulerBackend(taskScheduler)
++    var executorIds = backend.runningJobUUIDs.map(_.toString).toSeq
++
++    backend.doKillExecutors(executorIds)
++    assert(backend.abortedJobIds == backend.runningJobUUIDs)
++
++    var jobs = getJobs(backend)
++
++    // force job status update and simulate that one of the jobs wasn't aborted via dyn-alloc
++    backend.abortedJobIds -= jobs.head.getUUID
++    for (job <- jobs) backend.jobListener.onStatusUpdate(job)
++
++    assert(backend.abortedJobIds.isEmpty)
++    assert(backend.runningJobUUIDs.size == 1)
++    assert(backend.currentCoresLimit == 2)
++  }
++
++  test("cook doesn't request new jobs when failure limit was exceeded") {
++    val taskScheduler = mock[TaskSchedulerImpl]
++    when(taskScheduler.sc).thenReturn(sc)
++
++    val backend = createSchedulerBackend(taskScheduler)
++    var executorIds = backend.runningJobUUIDs.map(_.toString).toSeq
++
++    backend.doKillExecutors(executorIds)
++    assert(backend.abortedJobIds == backend.runningJobUUIDs)
++
++    // force job status update and simulate that two jobs weren't aborted via dyn-alloc
++    var jobs = getJobs(backend)
++    backend.abortedJobIds -= jobs(0).getUUID
++    backend.abortedJobIds -= jobs(2).getUUID
++    for (job <- jobs) backend.jobListener.onStatusUpdate(job)
++
++    assert(backend.abortedJobIds.isEmpty)
++    assert(backend.runningJobUUIDs.size == 1)
++    assert(backend.totalFailures == 2)
++    assert(backend.currentCoresLimit == 2)
++
++    executorIds = backend.runningJobUUIDs.map(_.toString).toSeq
++    backend.doKillExecutors(executorIds)
++
++    // force job status update and simulate that none of the jobs was aborted via dyn-alloc
++    jobs = getJobs(backend)
++    backend.abortedJobIds = Set()
++    for (job <- jobs) backend.jobListener.onStatusUpdate(job)
++
++    assert(backend.abortedJobIds.isEmpty)
++    assert(backend.runningJobUUIDs.isEmpty)
++    assert(backend.totalFailures == 3)
++    assert(backend.currentCoresLimit == 3)
++
++    backend.requestRemainingCores()
++
++    assert(backend.runningJobUUIDs.size == 3)
++  }
++
++  test("cook doesn't update aborted-jobs when aborting a job fails") {
++    val jobId = UUID.randomUUID()
++
++    val taskScheduler = mock[TaskSchedulerImpl]
++    when(taskScheduler.sc).thenReturn(sc)
++
++    val jobClientMock = mock[JobClient]
++    when(jobClientMock.abort(List(jobId).asJavaCollection)).thenThrow(mock[JobClientException])
++
++    val backend = new CoarseCookSchedulerBackend(
++      taskScheduler, sc, "127.0.0.1", 12321, "vagrant", "ignorePassword"
++    ) {
++      override val jobClient = jobClientMock
++    }
++    backend.doKillExecutors(Seq(jobId.toString)).onComplete{
++      case Success(value) => assert(!value)
++      case Failure(err) => err.printStackTrace()
++    }
++    assert(!backend.abortedJobIds.contains(jobId))
++  }
++}
+-- 
+2.10.1
+

--- a/spark/README.md
+++ b/spark/README.md
@@ -30,6 +30,17 @@ git apply --check 0001-Add-cook-support-for-spark-v1.6.1.patch
 git am < 0001-Add-cook-support-for-spark-v1.6.1.patch
 ```
 
+## Instructions
+
+```
+cd spark
+git checkout v1.6.1
+git apply --stat 0001-Add-cook-support-for-spark-v2.0.1.patch
+git apply --check 0001-Add-cook-support-for-spark-v2.0.1.patch
+git am < 0001-Add-cook-support-for-spark-v2.0.1.patch
+```
+
+
 ## Installation
 
 Please refer to [Building Spark](http://spark.apache.org/docs/latest/building-spark.html)


### PR DESCRIPTION
Notable changes from the patch for 1.6.1:
- The method signatures for doRequestTotalExecutors,doKillExecutors
  changed to return Future, corresponding changes have also been changed
- Moved the calculateTotalmemory method to CoarseCookSchedulerBackend
  since it's not implemented in MesosBackend anymore

The naming scheme seems to have changed since version 1.6.1
and I haven't been able to actually execute jobs with it yet but I'm not
sure if that's because of the patch or I'm not starting Cook right.
