### PR TITLE
Adds packaging info for pypi

### DIFF
--- a/cli/cook/subcommands/submit.py
+++ b/cli/cook/subcommands/submit.py
@@ -144,7 +144,7 @@ def submit(clusters, args):
     raw = job.pop('raw', None)
     command_from_command_line = job.pop('command', None)
     application_name = job.pop('application_name', 'cook-scheduler-cli')
-    application_version = job.pop('application_version', pkg_resources.require('twosigma.cook-cli')[0].version)
+    application_version = job.pop('application_version', pkg_resources.require('cook_client')[0].version)
     job['application'] = {'name': application_name, 'version': application_version}
 
     if raw:

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -16,8 +16,11 @@ test_requirements = [
 ]
 
 setup(
-    name='twosigma.cook-cli',
-    version='0.1.0a1',
+    name='cook_client',
+    version='0.1.0a4',
+    description="Two Sigma's Cook CLI",
+    long_description="This package contains Two Sigma's Cook Scheduler command line interface, cs. cs allows you to "
+                     "submit jobs and view jobs, job instances, and job groups across multiple Cook clusters.",
     packages=['cook', 'cook.subcommands'],
     entry_points={'console_scripts': ['cs = cook.__main__:main']},
     install_requires=requirements,


### PR DESCRIPTION
This has been uploaded to pypi here:

https://pypi.python.org/pypi/cook-client/0.1.0a4

I confirmed that in a fresh virtualenv, you can `pip install cook_client` and then run `cs`.