### PR TITLE
Adds support for (optional) counters to the CLI

### DIFF
--- a/cli/.cs.json
+++ b/cli/.cs.json
@@ -23,7 +23,7 @@
     "host": "localhost",
     "port": 8125,
     "line-formats": {
-      "count": "{name}:{value}|c"
+      "count": "{namespace}.{name}:{value}|c"
     }
   }
 }

--- a/cli/.cs.json
+++ b/cli/.cs.json
@@ -17,5 +17,13 @@
       "url": "http://127.0.0.1:22321/",
       "disabled": true
     }
-  ]
+  ],
+  "metrics": {
+    "disabled": true,
+    "host": "localhost",
+    "port": 8125,
+    "line-formats": {
+      "count": "{name}:{value}|c"
+    }
+  }
 }

--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -111,7 +111,7 @@ def run(args):
         config = load_config(config_path)
         try:
             metrics.initialize(config)
-            metrics.inc('cs.commands.%s' % action)
+            metrics.inc('command.%s.runs' % action)
             clusters = load_target_clusters(config, url, cluster)
             http.configure(config)
             args = {k: v for k, v in args.items() if v is not None}

--- a/cli/cook/metrics.py
+++ b/cli/cook/metrics.py
@@ -17,42 +17,54 @@ def initialize(config):
     disabled in which case this is essentially a no-op
     """
     global __disabled
-    metrics_config = config.get('metrics')
-    __disabled = metrics_config.get('disabled')
-    if __disabled:
-        return
+    try:
+        metrics_config = config.get('metrics')
+        __disabled = metrics_config.get('disabled')
+        if __disabled:
+            return
 
-    global __conn
-    global __line_formats
-    __conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    __conn.connect((metrics_config.get('host'), metrics_config.get('port')))
-    __line_formats = metrics_config.get('line-formats')
+        global __conn
+        global __line_formats
+        __conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        __conn.connect((metrics_config.get('host'), metrics_config.get('port')))
+        __line_formats = metrics_config.get('line-formats')
+    except:
+        __disabled = True
+        logging.exception('exception when initializing metrics')
 
 
 def close():
     """Closes the metrics module (unless disabled)"""
+    global __disabled
     if __disabled:
         return
-    __conn.close()
+    try:
+        __conn.close()
+    except:
+        __disabled = True
+        logging.exception('exception when closing metrics socket')
 
 
 def __send(metric):
     """Sends the given metric using the configured line format"""
-    line_format = __line_formats[metric['type']]
+    global __disabled
     try:
+        line_format = __line_formats[metric['type']]
         metric_line = line_format.format(**metric)
         logging.info('sending metric %s' % metric_line)
         __conn.send(('%s\n' % metric_line).encode())
     except:
-        logging.exception('exception when sending metric %s using line format %s' % (metric, line_format))
+        __disabled = True
+        logging.exception('exception when sending metric %s' % metric)
 
 
-def inc(metric_name):
-    """Increments a counter with the given metric_name"""
+def inc(metric_name, count=1):
+    """Increments a counter with the given metric_name by count"""
     if __disabled:
         return
-    metric = {'name': metric_name,
-              'value': 1,
+    metric = {'namespace': 'cs',
+              'name': metric_name,
+              'value': count,
               'host': __host,
               'user': __user,
               'type': 'count'}

--- a/cli/cook/metrics.py
+++ b/cli/cook/metrics.py
@@ -1,0 +1,59 @@
+import logging
+import socket
+
+from cook.util import current_user
+
+__line_formats = None
+__conn = None
+__host = socket.gethostname()
+__user = current_user()
+__disabled = True
+
+
+def initialize(config):
+    """
+    Initializes the metrics module using the given
+    config; note that metrics can be completely
+    disabled in which case this is essentially a no-op
+    """
+    global __disabled
+    metrics_config = config.get('metrics')
+    __disabled = metrics_config.get('disabled')
+    if __disabled:
+        return
+
+    global __conn
+    global __line_formats
+    __conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    __conn.connect((metrics_config.get('host'), metrics_config.get('port')))
+    __line_formats = metrics_config.get('line-formats')
+
+
+def close():
+    """Closes the metrics module (unless disabled)"""
+    if __disabled:
+        return
+    __conn.close()
+
+
+def __send(metric):
+    """Sends the given metric using the configured line format"""
+    line_format = __line_formats[metric['type']]
+    try:
+        metric_line = line_format.format(**metric)
+        logging.info('sending metric %s' % metric_line)
+        __conn.send(('%s\n' % metric_line).encode())
+    except:
+        logging.exception('exception when sending metric %s using line format %s' % (metric, line_format))
+
+
+def inc(metric_name):
+    """Increments a counter with the given metric_name"""
+    if __disabled:
+        return
+    metric = {'name': metric_name,
+              'value': 1,
+              'host': __host,
+              'user': __user,
+              'type': 'count'}
+    __send(metric)

--- a/cli/cook/subcommands/submit.py
+++ b/cli/cook/subcommands/submit.py
@@ -5,7 +5,7 @@ import shlex
 import sys
 import uuid
 
-from cook import colors, http
+from cook import colors, http, metrics
 from cook.util import deep_merge, is_valid_uuid, read_lines, print_info, current_user
 
 
@@ -85,6 +85,7 @@ def submit_federated(clusters, jobs):
             resp = http.post(cluster, 'rawscheduler', {'jobs': jobs})
             print_submit_result(cluster, resp)
             if resp.status_code == 201:
+                metrics.inc('command.submit.jobs', len(jobs))
                 return 0
         except IOError as ioe:
             logging.info(ioe)


### PR DESCRIPTION
This PR adds support for optionally configuring metrics to be sent via TCP using your line format of choice.

This has been tested both with the StatsD line format and our internal line format.

Example of metrics graphed in Graphite:
![image](https://user-images.githubusercontent.com/444778/30997898-73273418-a490-11e7-8ca5-b3ad72cdd95b.png)
