### PR TITLE
scheduler:  Allow mesos framework name to be configured.

### DIFF
--- a/scheduler/docs/configuration.asc
+++ b/scheduler/docs/configuration.asc
@@ -109,6 +109,10 @@ We'll look at the configurable options in turn:
   This sets the role that Cook will connect to Mesos with. Default: `*`
   You can omit this property unless you've enabled security features in Mesos. The value should be in authorized list for the current `:principal` in `register_frameworks` Action in Mesos Authorization file. See http://mesos.apache.org/documentation/latest/authorization/ for details.
 
+`:framework-name`::
+  This sets part of the name of the framework that Cook will register to Mesos. Default: Cook
+  When connecting to Mesos, Cook will use a framework name like "YourFrameworkName-e254483".  It will append the current git hash to the value you specify here.
+
 `:enable-gpu-support`::
   This enables GPU support for Cook.
   It is a boolean value, with default value `false`.

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -80,7 +80,7 @@
                       (route/not-found "<h1>Not a valid route</h1>")))})
 
 (def mesos-scheduler
-  {:mesos-scheduler (fnk [[:settings mesos-master mesos-master-hosts mesos-leader-path mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset task-constraints riemann mesos-gpu-enabled rebalancer good-enough-fitness] mesos-datomic mesos-datomic-mult curator-framework mesos-pending-jobs-atom]
+  {:mesos-scheduler (fnk [[:settings mesos-master mesos-master-hosts mesos-leader-path mesos-failover-timeout mesos-principal mesos-role mesos-framework-name offer-incubate-time-ms fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset task-constraints riemann mesos-gpu-enabled rebalancer good-enough-fitness] mesos-datomic mesos-datomic-mult curator-framework mesos-pending-jobs-atom]
                          (try
                            (Class/forName "org.apache.mesos.Scheduler")
                            ((lazy-load-var 'cook.mesos/start-mesos-scheduler)
@@ -93,6 +93,7 @@
                             mesos-failover-timeout
                             mesos-principal
                             mesos-role
+                            mesos-framework-name
                             offer-incubate-time-ms
                             task-constraints
                             (:host riemann)
@@ -355,6 +356,8 @@
                            principal)
      :mesos-role (fnk [[:config [:mesos {role "*"}]]]
                            role)
+     :mesos-framework-name (fnk [[:config [:mesos {framework-name "Cook"}]]]
+                                framework-name)
      ;:riemann-metrics (fnk [[:config [:metrics {riemann nil}]]]
      ;                  (when riemann
      ;                    (when-not (= 4 (count (select-keys riemann [:host :port])))

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -77,7 +77,7 @@
 
 (defn start-mesos-scheduler
   "Starts a leader elector that runs a mesos."
-  [mesos-master mesos-master-hosts curator-framework mesos-datomic-conn mesos-datomic-mult zk-prefix mesos-failover-timeout mesos-principal mesos-role offer-incubate-time-ms task-constraints riemann-host riemann-port mesos-pending-jobs-atom gpu-enabled? rebalancer-config
+  [mesos-master mesos-master-hosts curator-framework mesos-datomic-conn mesos-datomic-mult zk-prefix mesos-failover-timeout mesos-principal mesos-role mesos-framework-name offer-incubate-time-ms task-constraints riemann-host riemann-port mesos-pending-jobs-atom gpu-enabled? rebalancer-config
    {:keys [fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn
            fenzo-floor-iterations-before-reset good-enough-fitness]
     :as fenzo-config}]
@@ -121,7 +121,9 @@
                                                       scheduler
                                                       (merge
                                                         {:user ""
-                                                         :name (str "Cook-" cook.util/version)
+                                                         :name (str mesos-framework-name
+                                                                    "-"
+                                                                    cook.util/version)
                                                          :checkpoint true}
                                                         (when mesos-role
                                                           {:role mesos-role})


### PR DESCRIPTION
Git hash will still be included.