### PR TITLE
Add job constraints

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -51,6 +51,12 @@ def retrieve_cook_url(varname='COOK_SCHEDULER_URL', value='http://localhost:1232
     return cook_url
 
 
+def retrieve_mesos_url(varname='MESOS_URL', value='http://localhost:5050'):
+    mesos_url = os.getenv(varname, value)
+    logger.info('Using mesos url %s' % mesos_url)
+    return mesos_url
+
+
 def is_connection_error(exception):
     return isinstance(exception, requests.exceptions.ConnectionError)
 
@@ -107,3 +113,9 @@ def query_jobs(cook_url, **kwargs):
     the request.
     """
     return session.get('%s/rawscheduler' % cook_url, params=kwargs)
+
+def get_mesos_state(mesos_url):
+    """
+    Queries the state.json from mesos
+    """
+    return session.get('%s/state.json' % mesos_url).json()

--- a/scheduler/docs/scheduler-rest-api.asc
+++ b/scheduler/docs/scheduler-rest-api.asc
@@ -80,6 +80,7 @@ The request body is list of job maps with each entry containing a map of the fol
 |`ports` | integer | Number of ports that should be opened for the job.
 |`uris` | list of URI objects | A list of URIs that will be fetched into the container before launch.
 |`env` | JSON map | A map of environment variables to be provided to the job.
+|`constraints` | list | list of constraints in form [attribute, operator, pattern]
 |`disable_mea_culpa_retries` | boolean | Flag to disable mea culpa retries. If true, mea culpa retries will count against the job's retry count.
 |====
 
@@ -113,12 +114,23 @@ The request body is list of job maps with each entry containing a map of the fol
                  "extract": true
              }
          ],
+         "constraints" : [["instance_type", "EQUALS", "r3.8xlarge"]],
          "command" : "echo hello world"
       }
    ]
 }
 ----
 
+===== Constraints
+
+Constraints provide controls over where a job is placed on the cluster. 
+There are both job and group level constraints.
+This will discuss job constraints, see the docs/groups.md for more details on group constraints.
+
+Constraints are specified as a tuple of attribute, operator, pattern.
+Attribute can be any attribute set on a host in the cluster.
+Cook currently only supports the EQUALS operator. In the future, we will add more operators.
+For the case of the EQUALS, Cook will only schedule a job on a host for which the attribute's value equals pattern.
 
 .Possible response codes
 [options="header"]

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -197,7 +197,7 @@
 (def Constraint
   "Schema for user defined job host constraint"
   [(s/one NonEmptyString "attribute")
-   (s/one (s/pred #(contains? (set (map (comp name util/without-ns) constraint-operators))
+   (s/one (s/pred #(contains? (set (map name constraint-operators))
                               (str/lower-case %))
                   'constraint-operator-exists?)
           "operator")
@@ -464,13 +464,12 @@
         constraints (mapcat (fn [[attribute operator pattern]]
                               (let [constraint-var-id (d/tempid :db.part/user)]
                                 [[:db/add db-id :job/constraint constraint-var-id]
-                                 (merge {:db/id constraint-var-id
-                                         :constraint/attribute attribute
-                                         :constraint/operator (keyword "constraint.operator"
-                                                                       (str/lower-case operator))}
-                                        (when pattern
-                                          {:constraint/pattern pattern}))]))
-                                 constraints)
+                                 {:db/id constraint-var-id
+                                  :constraint/attribute attribute
+                                  :constraint/operator (keyword "constraint.operator"
+                                                                (str/lower-case operator))
+                                  :constraint/pattern pattern}]))
+                            constraints)
         container (if (nil? container) [] (build-container user db-id container))
         ;; These are optionally set datoms w/ default values
         maybe-datoms (reduce into
@@ -770,7 +769,7 @@
                          :job/constraint
                          (map util/remove-datomic-namespacing)
                          (map (fn [{:keys [attribute operator pattern]}]
-                                (->> [attribute (str/upper-case (name (util/without-ns operator))) pattern]
+                                (->> [attribute (str/upper-case (name operator)) pattern]
                                      (map str)))))
         instances (map (fn [instance]
                          (let [hostname (:instance/hostname instance)

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -28,7 +28,7 @@
             [compojure.core :refer (ANY GET POST routes)]
             [cook.mesos.quota :as quota]
             [cook.mesos.reason :as reason]
-            [cook.mesos.schema :refer (host-placement-types straggler-handling-types constraint-operators)]
+            [cook.mesos.schema :refer (constraint-operators host-placement-types straggler-handling-types)]
             [cook.mesos.share :as share]
             [cook.mesos.unscheduled :as unscheduled]
             [cook.mesos.util :as util]
@@ -198,10 +198,10 @@
   "Schema for user defined job host constraint"
   [(s/one NonEmptyString "attribute")
    (s/one (s/pred #(contains? (set (map (comp name util/without-ns) constraint-operators))
-                              (clojure.string/lower-case %))
+                              (str/lower-case %))
                   'constraint-operator-exists?)
           "operator")
-   (s/optional NonEmptyString "pattern")])
+   (s/one NonEmptyString "pattern")])
 
 (s/defschema JobName
   (s/both s/Str (s/both s/Str (s/pred max-128-characters-and-alphanum? 'max-128-characters-and-alphanum?))))
@@ -467,7 +467,7 @@
                                  (merge {:db/id constraint-var-id
                                          :constraint/attribute attribute
                                          :constraint/operator (keyword "constraint.operator"
-                                                                       (clojure.string/lower-case operator))}
+                                                                       (str/lower-case operator))}
                                         (when pattern
                                           {:constraint/pattern pattern}))]))
                                  constraints)
@@ -770,8 +770,7 @@
                          :job/constraint
                          (map util/remove-datomic-namespacing)
                          (map (fn [{:keys [attribute operator pattern]}]
-                                (->> [attribute (clojure.string/upper-case (name (util/without-ns operator))) pattern]
-                                     (remove nil?)
+                                (->> [attribute (str/upper-case (name (util/without-ns operator))) pattern]
                                      (map str)))))
         instances (map (fn [instance]
                          (let [hostname (:instance/hostname instance)

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -17,7 +17,6 @@
   (:require [clojure.tools.logging :as log]
             [cook.mesos.group :as group]
             [cook.mesos.util :as util]
-            [plumbing.core :as pc]
             [swiss.arrows :refer :all])
   (:import com.netflix.fenzo.VirtualMachineLease))
 

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -133,8 +133,7 @@
                         (log/error (str "Unknown operator " operator
                                         " api.clj should have prevented this from happening."))
                         true))))
-          constraint->passes? (pc/map-from-keys vm-passes-constraint? constraints)
-          passes? (every? val constraint->passes?)]
+          passes? (every? vm-passes-constraint? constraints)]
       [passes? (when-not passes?
                  "Host doesn't pass at least one user supplied constraint.")]))
   (job-constraint-evaluate

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -232,7 +232,8 @@
                              :normal (dru/sorted-task-scored-task-pairs user->dru-divisors user->sorted-running-task-ents)
                              :gpu (dru/sorted-task-cumulative-gpu-score-pairs user->dru-divisors user->sorted-running-task-ents))
          task->scored-task (into (pm/priority-map-keyfn (case category
-                                                          :normal (comp - :dru)
+                                                          :normal (juxt (comp - :dru)
+                                                                        (comp util/task-ent->user :task))
                                                           :gpu (fnil - 0)))
                                  scored-task-pairs)]
      (->State task->scored-task

--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -73,6 +73,14 @@
     :db/cardinality :db.cardinality/many
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
+    :db/ident :job/constraint
+    :db/valueType :db.type/ref
+    :db/isComponent true
+    :db/cardinality :db.cardinality/many
+    :db/doc "A map of attribute to value patterns that constrain what hosts
+             a job may be placed on"
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
     :db/ident :job/state
     :db/valueType :db.type/ref
     :db/cardinality :db.cardinality/one
@@ -383,6 +391,29 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
+   ;; Host constraint attributes
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :constraint/attribute
+    :db/doc "Attribute of host to constrain on"
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :constraint/operator
+    :db/doc "Operator to use to evaulate pattern"
+    :db/valueType :db.type/ref
+    :db/isComponent true
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :constraint/pattern
+    :db/doc "Pattern that must pass on value of attribute for host to be valid
+             to place task on"
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/user)
+    :db/ident :constraint.operator/equals}
    ;; Application attributes
    {:db/id (d/tempid :db.part/db)
     :db/doc
@@ -700,6 +731,11 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
   (->> schema-attributes
        (map :db/ident)
        (filter #(= "host-placement.type" (namespace %)))))
+
+(def constraint-operators
+  (->> schema-attributes
+       (map :db/ident)
+       (filter #(= "constraint.operator" (namespace %)))))
 
 (def db-fns
   [{:db/id (d/tempid :db.part/user)

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1054,6 +1054,7 @@
                    :env {}
                    :instances ()
                    :labels {}
+                   :constraints []
                    :retries_remaining 1
                    :state "waiting"
                    :status "waiting"

--- a/scheduler/test/cook/test/mesos/constraints.clj
+++ b/scheduler/test/cook/test/mesos/constraints.clj
@@ -36,10 +36,16 @@
 (deftest test-user-defined-constraint
   (let [constraints [{:constraint/attribute "is_spot"
                       :constraint/operator :constraint.operator/equals
-                      :constraint/pattern "true"}]
+                      :constraint/pattern "true"}
+                     {:constraint/attribute "instance_type"
+                      :constraint/operator :constraint.operator/equals
+                      :constraint/pattern "mem.large"}]
         user-defined-constraint (constraints/->user-defined-constraint constraints)]
-    (is (= true (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "true"}))))
-    (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "false"}))))
+    (is (= true (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "true" "instance_type" "mem.large"}))))
+    (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "true" "instance_type" "cpu.large"}))))
+    (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "false" "instance_type" "mem.large"}))))
+    (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "true"}))))
+    (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {"instance_type" "mem.large"}))))
     (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {}))))))
 
 

--- a/scheduler/test/cook/test/mesos/constraints.clj
+++ b/scheduler/test/cook/test/mesos/constraints.clj
@@ -33,6 +33,15 @@
   (is (= "attribute-equals-host-placement-group-constraint"
          (constraints/group-constraint-name (constraints/->attribute-equals-host-placement-group-constraint nil)))))
 
+(deftest test-user-defined-constraint
+  (let [constraints [{:constraint/attribute "is_spot"
+                      :constraint/operator :constraint.operator/equals
+                      :constraint/pattern "true"}]
+        user-defined-constraint (constraints/->user-defined-constraint constraints)]
+    (is (= true (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "true"}))))
+    (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "false"}))))
+    (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {}))))))
+
 
 (deftest test-gpu-constraint
   (let [fid #mesomatic.types.FrameworkID{:value "my-framework-id"}

--- a/travis/minimesosFile
+++ b/travis/minimesosFile
@@ -2,7 +2,7 @@ minimesos {
     clusterName = "Cook Simulation Cluster"
     loggingLevel = "INFO"
     mapAgentSandboxVolume = true
-    mapPortsToHost = false
+    mapPortsToHost = true
     mesosVersion = "1.0.0"
     timeout = 60
 


### PR DESCRIPTION
This adds the ability to set constraints on individual jobs and provides a way to grow the constraints api in the future. It is inspired by marathon's constraint api: https://mesosphere.github.io/marathon/docs/constraints.html