### PR TITLE
Improve the performance of get-jobs-by-user-and-state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
- 
+
+## [unreleased] 
+### Changed
+- Optimized the query in the list endpoint to avoid an expensive datomic join, from @pschorf and @wyegelwel
+- Change the list endpoint time range to be inclusive on start, from @wyegelwel
+
 ## [1.4.0] - 2017-06-09
 ### Added
 - Added simulator to test scheduler performance, from @wyegelwel

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -134,7 +134,7 @@ class CookTest(unittest.TestCase):
         resp = util.session.post('%s/rawscheduler' % self.cook_url, json=request_body)
         self.assertEqual(resp.status_code, 201)
 
-        time.sleep(1)
+        time.sleep(5)
 
         request_body = {'jobs': [job_specs[1]]}
         resp = util.session.post('%s/rawscheduler' % self.cook_url, json=request_body)
@@ -147,7 +147,7 @@ class CookTest(unittest.TestCase):
         # start-ms and end-ms are exclusive
 
         # query where start-ms and end-ms are the submit times of jobs 1 & 2 respectively
-        resp = util.session.get('%s/list?user=%s&state=waiting&start-ms=%s&end-ms=%s'
+        resp = util.session.get('%s/list?user=%s&state=waiting%%2Brunning%%2Bcompleted&start-ms=%s&end-ms=%s'
                                 % (self.cook_url, user, submit_times[0] - 1, submit_times[1] + 1))
         self.assertEqual(200, resp.status_code)
         jobs = resp.json()
@@ -155,7 +155,7 @@ class CookTest(unittest.TestCase):
         self.assertTrue(any(job for job in jobs if job['uuid'] == job_specs[1]['uuid']))
 
         # query just for job 1
-        resp = util.session.get('%s/list?user=%s&state=waiting&start-ms=%s&end-ms=%s'
+        resp = util.session.get('%s/list?user=%s&state=waiting%%2Brunning%%2Bcompleted&start-ms=%s&end-ms=%s'
                                 % (self.cook_url, user, submit_times[0] - 1, submit_times[1]))
         self.assertEqual(200, resp.status_code)
         jobs = resp.json()
@@ -163,16 +163,16 @@ class CookTest(unittest.TestCase):
         self.assertFalse(any(job for job in jobs if job['uuid'] == job_specs[1]['uuid']))
 
         # query just for job 2
-        resp = util.session.get('%s/list?user=%s&state=waiting&start-ms=%s&end-ms=%s'
-                                % (self.cook_url, user, submit_times[0], submit_times[1] + 1))
+        resp = util.session.get('%s/list?user=%s&state=waiting%%2Brunning%%2Bcompleted&start-ms=%s&end-ms=%s'
+                                % (self.cook_url, user, submit_times[0]+1, submit_times[1] + 1))
         self.assertEqual(200, resp.status_code)
         jobs = resp.json()
         self.assertFalse(any(job for job in jobs if job['uuid'] == job_specs[0]['uuid']))
         self.assertTrue(any(job for job in jobs if job['uuid'] == job_specs[1]['uuid']))
 
         # query for neither
-        resp = util.session.get('%s/list?user=%s&state=waiting&start-ms=%s&end-ms=%s'
-                                % (self.cook_url, user, submit_times[0], submit_times[1]))
+        resp = util.session.get('%s/list?user=%s&state=waiting%%2Brunning%%2Bcompleted&start-ms=%s&end-ms=%s'
+                                % (self.cook_url, user, submit_times[0]+1, submit_times[1]))
         self.assertEqual(200, resp.status_code)
         jobs = resp.json()
         self.assertFalse(any(job for job in jobs if job['uuid'] == job_specs[0]['uuid']))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -325,6 +325,8 @@
                                      (log/info "Using kerberos middleware")
                                      (lazy-load-var 'cook.spnego/require-gss))
                                    :else (throw (ex-info "Missing authorization configuration" {}))))
+     :list-batch-period (fnk [[:config {list-batch-period-minutes (* 60 24)}]]
+                             (t/minutes list-batch-period-minutes))
      :rate-limit (fnk [[:config {rate-limit nil}]]
                    (let [{:keys [user-limit-per-m]
                           :or {user-limit-per-m 600}} rate-limit]

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1605,7 +1605,8 @@
                                                                                   user
                                                                                   %
                                                                                   start
-                                                                                  end)
+                                                                                  end
+                                                                                  limit)
                                                 states)))
                                       (sort-by :job/submit-time)
                                       reverse

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1535,7 +1535,7 @@
 (timers/deftimer [cook-scheduler handler list-endpoint])
 
 (defn list-resource
-  [db framework-id is-authorized-fn]
+  [db framework-id is-authorized-fn batch-period]
   (liberator/resource
    :available-media-types ["application/json"]
    :allowed-methods [:get]
@@ -1606,6 +1606,7 @@
                                                                                   %
                                                                                   start
                                                                                   end
+                                                                                  batch-period
                                                                                   limit)
                                                 states)))
                                       (sort-by :job/submit-time)
@@ -1674,7 +1675,9 @@
 ;;
 (defn main-handler
   [conn fid mesos-pending-jobs-fn
-   {:keys [task-constraints is-authorized-fn] gpu-enabled? :mesos-gpu-enabled :as settings}]
+   {:keys [task-constraints is-authorized-fn list-batch-period] 
+    gpu-enabled? :mesos-gpu-enabled
+    :as settings}]
   (->
    (routes
     (c-api/api
@@ -1819,7 +1822,7 @@
     (ANY "/running" []
          (running-jobs conn is-authorized-fn))
     (ANY "/list" []
-         (list-resource (db conn) fid is-authorized-fn)))
+         (list-resource (db conn) fid is-authorized-fn list-batch-period)))
    (format-params/wrap-restful-params {:formats [:json-kw]
                                        :handle-error c-mw/handle-req-error})
    (streaming-json-middleware)))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -245,7 +245,7 @@
                                     :in $ ?user ?state ?start ?end
                                     :where
                                     [?j :job/submit-time ?t]
