### PR TITLE
Improve the performance of list endpoint

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -325,8 +325,6 @@
                                      (log/info "Using kerberos middleware")
                                      (lazy-load-var 'cook.spnego/require-gss))
                                    :else (throw (ex-info "Missing authorization configuration" {}))))
-     :list-batch-period (fnk [[:config {list-batch-period-minutes (* 60 24)}]]
-                             (t/minutes list-batch-period-minutes))
      :rate-limit (fnk [[:config {rate-limit nil}]]
                    (let [{:keys [user-limit-per-m]
                           :or {user-limit-per-m 600}} rate-limit]

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -228,7 +228,7 @@
 ;; This works because the submission time and job/user field
 ;; are set at the same time, in "real" time. This means that
 ;; jobs submitted after `start` will have been created after
-;; expanded starti
+;; expanded start
 (defn get-jobs-by-user-and-states
   "Returns all job entities for a particular user
    in a particular state, in the specified timeframe,

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -23,7 +23,8 @@
             [datomic.api :as d :refer (q)]
             [metatransaction.core :refer (db)]
             [metrics.timers :as timers]
-            [plumbing.core :as pc :refer (map-vals map-keys)]))
+            [plumbing.core :as pc :refer (map-vals map-keys)])
+  (:import [java.util Date]))
 
 (defn get-all-resource-types
   "Return a list of all supported resources types. Example, :cpus :mem :gpus ..."
@@ -217,42 +218,30 @@
    (->> (conj (vec (periodic-seq start end period-like)) end)
         (partition 2 1))))
 
-(defn get-jobs-by-user-and-state
+(defn get-jobs-by-user-and-states
   "Returns all job entities for a particular user
    in a particular state, in the specified timeframe,
    without a custom executor."
-  [db user state start end period-like limit]
-  (let [intervals (generate-intervals (tc/from-date start) (tc/from-date end) period-like)
-        job-batches (if (= state :job.state/completed)
-                      (map (fn query-in-chunks
-                             [interval]
-                             (let [[interval-start interval-end] (map tc/to-date interval)]
-                               (q '[:find [?j ...]
-                                    :in $ ?user ?state ?start ?end
-                                    :where
-                                    [?j :job/submit-time ?t]
-                                    [(<= ?start ?t)]
-                                    [(< ?t ?end)]
-                                    [?j :job/user ?user]
-                                    [?j :job/state ?state]
-                                    [?j :job/custom-executor false]]
-                                  db user state interval-start interval-end)))
-                           intervals)
-                      [(q '[:find [?j ...]
-                             :in $ ?user ?state ?start ?end
-                             :where
-                             [?j :job/state ?state]
-                             [?j :job/user ?user]
-                             [?j :job/submit-time ?t]
-                             [(<= ?start ?t)]
-                             [(< ?t ?end)]
-                             [?j :job/custom-executor false]]
-                           db user state start end)])]
-    (->> job-batches
-         (map sort)
-         (apply concat)
-         (take limit)
-         (map (partial d/entity db)))))
+  [db user states start end limit]
+  (let [states (set states)
+        ;; Expand the time range so that clock skew between cook
+        ;; and datomic doesn't cause us to miss jobs
+        ;; 1 hour was picked because a skew larger than that would be
+        ;; susipious
+        expanded-start (Date. (- (.getTime start) 
+                                 (-> 1 t/hours t/in-millis)))
+        expanded-end (Date. (+ (.getTime end)
+                               (-> 1 t/hours t/in-millis)))] 
+    (->> (d/seek-datoms db :avet :job/user user (d/entid-at db :db.part/user expanded-start))
+         (take-while #(and (< (.e %) (d/entid-at db :db.part/user expanded-end))
+                           (= (.a %) (d/entid db :job/user))
+                           (= (.v %) user)))
+         (map #(.e %))
+         (map (partial d/entity db))
+         (filter #(<= (.getTime start) (.getTime (:job/submit-time %))))
+         (filter #(< (.getTime (:job/submit-time %)) (.getTime end)))
+         (filter #(contains? states (:job/state %)))
+         (take limit))))
 
 (defn jobs-by-user-and-state
   "Returns all job entities for a particular user

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -77,13 +77,12 @@
    "mem" 2048.0})
 
 (defn basic-handler
-  [conn & {:keys [cpus memory-gb gpus-enabled retry-limit list-batch-period] 
-           :or {cpus 12 memory-gb 100 gpus-enabled false retry-limit 200 list-batch-period 1440}}]
+  [conn & {:keys [cpus memory-gb gpus-enabled retry-limit] 
+           :or {cpus 12 memory-gb 100 gpus-enabled false retry-limit 200}}]
   (main-handler conn "my-framework-id" (fn [] [])
                 {:task-constraints {:cpus cpus :memory-gb memory-gb :retry-limit retry-limit}
                  :mesos-gpu-enabled gpus-enabled
-                 :is-authorized-fn authorized-fn
-                 :list-batch-period (t/minutes 1440)}))
+                 :is-authorized-fn authorized-fn}))
 
 (defn response->body-data [{:keys [body]}]
   (let [baos (ByteArrayOutputStream.)


### PR DESCRIPTION
Switching to seek-datoms allows that function to be completely lazy, meaning we hold on to a lot less memory. Switching to seek-datoms also means we can seek to exactly the time point we are interested in and has shown query speed ups of >10x