### PR TITLE
Move benchmarking to a separate travis build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ env:
     - CLJ_HTTP_ASYNC_POOL_TEST_DURATION_MULTIPLIER=5
   matrix:
     - COOK_EXECUTOR='1' TEST_DIR=executor DEPS_CMD='travis/setup.sh' TEST_CMD='travis/run_tests.sh'
-    - COOK_EXECUTOR='1' TEST_DIR=scheduler DEPS_CMD='lein with-profiles +test deps' TEST_CMD='lein test :all'
+    - COOK_EXECUTOR='1' TEST_DIR=scheduler DEPS_CMD='lein with-profiles +test deps' TEST_CMD='lein test :all-but-benchmark'
+    - COOK_EXECUTOR='1' TEST_DIR=scheduler DEPS_CMD='lein with-profiles +test deps' TEST_CMD='lein test :benchmark'
     - COOK_EXECUTOR='1' TEST_DIR=jobclient DEPS_CMD='mvn dependency:resolve' TEST_CMD='mvn test'
     - COOK_EXECUTOR='1' TEST_DIR=simulator DEPS_CMD='travis/prepare_simulation.sh' TEST_CMD='travis/run_simulation.sh'
     - COOK_EXECUTOR='1' TEST_DIR=integration DEPS_CMD='travis/prepare_integration.sh' TEST_CMD='travis/run_integration.sh'
@@ -29,6 +30,7 @@ env:
 matrix:
     fast_finish: true
     allow_failures:
+      - env: COOK_EXECUTOR='1' TEST_DIR=scheduler DEPS_CMD='lein with-profiles +test deps' TEST_CMD='lein test :benchmark'
       - env: COOK_EXECUTOR='1' TEST_DIR=integration DEPS_CMD='travis/prepare_integration.sh' TEST_CMD='travis/run_integration.sh explicit'
 before_script: (cd $TEST_DIR && $DEPS_CMD)
 script: cd $TEST_DIR && $TEST_CMD

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -171,11 +171,11 @@
 
   :plugins [[lein-print "0.1.0"]]
 
-  :test-selectors {:default (complement #(or (:integration %)
-                                             (:benchmark %)))
-                   :integration :integration
+  :test-selectors {:all (constantly true)
+                   :all-but-benchmark (complement :benchmark)
                    :benchmark :benchmark
-                   :all (constantly true)}
+                   :default (complement #(or (:integration %) (:benchmark %)))
+                   :integration :integration}
 
   :main cook.components
   :jvm-opts ["-Dpython.cachedir.skip=true"

--- a/scheduler/test/cook/test/benchmark.clj
+++ b/scheduler/test/cook/test/benchmark.clj
@@ -16,17 +16,14 @@
 
 (ns cook.test.benchmark
   (:use clojure.test)
-  (:require [clojure.core.async :as async]
+  (:require [cook.mesos.dru :as dru]
             [cook.mesos.ranker :as ranker]
-            [cook.mesos.util :as util]
-            [cook.mesos.dru :as dru]
-            [cook.mesos.share :as share]
             [cook.mesos.scheduler :as sched]
+            [cook.mesos.share :as share]
+            [cook.mesos.util :as util]
             [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance init-offer-cache poll-until)]
             [criterium.core :as cc]
-            [datomic.api :as d]
-            [plumbing.core :as pc]
-            ))
+            [datomic.api :as d]))
 
 (defn create-running-job
   [conn host & args]
@@ -52,7 +49,6 @@
         (cc/quick-bench (sched/rank-jobs db offensive-job-filter))))
     (testing "rank-jobs minus offensive-job-filter"
       (let [db (d/db conn)
-            task-constraints {:memory-gb 100 :cpus 30}
             offensive-job-filter identity]
         (println "============ rank-jobs minus offensive-job-filter timing ============")
         (cc/quick-bench (sched/rank-jobs db offensive-job-filter))))


### PR DESCRIPTION
Introducing benchmarking in the scheduler testing stage increases that stage to over 11 minutes, while other stages take 8 minutes or less. So moving benchmarking to a separate stage. Also, the benchmarks have no assertions, so moving them to 'allow failures'.