### PR TITLE
Make sandbox dir fetch error debug

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -749,7 +749,7 @@
       (str "http://" agent-hostname ":5051" "/files/read.json?path="
            (URLEncoder/encode directory "UTF-8")))
     (catch Exception e
-      (log/error e "Unable to retrieve directory path for" executor-id "on agent" agent-hostname)
+      (log/debug e "Unable to retrieve directory path for" executor-id "on agent" agent-hostname)
       nil)))
 
 (defn- instance->instance-map


### PR DESCRIPTION
It is expected that we aren't going to be able to retrieve the sandbox dir for jobs that were run long enough ago. The logs are filled with these errors that are noise