### PR TITLE
A job can only be a straggler once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+### Changed
+- A job that already has had a straggler instance will not have subsequent instances be considered stragglers, from @wyegelwel
+
 ## [1.5.6] - 2017-08-07
 ### Changed
 - Performance improvement in rank jobs, from @wyegelwel

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -520,10 +520,12 @@ class CookTest(unittest.TestCase):
         self.assertEqual(200, jobs.status_code)
         jobs = jobs.json()
         self.logger.debug('Loaded jobs %s', jobs)
-        self.assertEqual('success', jobs[0]['state'], 'Job details: %s' % (json.dumps(jobs[0], sort_keys=True)))
-        self.assertEqual('success', jobs[1]['state'])
-        self.assertEqual(2, len(jobs[1]['instances']))
-        self.assertEqual(2004, jobs[1]['instances'][0]['reason_code'])
+        fast_job = job[0]
+        slow_job = job[1]
+        self.assertEqual('success', fast_job['state'], 'Job details: %s' % (json.dumps(fast_job, sort_keys=True)))
+        self.assertEqual('success', slow_job['state'])
+        self.assertEqual(2, len(slow_job['instances']))
+        self.assertEqual(2004, slow_job['instances'][0]['reason_code'])
 
     def test_expected_runtime_field(self):
         # Should support expected_runtime

--- a/scheduler/docs/groups.md
+++ b/scheduler/docs/groups.md
@@ -42,13 +42,15 @@ When running a lot of jobs, occasionally it happens that one or two of them run 
 rest.  This can be because they are on a box that is in a bad state, experiencing network problems
 or the process is in a bad state. To avoid having to manually monitor the jobs to find and address
 these problem cases, Cook can be configured to kill and restart jobs in a group that have been
-running much longer then the other jobs in the group. 
+running much longer then the other jobs in the group.
 
 To configure this, set the straggler handling type to `quantile-deviation`. This will have Cook look
 for jobs that have been running multiple times longer than a particular quantile of the group. The
 parameters, `quantile` and `multiplier` decide when a job is considered a straggler. The
 `quantile` decides the target runtime of the group and the `multipier` decides how many times
 longer than the run time of the quantile job before a job is marked as a straggler.
+If a job has already had an instance killed for being as straggler subsequent instances will not be
+considered a straggler regardless of how long it has run for.
 
 ## Host placement constraints
 

--- a/scheduler/docs/groups.md
+++ b/scheduler/docs/groups.md
@@ -49,8 +49,8 @@ for jobs that have been running multiple times longer than a particular quantile
 parameters, `quantile` and `multiplier` decide when a job is considered a straggler. The
 `quantile` decides the target runtime of the group and the `multipier` decides how many times
 longer than the run time of the quantile job before a job is marked as a straggler.
-If a job has already had an instance killed for being as straggler subsequent instances will not be
-considered a straggler regardless of how long it has run for.
+If a job has already had an instance killed for being a straggler, subsequent instances will not be
+considered stragglers regardless of how long they have run for.
 
 ## Host placement constraints
 

