### PR TITLE
Simulator: display additional info in logs

### DIFF
--- a/simulator/src/main/cook/sim/reporting.clj
+++ b/simulator/src/main/cook/sim/reporting.clj
@@ -72,19 +72,29 @@
                    ;; for now, each job can only belong to 1 group
                    first)]
     (job-result-validator
-     (merge
-      {:id job-id
-       :requested-at action-at
-       :name (:job/name sim-job)
-       :username (:job/username sim-job)
-       :details (into {} (d/touch cook-job))
-       :started-at started-at
-       :finished-at finished-at
-       :wait-time (when started-at (- started-at action-at))
-       :turnaround (when finished-at (- finished-at action-at))
-       :overhead (overhead-time sim-job action-at instances)
-       :instance-count (count instances)}
-      (when group {:group group})))))
+      (merge
+        {:id job-id
+         :requested-at action-at
+         :name (:job/name sim-job)
+         :username (:job/username sim-job)
+         :details (into {:instances (map (fn instance-detail [instance]
+                                           (let [instance' (d/touch instance)]
+                                             (try
+                                               (if-let [reason-id (-> instance' :instance/reason :db/id)]
+                                                 (let [reason-ent (->> reason-id (d/entity cook-db) d/touch)]
+                                                   (assoc instance' :instance/reason reason-ent))
+                                                 instance')
+                                               (catch Throwable e
+                                                 instance'))))
+                                         instances)}
+                        (d/touch cook-job))
+         :started-at started-at
+         :finished-at finished-at
+         :wait-time (when started-at (- started-at action-at))
+         :turnaround (when finished-at (- finished-at action-at))
+         :overhead (overhead-time sim-job action-at instances)
+         :instance-count (count instances)}
+        (when group {:group group})))))
 
 (defn warn-about-unscheduled
   "The only effect of this function is to print out to STDOUT (for the cli).
@@ -95,14 +105,13 @@
         unscheduled-count (count unscheduled-jobs)]
     (if (pos? unscheduled-count)
       (do
-        (println "Warning!  This simulation had " unscheduled-count
-                 " jobs that were never scheduled by Cook.")
+        (println "Warning!  This simulation had" unscheduled-count "jobs that were never scheduled by Cook.")
         (println "This could be because you are analyzing before the jobs had a chance to finish...")
-       (println "or it could mean that there's a problem with Cook,")
-       (println "or with the Simulator's ability to connect to Cook.")
-       (doseq [job unscheduled-jobs]
-         (println "Job" (:id job))
-         (println "details from Cook DB:" (:details job)))))))
+        (println "or it could mean that there's a problem with Cook,")
+        (println "or with the Simulator's ability to connect to Cook.")
+        (doseq [job unscheduled-jobs]
+          (println "Unscheduled job" (:id job))
+          (println "  details from Cook DB:" (:details job)))))))
 
 (defn unfinished-jobs
   "Given a collection of job-results, returns a filtered version that contains only
@@ -120,12 +129,12 @@
         unfinished-count (count unfinished)]
     (if (pos? unfinished-count)
       (do
-        (println "Warning!  This simulation had " unfinished-count " jobs that were started but never finished.")
+        (println "Warning!  This simulation had" unfinished-count "jobs that were started but never finished.")
         (println "This makes it so that some creativity must be used in order to present average turnaround/overhead time for the entire sim, or to do job-by-job performance comparisions against another sim.")
         (doseq [job unfinished]
-          (println "Job" (:id job))
-          ;;(println "details from Cook DB:" (:details job))
-          )))))
+          (println "Unfinished job:" (:id job))
+          (println "  details about job:" (dissoc job :details))
+          (println "  details from Cook DB:" (:details job)))))))
 
 (defn summarize-preemption
   "This function prints out to STDOUT (for the cli).
@@ -240,7 +249,7 @@
   at the start of each of the sims."
   [sim-db cook-db setting sim-ids]
   (map (fn [sim-id] (setting (preemption-settings-as-of-sim-start
-                              sim-db cook-db sim-id)))
+                               sim-db cook-db sim-id)))
        sim-ids))
 
 (defn add-line-for-cook-version
@@ -289,15 +298,15 @@
                           :legend true
                           :series-label "baseline")]
     (reduce
-     #(add-line-for-cook-version :sim-db sim-db
-                                 :cook-db cook-db
-                                 :baseline-sims baseline-sims
-                                 :sift-pred sift-pred
-                                 :metric metric
-                                 :knob knob
-                                 :chart %1
-                                 :compared-sims %2)
-     baseline-chart compared-sim-sets)))
+      #(add-line-for-cook-version :sim-db sim-db
+                                  :cook-db cook-db
+                                  :baseline-sims baseline-sims
+                                  :sift-pred sift-pred
+                                  :metric metric
+                                  :knob knob
+                                  :chart %1
+                                  :compared-sims %2)
+      baseline-chart compared-sim-sets)))
 
 
 (defn add-line-for-sim


### PR DESCRIPTION
Independent changes to declutter diff in cook-executor PR