### PR TITLE
Fix javac issue with Cook scheduler docker container

### DIFF
--- a/integration/bin/run-integration.sh
+++ b/integration/bin/run-integration.sh
@@ -34,6 +34,7 @@ then
 fi
 
 docker run \
+       --rm \
        --name=cook-integration \
        -e "COOK_SCHEDULER_URL=${COOK_URL}" \
        ${COOK_MULTICLUSTER_ENV} \

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM mesosphere/mesos:1.0.1-rc1
+FROM mesosphere/mesos:1.3.0
 
 RUN apt-get -y update
 RUN apt-get -y install curl
@@ -15,20 +15,19 @@ RUN curl -o $HOME/bin/lein https://raw.githubusercontent.com/technomancy/leining
 RUN chmod a+x $HOME/bin/lein
 RUN lein
 
-# Create and set the cook dir
-RUN mkdir -p /opt/cook
+# Create and set the cook dir, copying project file
+COPY project.clj /opt/cook/
 WORKDIR /opt/cook
 
 # Fetch dependencies
 ## Only copy the project.clj so that we can use the cached layer
 ## with fetched dependencies as long as project.clj isn't modified
-COPY project.clj /opt/cook
 RUN lein deps
 
-# Copy everything
-COPY . /opt/cook
+# Copy the whole scheduler into the container
+COPY . /opt/cook/
 
 # Run cook
 EXPOSE 12321
-ENTRYPOINT ["lein", "run"]
+ENTRYPOINT ["lein", "with-profiles", "+docker", "run"]
 CMD ["container-config.edn"]

--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -41,6 +41,7 @@ echo "Starting cook..."
 docker run \
     -i \
     -t \
+    --rm \
     --network=bridge \
     --name=${NAME} \
     --publish=${COOK_NREPL_PORT}:${COOK_NREPL_PORT} \

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -162,7 +162,12 @@
     :source-paths []}
 
    :test-console
-   {:jvm-opts ["-Dcook.test.logging.console"]}}
+   {:jvm-opts ["-Dcook.test.logging.console"]}
+
+   :docker
+   ; avoid calling javac in docker
+   ; (.java sources are only used for unit test support)
+   {:java-source-paths ^:replace []}}
 
   :plugins [[lein-print "0.1.0"]]
 


### PR DESCRIPTION
Avoid running `javac` to compile `SimpleAssignmentResult.java`, which is only used for unit tests.

Also added the `--rm` option to our `docker run` scripts to auto-remove the instances on exit. (That way you shouldn't have to manually run `docker rm` to clean up the clutter quite so often.)

Also bumped the `mesosphere/mesos` docker image used as the base for our Cook Scheduler container up to a more recent stable version (we were using a release candidate image before).