--- a/scheduler/src/cook/mesos/group.clj
+++ b/scheduler/src/cook/mesos/group.clj
@@ -17,8 +17,8 @@
 (defmethod find-stragglers :quantile-deviation
   ;; Given a group entity, waits for at least `quantile` quantile jobs to complete
   ;; and a straggler is any task that has been running `multiplier` times the run
-  ;; time of the quantile-th job
-  ;; If a job was already restarted for having a straggler it won't be restarted again
+  ;; time of the quantile-th job.
+  ;; If a job was already restarted for having a straggler it won't be restarted again.
   [group-ent]
   (let [{:keys [quantile multiplier] :as params} (->> group-ent
                                                       :group/straggler-handling

--- a/scheduler/src/cook/mesos/group.clj
+++ b/scheduler/src/cook/mesos/group.clj
@@ -4,7 +4,7 @@
             [cook.mesos.util :as util]))
 
 (defmulti find-stragglers
-  "Given a group entity, returns a list of task entities 
+  "Given a group entity, returns a list of task entities
    that are considered stragglers"
   (fn [group-ent]
     (-> group-ent :group/straggler-handling :straggler-handling/type util/without-ns)))
@@ -16,14 +16,15 @@
 
 (defmethod find-stragglers :quantile-deviation
   ;; Given a group entity, waits for at least `quantile` quantile jobs to complete
-  ;; and a straggler is any task that has been running `multiplier` times the run 
+  ;; and a straggler is any task that has been running `multiplier` times the run
   ;; time of the quantile-th job
+  ;; If a job was already restarted for having a straggler it won't be restarted again
   [group-ent]
   (let [{:keys [quantile multiplier] :as params} (->> group-ent
-                                                      :group/straggler-handling 
-                                                      :straggler-handling/parameters 
+                                                      :group/straggler-handling
+                                                      :straggler-handling/parameters
                                                       (into {})
-                                                      (util/deep-transduce-kv 
+                                                      (util/deep-transduce-kv
                                                         (map (juxt (comp util/without-ns first) second))))
         jobs (:group/job group-ent)
         running-tasks (->> jobs
@@ -33,16 +34,23 @@
                               (mapcat :job/instance)
                               (filter #(= (:instance/status %) :instance.status/success)))
         ;; decrement jobs by 1 to avoid odd issues when there are few instances
-        ;; for example, if there are only 2 jobs, than any quantile will use 
-        ;; the first job to complete 
+        ;; for example, if there are only 2 jobs, than any quantile will use
+        ;; the first job to complete
         quantile-job-idx (int (* (dec (count jobs)) quantile))]
     (when (> (count successful-tasks) quantile-job-idx)
       (let [sorted-success-tasks (sort-by (comp t/in-seconds util/task-run-time) successful-tasks)
             target-task (nth sorted-success-tasks quantile-job-idx)
             target-runtime-seconds (t/in-seconds (util/task-run-time target-task))
-            max-runtime-seconds (* target-runtime-seconds multiplier)]
-        (filter #(> (t/in-seconds (util/task-run-time %)) max-runtime-seconds)
-                running-tasks)))))
+            max-runtime-seconds (* target-runtime-seconds multiplier)
+            instance->job-failure-reasons (fn instance->job-failure-reasons
+                                            [instance]
+                                            (->> instance
+                                                 :job/_instance
+                                                 :job/instance
+                                                 (map (comp :reason/name :instance/reason))))]
+        (->> running-tasks
+             (filter #(> (t/in-seconds (util/task-run-time %)) max-runtime-seconds))
+             (remove #(contains? (set (instance->job-failure-reasons %)) :straggler)))))))
 
 (defn group->running-task-set
   "Returns all the possibly running (running or unknown, unknown-state instances are in an unknown

--- a/scheduler/test/cook/test/mesos/group.clj
+++ b/scheduler/test/cook/test/mesos/group.clj
@@ -90,6 +90,60 @@
             straggler-task-a (d/entity db straggler-a)
             straggler-task-b (d/entity db straggler-b)]
         (is (= #{straggler-task-a straggler-task-b} (set (group/find-stragglers group-ent))))))
+    (testing "quantile deviation straggler-handling, stragglers found but was already a straggler"
+      (let [straggler-handling {:straggler-handling/type :straggler-handling.type/quantile-deviation
+                                :straggler-handling/parameters
+                                {:straggler-handling.quantile-deviation/quantile 0.5
+                                 :straggler-handling.quantile-deviation/multiplier 2.0}}
+            group-ent-id (create-dummy-group conn :straggler-handling straggler-handling)
+
+            _ (create-dummy-instance conn
+                                     (create-dummy-job conn :group group-ent-id)
+                                     :instance-status :instance.status/success
+                                     :start-time (tc/to-date (t/ago (t/hours 3)))
+                                     :end-time (tc/to-date (t/ago (t/hours 2))))
+            _ (create-dummy-instance conn
+                                     (create-dummy-job conn :group group-ent-id)
+                                     :instance-status :instance.status/success
+                                     :start-time (tc/to-date (t/ago (t/hours 3)))
+                                     :end-time (tc/to-date (t/ago (t/hours 2))))
+            _ (create-dummy-instance conn
+                                     (create-dummy-job conn :group group-ent-id)
+                                     :instance-status :instance.status/success
+                                     :start-time (tc/to-date (t/ago (t/hours 3)))
+                                     :end-time (tc/to-date (t/ago (t/hours 2))))
+            _ (create-dummy-instance conn
+                                     (create-dummy-job conn :group group-ent-id)
+                                     :instance-status :instance.status/success
+                                     :start-time (tc/to-date (t/ago (t/hours 3)))
+                                     :end-time (tc/to-date (t/ago (t/hours 2))))
+            _ (create-dummy-instance conn
+                                     (create-dummy-job conn :group group-ent-id)
+                                     :instance-status :instance.status/success
+                                     :start-time (tc/to-date (t/ago (t/hours 3)))
+                                     :end-time (tc/to-date (t/ago (t/hours 2))))
+            _ (create-dummy-instance conn
+                                     (create-dummy-job conn :group group-ent-id)
+                                     :instance-status :instance.status/success
+                                     :start-time (tc/to-date (t/ago (t/hours 3)))
+                                     :end-time (tc/to-date (t/ago (t/hours 2))))
+            job-not-straggler (create-dummy-job conn :group group-ent-id)
+            _ (create-dummy-instance conn job-not-straggler :instance-status :instance.status/running
+                                     :start-time (tc/to-date (t/ago (t/minutes 100))))
+            job-straggler-a (create-dummy-job conn :group group-ent-id)
+            straggler-a (create-dummy-instance conn job-straggler-a :instance-status :instance.status/running
+                                               :start-time (tc/to-date (t/ago (t/minutes 190))))
+            job-straggler-b (create-dummy-job conn :group group-ent-id)
+            straggled-b (create-dummy-instance conn job-straggler-b :instance-status :instance.status/failed
+                                               :reason :straggler
+                                               :start-time (tc/to-date (t/ago (t/hours 4)))
+                                               :end-time (tc/to-date (t/ago (t/hours 2))))
+            not-straggler-b (create-dummy-instance conn job-straggler-b :instance-status :instance.status/running
+                                               :start-time (tc/to-date (t/ago (t/minutes 121))))
+            db (d/db conn)
+            group-ent (d/entity db group-ent-id)
+            straggler-task-a (d/entity db straggler-a)]
+        (is (= #{straggler-task-a} (set (group/find-stragglers group-ent))))))
     (testing "quantile deviation straggler-handling, not enough jobs complete"
       (let [straggler-handling {:straggler-handling/type :straggler-handling.type/quantile-deviation
                                 :straggler-handling/parameters


### PR DESCRIPTION
Currently straggler handling will kill an instance if it passes the straggler test regardless of if the job has been considered a straggler before. This is problematic for jobs that actually *do* run much longer than all the others in the batch. In order to let the job progress, a job will now only be able to have a single straggler.