### PR TITLE
Avoids lein deps when project.clj hasn't changed

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -6,21 +6,29 @@ RUN apt-get -y install curl
 # Env setup
 ENV HOME "/root/"
 ENV LEIN_ROOT true
-
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
 
-# Lein Setup
+# Lein setup
 RUN mkdir $HOME/bin
 ENV PATH $PATH:$HOME/bin
 RUN curl -o $HOME/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
 RUN chmod a+x $HOME/bin/lein
 RUN lein
 
+# Create and set the cook dir
 RUN mkdir -p /opt/cook
 WORKDIR /opt/cook
-COPY . /opt/cook
+
+# Fetch dependencies
+## Only copy the project.clj so that we can use the cached layer
+## with fetched dependencies as long as project.clj isn't modified
+COPY project.clj /opt/cook
 RUN lein deps
 
+# Copy everything
+COPY . /opt/cook
+
+# Run cook
 EXPOSE 12321
 ENTRYPOINT ["lein", "run"]
 CMD ["container-config.edn"]

--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -9,8 +9,17 @@ if [ "$(docker ps -aq -f name=${NAME})" ]; then
 fi
 
 $(minimesos info | grep ZOOKEEPER)
+EXIT_CODE=$?
+if [ ${EXIT_CODE} -eq 0 ]
+then
+    ZK=${MINIMESOS_ZOOKEEPER%;}
+    echo "ZK = ${ZK}"
+else
+    echo "Could not get ZK URI from minimesos; you may need to restart minimesos"
+    exit ${EXIT_CODE}
+fi
 
-ZK=${MINIMESOS_ZOOKEEPER%;}
+echo "Starting cook..."
 docker run \
     -i \
     -t \


### PR DESCRIPTION
This makes building the docker image much faster when you haven't changed `project.clj`.