### PR TITLE
Remove the distinction of backfilled jobs

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -689,7 +689,7 @@
                     base {:task_id (:instance/task-id instance)
                           :hostname hostname
                           :ports (:instance/ports instance)
-                          :backfilled (:instance/backfilled? instance false)
+                          :backfilled false ;; Backfill has been deprecated
                           :preempted (:instance/preempted? instance false)
                           :slave_id (:instance/slave-id instance)
                           :executor_id (:instance/executor-id instance)

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -229,7 +229,7 @@
                                             (group-by util/task-ent->user)
                                             (map (fn [[user task-ents]]
                                                    [user (into (sorted-set-by (case category
-                                                                                :normal (util/same-user-task-comparator-penalize-backfill)
+                                                                                :normal (util/same-user-task-comparator)
                                                                                 :gpu (util/same-user-task-comparator))) task-ents)]))
                                             (into {}))
         task->scored-task (into (pm/priority-map-keyfn (case category
@@ -262,7 +262,7 @@
         (reduce (fn [task-ents-by-user task-ent]
                   (let [user (util/task-ent->user task-ent)
                         f (if (= new-running-task-ent task-ent)
-                            (fnil conj (sorted-set-by (util/same-user-task-comparator-penalize-backfill)))
+                            (fnil conj (sorted-set-by (util/same-user-task-comparator)))
                             disj)]
                     (update-in task-ents-by-user [user] f task-ent)))
                 user->sorted-running-task-ents

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -625,7 +625,7 @@
                 handle-resource-offer!-transact-task-duration
                 @(d/transact
                    conn
-                   task-txns))
+                   (reduce into [] task-txns)))
               (log/info "Launching" (count task-txns) "tasks")
               (log/info "Matched tasks" task-txns)
               ;; This launch-tasks MUST happen after the above transaction in

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -567,16 +567,12 @@
                                                :when (= :gpu (util/categorize-job (:job task-request)))]
                                            (:job/uuid (:job task-request))))
               matched-head? (contains? matched-normal-job-uuids (-> considerable-by :normal first))
+              remove-matched-jobs (fn remove-matched-jobs [existing-jobs matched-job-uuids]
+                                    (remove #(contains? matched-job-uuids (:job/uuid %)) existing-jobs))
               update-scheduler-contents (fn update-scheduler-contents [scheduler-contents-by]
                                           (-> scheduler-contents-by
-                                              (update-in [:gpu] 
-                                                         #(remove (fn [{pending-job-uuid :job/uuid}]
-                                                                    (contains? matched-gpu-job-uuids pending-job-uuid))
-                                                                  %))
-                                              (update-in [:normal] 
-                                                         #(remove (fn [{pending-job-uuid :job/uuid}]
-                                                                    (contains? matched-normal-job-uuids pending-job-uuid))
-                                                                  %))))
+                                              (update-in [:gpu] remove-matched-jobs matched-gpu-job-uuids)
+                                              (update-in [:normal] remove-matched-jobs matched-normal-job-uuids)))
 			  first-considerable-resources (-> considerable-by :normal first util/job-ent->resources)
               match-resource-requirements (util/sum-resources-of-jobs matched-normal-jobs)]
           (log/debug "got matches:" matches)

--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -396,7 +396,7 @@
 ;;                                 this causes a lot of unexpected behavior (jobs being preempted out of priority 
 ;;                                 order) and lots of bugs (it is hard to correctly update jobs). The concept of 
 ;;                                 backfill is not worth the added problems and so it is being removed."
-     :db/doc "If this is true, then this instance should be preempted first regardless of priority. It's okay to upgrade an instance to be non-backfilled after a while."
+     :db/doc "DEPRECATED: If this is true, then this instance should be preempted first regardless of priority. It's okay to upgrade an instance to be non-backfilled after a while."
      :db/valueType :db.type/boolean
      :db/cardinality :db.cardinality/one
      :db.install/_attribute :db.part/db}

--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -388,6 +388,14 @@
      :db.install/_attribute :db.part/db}
     {:db/id (d/tempid :db.part/db)
      :db/ident :instance/backfilled?
+;;;   In a future version, datomic adds these schema values, leaving the info here when that occurs
+;;     :schema/deprecated true
+;;     :schema/deprecated-because "The concept of backfill was meant to allow Cook to schedule jobs out of order 
+;;                                 temporarily but treat the jobs as opportunistic and upgrade the jobs out of 
+;;                                 backfill later once the scheduling order had been corrected. Unfortunately, 
+;;                                 this causes a lot of unexpected behavior (jobs being preempted out of priority 
+;;                                 order) and lots of bugs (it is hard to correctly update jobs). The concept of 
+;;                                 backfill is not worth the added problems and so it is being removed."
      :db/doc "If this is true, then this instance should be preempted first regardless of priority. It's okay to upgrade an instance to be non-backfilled after a while."
      :db/valueType :db.type/boolean
      :db/cardinality :db.cardinality/one

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -271,16 +271,6 @@
   (fn [task1 task2]
       (compare (task->feature-vector task1) (task->feature-vector task2))))
 
-(defn same-user-task-comparator-penalize-backfill
-  "Same as same-user-task-comparator, but we treat jobs which were backfilled as being the lowest priority"
-  []
-  (letfn [(comparable-with-backfill
-            [task]
-            (vec (cons (if (:instance/backfilled? task) 1 0)
-                       (task->feature-vector task))))]
-    (fn [task1 task2]
-      (compare (comparable-with-backfill task1) (comparable-with-backfill task2)))))
-
 (defn retry-job!
   "Sets :job/max-retries to the given value for the given job UUID.
    Throws an exception if there is no job with that UUID."

--- a/scheduler/test/cook/test/mesos/dru.clj
+++ b/scheduler/test/cook/test/mesos/dru.clj
@@ -89,7 +89,7 @@
             ordered-drus [1.0 1.0 1.0 1.5 4.0 5.5]]
         (is (= ordered-drus
                (map (comp :dru second)
-                    (dru/sorted-task-scored-task-pairs (map-vals (partial sort-by identity (util/same-user-task-comparator-penalize-backfill)) 
+                    (dru/sorted-task-scored-task-pairs (map-vals (partial sort-by identity (util/same-user-task-comparator))
                                                           (group-by util/task-ent->user task-ents))
                                                 {"ljin" share "wzhao" share "sunil" share}))))))))
 

