### PR TITLE
Adds list to the CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -75,6 +75,17 @@ UUIDs are passed as positional arguments.
 This command shows information about the queried jobs, instances, and groups. 
 If you use `--json`, the command returns a JSON representation instead of tables.
 
+#### `list`
+
+The `list` command allows you to list all jobs:
+
+- in a particular state (e.g. running / waiting),
+- for a particular user,
+- submitted within the last X hours,
+- with a particular name pattern (e.g. "spark*")
+
+As with `show`, `list` will list jobs across all configured clusters.
+
 ### Examples
 
 Simple job creation:
@@ -132,4 +143,14 @@ ls
 
 Job Instance                          Run Time                      Host        Instance Status
 3c625387-b9a6-40db-a971-f37a7eb728e6  0 seconds (started just now)  172.17.0.7  Success
+```
+
+List all jobs submitted by root, in any state, within the last (one) hour:
+```bash
+$ cs list --user root --state all --lookback 1
+Cluster    UUID                                  Name                                  Memory      CPUs    Priority  Attempts    Submitted       Command    Job Status
+dev0       df1ecf44-e42e-4aa3-8cc3-40a289b98666  ff9e3613-97c5-4a33-b4bd-5194fae9c29e  128 MB         1          50  1 / 1       44 minutes ago  exit 1     Failed
+dev0       ec62e5c3-a2e0-454b-ada6-e31ac35ff79b  ff9e3613-97c5-4a33-b4bd-5194fae9c29e  128 MB         1          50  1 / 1       44 minutes ago  ls         Success
+dev0       9bd67f93-824a-4f82-a7b1-599b3cc5a8c3  ff9e3613-97c5-4a33-b4bd-5194fae9c29e  128 MB         1          50  1 / 1       44 minutes ago  sleep 60   Success
+dev0       07420e7b-915a-468f-b53b-be67debcc915  ff9e3613-97c5-4a33-b4bd-5194fae9c29e  128 MB         1          50  0 / 1       44 minutes ago  ls         Waiting
 ```

--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -5,19 +5,23 @@ import os
 from urllib.parse import urlparse
 
 from cook import util, http, colors
-from cook.subcommands import submit, show, wait
+from cook.subcommands import submit, show, wait, list
 from cook.util import deep_merge, load_first_json_file
 
 # Default locations to check for configuration files if one isn't given on the command line
 DEFAULT_CONFIG_PATHS = ['.cs.json',
                         os.path.expanduser('~/.cs.json')]
 
-DEFAULT_CONFIG = {'defaults': {'submit': {'cpus': 1,
-                                          'max-retries': 1,
-                                          'mem': 128}},
+DEFAULT_CONFIG = {'defaults': {},
                   'http': {'retries': 2,
                            'connect-timeout': 3.05,
                            'read-timeout': 5}}
+
+
+def add_defaults(action, defaults):
+    """Adds default arguments for the given action to the DEFAULT_CONFIG map"""
+    DEFAULT_CONFIG['defaults'][action] = defaults
+
 
 parser = argparse.ArgumentParser(description='cs is the Cook Scheduler CLI')
 parser.add_argument('--cluster', '-c', help='the name of the Cook scheduler cluster to use')
@@ -29,9 +33,10 @@ parser.add_argument('--verbose', '-v', help='be more verbose/talkative (useful f
 
 subparsers = parser.add_subparsers(dest='action')
 
-actions = {'submit': submit.register(subparsers.add_parser),
-           'show': show.register(subparsers.add_parser),
-           'wait': wait.register(subparsers.add_parser)}
+actions = {'submit': submit.register(subparsers.add_parser, add_defaults),
+           'show': show.register(subparsers.add_parser, add_defaults),
+           'wait': wait.register(subparsers.add_parser, add_defaults),
+           'list': list.register(subparsers.add_parser, add_defaults)}
 
 
 def load_target_clusters(config, url=None, cluster=None):

--- a/cli/cook/http.py
+++ b/cli/cook/http.py
@@ -62,10 +62,10 @@ def make_data_request(make_request_fn):
         if resp.status_code == requests.codes.ok:
             return resp.json()
         else:
-            return {}
+            return []
     except requests.exceptions.ConnectionError as ce:
         logging.info(ce)
-        return {}
+        return []
     except json.decoder.JSONDecodeError as jde:
         logging.exception(jde)
-        return {}
+        return []

--- a/cli/cook/http.py
+++ b/cli/cook/http.py
@@ -1,4 +1,6 @@
+import json
 import logging
+from urllib.parse import urljoin
 
 import requests
 
@@ -19,11 +21,51 @@ def configure(config):
     session.mount('http://', http_adapter)
 
 
-def post(url, json):
+def __post(url, json_body):
     """Sends a POST with the json payload to the given url"""
-    return session.post(url, json=json, timeout=timeouts)
+    return session.post(url, json=json_body, timeout=timeouts)
 
 
-def get(url, params=None):
+def __get(url, params=None):
     """Sends a GET with params to the given url"""
     return session.get(url, params=params, timeout=timeouts)
+
+
+def __make_url(cluster, endpoint):
+    """Given a cluster and an endpoint, returns the corresponding full URL"""
+    return urljoin(cluster['url'], endpoint)
+
+
+def post(cluster, endpoint, json_body):
+    """POSTs data to cluster at /endpoint"""
+    url = __make_url(cluster, endpoint)
+    resp = __post(url, json_body)
+    logging.info('response from cook: %s' % resp.text)
+    return resp
+
+
+def get(cluster, endpoint, params):
+    """GETs data corresponding to the given params from cluster at /endpoint"""
+    url = __make_url(cluster, endpoint)
+    resp = __get(url, params)
+    logging.info('response from cook: %s' % resp.text)
+    return resp
+
+
+def make_data_request(make_request_fn):
+    """
+    Makes a request (using make_request_fn), parsing the
+    assumed-to-be-JSON response and handling common errors
+    """
+    try:
+        resp = make_request_fn()
+        if resp.status_code == requests.codes.ok:
+            return resp.json()
+        else:
+            return {}
+    except requests.exceptions.ConnectionError as ce:
+        logging.info(ce)
+        return {}
+    except json.decoder.JSONDecodeError as jde:
+        logging.exception(jde)
+        return {}

--- a/cli/cook/subcommands/list.py
+++ b/cli/cook/subcommands/list.py
@@ -80,7 +80,8 @@ def list_jobs(clusters, args):
             show_data(cluster_job_pairs)
         return 0
     else:
-        print_no_data(clusters)
+        if not as_json:
+            print_no_data(clusters)
         return 1
 
 

--- a/cli/cook/subcommands/list.py
+++ b/cli/cook/subcommands/list.py
@@ -18,7 +18,7 @@ def print_no_data(clusters):
 
 
 def list_jobs_on_cluster(cluster, state, user, lookback_hours, name, limit):
-    """Queries cluster for jobs with the given state / user / time / name."""
+    """Queries cluster for jobs with the given state / user / time / name"""
     now_ms = int(round(time.time() * 1000))
     lookback_ms = int(lookback_hours * MILLIS_PER_HOUR)
     start_ms = now_ms - lookback_ms

--- a/cli/cook/subcommands/list.py
+++ b/cli/cook/subcommands/list.py
@@ -1,0 +1,110 @@
+import argparse
+import json
+import time
+
+from tabulate import tabulate
+
+from cook import colors, http
+from cook.subcommands.show import query_across_clusters, format_job_status, format_job_memory, format_job_attempts
+from cook.util import current_user, print_info, millis_to_date_string
+
+MILLIS_PER_HOUR = 60 * 60 * 1000
+
+
+def print_no_data(clusters):
+    """Prints a message indicating that no data was found in the given clusters"""
+    clusters_text = ' / '.join([c['name'] for c in clusters])
+    print(colors.failed('No jobs found in %s.' % clusters_text))
+
+
+def list_jobs_on_cluster(cluster, state, user, lookback_hours, name, limit):
+    """Queries cluster for jobs with the given state / user / time / name."""
+    now_ms = int(round(time.time() * 1000))
+    lookback_ms = int(lookback_hours * MILLIS_PER_HOUR)
+    start_ms = now_ms - lookback_ms
+    params = {'state': state, 'user': user, 'start-ms': start_ms, 'name': name, 'limit': limit}
+    jobs = http.make_data_request(lambda: http.get(cluster, 'list', params=params))
+    entities = {'jobs': jobs, 'count': len(jobs)}
+    return entities
+
+
+def query(clusters, state, user, lookback_hours, name, limit):
+    """
+    Uses query_across_clusters to make the /list
+    requests in parallel across the given clusters
+    """
+
+    def submit(cluster, executor):
+        return executor.submit(list_jobs_on_cluster, cluster, state, user, lookback_hours, name, limit)
+
+    return query_across_clusters(clusters, submit)
+
+
+def show_data(cluster_job_pairs):
+    """
+    Given a collection of (cluster, job) pairs,
+    formats a table showing the most relevant job fields
+    """
+    headers = ['Cluster', 'UUID', 'Name', 'Memory', 'CPUs', 'Priority',
+               'Attempts', 'Submitted', 'Command', 'Job Status']
+    rows = [[cluster,
+             job['uuid'],
+             job['name'],
+             format_job_memory(job),
+             job['cpus'],
+             job['priority'],
+             format_job_attempts(job),
+             millis_to_date_string(job['submit_time']),
+             job['command'] if len(job['command']) <= 50 else ('%s...' % job['command'][:47]),
+             format_job_status(job)]
+            for (cluster, job) in cluster_job_pairs]
+    job_table = tabulate(rows, headers=headers, tablefmt='plain')
+    print_info(job_table)
+
+
+def list_jobs(clusters, args):
+    """Prints info for the jobs with the given list criteria"""
+    as_json = args.get('json')
+    state = args.get('state')
+    user = args.get('user')
+    lookback_hours = args.get('lookback')
+    name = args.get('name')
+    limit = args.get('limit')
+
+    query_result = query(clusters, state, user, lookback_hours, name, limit)
+    if as_json:
+        print(json.dumps(query_result))
+    if query_result['count'] > 0:
+        if not as_json:
+            cluster_job_pairs = [(c, j) for c, e in query_result['clusters'].items() for j in e['jobs']]
+            show_data(cluster_job_pairs)
+        return 0
+    else:
+        print_no_data(clusters)
+        return 1
+
+
+def valid_state(state_string):
+    """Allows argparse to flag user-provided state strings as valid or not"""
+    if state_string == 'all':
+        return 'waiting+running+completed'
+    states = state_string.split('+')
+    if all(s in ('waiting', 'running', 'completed', 'failed', 'success') for s in states):
+        return state_string
+    else:
+        raise argparse.ArgumentTypeError('%s is not a valid state filter' % state_string)
+
+
+def register(add_parser, add_defaults):
+    """Adds this sub-command's parser and returns the action function"""
+    list_parser = add_parser('list', help='list jobs by state / user / time / name')
+    list_parser.add_argument('--state', '-s', help='list running / waiting / completed jobs', type=valid_state)
+    list_parser.add_argument('--user', '-u', help='list jobs for a user')
+    list_parser.add_argument('--lookback', '-t', help='list jobs for the last X hours', type=float)
+    list_parser.add_argument('--name', '-n', help='list jobs with a particular name pattern')
+    list_parser.add_argument('--limit', '-l', help='limit the number of results')
+    list_parser.add_argument('--json', help='show the data in JSON format', dest='json', action='store_true')
+
+    add_defaults('list', {'state': 'running', 'user': current_user(), 'lookback': 6, 'limit': 150})
+
+    return list_jobs

--- a/cli/cook/subcommands/show.py
+++ b/cli/cook/subcommands/show.py
@@ -218,7 +218,7 @@ def query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, enti
         return pred(resp_.json())
 
     entities = http.make_data_request(lambda: make_request_fn(cluster, uuids))
-    if pred:
+    if pred and len(entities) > 0:
         if entity_type == 'job':
             wait_text = 'Waiting for the following jobs'
         elif entity_type == 'instance':
@@ -335,7 +335,8 @@ def show(clusters, args):
     if query_result['count'] > 0:
         return 0
     else:
-        print_no_data(clusters)
+        if not as_json:
+            print_no_data(clusters)
         return 1
 
 

--- a/cli/cook/subcommands/wait.py
+++ b/cli/cook/subcommands/wait.py
@@ -1,4 +1,4 @@
-from cook.subcommands.show import query, print_no_data
+from cook.subcommands.show import print_no_data, query
 
 from cook.util import strip_all, print_info, seconds_to_timedelta
 
@@ -43,10 +43,13 @@ def wait(clusters, args):
         return 1
 
 
-def register(add_parser):
+def register(add_parser, add_defaults):
     """Adds this sub-command's parser and returns the action function"""
     wait_parser = add_parser('wait', help='wait for job(s) to complete by uuid')
     wait_parser.add_argument('uuid', nargs='+')
-    wait_parser.add_argument('--timeout', '-t', default=None, help='maximum time (in seconds) to wait', type=int)
-    wait_parser.add_argument('--interval', '-i', default=5, help='time (in seconds) to wait between polling', type=int)
+    wait_parser.add_argument('--timeout', '-t', help='maximum time (in seconds) to wait', type=int)
+    wait_parser.add_argument('--interval', '-i', help='time (in seconds) to wait between polling', type=int)
+
+    add_defaults('wait', {'timeout': None, 'interval': 5})
+
     return wait

--- a/cli/cook/util.py
+++ b/cli/cook/util.py
@@ -1,14 +1,12 @@
 """Module containing utility functions that don't fit nicely anywhere else."""
 
 import json
+import logging
 import os
 import sys
 import time
 import uuid
 from datetime import datetime, timedelta
-
-import logging
-from urllib.parse import urljoin
 
 import arrow
 import humanfriendly
@@ -107,11 +105,6 @@ def is_valid_uuid(uuid_to_test, version=4):
     return str(uuid_obj) == uuid_to_test
 
 
-def make_url(cluster, endpoint):
-    """Given a cluster and an endpoint, returns the corresponding full URL"""
-    return urljoin(cluster['url'], endpoint)
-
-
 silent = False
 
 
@@ -143,3 +136,8 @@ def millis_to_date_string(ms):
     s, _ = divmod(ms, 1000)
     utc = time.gmtime(s)
     return arrow.get(utc).humanize()
+
+
+def current_user():
+    """Returns the value of the USER environment variable"""
+    return os.environ['USER']

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -105,3 +105,18 @@ class temp_config_file:
 
     def __exit__(self, _, __, ___):
         os.remove(self.path)
+
+
+def list_jobs(cook_url=None, list_flags=None):
+    """Invokes the list subcommand"""
+    args = 'list %s' % list_flags + ' ' if list_flags else ''
+    cp = cli(args, cook_url)
+    return cp
+
+
+def list_jobs_json(cook_url=None, list_flags=None):
+    """Invokes the list subcommand with --json"""
+    cp = list_jobs(cook_url, '%s--json' % (list_flags + ' ' if list_flags else ''))
+    response = json.loads(stdout(cp))
+    jobs = [job for entities in response['clusters'].values() for job in entities['jobs']]
+    return cp, jobs

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -48,8 +48,8 @@ class CookTest(unittest.TestCase):
         job = util.load_job(self.cook_url, job_uuid)
         message = json.dumps(job, sort_keys=True)
         self.assertEqual('waiting', job['status'], message)
-        job_instances = sorted(job['instances'], key=lambda i: i['end_time'])
-        self.assertTrue(len(job_instances) >= 2, message) # sort job instances
+        job_instances = sorted(job['instances'], key=lambda instance: instance['end_time'])
+        self.assertTrue(len(job_instances) >= 2, message)  # sort job instances
         for i in range(1, len(job_instances)):
             message = 'Index ' + str(i) + json.dumps(job_instances[i], sort_keys=True)
             self.assertEqual('failed', job_instances[i]['status'], message)
@@ -230,7 +230,7 @@ class CookTest(unittest.TestCase):
         request_body = {'jobs': [job_spec]}
         resp = util.session.post('%s/rawscheduler' % self.cook_url, json=request_body)
         self.assertEqual(resp.status_code, 201)
-        return util.load_job(self.cook_url, job_spec['uuid'])['user']
+        return util.get_user(self.cook_url, job_spec['uuid'])
 
     def test_list_jobs_by_state(self):
         # schedule a bunch of jobs in hopes of getting jobs into different statuses
@@ -743,10 +743,10 @@ class CookTest(unittest.TestCase):
 
     def test_queue_endpoint(self):
         job_uuid, resp = util.submit_job(self.cook_url, constraints=[["HOSTNAME",
-                                                                          "EQUALS",
-                                                                          "lol won't get scheduled"]])
+                                                                      "EQUALS",
+                                                                      "lol won't get scheduled"]])
         self.assertEqual(201, resp.status_code, resp.content)
-        time.sleep(30) # Need to wait for a rank cycle
+        time.sleep(30)  # Need to wait for a rank cycle
         queue = util.session.get('%s/queue' % self.cook_url)
         self.assertEqual(200, queue.status_code, queue.content)
         self.assertTrue(any([job['job/uuid'] == job_uuid for job in queue.json()['normal']]))
@@ -754,11 +754,11 @@ class CookTest(unittest.TestCase):
 
     def test_basic_docker_job(self):
         job_uuid, resp = util.submit_job(
-                self.cook_url,
-                name="check_alpine_version",
-                command="cat /etc/alpine-release",
-                container={"type": "DOCKER",
-                           "docker": { 'image': "alpine:latest" }})
+            self.cook_url,
+            name="check_alpine_version",
+            command="cat /etc/alpine-release",
+            container={"type": "DOCKER",
+                       "docker": {'image': "alpine:latest"}})
         self.assertEqual(resp.status_code, 201)
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
         self.assertEqual('success', job['instances'][0]['status'])
@@ -770,9 +770,9 @@ class CookTest(unittest.TestCase):
                                          container={'type': 'DOCKER',
                                                     'docker': {'image': 'python:3.6',
                                                                'network': 'BRIDGE',
-                                                               'port-mapping': [{'host-port': 0, # first assigned port
+                                                               'port-mapping': [{'host-port': 0,  # first assigned port
                                                                                  'container-port': 8080},
-                                                                                {'host-port': 1, # second assigned port
+                                                                                {'host-port': 1,  # second assigned port
                                                                                  'container-port': 9090,
                                                                                  'protocol': 'udp'}]}})
         self.assertEqual(resp.status_code, 201, resp.content)
@@ -784,7 +784,7 @@ class CookTest(unittest.TestCase):
             # Get agent host/port
             state = util.get_mesos_state(self.mesos_url)
             agent = [agent for agent in state['slaves']
-                 if agent['hostname'] == instance['hostname']][0]
+                     if agent['hostname'] == instance['hostname']][0]
             # Get the host and port of the agent API.
             # Example pid: "slave(1)@172.17.0.7:5051"
             agent_hostport = agent['pid'].split('@')[1]
@@ -795,7 +795,7 @@ class CookTest(unittest.TestCase):
             container_id = 'mesos-%s.%s' % (agent['id'], executor['container'])
             self.logger.debug('container_id: %s' % container_id)
 
-            @retry(stop_max_delay=60000, wait_fixed=1000) # Wait for docker container to start
+            @retry(stop_max_delay=60000, wait_fixed=1000)  # Wait for docker container to start
             def get_docker_info():
                 self.logger.info('Running containers: %s' % subprocess.check_output(['docker', 'ps']).decode('utf-8'))
                 return json.loads(subprocess.check_output(['docker', 'inspect', container_id]).decode('utf-8'))

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -164,22 +164,8 @@ def wait_for_job(cook_url, job_id, status, max_delay=120000):
         raise
 
 
-def query_jobs(cook_url, **kwargs):
-    """
-    Queries cook for a set of jobs, by job and/or instance uuid. The kwargs
-    passed to this function are sent straight through as query parameters on
-    the request.
-    """
-    return session.get('%s/rawscheduler' % cook_url, params=kwargs)
-
-
 def multi_cluster_tests_enabled():
     return os.getenv('COOK_MULTI_CLUSTER') is not None
-
-  
-def get_job(cook_url, job_uuid):
-    """Loads a job by UUID using GET /rawscheduler"""
-    return query_jobs(cook_url, job=[job_uuid]).json()[0]
 
 
 def wait_for_exit_code(cook_url, job_id):
@@ -242,10 +228,15 @@ def contains_job_uuid(jobs, job_uuid):
     """Returns true if jobs contains a job with the given uuid"""
     return any(job for job in jobs if job['uuid'] == job_uuid)
 
+
 def get_executor(agent_state, executor_id):
-    '''Returns the executor with id executor_id from agent_state'''
+    """Returns the executor with id executor_id from agent_state"""
     for framework in agent_state['frameworks']:
         for executor in framework['executors']:
             if executor['id'] == executor_id:
                 return executor
 
+
+def get_user(cook_url, job_uuid):
+    """Retrieves the job corresponding to the given job_uuid and returns the user"""
+    return load_job(cook_url, job_uuid)['user']


### PR DESCRIPTION
## What's in here?

- [x] the `list` sub-command
- [x] integration tests that invoke `cs list ...`
- [x] documentation for this sub-command

## What's still missing from the CLI?

- the following sub-commands: 
  - `submit-group`
  - `kill`
  - `retry`
- configurable authentication

The reason these things are not here is just to keep this PR relatively small. Once we get this merged, we will work on adding these items as well.