### PR TITLE
Incremental update functions for ranking

### DIFF
--- a/scheduler/src/cook/mesos/ranker.clj
+++ b/scheduler/src/cook/mesos/ranker.clj
@@ -1,0 +1,75 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.mesos.ranker
+  (:require [cook.mesos.dru :as dru]
+            [cook.mesos.share :as share]
+            [cook.mesos.util :as util]
+            [plumbing.core :as pc]))
+
+;; TODO: Look into data.avl to store sets and use transients 
+(defn update-rank-state-helper
+  [rank-state update-fn task]
+  (let [job (:job/_instance task)
+        category (util/categorize-job job)
+        user (:job/user job)]
+    (-> rank-state
+        (update-in [:category->user->sorted-tasks category user]
+                   #(update-fn % task)))))
+
+(defn add-task
+  "Adds task to rank-state while correctly maintaining sorted order.
+   Returns updated rank-state"
+  [rank-state task]
+  (update-rank-state-helper rank-state 
+                            (fnil conj (sorted-set-by (util/same-user-task-comparator)))
+                            task))
+
+(defn remove-task
+  "Adds task to rank-state while correctly maintaining sorted order.
+   Returns updated rank-state"
+  [rank-state task]
+  (update-rank-state-helper rank-state 
+                            (fnil disj (sorted-set-by (util/same-user-task-comparator)))
+                            task))
+
+(def category->sort-jobs-by-dru-fn {:normal dru/sorted-task-scored-task-pairs 
+                                    :gpu dru/sorted-task-cumulative-gpu-score-pairs})
+
+(defn sort-jobs-by-dru-rank-state
+  "Sort tasks by dru and filter to waiting jobs.
+   returns map of categories to sorted jobs"
+  [{:keys [category->user->sorted-tasks] :as rank-state} 
+   user->dru-divisors]
+  (letfn [(sort-jobs-by-dru-category-helper 
+            [[category user->sorted-tasks]]
+            (let [sort-jobs-by-dru-fn (category->sort-jobs-by-dru-fn category)]
+              [category 
+               (->> user->sorted-tasks
+                    (sort-jobs-by-dru-fn user->dru-divisors)
+                    (filter (fn filter-to-waiting [[task _]] 
+                              (= (get-in task [:job/_instance :job/state]) :job.state/waiting)))
+                    (map (fn get-job [[task _]] 
+                           (:job/_instance task))))]))]
+    (into {} (map sort-jobs-by-dru-category-helper) category->user->sorted-tasks)))
+
+(defn rank-jobs
+  "Returns map where keys are categories of jobs and vals are seq of jobs waiting
+   to be scheduled in order of Cook's desire to schedule it"
+  [db rank-state]
+  (let [user->dru-divisors (share/create-user->share-fn db)] 
+    (sort-jobs-by-dru-rank-state rank-state user->dru-divisors)))
+ 
+

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -1191,6 +1191,68 @@
              ;; Return all 0's for a user who does NOT have any running job.
              (zipmap (util/get-all-resource-types db) (repeat 0.0)))})))
 