-                                    [(< ?start ?t)]
+                                    [(<= ?start ?t)]
                                     [(< ?t ?end)]
                                     [?j :job/user ?user]
                                     [?j :job/state ?state]
@@ -258,7 +258,7 @@
                              [?j :job/state ?state]
                              [?j :job/user ?user]
                              [?j :job/submit-time ?t]
-                             [(< ?start ?t)]
+                             [(<= ?start ?t)]
                              [(< ?t ?end)]
                              [?j :job/custom-executor false]]
                            db user state start end)])]

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -77,11 +77,13 @@
    "mem" 2048.0})
 
 (defn basic-handler
-  [conn & {:keys [cpus memory-gb gpus-enabled retry-limit] :or {cpus 12 memory-gb 100 gpus-enabled false retry-limit 200}}]
+  [conn & {:keys [cpus memory-gb gpus-enabled retry-limit list-batch-period] 
+           :or {cpus 12 memory-gb 100 gpus-enabled false retry-limit 200 list-batch-period 1440}}]
   (main-handler conn "my-framework-id" (fn [] [])
                 {:task-constraints {:cpus cpus :memory-gb memory-gb :retry-limit retry-limit}
                  :mesos-gpu-enabled gpus-enabled
-                 :is-authorized-fn authorized-fn}))
+                 :is-authorized-fn authorized-fn
+                 :list-batch-period (t/minutes 1440)}))
 
 (defn response->body-data [{:keys [body]}]
   (let [baos (ByteArrayOutputStream.)

--- a/scheduler/test/cook/test/mesos/util.clj
+++ b/scheduler/test/cook/test/mesos/util.clj
@@ -267,23 +267,6 @@
              end]]
            (util/generate-intervals start end (t/hours 7))))))
 
-(def test-accumulate-n-from-batches
-  (let [batches [(map identity (range 2))  ;; Make them realize-able
-                 (map identity (range 10))
-                 (map identity (range))]]
-    (is (= (util/accumulate-n-from-batches 1 batches)
-           [0]))
-    (is (= (map realized? batches)
-           [true false false]))
-    (is (= (util/accumulate-n-from-batches 3 batches)
-           [0 1 0]))
-    (is (= (map realized? batches)
-           [true true false]))
-    (is (= (util/accumulate-n-from-batches 17 batches)
-           (concat (range 2) (range 10) (range 5))))
-    (is (= (map realized? batches)
-           [true true true]))))
-
 (def test-get-jobs-by-user-and-state
   (let [uri "datomic:mem://test-get-pending-job-ents"
         conn (restore-fresh-database! uri)]
@@ -311,35 +294,35 @@
       (testing (str "get " state " jobs")
         (is (= 2 (count (util/get-jobs-by-user-and-state (d/db conn) "u1" state
                                                          #inst "2017-06-02" #inst "2017-06-03"
-                                                         10))))
+                                                         (t/days 1) 10))))
         (is (= 1 (count (util/get-jobs-by-user-and-state (d/db conn) "u1" state
                                                          #inst "2017-06-02" #inst "2017-06-03"
-                                                         1))))
+                                                         (t/days 1) 1))))
         (is (= (map :job/submit-time
                     (util/get-jobs-by-user-and-state (d/db conn) "u1" state
                                                      #inst "2017-06-02" #inst "2017-06-03"
-                                                     1))
+                                                     (t/days 1) 1))
                [#inst "2017-06-02T12:00:00"]))
         (is (= 3 (count (util/get-jobs-by-user-and-state (d/db conn) "u1" state
                                                          #inst "2017-06-02" #inst "2017-06-04"
-                                                         10))))
+                                                         (t/days 1) 10))))
         (is (= 2 (count (util/get-jobs-by-user-and-state (d/db conn) "u1" state
                                                          #inst "2017-06-02" #inst "2017-06-04"
-                                                         2))))
+                                                         (t/days 1) 2))))
         (is (= (map :job/submit-time
                     (util/get-jobs-by-user-and-state (d/db conn) "u1" state
                                                      #inst "2017-06-02" #inst "2017-06-03"
-                                                     2))
+                                                     (t/days 1) 2))
                [#inst "2017-06-02T12:00:00" #inst "2017-06-02T12:01:00"]))
 
         (is (= 1 (count (util/get-jobs-by-user-and-state (d/db conn) "u2" state
                                                          #inst "2017-06-02" #inst "2017-06-04"
-                                                         10))))
+                                                         (t/days 1) 10))))
         (is (= 0 (count (util/get-jobs-by-user-and-state (d/db conn) "u3" state
                                                          #inst "2017-06-02" #inst "2017-06-04"
-                                                         10))))
+                                                         (t/days 1) 10))))
         (is (= 0 (count (util/get-jobs-by-user-and-state (d/db conn) "u1" state
                                                          #inst "2017-06-01" #inst "2017-06-02"
-                                                         10))))))))
+                                                         (t/days 1) 10))))))))
 
 (comment (run-tests))


### PR DESCRIPTION
By chunking by day, we prevent datomic from doing large joins which it apparently is not well optimized for.