### PR TITLE
Fixes race condition in test-read-chan

### DIFF
--- a/scheduler/test/cook/test/mesos/util.clj
+++ b/scheduler/test/cook/test/mesos/util.clj
@@ -249,8 +249,9 @@
     (is (= (count (util/read-chan ch 10)) 5))
     (is (= (count (util/read-chan ch 10)) 0))
     (async/<!! (async/onto-chan ch (range 10) false))
-    (async/onto-chan ch (range 10) false)
-    (is (= (count (util/read-chan ch 10)) 10))
-    (is (= (count (util/read-chan ch 10)) 10))))
+    (let [oc (async/onto-chan ch (range 10) false)]
+      (is (= (count (util/read-chan ch 10)) 10))
+      (async/<!! oc)
+      (is (= (count (util/read-chan ch 10)) 10)))))
 
 (comment (run-tests))


### PR DESCRIPTION
This test has a race condition, e.g.:

https://travis-ci.org/twosigma/Cook/jobs/242101623#L1147-L1149

I was able to reproduce the race locally. After this fix, I ran this in a `dotimes` 1000 with no fails.