+;; TODO: Look into data.avl to store sets and use transients 
+;; TODO: store and update merge of running and waiting as well 
+;;       so rank jobs is supa fast
+(defn update-rank-state-helper
+  [rank-state update-fn k task]
+  (let [job (:job/_instance task)
+        category (util/categorize-job job)
+        user (:job/user job)]
+    (-> rank-state
+        (update-in [k category user]
+                   #(update-fn % task)))))
+
+(defn add-task-waiting 
+  [rank-state task]
+  (update-rank-state-helper rank-state 
+                            (fnil conj (sorted-set-by (util/same-user-task-comparator)))
+                            :category->user->waiting-tasks-sorted
+                            task))
+
+(defn remove-task-waiting 
+  [rank-state task]
+  (update-rank-state-helper rank-state 
+                            (fnil disj (sorted-set-by (util/same-user-task-comparator)))
+                            :category->user->waiting-tasks-sorted
+                            task))
+
+(defn add-task-running
+  [rank-state task]
+  (update-rank-state-helper rank-state 
+                            (fnil conj (sorted-set-by (util/same-user-task-comparator)))
+                            :category->user->running-tasks-sorted
+                            task))
+
+(defn remove-task-running
+  [rank-state task]
+  (update-rank-state-helper rank-state 
+                            (fnil disj (sorted-set-by (util/same-user-task-comparator)))
+                            :category->user->running-tasks-sorted
+                            task))
+
+(def category->sort-jobs-by-dru-fn {:normal dru/sorted-task-scored-task-pairs 
+                                    :gpu dru/sorted-task-cumulative-gpu-score-pairs})
+
+(defn sort-jobs-by-dru-rank-state
+  [{:keys [category->user->running-tasks-sorted category->user->waiting-tasks-sorted] :as rank-state} 
+   user->dru-divisors]
+  (letfn [(sort-jobs-by-dru-category-helper [[category user->sorted-tasks]]
+            ;; TODO store waiting jobs instead of waiting tasks (or make create-task-ent deterministic)
+            ;; Favor making create-task-ent deterministic by setting task id to job uuid since we won't 
+            ;; actually use it
+            (let [sort-jobs-by-dru-fn (category->sort-jobs-by-dru-fn category)]
+              [category 
+               (->> user->sorted-tasks
+                    (sort-jobs-by-dru-fn user->dru-divisors)
+                    (filter (fn [[task _]] (= (get-in task [:job/_instance :job/state]) :job.state/waiting)))
+                    (map (fn [[task _]] (:job/_instance task))))]))]
+    (into {} (map sort-jobs-by-dru-category-helper) 
+      (merge-with (partial merge-with into)
+                  category->user->waiting-tasks-sorted 
+                  category->user->running-tasks-sorted))))
+
+
 (defn sort-jobs-by-dru-helper
   "Return a list of job entities ordered by the provided sort function"
   [pending-task-ents running-task-ents user->dru-divisors sort-task-scored-task-pairs sort-jobs-duration]
@@ -1222,6 +1284,7 @@
   [pending-task-ents running-task-ents user->dru-divisors]
   (sort-jobs-by-dru-helper pending-task-ents running-task-ents user->dru-divisors
                            dru/sorted-task-cumulative-gpu-score-pairs sort-gpu-jobs-hierarchy-duration))
+
 
 (defn sort-jobs-by-dru-category
   "Returns a map from job category to a list of job entities, ordered by dru"
@@ -1530,3 +1593,4 @@
     {:scheduler (create-mesos-scheduler framework-id gpu-enabled? conn heartbeat-ch
                                         fenzo offers-chan match-trigger-chan handle-progress-message)
      :view-incubating-offers (fn get-resources-atom [] @resources-atom)}))
+

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -1223,7 +1223,6 @@
   (sort-jobs-by-dru-helper pending-task-ents running-task-ents user->dru-divisors
                            dru/sorted-task-cumulative-gpu-score-pairs sort-gpu-jobs-hierarchy-duration))
 
-
 (defn sort-jobs-by-dru-category
   "Returns a map from job category to a list of job entities, ordered by dru"
   [unfiltered-db]
@@ -1531,4 +1530,3 @@
     {:scheduler (create-mesos-scheduler framework-id gpu-enabled? conn heartbeat-ch
                                         fenzo offers-chan match-trigger-chan handle-progress-message)
      :view-incubating-offers (fn get-resources-atom [] @resources-atom)}))
-

--- a/scheduler/test/cook/test/benchmark.clj
+++ b/scheduler/test/cook/test/benchmark.clj
@@ -17,6 +17,7 @@
 (ns cook.test.benchmark
   (:use clojure.test)
   (:require [clojure.core.async :as async]
+            [cook.mesos.ranker :as ranker]
             [cook.mesos.util :as util]
             [cook.mesos.dru :as dru]
             [cook.mesos.share :as share]
@@ -71,34 +72,23 @@
           nil)))))
 
 (deftest ^:benchmark bench-rank-jobs-state
-  (time (let [uri "datomic:mem://bench-rank-jobs-state"
-              conn (restore-fresh-database! uri)
-              ;; Cheap way to have a non-uniform distribution of users
-              pick-user (fn [] (first (shuffle ["a" "a" "a" "a" "b" "b" "c" "c" "d" "e" "f"])))]
-          (dotimes [_ 50000]
-            (create-dummy-job conn :user (pick-user) :ncpus (inc (rand-int 20)) :memory (inc (rand-int 100000))))
-          (dotimes [_ 10000]
-            (create-running-job conn "abc" :user (pick-user) :job-state :job.state/running))
-          (let [db (d/db conn)
-                pending-task-ents (map util/create-task-ent (util/get-pending-job-ents db))
-                running-task-ents (util/get-running-task-ents db)
-                rank-state {:category->user->running-tasks-sorted {}
-                            :category->user->waiting-tasks-sorted {}}
-                rank-state (time (reduce sched/add-task-waiting rank-state pending-task-ents))
-                rank-state (time (reduce sched/add-task-running rank-state running-task-ents)) ]
-            (testing "merging-running-and-waiting"
-              (let [category->user->waiting-tasks-sorted (:category->user->waiting-tasks-sorted rank-state)
-                    category->user->running-tasks-sorted (:category->user->running-tasks-sorted rank-state)] 
-                (do
-                  (println "============ merge-running-and-waiting timing ============")
-                  (cc/quick-bench (merge-with (partial merge-with into)
-                                              category->user->waiting-tasks-sorted 
-                                              category->user->running-tasks-sorted))
-                  nil))
-              )
-            (time (testing "sort-jobs-by-dru-helper"
-                    (do
-                      (println "============ sort-jobs-by-dru timing ============")
-                      (cc/quick-bench (sched/sort-jobs-by-dru-rank-state rank-state
-                                                                         (share/create-user->share-fn db)))
-                      nil)))))))
+  (let [uri "datomic:mem://bench-rank-jobs-state"
+        conn (restore-fresh-database! uri)
+        ;; Cheap way to have a non-uniform distribution of users
+        pick-user (fn [] (first (shuffle ["a" "a" "a" "a" "b" "b" "c" "c" "d" "e" "f"])))]
+    (dotimes [_ 50000]
+      (create-dummy-job conn :user (pick-user) :ncpus (inc (rand-int 20)) :memory (inc (rand-int 100000))))
+    (dotimes [_ 10000]
+      (create-running-job conn "abc" :user (pick-user) :job-state :job.state/running))
+    (let [db (d/db conn)
+          pending-task-ents (map util/create-task-ent (util/get-pending-job-ents db))
+          running-task-ents (util/get-running-task-ents db)
+          rank-state {:category->user->running-tasks-sorted {}
+                      :category->user->waiting-tasks-sorted {}}
+          rank-state (reduce ranker/add-task rank-state pending-task-ents)
+          rank-state (reduce ranker/add-task rank-state running-task-ents) ]
+      (testing "sort-jobs-by-dru-helper"
+        (do
+          (println "============ sort-jobs-by-dru timing ============")
+          (cc/quick-bench (ranker/rank-jobs db rank-state))
+          nil)))))

