### PR TITLE
Integration test for cook scheduler / rebalancer using mock mesos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pom.xml.asc
 scheduler/checkouts
 scheduler/log/
 scheduler/src/cfg
+scheduler/trace*.csv
 src/cfg/current.clj
 target
 test-log

--- a/scheduler/src/cook/mesos/dru.clj
+++ b/scheduler/src/cook/mesos/dru.clj
@@ -91,7 +91,7 @@
    Initial code from: http://blog.malcolmsparks.com/?p=42"
   ([key-fn ^java.util.Comparator comp-fn colls]
    (letfn [(next-item [[_ colls]]
-             (if (nil? colls)
+             (if-not (seq colls)
                [:end nil] ; Allow nil items in colls
                (let [[[yield & remaining] & other-colls]
                      (sort-by (comp key-fn first) comp-fn colls)]

--- a/scheduler/src/cook/mesos/mesos_mock.clj
+++ b/scheduler/src/cook/mesos/mesos_mock.clj
@@ -1,0 +1,430 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.mesos.mesos-mock
+  (:require [chime :refer [chime-at chime-ch]]
+            [clj-time.coerce :as tc]
+            [clj-time.core :as t]
+            [clj-time.periodic :as periodic]
+            [clojure.core.async :as async]
+            [clojure.edn :as edn]
+            [clojure.tools.logging :as log]
+            [cook.mesos.scheduler :as s]
+            [datomic.api :as d :refer (q)]
+            [mesomatic.scheduler :as mesos]
+            [mesomatic.types :as mesos-type]
+            [mesomatic.types :as mtypes]
+            [metrics.counters :as counters]
+            [metrics.gauges :as gauges]
+            [metrics.histograms :as histograms]
+            [metrics.meters :as meters]
+            [metrics.timers :as timers]
+            [plumbing.core :refer (map-vals map-from-vals)])
+  (import com.netflix.fenzo.TaskAssignmentResult
+          com.netflix.fenzo.TaskScheduler
+          com.netflix.fenzo.VirtualMachineLease
+          com.netflix.fenzo.plugins.BinPackingFitnessCalculators
+          java.util.concurrent.TimeUnit
+          org.apache.mesos.Protos$OfferID
+          org.apache.mesos.Protos$Status
+          org.apache.mesos.SchedulerDriver
+          org.mockito.Mockito))
+
+(def resource->type {:cpus :scalar
+                     :mem :scalar
+                     :ports :ranges})
+
+(defn make-offer
+  "Takes a `host` which contain a key `:available-resources`
+   and generates a list of offers
+
+   Parameters:
+   `host` host info, see above for a description of the schema"
+  [host]
+  (-> host
+      (assoc :id {:value (str (java.util.UUID/randomUUID))})
+      (update :slave-id (fn [slave-id] {:value slave-id}))
+      (dissoc :available-resources)
+      (assoc :resources
+             (for [[resource-name role->resource] (:available-resources host)
+                   [role resource] role->resource]
+               {:name (name resource-name)
+                :role role
+                (resource->type resource-name) resource
+                :type (keyword (str "value-" (name (resource->type resource-name))))}))))
+
+(defn clear-out-resources
+  "Removes all the resources in a resource map passed in.
+   It is assumed this is a called on available-resources
+
+   Parameters:
+   `resources` resource map of the form {<resource> {<role> {<quantity}}
+
+   Returns:
+   resource map in form {<resource> {}}"
+  [resources]
+  (into {} (map #(vector % {})) (keys resources)))
+
+(defn prepare-new-offers
+  "Prepares new offers to send to the scheduler and returns an updated state
+   given the new offers
+
+   Parameters:
+   `state` the state of the mock mesos, see above for a description of the schema
+
+   returns [new-offers new-state]"
+  [{:keys [slave-id->host offer-id->offer task-id->task] :as state}]
+  (let [new-offers (filter (comp seq :resources)
+                           (map make-offer (vals slave-id->host)))
+        new-offers (filter (fn [{:keys [resources]}]
+                             (some #(> (get % :scalar 0) 0) resources))
+                           new-offers)]
+    [new-offers
+     (-> state
+          (update :slave-id->host
+                  #(map-vals (fn [host]
+                               (update host :available-resources clear-out-resources))
+                             %))
+          (update :offer-id->offer #(into % (map-from-vals (comp :value :id) new-offers))))]))
+
+
+(defn combine-ranges
+  "Takes a list of ranges specified as: {:begin <num> :end <num2>} and
+   returns a new list where ranges are consecutive.
+
+   Parameters:
+   `ranges` list of ranges {:being <num1> :end <num2>}"
+  [ranges]
+  (let [ranges (sort-by :begin ranges)]
+    (reduce (fn [ranges' new-range]
+              (let [last-range (last ranges')]
+                (if last-range
+                  (if (= (inc (:end last-range)) (:begin new-range))
+                    (conj (vec (butlast ranges')) {:begin (:begin last-range)
+                                                   :end (:end new-range)})
+                    (conj ranges' new-range))
+                  (conj ranges' new-range))))
+      []
+      ranges)))
+
+(defn range-contains?
+  "Returns true if range-a contains range-b"
+  [range-a range-b]
+  (and (<= (:begin range-a) (:begin range-b))
+       (>= (:end range-a) (:end range-b))))
+
+(defn ranges-contains?
+  "Returns true if ranges contains the considered range"
+  [ranges range-b]
+  (some #(range-contains? % range-b) ranges))
+
+(defn subtract-range
+  "Given range `a` and range `b`, returns a list of ranges {:begin <num> :end <num2>}
+   such that the values in `b` are removed from `a`"
+  [range-a range-b]
+  (when-not (range-contains? range-a range-b)
+    (throw (ex-info "Range a must contain range b"
+                    {:range-a range-a :range-b range-b})))
+  ;; ----------- range-a
+  ;;    --       range-b
+  ;; ---  ------ out
+  ;; KB     KE
+  (let [keep-begin {:begin (:begin range-a) :end (dec (:begin range-b))}
+        keep-end {:begin (inc (:end range-b)) :end (:end range-a)}]
+    (cond
+      (and (= (:begin range-a) (:begin range-b))
+           (= (:end range-a) (:end range-b)))
+      []
+
+      (= (:begin range-a) (:begin range-b))
+      [keep-end]
+
+      (= (:end range-a) (:end range-b))
+      [keep-begin]
+
+      :else
+      [keep-begin keep-end])))
+
+(defn subtract-ranges
+  "Given ranges `a` and `b`, each a list of ranges,
+   returns a list of ranges such that `b` is removed from `a`"
+  [ranges-a ranges-b]
+  (when-not (every? (partial ranges-contains? ranges-a) ranges-b)
+    (throw (ex-info "ranges-a must contain ranges-b"
+                    {:ranges-a ranges-a :ranges-b ranges-b})))
+  (reduce (fn [ranges range-to-remove]
+            (mapcat
+              (fn [r]
+                (if (range-contains? r range-to-remove)
+                  (subtract-range r range-to-remove)
+                  [r]))
+              ranges))
+          ranges-a
+          ranges-b))
+
+(defn combine-resources
+  "Given a list of resources in the shape
+   {:role <role> :type <resource-type> :name <resource_name> :<resource-type-val> <resource-val>}
+
+   Combine the resources into a map in the shape
+   {<resource-name> {<role> <value>}
+   ...}"
+  ([resources]
+   (combine-resources resources {}))
+  ([resources initial]
+   (reduce (fn [avail {:keys [name role] :as resource-info}]
+             (update-in avail
+                        [(keyword name) role]
+                        (fn [resource-val]
+                          (condp = (resource->type (keyword name))
+                            :scalar (+ (or resource-val 0) (:scalar resource-info))
+                            :ranges (combine-ranges (into (or resource-val [])
+                                                          (:ranges resource-info)))))))
+           initial
+           resources)))
+
+
+(defn subtract-resources
+  "Given two resource maps in the shape
+   {<resource-name> {<role> <value>}
+   ...}
+
+   Return a single resource map in the same shape where the
+   resources of `b` are removed from `a`
+   "
+  [resource-map-a resource-map-b]
+  (when-not (clojure.set/superset? (set (keys resource-map-a)) (set (keys resource-map-b)))
+    (throw (ex-info (str "A must contain a superset of resources of B")
+                    {:a-resources (keys resource-map-a)
+                     :b-resources (keys resource-map-b)})))
+  (->> (for [resource (keys resource-map-a)]
+         (let [role->resource-a (get resource-map-a resource)
+               role->resource-b (get resource-map-b resource)
+               _ (when-not (every? #(contains? (set (keys role->resource-a)) %)
+                                 (keys role->resource-b))
+                         (throw (ex-info "Every role to subtract must exist in `a`"
+                                         {:roles-a (keys role->resource-a)
+                                          :roles-b (keys role->resource-b)})))
+               role->resource' (condp = (resource->type resource)
+                                 :scalar (merge-with - role->resource-a role->resource-b)
+                                 :ranges (merge-with subtract-ranges role->resource-a role->resource-b))]
+           [resource role->resource']))
+       (into {})))
+
+(defn complete-task!
+  "Marks the task as complete in the state and updates the resources
+   Returns the updated state"
+  [state task-id scheduler driver task-state]
+  (log/debug "Completing task" {:task-id task-id :state task-state :task (get-in state [:task-id->task task-id])})
+  (if-let [task (get-in state [:task-id->task task-id])]
+    (do
+      (.statusUpdate scheduler driver (mesos-type/->pb :TaskStatus
+                                                       {:task-id {:value task-id}
+                                                        :state task-state}))
+      (-> state
+          (update :task-id->task #(dissoc % task-id))
+          (update :task-id->completed-task #(assoc % task-id (assoc task :complete-time (t/now))))
+          (update-in [:slave-id->host (:value (:slave-id task)) :available-resources]
+                     #(combine-resources (:resources task) %))))
+    state))
+
+(defmulti handle-action!
+  "Handles the particular action, likely calling methods on the scheduler
+   and returning an updated state
+
+   Parameters:
+   `action` the option to dispatch off
+   `data` data corresponding to the action and specific to the action
+   `state` the current state of 'mesos'
+   `driver` the driver used by the scheduler
+   `scheduler` the scheduler framework connected to mesos"
+  (fn [action data state driver scheduler]
+    action))
+
+(defmethod handle-action! :decline
+  [action offer-id {:keys [offer-id->offer task-id->task slave-id->host] :as state} driver scheduler]
+  (if-let [offer (get offer-id->offer offer-id)]
+    (-> state
+        (update :offer-id->offer #(dissoc % offer-id))
+        (update-in [:slave-id->host (:value (:slave-id offer)) :available-resources]
+                   #(combine-resources (:resources offer) %)))
+    (throw (ex-info "Unknown offer-id" {:offer-id offer-id}))))
+
+(defmethod handle-action! :kill-task
+  [action task-id {:keys [offer-id->offer task-id->task slave-id->host] :as state} driver scheduler]
+  (log/debug "Killing task " {:task-id task-id})
+  (complete-task! state task-id scheduler driver :task-killed))
+
+
+(defmethod handle-action! :launch
+  [action {:keys [offer-ids tasks] :as in} {:keys [offer-id->offer task-id->task slave-id->host] :as state} driver scheduler]
+  (log/debug "In launch handle-action!" in)
+  (let [offers (map offer-id->offer offer-ids)
+        slave-id (:value (:slave-id (first tasks)))]
+    (when-not (every? #(= slave-id (:value (:slave-id %))) tasks)
+      (throw (ex-info "All tasks must have same slave-id"
+                      {:slave-ids (map (comp :value :slave-id) tasks)})))
+    (when-not (get slave-id->host slave-id)
+      (throw (ex-info "Unknown slave-id" {:slave-id slave-id :known-slave-ids (keys slave-id->host)})))
+    (when (some nil? offers)
+      (throw (ex-info "Unknown offers"
+                      {:unknown-offers
+                       (remove #(contains? (set (keys offer-id->offer)) %)
+                               offer-ids)})))
+    (when-not (every? #(= slave-id (:value (:slave-id %))) offers)
+      (throw (ex-info "Some offers don't match slave id of tasks"
+                      {:expected-slave-id slave-id
+                       :mismatched-offers (filter #(not= slave-id (:value (:slave-id %)))
+                                                  offers)})))
+    (let [host (get slave-id->host slave-id)
+          available-resources (combine-resources (mapcat :resources offers) (:available-resources host))
+          requested-resources (combine-resources (mapcat :resources tasks))
+          resources' (subtract-resources available-resources requested-resources)
+          tasks (map #(assoc % :launched-time (t/now)) tasks)
+          task->runtime-ms (-> state :config :task->runtime-ms)]
+      (log/info "Resources requested by tasks: " {:requested-resources requested-resources})
+      ;; May need to put this in a thread..
+      (doseq [task tasks]
+        (.statusUpdate scheduler
+                       driver
+                       (mesos-type/->pb :TaskStatus
+                                        {:task-id {:value (:value (:task-id task))}
+                                         :state :task-running})))
+      (log/debug "Launching tasks " {:tasks tasks})
+      (-> state
+          (update :task-id->task #(into % (map-from-vals (comp :value :task-id) tasks)))
+          (update :complete-chan->task-id
+                  #(into % (map (fn [{:keys [task-id] :as task}]
+                                  [(async/timeout (task->runtime-ms task)) (:value task-id)]))
+                         tasks))
+          (assoc-in [:slave-id->host slave-id :available-resources] resources')
+          (update :offer-id->offer #(apply dissoc % offer-ids))))))
+
+(defmethod handle-action! :reconcile
+  [action statuses {:keys [offer-id->offer task-id->task slave-id->host] :as state} driver scheduler]
+  ;; TODO: implement
+  )
+
+(defn default-task->runtime-ms
+  "Takes a task spec and casts the command to a number
+   as runtime"
+  [task]
+  (-> task :command :value read-string))
+
+(defn default-task->complete-status
+  "Returns completed successfully"
+  [_]
+  ;; TODO: support more completion states
+  :task-finished)
+
+(defn mesos-driver-mock
+  "A mock mesos implementation.
+
+   It stores the 'hosts' in the cluster, how much resources are available on
+   each host, what jobs are running on each 'host' and how much longer each
+   job is expected to run for.
+
+   Parameters:
+   `hosts` is a seq of maps that contain a hostname, agent id, resources and attributes
+   `speed-multiplier` is a number >1 which is how much to speed up 'time'
+   `task->runtime-ms` is a function that takes a task spec and returns the runtime in millis
+   `task->complete-status` is a function that takes atask spec and returns a mesos complete status
+   `scheduler` is an implementation of the mesomatic scheduler protocol"
+  ([hosts speed-multiplier scheduler]
+   (mesos-driver-mock hosts speed-multiplier default-task->runtime-ms scheduler))
+  ([hosts speed-multiplier task->runtime-ms scheduler]
+   (mesos-driver-mock hosts speed-multiplier task->runtime-ms default-task->complete-status scheduler))
+  ([hosts speed-multiplier task->runtime-ms task->complete-status scheduler]
+   (let [action-chan (async/chan 10) ; This will block calls to the driver. This may be problematic..
+         exit-chan (async/chan)
+         start-chan (async/chan)
+         driver (reify SchedulerDriver
+                  (declineOffer [this offer-id]
+                    (log/debug "Declining offer" {:offer-id offer-id})
+                    (async/>!! action-chan [:decline (:value (mesos-type/pb->data offer-id))])
+                    Protos$Status/DRIVER_RUNNING)
+                  (join [this]
+                    (async/<!! exit-chan)
+                    Protos$Status/DRIVER_RUNNING)
+                  (stop [this]
+                    (async/close! exit-chan))
+                  (killTask [this task-id]
+                    (log/debug "In driver killTask" {:task-id task-id :pb->data (mesos-type/pb->data task-id) :value (:value (mesos-type/pb->data task-id))})
+                    (async/>!! action-chan [:kill-task (:value (mesos-type/pb->data task-id))])
+                    Protos$Status/DRIVER_RUNNING)
+                  (^Protos$Status launchTasks [this ^java.util.Collection offer-ids ^java.util.Collection tasks]
+                    (log/debug "Launch tasks called" {:tasks tasks :offer-ids offer-ids})
+                    (async/>!! action-chan [:launch {:offer-ids (map (comp :value mesos-type/pb->data) offer-ids)
+                                                     :tasks (map mesos-type/pb->data tasks)}])
+                    Protos$Status/DRIVER_RUNNING)
+                  (reconcileTasks [this statuses]
+                    (async/>!! action-chan [:reconcile statuses])
+                    Protos$Status/DRIVER_RUNNING)
+                  (start [this]
+                    (async/close! start-chan)
+                    Protos$Status/DRIVER_RUNNING))
+         hosts (->> hosts
+                    (map #(assoc % :available-resources (:resources %)))
+                    (map #(update % :slave-id str)))]
+     (async/thread
+       (try
+         (async/<!! start-chan)
+         (.registered scheduler
+                      driver
+                      (mesos-type/->pb :FrameworkID {:value "cool-framework-id"})
+                      (mesos-type/->pb :MasterInfo {:id "silly id"
+                                                    :ip 127
+                                                    :port 5050
+                                                    :version "1.0.1"}))
+         (loop [state {:config {:task->runtime-ms task->runtime-ms
+                                :task->complete-status task->complete-status
+                                :speed-multiplier speed-multiplier}
+                       :slave-id->host (map-from-vals :slave-id hosts)
+                       :offer-id->offer {}
+                       :task-id->task {}
+                       :task-id->completed-task {} ;;TODO test this in kill
+                       :complete-chan->task-id {}}
+                new-offer-chan (async/timeout (/ 1000 speed-multiplier))]
+           (log/info "State before " state)
+           (let [[v ch] (async/alts!! (concat [exit-chan action-chan new-offer-chan]
+                                              (keys (:complete-chan->task-id state)))
+                                      :priority true)
+                 _ (log/debug "Picked next decision" {:v v :ch ch})
+                 [state' new-offer-chan]
+                 (condp = ch
+                   exit-chan nil
+                   action-chan (let [[action data] v
+                                     _ (log/debug "Handling action" {:action action :data data})
+                                     state' (handle-action! action data state driver scheduler)]
+                                 (log/trace {:action action :data data :state' state'})
+                                 [state' new-offer-chan])
+                   new-offer-chan (let [[new-offers state'] (prepare-new-offers state)]
+                                    (log/debug "Sending offers" {:offers new-offers})
+                                    (when (seq new-offers)
+                                      (.resourceOffers scheduler driver (mapv (partial mesos-type/->pb :Offer) new-offers)))
+                                    [state' (async/timeout (/ 1000 speed-multiplier))])
+                   ;; Else
+                   (let [task-id ((:complete-chan->task-id state) ch)
+                         _ (log/debug "Task complete: " task-id)
+                         task ((:task-id->task state) task-id)
+                         state' (-> state
+                                    (complete-task! task-id scheduler driver (task->complete-status task))
+                                    (update :complete-chan->task-id #(dissoc % ch)))]
+                     [state' new-offer-chan]))]
+             (when state'
+               (recur state' new-offer-chan))))
+         (catch Exception ex
+           (log/fatal ex "Error while simulating mesos"))))
+     (mesos/wrap-driver driver))))

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -215,7 +215,6 @@
    value
    host->spare-resources A map from host to spare resources.
    user->dru-divisors A map from user to dru divisors."
-<<<<<<< 9683d7a9dcdce0bdfdcb28f5d2b9ae02471f7a5e
   ([db running-task-ents pending-job-ents host->spare-resources category]
    (init-state db running-task-ents pending-job-ents host->spare-resources category []))
   ([db running-task-ents pending-job-ents host->spare-resources category preempted-tasks]
@@ -388,7 +387,7 @@
         jobs-to-make-room-for (filter (partial util/job-allowed-to-start? db)
                                       pending-job-ents)
         init-state (init-state db (util/get-running-task-ents db) jobs-to-make-room-for host->spare-resources category)]
-    (log/debug "Jobs to make room for" jobs-to-make-room-for)
+    (log/debug "Jobs to make room for:" jobs-to-make-room-for)
     (loop [state init-state
            remaining-preemption max-preemption
            [pending-job-ent & jobs-to-make-room-for] jobs-to-make-room-for

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -15,12 +15,10 @@
 ;;
 (ns cook.mesos.rebalancer
   (:require [chime :refer [chime-at]]
-            [clj-http.client :as http]
             [clj-time.core :as time]
             [clj-time.periodic :as periodic]
             [clojure.core.async :as async]
-            [clojure.core.reducers :as r]
-            [clojure.data.json :as json]
+            [clojure.core.reducers :as r] 
             [clojure.data.priority-map :as pm]
             [clojure.tools.logging :as log]
             [clojure.walk :refer (keywordize-keys)]
@@ -217,6 +215,7 @@
    value
    host->spare-resources A map from host to spare resources.
    user->dru-divisors A map from user to dru divisors."
+<<<<<<< 9683d7a9dcdce0bdfdcb28f5d2b9ae02471f7a5e
   ([db running-task-ents pending-job-ents host->spare-resources category]
    (init-state db running-task-ents pending-job-ents host->spare-resources category []))
   ([db running-task-ents pending-job-ents host->spare-resources category preempted-tasks]
@@ -230,24 +229,26 @@
          user->sorted-running-task-ents (->> running-task-ents
                                              (group-by util/task-ent->user)
                                              (map (fn [[user task-ents]]
-                                                    [user (into (sorted-set-by (case category
-                                                                                 :normal (util/same-user-task-comparator)
-                                                                                 :gpu (util/same-user-task-comparator))) task-ents)]))
+                                                    [user (into (sorted-set-by (util/same-user-task-comparator)) 
+                                                                task-ents)]))
                                              (into {}))
+         scored-task-pairs (case category
+                             :normal (dru/sorted-task-scored-task-pairs user->dru-divisors user->sorted-running-task-ents)
+                             :gpu (dru/sorted-task-cumulative-gpu-score-pairs user->dru-divisors user->sorted-running-task-ents))
          task->scored-task (into (pm/priority-map-keyfn (case category
                                                           :normal (comp - :dru)
                                                           :gpu (fnil - 0)))
-                                 (case category
-                                   :normal (dru/sorted-task-scored-task-pairs user->dru-divisors user->sorted-running-task-ents)
-                                   :gpu (dru/sorted-task-cumulative-gpu-score-pairs user->dru-divisors user->sorted-running-task-ents)))]
-     (->State task->scored-task
-              user->sorted-running-task-ents
-              host->spare-resources
-              user->dru-divisors
+                                 scored-task-pairs)]
+     (->State task->scored-task 
+              user->sorted-running-task-ents 
+              host->spare-resources 
+              user->dru-divisors 
               (case category
                 :normal compute-pending-normal-job-dru
                 :gpu compute-pending-gpu-job-dru)
               preempted-tasks))))
+   
+
 
 (defn next-state
   "Takes state, a pending job entity to launch and a preemption decision, returns the next state"
@@ -372,6 +373,7 @@
 (defn compute-next-state-and-preemption-decision
   "Takes state, params and a pending job entity, returns new state and preemption decision"
   [offer-cache state params pending-job]
+  (log/debug "Trying to find space for: " pending-job)
   (if-let [preemption-decision (compute-preemption-decision offer-cache state params pending-job)]
     [(next-state state pending-job preemption-decision) preemption-decision]
     [state nil]))
@@ -386,6 +388,7 @@
         jobs-to-make-room-for (filter (partial util/job-allowed-to-start? db)
                                       pending-job-ents)
         init-state (init-state db (util/get-running-task-ents db) jobs-to-make-room-for host->spare-resources category)]
+    (log/debug "Jobs to make room for" jobs-to-make-room-for)
     (loop [state init-state
            remaining-preemption max-preemption
            [pending-job-ent & jobs-to-make-room-for] jobs-to-make-room-for
@@ -448,21 +451,7 @@
         (when-let [task-id (:instance/task-id task-ent)]
           (mesos/kill-task! driver {:value task-id}))))))
 
-(defn get-mesos-utilization
-  [mesos-master-hosts]
-  (let [mesos-master-urls (map #(str "http://" % ":5050/metrics/snapshot") mesos-master-hosts)
-        get-stats (fn [url] (some->> url
-                                     (http/get)
-                                     (:body)
-                                     (json/read-str)))
-        utilization (some-<>> mesos-master-urls
-                              (map get-stats)
-                              (filter #(pos? (get % "master/elected")))
-                              (first)
-                              (select-keys <> ["master/cpus_percent" "master/mem_percent"])
-                              (vals)
-                              (apply max))]
-    utilization))
+
 
 (def datomic-params [:min-utilization-threshold
                      :safe-dru-threshold
@@ -487,7 +476,7 @@
                                            recognized-params))])))))
 
 (defn start-rebalancer!
-  [{:keys [conn driver mesos-master-hosts pending-jobs-atom offer-cache view-incubating-offers view-mature-offers config]}]
+  [{:keys [conn driver get-mesos-utilization pending-jobs-atom offer-cache view-incubating-offers view-mature-offers config]}]
   (binding [metrics-dru-scale (:dru-scale config)]
     (update-datomic-params-from-config! conn config)
 
@@ -507,8 +496,9 @@
                                                  host->combined-offers))))
           shutdown-rebalancer (chime-at (periodic/periodic-seq (time/now) rebalance-interval)
                                         (fn [now]
+                                          (log/info "Rebalance cycle starting")
                                           (let [params (read-datomic-params conn)
-                                                utilization (get-mesos-utilization mesos-master-hosts)
+                                                utilization (get-mesos-utilization)
                                                 host->spare-resources (->> @host->combined-offers-atom
                                                                            (map (fn [[k v]]
                                                                                   (when (time/before?

--- a/scheduler/test/cook/test/mesos/mesos_mock.clj
+++ b/scheduler/test/cook/test/mesos/mesos_mock.clj
@@ -1,0 +1,844 @@
+(ns cook.test.mesos.mesos-mock
+  (:use clojure.test)
+  (:require [clojure.core.async :as async]
+            [clojure.data.csv :as csv]
+            [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
+            [cook.mesos :as c]
+            [cook.mesos.mesos-mock :as mm]
+            [cook.mesos.share :as share]
+            [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance)]
+            [datomic.api :as d]
+            [mesomatic.scheduler :as mesos]
+            [mesomatic.types :as mesos-types])
+  (:import org.apache.curator.framework.CuratorFrameworkFactory
+           org.apache.curator.framework.state.ConnectionStateListener
+           org.apache.curator.retry.BoundedExponentialBackoffRetry))
+
+(defn string->uuid
+  "Parses the uuid if `uuid-str` is a uuid, returns nil otherwise"
+  [uuid-str]
+  (try
+    (java.util.UUID/fromString uuid-str)
+    (catch Exception e
+      nil)))
+
+(defn noop-mock-scheduler
+  []
+  (mesos/scheduler
+    (registered [this driver framework-id master-info])
+    (reregistered [this driver master-info])
+    (offer-rescinded [this driver offer-id])
+    (framework-message [this driver executor-id slave-id data])
+    (disconnected [this driver])
+    (slave-lost [this driver slave-id])
+    (executor-lost [this driver executor-id slave-id status])
+    (error [this driver message])
+    (resource-offers [this driver offers])
+    (status-update [this driver status])))
+
+(deftest make-offer
+  (let [basic-host-info {:hostname "hosta"
+                         :attributes {}
+                         :resources {:cpus {"*" 10}
+                                     :mem {"*" 100000}
+                                     :ports {"*" [{:begin 10000 :end 20000}]}}
+                         :available-resources {:cpus {"*" 10}
+                                               :mem {"*" 100000}
+                                               :ports {"*" [{:begin 10000 :end 20000}]}}
+                         :slave-id "e8ab3892-3023-4546-888d-67cc13eac3cc"}
+        offer (mm/make-offer basic-host-info)]
+    (is (string->uuid (-> offer :id :value)))
+    (is (= (dissoc offer :id)
+           {:hostname "hosta"
+            :attributes {}
+            :resources [{:name "cpus", :role "*", :scalar 10 :type :value-scalar}
+                        {:name "mem", :role "*", :scalar 100000 :type :value-scalar}
+                        {:name "ports", :role "*", :ranges [{:begin 10000, :end 20000}] :type :value-ranges}]
+            :slave-id {:value "e8ab3892-3023-4546-888d-67cc13eac3cc"}}))))
+
+(deftest prepare-new-offers
+  (let [state {:slave-id->host
+               {"e8ab3892-3023-4546-888d-67cc13eac3cc"
+                {:hostname "hosta"
+                 :attributes {}
+                 :resources {:cpus {"*" 10}
+                             :mem {"*" 100000}
+                             :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :available-resources {:cpus {"*" 10}
+                                       :mem {"*" 100000}
+                                       :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :slave-id "e8ab3892-3023-4546-888d-67cc13eac3cc"}
+
+                "a5cb3212-3023-4546-888d-67cc13eac3dd"
+                {:hostname "hostb"
+                 :attributes {}
+                 :resources {:cpus {"*" 12}
+                             :mem {"*" 120000}
+                             :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :available-resources {:cpus {}
+                                       :mem {}
+                                       :ports {}}
+                 :slave-id "a5cb3212-3023-4546-888d-67cc13eac3dd"}}
+               :offer-id->offer
+               {"8fe5bf6c-ea39-4700-b1f6-9fd8a0271d7c"
+                {:id {:value "8fe5bf6c-ea39-4700-b1f6-9fd8a0271d7c"}
+                 :slave-id {:value "a5cb3212-3023-4546-888d-67cc13eac3dd"}
+                 :hostname "hostb"
+                 :resources [{:name "cpus" :role "*" :scalar 12 :type :value-scalar}
+                             {:name "mem" :role "*" :scalar 120000 :type :value-scalar}
+                             {:name "ports" :role "*" :ranges [{:begin 10000 :end 20000}] :type :value-ranges}]}}
+               :task-id->task {}}
+        [new-offers new-state] (mm/prepare-new-offers state)]
+    (is (= (count new-offers) 1))
+    (is (= (:slave-id->host new-state)
+           {"e8ab3892-3023-4546-888d-67cc13eac3cc"
+            {:hostname "hosta"
+             :attributes {}
+             :resources {:cpus {"*" 10}
+                         :mem {"*" 100000}
+                         :ports {"*" [{:begin 10000 :end 20000}]}}
+             :available-resources {:cpus {}
+                                   :mem {}
+                                   :ports {}}
+             :slave-id "e8ab3892-3023-4546-888d-67cc13eac3cc"}
+
+            "a5cb3212-3023-4546-888d-67cc13eac3dd"
+            {:hostname "hostb"
+             :attributes {}
+             :resources {:cpus {"*" 12}
+                         :mem {"*" 120000}
+                         :ports {"*" [{:begin 10000 :end 20000}]}}
+             :available-resources {:cpus {}
+                                   :mem {}
+                                   :ports {}}
+             :slave-id "a5cb3212-3023-4546-888d-67cc13eac3dd"}}))
+    (is (= (count (vals (:offer-id->offer new-state))) 2))))
+
+(deftest combine-ranges
+  (is (= (mm/combine-ranges [{:begin 16 :end 20} {:begin 0 :end 2}
+                             {:begin 3 :end 5} {:begin 8 :end 10}])
+         [{:begin 0 :end 5} {:begin 8 :end 10} {:begin 16 :end 20}])))
+
+(deftest combine-resources
+  (is (= (mm/combine-resources [{:name "cpus" :role "*" :scalar 1 :type :value-scalar}
+                                {:name "cpus" :role "*" :scalar 6 :type :value-scalar}
+                                {:name "mem" :role "*" :scalar 60000 :type :value-scalar}
+                                {:name "ports" :role "*" :ranges [{:begin 10000 :end 15000}] :type :value-ranges}
+                                {:name "ports" :role "*" :ranges [{:begin 15001 :end 15003}] :type :value-ranges}])
+         {:cpus {"*" 7}
+          :mem {"*" 60000}
+          :ports {"*" [{:begin 10000 :end 15003}]}})))
+
+(deftest range-contains?
+  (testing "ranges are the same"
+    (is (mm/range-contains? {:begin 0 :end 5} {:begin 0 :end 5})))
+  (testing "range larger on left"
+    (is (mm/range-contains? {:begin 0 :end 5} {:begin 1 :end 5})))
+  (testing "range strictly contains"
+    (is (mm/range-contains? {:begin 0 :end 5} {:begin 1 :end 4})))
+  (testing "range contains single number"
+    (is (mm/range-contains? {:begin 0 :end 5} {:begin 4 :end 4})))
+  (testing "range exceeds on left"
+    (is (not (mm/range-contains? {:begin 0 :end 5} {:begin -1 :end 5}))))
+  (testing "range exceeds on right"
+    (is (not (mm/range-contains? {:begin 0 :end 5} {:begin 1 :end 6}))))
+  (testing "range not contained completely on right"
+    (is (not (mm/range-contains? {:begin 0 :end 5} {:begin 6 :end 8}))))
+  (testing "range not contained completely on left"
+    (is (not (mm/range-contains? {:begin 0 :end 5} {:begin -2 :end -1})))))
+
+(deftest ranges-contains?
+  (is (mm/ranges-contains? [{:begin 0 :end 5} {:begin 7 :end 10}] {:begin 7 :end 8}))
+  (is (not (mm/ranges-contains? [{:begin 0 :end 5} {:begin 7 :end 10}] {:begin 5 :end 7}))))
+
+(deftest subtract-range
+  (testing "Full overlap"
+    (is (= (mm/subtract-range {:begin 0 :end 5} {:begin 0 :end 5})
+           [])))
+  (testing "Equal on left"
+    (is (= (mm/subtract-range {:begin 0 :end 5} {:begin 0 :end 4})
+           [{:begin 5 :end 5}])))
+  (testing "Equal on right"
+    (is (= (mm/subtract-range {:begin 0 :end 5} {:begin 1 :end 5})
+           [{:begin 0 :end 0}])))
+  (testing "Remove from middle"
+    (is (= (mm/subtract-range {:begin 0 :end 5} {:begin 2 :end 3})
+           [{:begin 0 :end 1} {:begin 4 :end 5}]))))
+
+(deftest subtract-ranges
+  (is (= (mm/subtract-ranges [{:begin 0 :end 10}] [{:begin 0 :end 2} {:begin 4 :end 5} {:begin 7 :end 8}])
+         [{:begin 3 :end 3} {:begin 6 :end 6} {:begin 9 :end 10}])))
+
+(deftest subtract-resources
+  (testing "Full subtraction test"
+    (is (= (mm/subtract-resources {:cpus {"*" 7
+                                          "cook" 3}
+                                   :mem {"*" 60000}
+                                   :ports {"*" [{:begin 10000 :end 15003} {:begin 16000 :end 20000}]
+                                           "cook" [{:begin 100 :end 200}]}}
+                                  {:cpus {"*" 4
+                                          "cook" 2}
+                                   :mem {"*" 30000}
+                                   :ports {"*" [{:begin 10000 :end 14003} {:begin 17000 :end 20000}]
+                                           "cook" [{:begin 100 :end 200}]}})
+           {:cpus {"*" 3
+                   "cook" 1}
+            :mem {"*" 30000}
+            :ports {"*" [{:begin 14004 :end 15003} {:begin 16000 :end 16999}]
+                    "cook" []}})))
+  (testing "not all resources subtracted"
+    (is (= (mm/subtract-resources {:cpus {"*" 7
+                                          "cook" 3}
+                                   :mem {"*" 60000}
+                                   :ports {"*" [{:begin 10000 :end 15003} {:begin 16000 :end 20000}]
+                                           "cook" [{:begin 100 :end 200}]}}
+                                  {:cpus {"*" 4
+                                          "cook" 2}
+                                   :mem {"*" 30000}})
+           {:cpus {"*" 3
+                   "cook" 1}
+            :mem {"*" 30000}
+            :ports {"*" [{:begin 10000 :end 15003} {:begin 16000 :end 20000}]
+                    "cook" [{:begin 100 :end 200}]}}))))
+
+(deftest handle-decline-action
+  (let [offer-id "8fe5bf6c-ea39-4700-b1f6-9fd8a0271d7c"
+        state {:slave-id->host
+               {"e8ab3892-3023-4546-888d-67cc13eac3cc"
+                {:hostname "hosta"
+                 :attributes {}
+                 :resources {:cpus {"*" 10}
+                             :mem {"*" 100000}
+                             :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :available-resources {:cpus {"*" 10}
+                                       :mem {"*" 100000}
+                                       :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :slave-id "e8ab3892-3023-4546-888d-67cc13eac3cc"}
+
+                "a5cb3212-3023-4546-888d-67cc13eac3dd"
+                {:hostname "hostb"
+                 :attributes {}
+                 :resources {:cpus {"*" 12}
+                             :mem {"*" 120000}
+                             :ports {"*" [{:begin 10000 :end 30000}]}}
+                 :available-resources {:cpus {}
+                                       :mem {}
+                                       :ports {}}
+                 :slave-id "a5cb3212-3023-4546-888d-67cc13eac3dd"}}
+               :offer-id->offer
+               {offer-id
+                {:id {:value offer-id}
+                 :slave-id {:value "a5cb3212-3023-4546-888d-67cc13eac3dd"}
+                 :hostname "hostb"
+                 :resources [{:name "cpus" :role "*" :scalar 7 :type :value-scalar}
+                             {:name "mem" :role "*" :scalar 70000 :type :value-scalar}
+                             {:name "ports" :role "*" :ranges [{:begin 10000 :end 20000}] :type :value-ranges}]}
+                "45cb7812-1233-4546-888d-67cc13eac398"
+                {:id {:value "45cb7812-1233-4546-888d-67cc13eac398"}
+                 :slave-id {:value "a5cb3212-3023-4546-888d-67cc13eac3dd"}
+                 :hostname "hostb"
+                 :resources [{:name "cpus" :role "*" :scalar 5 :type :value-scalar}
+                             {:name "mem" :role "*" :scalar 50000 :type :value-scalar}
+                             {:name "ports" :role "*" :ranges [{:begin 20001 :end 30000}] :type :value-ranges}]}
+                }
+               :task-id->task {}}
+        new-state (mm/handle-action! :decline offer-id state nil (noop-mock-scheduler))]
+    (is (= (count (:offer-id->offer new-state)) 1))
+    (is (= (get-in new-state [:slave-id->host "a5cb3212-3023-4546-888d-67cc13eac3dd"])
+           {:hostname "hostb"
+            :attributes {}
+            :resources {:cpus {"*" 12}
+                        :mem {"*" 120000}
+                        :ports {"*" [{:begin 10000 :end 30000}]}}
+            :available-resources {:cpus {"*" 7}
+                                  :mem {"*" 70000}
+                                  :ports {"*" [{:begin 10000 :end 20000}]}}
+            :slave-id "a5cb3212-3023-4546-888d-67cc13eac3dd"}))))
+
+(deftest handle-kill-action
+  (let [task-id "45cb7812-1233-4546-888d-67cc13eac398"
+        state {:slave-id->host
+               {"e8ab3892-3023-4546-888d-67cc13eac3cc"
+                {:hostname "hosta"
+                 :attributes {}
+                 :resources {:cpus {"*" 10}
+                             :mem {"*" 100000}
+                             :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :available-resources {:cpus {"*" 10}
+                                       :mem {"*" 100000}
+                                       :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :slave-id "e8ab3892-3023-4546-888d-67cc13eac3cc"}
+
+                "a5cb3212-3023-4546-888d-67cc13eac3dd"
+                {:hostname "hostb"
+                 :attributes {}
+                 :resources {:cpus {"*" 12}
+                             :mem {"*" 120000}
+                             :ports {"*" [{:begin 10000 :end 30000}]}}
+                 :available-resources {:cpus {"*" 7}
+                                       :mem {"*" 70000}
+                                       :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :slave-id "a5cb3212-3023-4546-888d-67cc13eac3dd"}}
+               :offer-id->offer {}
+               :task-id->task
+               {task-id
+                {:task-id {:value task-id}
+                 :slave-id {:value "a5cb3212-3023-4546-888d-67cc13eac3dd"}
+                 :name "to-kill"
+                 :resources [{:name "cpus" :role "*" :scalar 5 :type :value-scalar}
+                             {:name "mem" :role "*" :scalar 50000 :type :value-scalar}
+                             {:name "ports" :role "*" :ranges [{:begin 20001 :end 30000}] :type :value-ranges}]
+                 :labels {}
+                 :data ""}}}
+        new-state (mm/handle-action! :kill-task task-id state nil (noop-mock-scheduler))]
+    (is (= (count (:task-id->task new-state)) 0))
+    (is (= (get-in new-state [:slave-id->host "a5cb3212-3023-4546-888d-67cc13eac3dd"])
+           {:hostname "hostb"
+            :attributes {}
+            :resources {:cpus {"*" 12}
+                        :mem {"*" 120000}
+                        :ports {"*" [{:begin 10000 :end 30000}]}}
+            :available-resources {:cpus {"*" 12}
+                                  :mem {"*" 120000}
+                                  :ports {"*" [{:begin 10000 :end 30000}]}}
+            :slave-id "a5cb3212-3023-4546-888d-67cc13eac3dd"}))))
+
+
+(deftest handle-launch-action
+  (let [tasks [{:task-id {:value "45cb7812-1233-4546-888d-67cc13eac398"}
+                :slave-id {:value "a5cb3212-3023-4546-888d-67cc13eac3dd"}
+                :name "to-launch"
+                :command {:value "10000"
+                          :environment {}
+                          :user "user-A"
+                          :uris []}
+                :resources [{:name "cpus" :role "*" :scalar 8 :type :value-scalar}
+                            {:name "mem" :role "*" :scalar 80000 :type :value-scalar}
+                            {:name "ports" :role "*" :ranges [{:begin 12001 :end 25000}] :type :value-ranges}]
+                :labels {}
+                :data nil}]
+        tasks (map (comp mesos-types/pb->data (partial mesos-types/->pb :TaskInfo)) tasks)
+        offer-ids ["8fe5bf6c-ea39-4700-b1f6-9fd8a0271d7c" "45cb7812-1233-4546-888d-67cc13eac398"]
+        state {:config {:task->runtime-ms mm/default-task->runtime-ms}
+               :slave-id->host
+               {"e8ab3892-3023-4546-888d-67cc13eac3cc"
+                {:hostname "hosta"
+                 :attributes {}
+                 :resources {:cpus {"*" 10}
+                             :mem {"*" 100000}
+                             :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :available-resources {:cpus {"*" 10}
+                                       :mem {"*" 100000}
+                                       :ports {"*" [{:begin 10000 :end 20000}]}}
+                 :slave-id "e8ab3892-3023-4546-888d-67cc13eac3cc"}
+
+                "a5cb3212-3023-4546-888d-67cc13eac3dd"
+                {:hostname "hostb"
+                 :attributes {}
+                 :resources {:cpus {"*" 12}
+                             :mem {"*" 120000}
+                             :ports {"*" [{:begin 10000 :end 30000}]}}
+                 :available-resources {:cpus {}
+                                       :mem {}
+                                       :ports {}}
+                 :slave-id "a5cb3212-3023-4546-888d-67cc13eac3dd"}}
+               :offer-id->offer
+               {"8fe5bf6c-ea39-4700-b1f6-9fd8a0271d7c"
+                {:id {:value "8fe5bf6c-ea39-4700-b1f6-9fd8a0271d7c"}
+                 :slave-id {:value "a5cb3212-3023-4546-888d-67cc13eac3dd"}
+                 :hostname "hostb"
+                 :resources [{:name "cpus" :role "*" :scalar 7 :type :value-scalar}
+                             {:name "mem" :role "*" :scalar 70000 :type :value-scalar}
+                             {:name "ports" :role "*" :ranges [{:begin 10000 :end 20000}] :type :value-ranges}]}
+                "45cb7812-1233-4546-888d-67cc13eac398"
+                {:id {:value "45cb7812-1233-4546-888d-67cc13eac398"}
+                 :slave-id {:value "a5cb3212-3023-4546-888d-67cc13eac3dd"}
+                 :hostname "hostb"
+                 :resources [{:name "cpus" :role "*" :scalar 5 :type :value-scalar}
+                             {:name "mem" :role "*" :scalar 50000 :type :value-scalar}
+                             {:name "ports" :role "*" :ranges [{:begin 20001 :end 30000}] :type :value-ranges}]}}
+               :task-id->task {}}
+        new-state (mm/handle-action! :launch {:tasks tasks :offer-ids offer-ids} state nil (noop-mock-scheduler))]
+    (is (= (count (:offer-id->offer new-state)) 0))
+    (is (= (count (:task-id->task new-state)) 1))
+    (is (= (get-in new-state [:slave-id->host "a5cb3212-3023-4546-888d-67cc13eac3dd"])
+           {:hostname "hostb"
+            :attributes {}
+            :resources {:cpus {"*" 12}
+                        :mem {"*" 120000}
+                        :ports {"*" [{:begin 10000 :end 30000}]}}
+            :available-resources {:cpus {"*" 4.0}
+                                  :mem {"*" 40000.0}
+                                  :ports {"*" [{:begin 10000 :end 12000} {:begin 25001 :end 30000}]}}
+            :slave-id "a5cb3212-3023-4546-888d-67cc13eac3dd"}))))
+
+(defn make-random-host
+  [& {:keys [mem cpus ports uuid slave-id hostname attributes]
+      :or {mem {"*" 12000}
+           cpus {"*" 24}
+           ports {"*" [{:begin 0 :end 1000}]}
+           uuid (str (java.util.UUID/randomUUID))
+           slave-id (str (java.util.UUID/randomUUID))
+           attributes {}}}]
+  {:hostname (or hostname slave-id)
+   :attributes attributes
+   :resources {:cpus cpus
+               :mem mem
+               :ports ports}
+   :slave-id slave-id})
+
+(defn poll-until
+  "Polls `pred` every `interval-ms` and checks if it is true.
+   If true, returns. Otherwise, `poll-until` will wait
+   up to `max-wait-ms` at which point `poll-until` returns raises an exception"
+  [pred interval-ms max-wait-ms]
+  (let [start-ms (.getTime (java.util.Date.))]
+    (loop []
+      (when-not (pred)
+        (if (< (.getTime (java.util.Date.)) (+ start-ms max-wait-ms))
+          (recur)
+          (throw (ex-info "pred not true" {:interval-ms interval-ms
+                                           :max-wait-ms max-wait-ms})))))))
+
+(deftest mesos-driver-mock-offers
+  (testing "offers sent and received"
+    (let [registered-atom (atom false)
+          offer-atom (atom [])
+          scheduler (mesos/scheduler
+                      (registered [this driver framework-id master-info]
+                                  (reset! registered-atom true))
+                      (resource-offers [this driver offers]
+                                       (swap! offer-atom into offers )))
+          host (make-random-host)
+          speed-multiplier 20
+          mock-driver (mm/mesos-driver-mock [host] speed-multiplier scheduler)]
+      (mesos/start! mock-driver)
+      (poll-until #(= (count @offer-atom) 1) 20 600)
+      (mesos/stop! mock-driver)
+      (is @registered-atom)
+      (is (= (count @offer-atom) 1))
+      (is (= (get-in (first @offer-atom) [:slave-id :value]) (:slave-id host)))))
+  (testing "offers received, declined and received again"
+    (let [registered-atom (atom false)
+          offer-atom (atom [])
+          scheduler (mesos/scheduler
+                      (registered [this driver framework-id master-info]
+                                  (reset! registered-atom true))
+                      (resource-offers [this driver offers]
+                                       (log/debug offers)
+                                       ;; We want to make sure the offer, decline, re-offer loop works
+                                       ;; but it gets confusing if we go through the cycle more than once
+                                       (when-not (seq @offer-atom)
+                                         (async/thread
+                                           (doseq [offer offers]
+                                             (try
+                                               (mesos/decline-offer driver (:id offer))
+                                               (catch Exception ex
+                                                 (log/error ex))))))
+                                       (swap! offer-atom into offers)))
+          hosts [(make-random-host)]
+          speed-multiplier 20
+          mock-driver (mm/mesos-driver-mock hosts speed-multiplier scheduler)]
+      (mesos/start! mock-driver)
+      (poll-until #(= (count @offer-atom) 2) 20 600)
+      (mesos/stop! mock-driver)
+      (is @registered-atom)
+      (is (= (count @offer-atom) 2))))
+  (testing "offers received, declined and received again, multiple hosts"
+    (let [registered-atom (atom false)
+          offer-atom (atom [])
+          scheduler (mesos/scheduler
+                      (registered [this driver framework-id master-info]
+                                  (reset! registered-atom true))
+                      (resource-offers [this driver offers]
+                                       (log/debug offers)
+                                       ;; We want to make sure the offer, decline, re-offer loop works
+                                       ;; but it gets confusing if we go through the cycle more than once
+                                       (when-not (seq @offer-atom)
+                                         (async/thread
+                                           (doseq [offer offers]
+                                             (try
+                                               (mesos/decline-offer driver (:id offer))
+                                               (catch Exception ex
+                                                 (log/error ex))))))
+                                       (swap! offer-atom into offers)))
+          hosts [(make-random-host) (make-random-host) (make-random-host)]
+          speed-multiplier 20
+          mock-driver (mm/mesos-driver-mock hosts speed-multiplier scheduler)]
+      (mesos/start! mock-driver)
+      (poll-until #(= (count @offer-atom) 6) 20 1000)
+      (mesos/stop! mock-driver)
+      (is @registered-atom)
+      (is (= (count @offer-atom) 6)))))
+
+(defn random-task
+  [& {:keys [task-id slave-id name command-str env user uris mem cpus ports labels data]
+      :or {task-id (str (java.util.UUID/randomUUID))
+           slave-id (str (java.util.UUID/randomUUID))
+           name "my-cool-job"
+           command-str "50"
+           env {}
+           user "user-a"
+           uris []
+           mem {"*" 1000}
+           cpus {"*" 2}
+           ports {"*" [{:begin 1 :end 100}]}
+           labels {}
+           data nil}}]
+  (let [make-scalar-resources (fn [name [role scalar]]
+                                {:name name :role role :scalar scalar :type :value-scalar})
+        make-ranges-resources (fn [name [role ranges]]
+                                {:name name :role role :ranges ranges :type :value-ranges})
+        resources (concat (map (partial make-scalar-resources "cpus") cpus)
+                          (map (partial make-scalar-resources "mem") mem)
+                          (map (partial make-ranges-resources "ports") ports))]
+    {:task-id {:value task-id}
+     :slave-id {:value slave-id}
+     :name name
+     :command {:value command-str
+               :environment env
+               :user user
+               :uris uris}
+     :resources resources
+     :labels labels
+     :data data}))
+
+(deftest mesos-driver-mock-launch
+  ;; Note, both loading classes and jit-ing mesomatic files takes a long time
+  ;; which can cause tests to fail if they rely on tight
+  ;; timing assumptions and are only run once...
+  (testing "basic launch task"
+    (let [registered-atom (atom false)
+          launched-atom (atom [])
+          task-running-atom (atom [])
+          task-complete-atom (atom [])
+          atom-map {:registered-atom registered-atom
+                    :launched-atom launched-atom
+                    :task-running-atom task-running-atom
+                    :task-complete-atom task-complete-atom}]
+      (try
+        (let [slave-id (str (java.util.UUID/randomUUID))
+              cpus {"*" 2}
+              mem {"*" 1000}
+              ports {"*" [{:begin 1 :end 100}]}
+              task (random-task :mem mem :cpus cpus :ports ports :slave-id slave-id)
+              scheduler (mesos/scheduler
+                          (registered [this driver framework-id master-info]
+                                      (reset! registered-atom true))
+                          (resource-offers [this driver offers]
+                                           (log/info {:offers offers :count (count offers) :id (map :id offers)})
+                                           (when (seq offers)
+                                             (when (= (count @launched-atom) 0)
+                                               (swap! launched-atom conj (:task-id task))
+                                               (mesos/launch-tasks! driver
+                                                                    (map :id offers)
+                                                                    [task]))))
+                          (status-update [this driver status]
+                                         (log/info "Status update:" status)
+                                         (condp = (:state status)
+                                           :task-finished (swap! task-complete-atom conj (-> status :task-id :value))
+                                           :task-running (swap! task-running-atom conj (-> status :task-id :value))
+                                           (throw (ex-info "Unexpected status sent" {:status status})))))
+              hosts [(make-random-host :mem mem :cpus cpus :ports ports :slave-id slave-id)]
+              speed-multiplier 20
+              mock-driver (mm/mesos-driver-mock hosts speed-multiplier scheduler)]
+          (mesos/start! mock-driver)
+          (poll-until #(= (count @task-complete-atom) 1) 20 1000)
+          (log/warn "Calling stop")
+          (mesos/stop! mock-driver)
+          (is @registered-atom)
+          (is (= (count @launched-atom) 1))
+          (is (= (count @task-running-atom) 1))
+          (is (= (count @task-complete-atom) 1)))
+        (catch Throwable t
+          (throw (ex-info "Error while testing launch" atom-map t))))))
+  (testing "launch task"
+    (let [registered-atom (atom false)
+          launched-atom (atom [])
+          task-running-atom (atom [])
+          task-complete-atom (atom [])
+          atom-map {:registered-atom registered-atom
+                    :launched-atom launched-atom
+                    :task-running-atom task-running-atom
+                    :task-complete-atom task-complete-atom}]
+      (try
+        (let [slave-id (str (java.util.UUID/randomUUID))
+              cpus {"*" 2}
+              mem {"*" 1000}
+              ports {"*" [{:begin 1 :end 100}]}
+              task-a (random-task :mem mem :cpus cpus :ports ports :slave-id slave-id)
+              task-b (random-task :mem mem :cpus cpus :ports ports :slave-id slave-id)
+              scheduler (mesos/scheduler
+                          (registered [this driver framework-id master-info]
+                                      (reset! registered-atom true))
+                          (resource-offers [this driver offers]
+                                           (log/info {:offers offers :count (count offers) :id (map :id offers)})
+                                           (when (seq offers)
+                                             (when-let [task (condp = (count @launched-atom)
+                                                               0 task-a
+                                                               1 task-b
+                                                               2 nil)]
+                                               (log/info "Want to schedule task" {:task task})
+                                               (swap! launched-atom conj (:task-id task))
+                                               (log/info "Sending launch to mesos")
+                                               (mesos/launch-tasks! driver
+                                                                    (map :id offers)
+                                                                    [task]))))
+                          (status-update [this driver status]
+                                         (log/info "Status update:" status)
+                                         (condp = (:state status)
+                                           :task-finished (swap! task-complete-atom conj (-> status :task-id :value))
+                                           :task-running (swap! task-running-atom conj (-> status :task-id :value))
+                                           (throw (ex-info "Unexpected status sent" {:status status})))))
+              hosts [(make-random-host :mem mem :cpus cpus :ports ports :slave-id slave-id)]
+              speed-multiplier 20
+              mock-driver (mm/mesos-driver-mock hosts speed-multiplier scheduler)]
+          (mesos/start! mock-driver)
+          (poll-until #(= (count @task-complete-atom) 2) 20 1000)
+          (mesos/stop! mock-driver)
+          (is @registered-atom)
+          (is (= (count @launched-atom) 2))
+          (is (= (count @task-running-atom) 2))
+          (is (= (count @task-complete-atom) 2)))
+        (catch Throwable t
+          (throw (ex-info "Error while testing launch" atom-map t)))))))
+
+
+(deftest mesos-driver-mock-kill
+  (testing "kill task"
+    (let [registered-atom (atom false)
+          offer-atom (atom [])
+          launched-atom (atom [])
+          task-running-atom (atom [])
+          task-complete-atom (atom [])
+          atom-map {:registered-atom registered-atom
+                    :offer-atom offer-atom
+                    :launched-atom launched-atom
+                    :task-running-atom task-running-atom
+                    :task-complete-atom task-complete-atom}]
+      (try
+        (let [slave-id (str (java.util.UUID/randomUUID))
+              cpus {"*" 2}
+              mem {"*" 1000}
+              ports {"*" [{:begin 1 :end 100}]}
+              task (random-task :mem mem :cpus cpus :ports ports :slave-id slave-id)
+              scheduler (mesos/scheduler
+                          (registered [this driver framework-id master-info]
+                                      (reset! registered-atom true))
+                          (resource-offers [this driver offers]
+                                           (log/info {:offers offers :count (count offers) :id (map :id offers)})
+                                           (when (seq offers)
+                                             (when (< (count @launched-atom) 1)
+                                               (swap! launched-atom conj (:task-id task))
+                                               (mesos/launch-tasks! driver
+                                                                    (map :id offers)
+                                                                    [task]))
+                                             (swap! offer-atom into offers)))
+                          (status-update [this driver status]
+                                         (log/info "Status update:" status)
+                                         (condp = (:state status)
+                                           :task-killed (swap! task-complete-atom conj (-> status :task-id :value))
+                                           :task-running (let [task-id (-> status :task-id :value)]
+                                                           (is (= (:value (:task-id task)) task-id))
+                                                           (log/info "killing " task-id)
+                                                           (mesos/kill-task! driver {:value task-id})
+                                                           (swap! task-running-atom conj task-id))
+                                           (throw (ex-info "Unexpected status sent" {:status status})))))
+              hosts [(make-random-host :mem mem :cpus cpus :ports ports :slave-id slave-id)]
+              speed-multiplier 20
+              mock-driver (mm/mesos-driver-mock hosts speed-multiplier scheduler)]
+          (mesos/start! mock-driver)
+          (poll-until #(= (count @offer-atom) 2) 20 1000)
+          (log/warn "Calling stop")
+          (mesos/stop! mock-driver)
+          (is @registered-atom)
+          (is (= (count @offer-atom) 2))
+          (is (= (count @launched-atom) 1))
+          (is (= (count @task-running-atom) 1))
+          (is (= (count @task-complete-atom) 1)))
+        (catch Throwable t
+          (throw (ex-info "Error while testing launch" atom-map t)))))))
+
+(defn setup-test-curator-framework
+  ([]
+   (setup-test-curator-framework 2282))
+  ([zk-port]
+   ;; Copied from src/cook/components
+   ;; TODO: don't copy from components
+   (let [retry-policy (BoundedExponentialBackoffRetry. 100 120000 10)
+         ;; The 180s session and 30s connection timeouts were pulled from a google group
+         ;; recommendation
+         zookeeper-server (org.apache.curator.test.TestingServer. zk-port false)
+         zk-str (str "localhost:" zk-port)
+         curator-framework (CuratorFrameworkFactory/newClient zk-str 180000 30000 retry-policy)
+         ]
+     (.start zookeeper-server)
+     (.. curator-framework
+         getConnectionStateListenable
+         (addListener (reify ConnectionStateListener
+                        (stateChanged [_ client newState]
+                          (log/info "Curator state changed:"
+                                    (str newState))))))
+     (.start curator-framework)
+     [zookeeper-server curator-framework])))
+
+(defmacro with-cook-scheduler
+  [conn make-mesos-driver-fn
+   {:keys [get-mesos-utilization mesos-datomic-mult zk-prefix offer-incubate-time-ms
+           mea-culpa-failure-limit task-constraints riemann-host riemann-port
+           mesos-pending-jobs-atom gpu-enabled? rebalancer-config fenzo-config]
+    :or {get-mesos-utilization (fn [] 0.9) ; can get this from mesos mock later
+         zk-prefix "/cook"
+         offer-incubate-time-ms 1000
+         mea-culpa-failure-limit 5
+         task-constraints {:timeout-hours 1
+                           :timeout-interval-minutes 1
+                           :memory-gb 48
+                           :cpus 6
+                           :retry-limit 5}
+         riemann-host nil
+         riemann-port nil
+         gpu-enabled? false
+         rebalancer-config {:interval-seconds 5
+                            :dru-scale 1.0
+                            :min-utilization-threshold 0.0
+                            :safe-dru-threshold 1.0
+                            :min-dru-diff 0.5
+                            :max-preemption 100.0}
+         fenzo-config {:fenzo-max-jobs-considered 200
+                       :fenzo-scaleback 0.95
+                       :fenzo-floor-iterations-before-warn 10
+                       :fenzo-floor-iterations-before-reset 1000
+                       :good-enough-fitness 0.8}}
+    :as config}
+   & body]
+  `(let [[zookeeper-server# curator-framework#] (setup-test-curator-framework)
+         mesos-mult# (or ~mesos-datomic-mult (async/mult (async/chan)))
+         pending-jobs-atom# (or ~mesos-pending-jobs-atom (atom []))]
+     (try
+       (let [scheduler# (c/start-mesos-scheduler ~make-mesos-driver-fn ~get-mesos-utilization
+                                                 curator-framework# ~conn
+                                                 mesos-mult# ~zk-prefix
+                                                 ~offer-incubate-time-ms ~mea-culpa-failure-limit
+                                                 ~task-constraints ~riemann-host ~riemann-port
+                                                 pending-jobs-atom# ~gpu-enabled?
+                                                 ~rebalancer-config ~fenzo-config)]
+         ~@body)
+       (finally
+         (.close curator-framework#)
+         (.stop zookeeper-server#)
+         ;; TODO: Ensure cook scheduler shuts down fully
+         ))))
+
+(defn dump-jobs-to-csv
+  "Given a mesos db, dump a csv with a row per task
+
+   Rows:
+    * job_id
+    * instance_id
+    * start_time
+    * end_time
+    * hostname
+    * slave_id
+    * status"
+  [db file]
+  (let [tasks (d/q '[:find ?i ?task-id
+                     :where
+                     [?i :instance/task-id ?task-id]]
+                   db)
+        headers ["job_id" "instance_id" "start_time_ms"
+                 "end_time_ms" "hostname" "slave_id" "status"]
+        tasks (for [[task-ent-id task-id] tasks
+                    :let [task (d/entity db task-ent-id)]]
+                {"job_id" (:job/uuid (:job/_instance task))
+                 "instance_id" task-id
+                 "start_time_ms" (.getTime (:instance/start-time task))
+                 "end_time_ms" (.getTime (or (:instance/end-time task) (java.util.Date.)))
+                 "status" (:instance/status task)
+                 "hostname" (:instance/hostname task)
+                 "slave_id" (:instance/slave-id task)})]
+    (with-open [out-file (io/writer file)]
+      (csv/write-csv out-file
+                     (concat [headers]
+                             (map #(vals (select-keys % headers)) tasks))))))
+
+(deftest cook-scheduler-integration
+  ;; This tests the the case where one user has all the resources in the cluster
+  ;; and then another user shows up which causes the scheduler to preempt jobs
+  ;; so both may run.
+  ;; TODO: Explicitly check that both users have ~same resources instead of
+  ;;       simply checking that the first user had some jobs preempted
+  (testing "basic scheduling / rebalancing test"
+    (let [mesos-datomic-conn (restore-fresh-database! (str (gensym "datomic:mem://mock-mesos")))
+          mem 2000.0
+          cpus 2.0
+          ports [{:begin 1 :end 100}]
+          num-hosts 10
+          hosts (for [_ (range num-hosts)]
+                  (make-random-host :mem {"*" mem} :cpus {"*" cpus} :ports {"*" ports}))
+          speed-multiplier 20
+          make-mesos-driver-fn (fn [scheduler _];; _ is framework-id
+                                 (mm/mesos-driver-mock hosts speed-multiplier scheduler))]
+      (with-cook-scheduler mesos-datomic-conn make-mesos-driver-fn {}
+        (share/set-share! mesos-datomic-conn "default" :mem mem :cpus cpus :gpus 1.0)
+        ;; Note these two vars are lazy, need to realize to put them in db.
+        (let [user-a-job-ent-ids (for [_ (range 20)]
+                                   (create-dummy-job mesos-datomic-conn
+                                                     :user "a"
+                                                     :command "10000"
+                                                     :custom-executor? false
+                                                     :memory mem
+                                                     :ncpus cpus))
+
+              user-b-job-ent-ids (for [_ (range 5)]
+                                   (create-dummy-job mesos-datomic-conn
+                                                     :user "b"
+                                                     :command "1000"
+                                                     :custom-executor? false
+                                                     :memory mem
+                                                     :ncpus cpus))
+              update-status-error-ms 500]
+          ;; Transact user "a"s jobs
+          (doall user-a-job-ent-ids)
+          ;; Let them get scheduled
+          (Thread/sleep 5000)
+          ;; Transact user "b"s jobs
+          (doall user-b-job-ent-ids)
+          ;; Let the system complete
+          (poll-until (fn [] (every? (comp #(= (:job/state %) :job.state/completed)
+                                           (partial d/entity (d/db mesos-datomic-conn)))
+                                     user-a-job-ent-ids))
+                      500
+                      60000)
+          ;; Expect all jobs to run and complete, expect some of user "a"s jobs
+          ;; to be preempted
+          (let [job-ents (map (partial d/entity (d/db mesos-datomic-conn)) user-a-job-ent-ids)]
+            (is (some #(= (:reason/name (:instance/reason %)) :preempted-by-rebalancer) (mapcat :job/instance job-ents)))
+            (doseq [job-ent job-ents]
+              (let [instances (:job/instance job-ent)]
+                (is (= (:job/state job-ent) :job.state/completed))
+                (doseq [instance instances]
+                  (is (or (= (:instance/status instance) :instance.status/success)
+                          (= (:reason/name (:instance/reason instance)) :preempted-by-rebalancer)))
+                  (when (= (:instance/status instance) :instance.status/success)
+                    (is (< 0
+                           (- (.getTime (:instance/end-time instance))
+                              (.getTime (:instance/start-time instance))
+                              (read-string (:job/command job-ent)))
+                           update-status-error-ms)))))))
+          (doseq [job-ent-id user-b-job-ent-ids]
+            (let [job-ent (d/entity (d/db mesos-datomic-conn) job-ent-id)
+                  instances (:job/instance job-ent)
+                  instance (first instances)]
+              (is (= (count instances) 1))
+              (is (= (:job/state job-ent) :job.state/completed ))
+              (log/info "job i: " (d/touch job-ent))
+              (is (< 0
+                     (- (.getTime (:instance/end-time instance))
+                        (.getTime (:instance/start-time instance))
+                        (read-string (:job/command job-ent)))
+                     update-status-error-ms))))
+          (dump-jobs-to-csv (d/db mesos-datomic-conn) "trace-basic-scheduling-rebalancing-test.csv")
+          (when (log/enabled? :debug)
+            (dump-jobs-to-csv (d/db mesos-datomic-conn) "trace-basic-scheduling-rebalancing-test.csv")))))))


### PR DESCRIPTION
This PR includes a mock of mesos and a simulator that starts the scheduling aspects of cook to allow back testing and auditing behavior. The mock of mesos allows us to simulate arbitrarily large clusters (until computation or memory limits on the machine running the simulation are reached). The intent is this simulator will be run "faster than real time" so that running over a day or week of historical jobs can be done in minutes and hours.