--- a/scheduler/test/cook/test/mesos/rebalancer.clj
+++ b/scheduler/test/cook/test/mesos/rebalancer.clj
@@ -445,8 +445,8 @@
       (let [task-ent9 {:job/_instance job-ent9
                        :instance/hostname "hostB"
                        :instance/status :instance.status/running}
-            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent1 task-ent2 task-ent3 task-ent4])
-                                               "wzhao" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent5 task-ent7 task-ent9])}
+            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator)) [task-ent1 task-ent2 task-ent3 task-ent4])
+                                               "wzhao" (into (sorted-set-by (util/same-user-task-comparator)) [task-ent5 task-ent7 task-ent9])}
             host->spare-resources' {"hostA" {:mem 50.0 :cpus 50.0} "hostB" {:mem 5.0 :cpus 5.0 :gpus 0.0}}]
         (let [{task->scored-task'' :task->scored-task
                user->sorted-running-task-ents'' :user->sorted-running-task-ents
@@ -470,9 +470,9 @@
       (let [task-ent10 {:job/_instance job-ent10
                         :instance/hostname "hostA"
                         :instance/status :instance.status/running}
-            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent1 task-ent3 task-ent4])
-                                               "wzhao" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent5 task-ent6 task-ent8])
-                                               "sunil" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent10])}
+            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator)) [task-ent1 task-ent3 task-ent4])
+                                               "wzhao" (into (sorted-set-by (util/same-user-task-comparator)) [task-ent5 task-ent6 task-ent8])
+                                               "sunil" (into (sorted-set-by (util/same-user-task-comparator)) [task-ent10])}
             host->spare-resources' {"hostA" {:mem 50.0 :cpus 50.0 :gpus 0.0}}]
         (let [{task->scored-task'' :task->scored-task
                user->sorted-running-task-ents'' :user->sorted-running-task-ents
@@ -495,9 +495,9 @@
       (let [task-ent12 {:job/_instance job-ent12
                         :instance/hostname "hostA"
                         :instance/status :instance.status/running}
-            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent1 task-ent2 task-ent3 task-ent4])
-                                               "wzhao" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent5 task-ent6 task-ent7 task-ent8])
-                                               "sunil" (into (sorted-set-by (util/same-user-task-comparator-penalize-backfill)) [task-ent12])}
+            user->sorted-running-task-ents' {"ljin" (into (sorted-set-by (util/same-user-task-comparator)) [task-ent1 task-ent2 task-ent3 task-ent4])
+                                               "wzhao" (into (sorted-set-by (util/same-user-task-comparator)) [task-ent5 task-ent6 task-ent7 task-ent8])
+                                               "sunil" (into (sorted-set-by (util/same-user-task-comparator)) [task-ent12])}
             host->spare-resources' {"hostA" {:mem 10.0 :cpus 10.0 :gpus 0.0}}]
 
         (let [{task->scored-task'' :task->scored-task

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -106,7 +106,7 @@
 (defn create-dummy-instance
   "Return the entity id for the created instance."
   [conn job & {:keys [job-state instance-status start-time end-time hostname
-                      task-id progress backfilled? reason slave-id executor-id
+                      task-id progress reason slave-id executor-id
                       cancelled]
                :or  {job-state :job.state/running
                      instance-status :instance.status/unknown
@@ -114,7 +114,6 @@
                      end-time nil
                      hostname "localhost"
                      task-id (str (str (java.util.UUID/randomUUID)))
-                     backfilled? false
                      progress 0
                      reason nil
                      slave-id  (str (java.util.UUID/randomUUID))
@@ -125,7 +124,6 @@
                                   :job/_instance job
                                   :instance/hostname hostname
                                   :instance/progress progress
-                                  :instance/backfilled? backfilled?
                                   :instance/status instance-status
                                   :instance/start-time start-time
                                   :instance/task-id task-id


### PR DESCRIPTION
The concept of backfilled jobs was to allow Cook to schedule out of
order (specifically, skip the head of the queue) to oppurtunistically
improve utilization. However, this can lead to cases where the job at
the head of the queue is starved and not able to get scheduled. When
this occurs, we rely on the rebalancer to free up space such that the
head of the queue can run. Instances were explicitly marked as
backfilled when Cook scheduled out of order and were then upgraded out
of backfilled status once the jobs ahead of them had been scheduled.
Instances that were marked as backfilled were treated as the first
jobs to be preempted.

This caused a variety of problems:
1. Preempting backfilled jobs first caused unexpected behavior when a
backfilled, high priority job was preempted instead of a low priority
job
2. Upgrading jobs from backfilled to fully processed is error prone and
causes issues the ordering of the queue. Specifically, jobs that were
backfilled would remain in the queue (generally high in the queue) and
would be removed when the jobs ahead of them were scheduled. However, in
the event that the backfilled job failed, it would "jump the queue"
which means that jobs that fail very quickly that get backfilled can
wreck havoc on the utilization of the cluster

We are choosing to remove the backfill distinction (while still allowing
cook to schedule out of order) because it of the problems above and
because the rebalancer will still be able to preempt jobs to make room
for starved jobs, it just may not be the backfilled jobs.