### PR TITLE
Limit rebalancer jobs to consider to max preemptions

### DIFF
--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -383,8 +383,9 @@
    category is :normal or :gpu, depending on which type of job we're working with"
   [db offer-cache pending-job-ents host->spare-resources {:keys [max-preemption category] :as params}]
   (let [timer (timers/start rebalance-duration)
-        jobs-to-make-room-for (filter (partial util/job-allowed-to-start? db)
-                                      pending-job-ents)
+        jobs-to-make-room-for (->> pending-job-ents
+                                   (filter (partial util/job-allowed-to-start? db))
+                                   (take max-preemption))
         init-state (init-state db (util/get-running-task-ents db) jobs-to-make-room-for host->spare-resources category)]
     (log/debug "Jobs to make room for:" jobs-to-make-room-for)
     (loop [state init-state


### PR DESCRIPTION
Before this change, the rebalancer could potentially consider EVERY job in the queue for preemption. This would mean that a rebalance cycle could take many *minutes* and create a lot of garbage realizing all these preemption choices. When rebalancer cycles take minutes it means that the tasks that end up getting preempted are preempted on information from minutes ago and likely the jobs that room was being made for have already been scheduled.

This change limits the list to the total number of preemption choices the rebalancer is willing to make in a given cycle. It is possible that by not limiting the list Cook would preempt jobs not in the reduced list but that would mean Cook was preempting tasks to make room for a job far back in the queue which doesn't seem productive. 

This change will drastically reduce the long tail of rebalance cycles (by limiting the jobs to consider), reduce the amount of garbage it produces and reduce the amount of memory it must hold onto and the length of time to hold onto it.