--- a/scheduler/test/cook/test/mesos/ranker.clj
+++ b/scheduler/test/cook/test/mesos/ranker.clj
@@ -1,0 +1,101 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.test.mesos.ranker
+  (:use [clojure.test])
+  (:require [cook.mesos.ranker :as ranker]
+            [cook.mesos.share :as share]
+            [cook.mesos.util :as util]
+            [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance init-offer-cache poll-until)]
+            [datomic.api :as d :refer (q db)]
+            [plumbing.core :as pc]))
+
+
+(deftest test-rank-state-update
+  (let [uri "datomic:mem://test-rank-state-update"
+        conn (restore-fresh-database! uri) 
+        job-1 (create-dummy-job conn :user "a")
+        job-2 (create-dummy-job conn :user "a")
+        job-3 (create-dummy-job conn :user "a" :priority 100)
+        job-4 (create-dummy-job conn :user "b")
+        job-5 (create-dummy-job conn :user "c")
+        job->dummy-task (fn job->dummy-task [job-ent-id]
+                          (util/create-task-ent (d/touch (d/entity (d/db conn) job-ent-id))))
+        dummy-task-1 (job->dummy-task job-1)
+        dummy-task-2 (job->dummy-task job-2)
+        dummy-task-3 (job->dummy-task job-3)
+        dummy-task-4 (job->dummy-task job-4)
+        dummy-task-5 (job->dummy-task job-5)]
+    (testing "add / remove job test"
+      (let [rank-state {:category->user->sorted-tasks {}}
+            waiting-rank-state (fn waiting-rank-state 
+                                 [user->sorted]
+                                 {:category->user->sorted-tasks user->sorted})
+            rank-state (ranker/remove-task rank-state dummy-task-1)
+            _ (is (= rank-state
+                     (waiting-rank-state {:normal {"a" #{}}})))
+
+            rank-state (ranker/add-task rank-state dummy-task-1)
+            _ (is (= rank-state
+                     (waiting-rank-state {:normal {"a" #{dummy-task-1}}})))
+
+            rank-state (ranker/add-task rank-state dummy-task-2)
+            _ (is (= rank-state
+                     (waiting-rank-state {:normal {"a" #{dummy-task-1 dummy-task-2}}}))) 
+
+            rank-state (ranker/add-task rank-state dummy-task-3)
+            _ (is (= rank-state
+                     (waiting-rank-state {:normal {"a" #{dummy-task-3 dummy-task-1 dummy-task-2}}})))
+
+            rank-state (ranker/remove-task rank-state dummy-task-1)
+            _ (is (= rank-state
+                     (waiting-rank-state {:normal {"a" #{dummy-task-3 dummy-task-2}}})))
+
+            rank-state (ranker/add-task rank-state dummy-task-1)
+            _ (is (= rank-state
+                     (waiting-rank-state {:normal {"a" #{dummy-task-3 dummy-task-1 dummy-task-2}}})))
+
+            rank-state (ranker/add-task rank-state dummy-task-4)
+            _ (is (= rank-state
+                     (waiting-rank-state {:normal {"a" #{dummy-task-3 dummy-task-1 dummy-task-2}
+                                                   "b" #{dummy-task-4}}})))
+
+            rank-state (ranker/add-task rank-state (job->dummy-task job-5))
+            _ (is (= rank-state
+                     (waiting-rank-state {:normal {"a" #{dummy-task-3 dummy-task-1 dummy-task-2}
+                                                   "b" #{dummy-task-4}
+                                                   "c" #{dummy-task-5}}})))]))))
+
+(deftest test-rank-jobs
+  (let [uri "datomic:mem://test-rank-jobs"
+        conn (restore-fresh-database! uri) 
+        job-1 (create-dummy-job conn :user "a")
+        job-2 (create-dummy-job conn :user "a")
+        job-3 (create-dummy-job conn :user "a" :priority 100)
+        job-4 (create-dummy-job conn :user "b")
+        job-5 (create-dummy-job conn :user "c")
+        job->dummy-task (fn job->dummy-task [job-ent-id]
+                          (util/create-task-ent (d/touch (d/entity (d/db conn) job-ent-id))))
+        dummy-task-1 (job->dummy-task job-1)
+        dummy-task-2 (job->dummy-task job-2)
+        dummy-task-3 (job->dummy-task job-3)
+        dummy-task-4 (job->dummy-task job-4)
+        dummy-task-5 (job->dummy-task job-5)
+        dummy-tasks [dummy-task-1 dummy-task-2 dummy-task-3 
+                     dummy-task-4 dummy-task-5]
+        rank-state {:category->user->sorted-tasks {}}
+        rank-state (reduce ranker/add-task rank-state dummy-tasks)]
+    (is (= (ranker/rank-jobs (d/db conn) rank-state)
+           {:normal (map :job/_instance [dummy-task-3 dummy-task-4 dummy-task-5 dummy-task-1 dummy-task-2])}))))


### PR DESCRIPTION
This is the start of code to maintain state needed to compute the ranking of jobs. This allows us to incrementally rank jobs instead of re-doing the computation over again. 

This PR provides functions to update a rank-state map and code to compute the ranking of jobs from the rank-state though both need to be cleaned up and tested.

This PR does not include the code to call the functions to update the rank-state. I propose making that a separate PR. 