### PR TITLE
Explicitly configures :mesos :master-hosts

### DIFF
--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -8,12 +8,13 @@ if [ "$(docker ps -aq -f name=${NAME})" ]; then
     docker rm ${NAME}
 fi
 
-$(minimesos info | grep ZOOKEEPER)
+$(minimesos info | grep MINIMESOS)
 EXIT_CODE=$?
 if [ ${EXIT_CODE} -eq 0 ]
 then
     ZK=${MINIMESOS_ZOOKEEPER%;}
     echo "ZK = ${ZK}"
+    echo "MINIMESOS_MASTER_IP = ${MINIMESOS_MASTER_IP}"
 else
     echo "Could not get ZK URI from minimesos; you may need to restart minimesos"
     exit ${EXIT_CODE}
@@ -29,6 +30,7 @@ docker run \
     --publish=12321:12321 \
     -e "COOK_PORT=12321" \
     -e "MESOS_MASTER=${ZK}" \
+    -e "MESOS_MASTER_HOST=${MINIMESOS_MASTER_IP}" \
     -v ${DIR}/../log:/opt/cook/log \
     cook-scheduler:latest
 

--- a/scheduler/container-config.edn
+++ b/scheduler/container-config.edn
@@ -12,6 +12,7 @@
                                 :cpus 6}}
  :rebalancer {:dru-scale 1}
  :mesos {:master #config/env "MESOS_MASTER"
+         :master-hosts [#config/env "MESOS_MASTER_HOST"]
          :failover-timeout-ms nil ; When we close the instance of Cook, all its tasks are killed by Mesos
          :leader-path "/cook-scheduler"}
  :unhandled-exceptions {:log-level :error}


### PR DESCRIPTION
Without this, cook will attempt to derive `mesos-master-hosts` from `:mesos` `:master`, which in the case of our minimesos setup, is incorrect, and causes:

```bash
2017-04-21 21:16:05,589 INFO  cook.mesos.rebalancer [async-thread-macro-6] - Rebalance cycle starting
2017-04-21 21:16:05,651 ERROR cook.mesos.rebalancer [async-thread-macro-6] - Rebalance failed
java.net.ConnectException: Connection refused
```
