### PR TITLE
Adds optional flag to allow partial results when querying for jobs

### DIFF
--- a/integration/tests/cook/__init__.py
+++ b/integration/tests/cook/__init__.py
@@ -1,3 +1,3 @@
 import logging
 
-logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s', level=logging.INFO)
+logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s', level=logging.DEBUG)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -93,6 +93,11 @@ class CookTest(unittest.TestCase):
         self.assertEqual(2003, job['instances'][0]['reason_code'])
 
     def query_jobs(self, **kwargs):
+        """
+        Queries cook for a set of jobs, by job and/or instance uuid. The kwargs
+        passed to this function are sent straight through as query parameters on
+        the request.
+        """
         return self.session.get('%s/rawscheduler' % self.cook_url, params=kwargs)
 
     def get_job(self, job_uuid):

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1,3 +1,6 @@
+import uuid
+
+
 def get_in(dct, *keys):
     for key in keys:
         try:
@@ -5,3 +8,28 @@ def get_in(dct, *keys):
         except KeyError:
             return None
     return dct
+
+
+def is_valid_uuid(uuid_to_test, version=4):
+    """
+    Check if uuid_to_test is a valid UUID.
+    Parameters
+    ----------
+    uuid_to_test : str
+    version : {1, 2, 3, 4}
+    Returns
+    -------
+    `True` if uuid_to_test is a valid UUID, otherwise `False`.
+    Examples
+    --------
+    >>> is_valid_uuid('c9bf9e57-1685-4c89-bafb-ff5af830be8a')
+    True
+    >>> is_valid_uuid('c9bf9e58')
+    False
+    """
+    try:
+        uuid_obj = uuid.UUID(uuid_to_test, version=version)
+    except:
+        return False
+
+    return str(uuid_obj) == uuid_to_test

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -19,6 +19,7 @@
             [clj-http.client :as http]
             [clj-time.core :as t]
             [clojure.core.cache :as cache]
+            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk :refer (keywordize-keys)]
@@ -867,7 +868,7 @@
         [false {::error (str "UUID "
                              (str/join
                                \space
-                               (remove exists? jobs))
+                               (set/difference (set jobs) (set existing-jobs)))
                              " didn't correspond to a job")}]))))
 
 (defn check-job-params-present

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -850,7 +850,7 @@
                ::instances-requested instances}]
 
         (and allow-partial-results
-             (or (pos? existing-jobs)
+             (or (pos? (count existing-jobs))
                  (some some? instance-jobs)))
         [true {::jobs (into existing-jobs (filter some? instance-jobs))
                ::jobs-requested jobs

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -850,7 +850,7 @@
                ::instances-requested instances}]
 
         (and allow-partial-results
-             (or (> (count existing-jobs) 0)
+             (or (pos? existing-jobs)
                  (some some? instance-jobs)))
         [true {::jobs (into existing-jobs (filter some? instance-jobs))
                ::jobs-requested jobs

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -841,8 +841,7 @@
           instance-jobs (mapv instance-uuid->job-uuid instances)
           exists? #(job-exists? (db conn) %)]
       (cond
-        (and (not allow-partial-results)
-             (every? exists? jobs)
+        (and (every? exists? jobs)
              (every? some? instance-jobs))
         [true {::jobs (into jobs instance-jobs)
                ::jobs-requested jobs


### PR DESCRIPTION
We want to be able to query a particular cook cluster for a set of uuids, where some of them may not belong to that cluster, and get back the data for those that do match. This change allows for that, instead of always returning 404 if any of the uuids is invalid.
