### PR TITLE
WIP: Use non-standard Mesos files for stdout and stderr

### DIFF
--- a/executor/cook/config.py
+++ b/executor/cook/config.py
@@ -51,7 +51,7 @@ def initialize_config(environment):
     """
     max_bytes_read_per_line = int(environment.get('EXECUTOR_MAX_BYTES_READ_PER_LINE', 4 * 1024))
     max_message_length = int(environment.get('EXECUTOR_MAX_MESSAGE_LENGTH', 512))
-    progress_output_name = environment.get('PROGRESS_OUTPUT_FILE', 'stdout')
+    progress_output_name = environment.get('PROGRESS_OUTPUT_FILE', 'executor.stdout')
     progress_regex_string = environment.get('PROGRESS_REGEX_STRING', 'progress: (\d*), (.*)')
     progress_sample_interval_ms = int(environment.get('PROGRESS_SAMPLE_INTERVAL_MS', 1000))
     sandbox_directory = environment.get('MESOS_SANDBOX', '')

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -353,10 +353,10 @@ class CookExecutor(Executor):
         logging.info('Executor disconnected!')
 
     def launchTask(self, driver, task):
-        logging.info('Driver {} launching task {}'.format(driver, task))
+        logging.info('Driver {} launching task with id {}'.format(driver, get_task_id(task)))
 
-        stdout_file_path = os.path.join(self.config.sandbox_directory, 'stdout')
-        stderr_file_path = os.path.join(self.config.sandbox_directory, 'stderr')
+        stdout_file_path = os.path.join(self.config.sandbox_directory, 'executor.stdout')
+        stderr_file_path = os.path.join(self.config.sandbox_directory, 'executor.stderr')
         thread = Thread(target=manage_task,
                         args=(driver, task, self.stop_signal, self.completed_signal, self.config, stdout_file_path,
                               stderr_file_path))

--- a/executor/tests/test_config.py
+++ b/executor/tests/test_config.py
@@ -48,7 +48,7 @@ class ConfigTest(unittest.TestCase):
 
         self.assertEqual(4 * 1024, config.max_bytes_read_per_line)
         self.assertEqual(512, config.max_message_length)
-        self.assertEqual('stdout', config.progress_output_name)
+        self.assertEqual('executor.stdout', config.progress_output_name)
         self.assertEqual('progress: (\\d*), (.*)', config.progress_regex_string)
         self.assertEqual(1000, config.progress_sample_interval_ms)
         self.assertEqual('', config.sandbox_directory)

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -379,7 +379,7 @@
                        (throw (ex-info "Executor uri value is missing!" {:executor executor})))
                      (when (and (:portion executor) (not (<= 0 (:portion executor) 1)))
                        (throw (ex-info "Executor portion must be in the range [0, 1]!" {:executor executor})))
-                     (let [default-executor-config {:default-progress-output-file "stdout"
+                     (let [default-executor-config {:default-progress-output-file "executor.stdout"
                                                     :default-progress-regex-string "progress: (\\d*)(?: )?(.*)"
                                                     :log-level "INFO"
                                                     :max-message-length 512


### PR DESCRIPTION
Older versions of Mesos (e.g. 0.27.1) create the `stdout` and `stderr` with only read permissions for the user running the task. As a result, the Cook executor receives a permission error when it tries to open these files in append mode. As a workaround, we can instead use different files (`executor.stdout` and `executor.stderr`) which get created with read/write permission for the user running the task.

Note: This issue does not occur in later versions of Mesos (e.g. 1.2) where the `stdout` and `stderr` files are created with read/write permissions of the user running the task.