### PR TITLE
Order in priority message handling

### DIFF
--- a/executor/cook/__init__.py
+++ b/executor/cook/__init__.py
@@ -7,8 +7,6 @@ For more information on Mesos executors, see the "Working with Executors"
 section at http://mesos.apache.org/documentation/latest/app-framework-development-guide/
 """
 
-PROGRESS_MESSAGE_KEY = 'progress-message'
-
 RUNNING_POLL_INTERVAL_SECS = 1
 
 TASK_ERROR = 'TASK_ERROR'

--- a/executor/cook/config.py
+++ b/executor/cook/config.py
@@ -52,7 +52,7 @@ def initialize_config(environment):
     max_bytes_read_per_line = int(environment.get('EXECUTOR_MAX_BYTES_READ_PER_LINE', 4 * 1024))
     max_message_length = int(environment.get('EXECUTOR_MAX_MESSAGE_LENGTH', 512))
     progress_output_name = environment.get('PROGRESS_OUTPUT_FILE', 'stdout')
-    progress_regex_string = environment.get('PROGRESS_REGEX_STRING', 'progress: (\d*), (.*)')
+    progress_regex_string = environment.get('PROGRESS_REGEX_STRING', 'progress: (\d+), (.*)')
     progress_sample_interval_ms = int(environment.get('PROGRESS_SAMPLE_INTERVAL_MS', 1000))
     sandbox_directory = environment.get('MESOS_SANDBOX', '')
     shutdown_grace_period = environment.get('MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD', '2secs')

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -185,6 +185,9 @@ class ProgressWatcher(object):
                 progress_report = ProgressWatcher.match_progress_update(self.progress_regex_string, line)
                 if progress_report is not None:
                     percent, message = progress_report
+                    if not percent.isdigit():
+                        logging.info('Skipping "{}" as the percent entry is not an int'.format(progress_report))
+                        continue
                     logging.info('Updating progress to {} percent, message: {}'.format(percent, message))
                     sequence += 1
                     self.progress = {'progress-message': message.strip(),

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -71,13 +71,13 @@ class ProgressUpdater(object):
                     message_dict['task-id'] = self.task_id
                     progress_message = json.dumps(message_dict)
 
-                    if len(progress_message) > self.max_message_length and cook.PROGRESS_MESSAGE_KEY in message_dict:
-                        progress_str = message_dict[cook.PROGRESS_MESSAGE_KEY]
+                    if len(progress_message) > self.max_message_length and 'progress-message' in message_dict:
+                        progress_str = message_dict['progress-message']
                         num_extra_chars = len(progress_message) - self.max_message_length
                         allowed_progress_message_length = max(len(progress_str) - num_extra_chars - 3, 0)
                         new_progress_str = progress_str[:allowed_progress_message_length].strip() + '...'
                         logging.info('Progress message trimmed to {}'.format(new_progress_str))
-                        message_dict[cook.PROGRESS_MESSAGE_KEY] = new_progress_str
+                        message_dict['progress-message'] = new_progress_str
                         progress_message = json.dumps(message_dict)
 
                     self.send_message(self.driver, progress_message, self.max_message_length)
@@ -180,12 +180,16 @@ class ProgressWatcher(object):
         """
         if self.progress_regex_string:
             sleep_time_ms = 50
+            sequence = 0
             for line in self.tail(sleep_time_ms):
                 progress_report = ProgressWatcher.match_progress_update(self.progress_regex_string, line)
                 if progress_report is not None:
                     percent, message = progress_report
                     logging.info('Updating progress to {} percent, message: {}'.format(percent, message))
-                    self.progress = {cook.PROGRESS_MESSAGE_KEY: message.strip(), 'progress-percent': int(percent)}
+                    sequence += 1
+                    self.progress = {'progress-message': message.strip(),
+                                     'progress-percent': int(percent),
+                                     'progress-sequence': sequence}
                     yield self.progress
 
 

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -185,7 +185,7 @@ class ProgressWatcher(object):
                 progress_report = ProgressWatcher.match_progress_update(self.progress_regex_string, line)
                 if progress_report is not None:
                     percent, message = progress_report
-                    if not percent.isdigit():
+                    if not percent or not percent.isdigit():
                         logging.info('Skipping "{}" as the percent entry is not an int'.format(progress_report))
                         continue
                     logging.info('Updating progress to {} percent, message: {}'.format(percent, message))

--- a/executor/tests/test_config.py
+++ b/executor/tests/test_config.py
@@ -49,7 +49,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(4 * 1024, config.max_bytes_read_per_line)
         self.assertEqual(512, config.max_message_length)
         self.assertEqual('stdout', config.progress_output_name)
-        self.assertEqual('progress: (\\d*), (.*)', config.progress_regex_string)
+        self.assertEqual('progress: (\\d+), (.*)', config.progress_regex_string)
         self.assertEqual(1000, config.progress_sample_interval_ms)
         self.assertEqual('', config.sandbox_directory)
         self.assertEqual(2000, config.shutdown_grace_period_ms)

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -324,7 +324,10 @@ class ExecutorTest(unittest.TestCase):
             assert_message(self, expected_message_0, actual_encoded_message_0)
 
             actual_encoded_message_1 = driver.messages[1]
-            expected_message_1 = {'progress-message': 'line count is 20', 'progress-percent': 90, 'task-id': task_id}
+            expected_message_1 = {'progress-message': 'line count is 20',
+                                  'progress-percent': 90,
+                                  'progress-sequence': 1,
+                                  'task-id': task_id}
             assert_message(self, expected_message_1, actual_encoded_message_1)
 
             actual_encoded_message_2 = driver.messages[2]
@@ -363,11 +366,17 @@ class ExecutorTest(unittest.TestCase):
             assert_message(self, expected_message_0, actual_encoded_message_0)
 
             actual_encoded_message_1 = driver.messages[1]
-            expected_message_1 = {'progress-message': 'Fifty percent', 'progress-percent': 50, 'task-id': task_id}
+            expected_message_1 = {'progress-message': 'Fifty percent',
+                                  'progress-percent': 50,
+                                  'progress-sequence': 1,
+                                  'task-id': task_id}
             assert_message(self, expected_message_1, actual_encoded_message_1)
 
             actual_encoded_message_2 = driver.messages[2]
-            expected_message_2 = {'progress-message': 'Fifty-five percent', 'progress-percent': 55, 'task-id': task_id}
+            expected_message_2 = {'progress-message': 'Fifty-five percent',
+                                  'progress-percent': 55,
+                                  'progress-sequence': 2,
+                                  'task-id': task_id}
             assert_message(self, expected_message_2, actual_encoded_message_2)
 
             actual_encoded_message_3 = driver.messages[3]

--- a/executor/tests/test_progress.py
+++ b/executor/tests/test_progress.py
@@ -262,21 +262,21 @@ class ProgressTest(unittest.TestCase):
             file.flush()
 
             time.sleep(0.10)
-            self.assertEqual({'progress-message': 'Fifty percent', 'progress-percent': 50},
+            self.assertEqual({'progress-message': 'Fifty percent', 'progress-percent': 50, 'progress-sequence': 2},
                              progress_watcher.current_progress())
 
             file.write("Stage Three complete\n")
             file.flush()
 
             time.sleep(0.10)
-            self.assertEqual({'progress-message': 'Fifty percent', 'progress-percent': 50},
+            self.assertEqual({'progress-message': 'Fifty percent', 'progress-percent': 50, 'progress-sequence': 2},
                              progress_watcher.current_progress())
 
             file.write("^^^^JOB-PROGRESS: 55 Fifty-five percent\n")
             file.flush()
 
             time.sleep(0.10)
-            self.assertEqual({'progress-message': 'Fifty-five percent', 'progress-percent': 55},
+            self.assertEqual({'progress-message': 'Fifty-five percent', 'progress-percent': 55, 'progress-sequence': 3},
                              progress_watcher.current_progress())
 
             file.write("Stage Four complete\n")
@@ -285,7 +285,7 @@ class ProgressTest(unittest.TestCase):
             file.flush()
 
             time.sleep(0.10)
-            self.assertEqual({'progress-message': 'Hundred percent', 'progress-percent': 100},
+            self.assertEqual({'progress-message': 'Hundred percent', 'progress-percent': 100, 'progress-sequence': 4},
                              progress_watcher.current_progress())
 
         finally:
@@ -338,7 +338,8 @@ class ProgressTest(unittest.TestCase):
             read_progress_states_thread.join()
 
             expected_data = list(map(lambda x: {'progress-message': 'completed-{}-percent'.format(x),
-                                                'progress-percent': x},
+                                                'progress-percent': x,
+                                                'progress-sequence': x},
                                      range(1, 101)))
 
             self.assertEqual(expected_data, collected_data)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -150,6 +150,7 @@ class CookTest(unittest.TestCase):
         job_executor_type = util.get_job_executor_type(self.cook_url)
         command = 'echo "progress: 25 Twenty-five percent" && sleep 2 && ' \
                   'echo "progress: 50 Fifty percent" && sleep 2 && ' \
+                  'echo "progress: Sixty percent invalid format" && sleep 2 && ' \
                   'echo "progress: 75 Seventy-five percent" && sleep 2 && ' \
                   'echo "progress: Eighty percent invalid format" && sleep 2 && ' \
                   'echo "Done" && exit 0'

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -289,7 +289,7 @@ An example configuration looks like:
 {...
  :executor {:command "cook-executor"
             :default-progress-output-file "stdout"
-            :default-progress-regex-string "progress: (\d*)(?: )?(.*)"
+            :default-progress-regex-string "progress: (\d+)(?: )?(.*)"
             :log-level "INFO"
             :max-message-length 512
             :progress-sample-interval-ms 1000

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -377,8 +377,10 @@ The configuration values are defined as follows:
   The default value is 2500.
 
 `:sequence-cache-threshold`::
-  An integer representing the size of the task id to progress sequence cache to maintain.
+  An integer representing the max number of items in the task sequence cache.
   This cache is used to track the latest sequence number of progress message processed for a given task.
+  In order to avoid the potential for out-of-order progress updates,
+  this cache should be sized to handle the maximum number of active tasks that are reporting progress.
   The default value is 1000.
 
 === Debugging Facilities

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -356,7 +356,8 @@ An example configuration looks like:
 {...
  :progress {:batch-size 100
             :pending-threshold 4000
-            :publish-interval-ms 2500}
+            :publish-interval-ms 2500
+            :sequence-cache-threshold 1000}
  ...}
 ```
 
@@ -374,6 +375,11 @@ The configuration values are defined as follows:
 `:publish-interval-ms`::
   An integer representing the number of millisecond intervals at which progress updates will be published to datomic.
   The default value is 2500.
+
+`:sequence-cache-threshold`::
+  An integer representing the size of the task id to progress sequence cache to maintain.
+  This cache is used to track the latest sequence number of progress message processed for a given task.
+  The default value is 1000.
 
 === Debugging Facilities
 

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -481,7 +481,8 @@
      :progress (fnk [[:config {progress nil}]]
                    (merge {:batch-size 100
                            :pending-threshold 4000
-                           :publish-interval-ms 2500}
+                           :publish-interval-ms 2500
+                           :sequence-cache-threshold 1000}
                           progress))
      :riemann (fnk [[:config [:metrics {riemann nil}]]]
                 riemann)

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -380,7 +380,7 @@
                      (when (and (:portion executor) (not (<= 0 (:portion executor) 1)))
                        (throw (ex-info "Executor portion must be in the range [0, 1]!" {:executor executor})))
                      (let [default-executor-config {:default-progress-output-file "stdout"
-                                                    :default-progress-regex-string "progress: (\\d*)(?: )?(.*)"
+                                                    :default-progress-regex-string "progress: (\\d+)(?: )?(.*)"
                                                     :log-level "INFO"
                                                     :max-message-length 512
                                                     :portion 0.0

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -286,15 +286,15 @@
 
 (defn progress-aggregator
   "Aggregates the progress state specified in `data` into the current progress state `instance-id->progress-state`.
-   It drops messages if the aggregated state has more than `pending-progress-threshold` different entries.
+   It drops messages if the aggregated state has more than `pending-threshold` different entries.
    It returns the new progress state.
    The aggregator also makes a local best-effort to avoid updating the progress state of individual instances with
    stale data based on the value of progress-sequence in the message.
    We avoid this stale check in the datomic transaction as it is relatively expensive to perform the checks on a per
    instance basis in the query."
-  [pending-progress-threshold sequence-cache-store instance-id->progress-state {:keys [instance-id] :as data}]
+  [pending-threshold sequence-cache-store instance-id->progress-state {:keys [instance-id] :as data}]
   (meters/mark! progress-aggregator-message-rate)
-  (if (or (< (count instance-id->progress-state) pending-progress-threshold)
+  (if (or (< (count instance-id->progress-state) pending-threshold)
           (contains? instance-id->progress-state instance-id))
     (if (integer? (:progress-sequence data))
       (let [progress-state (select-keys data [:progress-message :progress-percent :progress-sequence])
@@ -326,19 +326,20 @@
 (defn progress-update-aggregator
   "Launches a long running go block that triggers publishing the latest aggregated instance-id->progress-state
    wrapped inside a chan whenever there is a read on the progress-state-chan.
-   It drops messages if the progress-aggregator-chan queue is larger than pending-progress-threshold or the aggregated
-   state has more than pending-progress-threshold different entries.
+   It drops messages if the progress-aggregator-chan queue is larger than pending-threshold or the aggregated
+   state has more than pending-threshold different entries.
    It returns the progress-aggregator-chan which can be used to send progress-state messages to the aggregator.
 
    Note: the wrapper chan is used due to our use of `util/xform-pipe`"
-  [pending-progress-threshold sequence-cache-threshold progress-state-chan]
+  [{:keys [pending-threshold publish-interval-ms sequence-cache-threshold]} progress-state-chan]
   (log/info "Starting progress update aggregator")
-  (let [progress-aggregator-chan (async/chan (async/sliding-buffer pending-progress-threshold))
+  (let [progress-aggregator-chan (async/chan (async/sliding-buffer pending-threshold))
         sequence-cache-store (-> {}
-                                (cache/lru-cache-factory :threshold sequence-cache-threshold)
-                                atom)
+                                 (cache/lru-cache-factory :threshold sequence-cache-threshold)
+                                 (cache/ttl-cache-factory :ttl (* 2 publish-interval-ms))
+                                 atom)
         progress-aggregator-fn (fn progress-aggregator-fn [instance-id->progress-state data]
-                                 (progress-aggregator pending-progress-threshold sequence-cache-store instance-id->progress-state data))
+                                 (progress-aggregator pending-threshold sequence-cache-store instance-id->progress-state data))
         aggregator-go-chan (util/reducing-pipe progress-aggregator-chan progress-aggregator-fn progress-state-chan
                                                :initial-state {})]
     (async/go
@@ -1546,9 +1547,9 @@
         [offers-chan resources-atom]
         (make-offer-handler conn driver-atom fenzo framework-id executor-config pending-jobs-atom offer-cache fenzo-max-jobs-considered
                             fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset match-trigger-chan)
-        {:keys [batch-size pending-threshold sequence-cache-threshold]} progress-config
+        {:keys [batch-size]} progress-config
         {:keys [progress-state-chan]} (progress-update-transactor progress-updater-trigger-chan batch-size conn)
-        progress-aggregator-chan (progress-update-aggregator pending-threshold sequence-cache-threshold progress-state-chan)
+        progress-aggregator-chan (progress-update-aggregator progress-config progress-state-chan)
         handle-progress-message (fn handle-progress-message-curried [progress-message-map]
                                  (handle-progress-message! progress-aggregator-chan progress-message-map))]
     (start-jobs-prioritizer! conn pending-jobs-atom task-constraints rank-trigger-chan)

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -287,19 +287,34 @@
 (defn progress-aggregator
   "Aggregates the progress state specified in `data` into the current progress state `instance-id->progress-state`.
    It drops messages if the aggregated state has more than `pending-progress-threshold` different entries.
-   It returns the new progress state."
+   It returns the new progress state.
+   The aggregator also makes a local best-effort to avoid updating the progress state of individual instances with
+   stale data based on the value of progress-sequence in the message.
+   We avoid this stale check in the datomic transaction as it is relatively expensive to perform the checks on a per
+   instance basis in the query."
   [pending-progress-threshold instance-id->progress-state {:keys [instance-id] :as data}]
   (meters/mark! progress-aggregator-message-rate)
   (if (or (< (count instance-id->progress-state) pending-progress-threshold)
           (contains? instance-id->progress-state instance-id))
-    (let [progress-state (select-keys data [:progress-message :progress-percent])
-          instance-id->progress-state' (assoc instance-id->progress-state instance-id progress-state)]
-      (let [old-count (count instance-id->progress-state)
-            new-count (count instance-id->progress-state')]
-        (when (zero? old-count)
-          (counters/clear! progress-aggregator-pending-states-count))
-        (counters/inc! progress-aggregator-pending-states-count (- new-count old-count)))
-      instance-id->progress-state')
+    (if (integer? (:progress-sequence data))
+      (let [progress-state (select-keys data [:progress-message :progress-percent :progress-sequence])
+            instance-id->progress-state' (update instance-id->progress-state instance-id
+                                                 (fn [current-state]
+                                                   (let [new-progress-sequence (:progress-sequence progress-state)
+                                                         old-progress-sequence (:progress-sequence current-state)]
+                                                     (if (or (nil? current-state)
+                                                             (< old-progress-sequence new-progress-sequence))
+                                                       progress-state
+                                                       current-state))))]
+        (let [old-count (count instance-id->progress-state)
+              new-count (count instance-id->progress-state')]
+          (when (zero? old-count)
+            (counters/clear! progress-aggregator-pending-states-count))
+          (counters/inc! progress-aggregator-pending-states-count (- new-count old-count)))
+        instance-id->progress-state')
+      (do
+        (log/warn "skipping" data "as it is missing an integer progress-sequence")
+        instance-id->progress-state))
     (do
       (meters/mark! progress-aggregator-drop-rate)
       (counters/inc! progress-aggregator-drop-count)
@@ -395,7 +410,7 @@
     handle-framework-message-duration
     (try
       (let [db (db conn)
-            {:strs [exit-code progress-message progress-percent sandbox-directory task-id] :as message}
+            {:strs [exit-code progress-message progress-percent progress-sequence sandbox-directory task-id] :as message}
             (-> (String. ^bytes framework-message "UTF-8") (json/read-str))
             _ (log/debug "Received framework message:" {:task-id task-id, :message message})
             _ (when (str/blank? task-id)
@@ -408,7 +423,8 @@
               (log/debug "Updating instance" instance-id "progress to" progress-percent progress-message)
               (handle-progress-message {:instance-id instance-id
                                         :progress-message progress-message
-                                        :progress-percent progress-percent}))
+                                        :progress-percent progress-percent
+                                        :progress-sequence progress-sequence}))
             (when (or exit-code sandbox-directory)
               (let [txns (cond-> []
                                  exit-code (conj [:db/add instance-id :instance/exit-code (int exit-code)])

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -598,3 +598,21 @@
                (when close?
                  (async/close! to))
                (recur (reducer state data)))))))
+
+(defn cache-lookup!
+  "Lookup a value by key in the cache store.
+   If the cache has the key, return the value corresponding to the key in the cache.
+   If the cache does not have the key, update the cache with key->not-found-value and return not-found-value."
+  [cache-store key not-found-value]
+  (cache/lookup (swap! cache-store
+                       #(if (cache/has? % key)
+                          (cache/hit % key)
+                          (cache/miss % key not-found-value)))
+                key))
+
+(defn cache-update!
+  "Updates the key->value mapping in the cache store."
+  [cache-store key value]
+  (swap! cache-store #(-> %
+                          (cache/evict key)
+                          (cache/miss key value))))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -604,11 +604,11 @@
    If the cache has the key, return the value corresponding to the key in the cache.
    If the cache does not have the key, update the cache with key->not-found-value and return not-found-value."
   [cache-store key not-found-value]
-  (cache/lookup (swap! cache-store
-                       #(if (cache/has? % key)
-                          (cache/hit % key)
-                          (cache/miss % key not-found-value)))
-                key))
+  (-> (swap! cache-store
+             #(if (cache/has? % key)
+                (cache/hit % key)
+                (cache/miss % key not-found-value)))
+      (cache/lookup key)))
 
 (defn cache-update!
   "Updates the key->value mapping in the cache store."

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1049,7 +1049,7 @@
             ;; no asynchronous transaction should be created
             (is (nil? (sched/handle-framework-message conn handle-progress-message message)))
             (is (nil? (query-instance-field instance-id :instance/progress-message)))
-            (is (= {:instance-id instance-id :progress-message progress-message :progress-percent nil}
+            (is (= {:instance-id instance-id :progress-message progress-message :progress-percent nil :progress-sequence nil}
                    (deref progress-aggregator-promise 1000 nil))))))
 
       (testing "progress update"
@@ -1060,23 +1060,31 @@
           (let [progress-aggregator-promise (promise)
                 handle-progress-message (handle-progress-message-factory progress-aggregator-promise)
                 progress-percent 20
-                message (make-message {:task-id task-id :progress-percent progress-percent})]
+                progress-sequence 11
+                message (make-message {:task-id task-id :progress-percent progress-percent :progress-sequence progress-sequence})]
             ;; no asynchronous transaction should be created
             (is (nil? (sched/handle-framework-message conn handle-progress-message message)))
             (is (= 0 (query-instance-field instance-id :instance/progress)))
             (is (nil? (query-instance-field instance-id :instance/progress-message)))
-            (is (= {:instance-id instance-id :progress-message nil :progress-percent progress-percent}
+            (is (= {:instance-id instance-id
+                    :progress-message nil
+                    :progress-percent progress-percent
+                    :progress-sequence progress-sequence}
                    (deref progress-aggregator-promise 1000 nil))))
 
           (let [progress-aggregator-promise (promise)
                 handle-progress-message (handle-progress-message-factory progress-aggregator-promise)
                 progress-percent 50
-                message (make-message {:task-id task-id :progress-percent progress-percent})]
+                progress-sequence 19
+                message (make-message {:task-id task-id :progress-percent progress-percent :progress-sequence progress-sequence})]
             ;; no asynchronous transaction should be created
             (is (nil? (sched/handle-framework-message conn handle-progress-message message)))
             (is (= 0 (query-instance-field instance-id :instance/progress)))
             (is (nil? (query-instance-field instance-id :instance/progress-message)))
-            (is (= {:instance-id instance-id :progress-message nil :progress-percent progress-percent}
+            (is (= {:instance-id instance-id
+                    :progress-message nil
+                    :progress-percent progress-percent
+                    :progress-sequence progress-sequence}
                    (deref progress-aggregator-promise 1000 nil))))))
 
       (testing "exit-code update"
@@ -1111,7 +1119,10 @@
             (is (= sandbox-directory (query-instance-field instance-id :instance/sandbox-directory)))
             (is (= 0 (query-instance-field instance-id :instance/progress)))
             (is (nil? (query-instance-field instance-id :instance/progress-message)))
-            (is (= {:instance-id instance-id :progress-message progress-message :progress-percent progress-percent}
+            (is (= {:instance-id instance-id
+                    :progress-message progress-message
+                    :progress-percent progress-percent
+                    :progress-sequence nil}
                    (deref progress-aggregator-promise 1000 nil)))))))))
 
 (deftest test-handle-stragglers
@@ -1683,26 +1694,43 @@
         (is (= [foo bar fie] (->> "T3" (get @messages-store) vec)))
         (is (= [foo] (->> "T4" (get @messages-store) vec)))))))
 
+(defn- progress-entry
+  [message percent sequence & {:keys [instance-id]}]
+  (cond-> {:progress-message message
+           :progress-percent percent
+           :progress-sequence sequence}
+          instance-id (assoc :instance-id instance-id)))
+
 (deftest test-progress-aggregator
-  (testing "basic update from inital state"
-    (is (= {"i1" {:progress-message "i1.m1" :progress-percent 10}}
-           (sched/progress-aggregator 10 {} {:instance-id "i1" :progress-message "i1.m1" :progress-percent 10}))))
+  (testing "basic update from initial state"
+    (is (= {"i1" (progress-entry "i1.m1" 10 1)}
+           (sched/progress-aggregator 10 {} (progress-entry "i1.m1" 10 1 :instance-id "i1")))))
 
   (testing "update state for known instance"
-    (is (= {"i1" {:progress-message "i1.m2" :progress-percent 20}}
-           (sched/progress-aggregator 10 {"i1" {:progress-message "i1.m1" :progress-percent 10}}
-                                      {:instance-id "i1" :progress-message "i1.m2" :progress-percent 20}))))
+    (is (= {"i1" (progress-entry "i1.m2" 20 2)}
+           (sched/progress-aggregator 10 {"i1" (progress-entry "i1.m1" 10 1)}
+                                      (progress-entry "i1.m2" 20 2 :instance-id "i1")))))
+
+  (testing "skip update state when missing progress-sequence"
+    (is (= {"i1" (progress-entry "i1.m1" 10 1)}
+           (sched/progress-aggregator 10 {"i1" (progress-entry "i1.m1" 10 1)}
+                                      (progress-entry "i1.m2" 20 nil :instance-id "i1")))))
+
+  (testing "do not update state for outdated message"
+    (is (= {"i1" (progress-entry "i1.m2" 20 2)}
+           (sched/progress-aggregator 10 {"i1" (progress-entry "i1.m2" 20 2)}
+                                      (progress-entry "i1.m1" 10 1 :instance-id "i1")))))
 
   (testing "handle threshold exceeded"
-    (is (= {"i1" {:progress-message "i1.m1" :progress-percent 10}}
-           (sched/progress-aggregator 1 {"i1" {:progress-message "i1.m1" :progress-percent 10}}
-                                      {:instance-id "i2" :progress-message "i2.m1" :progress-percent 20}))))
+    (is (= {"i1" (progress-entry "i1.m1" 10 1)}
+           (sched/progress-aggregator 1 {"i1" (progress-entry "i1.m1" 10 1)}
+                                      (progress-entry "i2.m2" 20 2 :instance-id "i2")))))
 
   (testing "handle threshold limit reached"
-    (is (= {"i1" {:progress-message "i1.m1" :progress-percent 10}
-            "i2" {:progress-message "i2.m1" :progress-percent 20}}
-           (sched/progress-aggregator 2 {"i1" {:progress-message "i1.m1" :progress-percent 10}}
-                                      {:instance-id "i2" :progress-message "i2.m1" :progress-percent 20})))))
+    (is (= {"i1" (progress-entry "i1.m1" 10 1)
+            "i2" (progress-entry "i2.m2" 20 2)}
+           (sched/progress-aggregator 2 {"i1" (progress-entry "i1.m1" 10 1)}
+                                      (progress-entry "i2.m2" 20 2 :instance-id "i2"))))))
 
 (deftest test-progress-update-aggregator
   (let [actual-progress-aggregator sched/progress-aggregator
@@ -1737,15 +1765,15 @@
           (let [pending-progress-threshold 10
                 progress-state-chan (async/chan)
                 progress-aggregator-chan (sched/progress-update-aggregator pending-progress-threshold progress-state-chan)]
-            (send progress-aggregator-chan {:instance-id "i1" :progress-message "i1.m1" :progress-percent 10})
-            (send progress-aggregator-chan {:instance-id "i2" :progress-message "i2.m1" :progress-percent 10})
-            (send progress-aggregator-chan {:instance-id "i3" :progress-message "i3.m1" :progress-percent 10})
-            (send progress-aggregator-chan {:instance-id "i2" :progress-message "i2.m2" :progress-percent 25})
-            (send progress-aggregator-chan {:instance-id "i1" :progress-message "i1.m2" :progress-percent 45} :sync true)
+            (send progress-aggregator-chan (progress-entry "i1.m1" 10 1 :instance-id "i1"))
+            (send progress-aggregator-chan (progress-entry "i2.m1" 10 1 :instance-id "i2"))
+            (send progress-aggregator-chan (progress-entry "i3.m1" 10 1 :instance-id "i3"))
+            (send progress-aggregator-chan (progress-entry "i2.m2" 25 2 :instance-id "i2"))
+            (send progress-aggregator-chan (progress-entry "i1.m2" 45 2 :instance-id "i1") :sync true)
 
-            (is (= {"i1" {:progress-message "i1.m2" :progress-percent 45}
-                    "i2" {:progress-message "i2.m2", :progress-percent 25}
-                    "i3" {:progress-message "i3.m1", :progress-percent 10}}
+            (is (= {"i1" (progress-entry "i1.m2" 45 2)
+                    "i2" (progress-entry "i2.m2" 25 2)
+                    "i3" (progress-entry "i3.m1" 10 1)}
                    (async/<!! progress-state-chan)))
             (is (= {} (async/<!! progress-state-chan)))
 
@@ -1766,11 +1794,11 @@
                     progress-state-chan (async/chan)
                     progress-aggregator-chan (sched/progress-update-aggregator pending-progress-threshold progress-state-chan)]
                 (dotimes [n 100]
-                  (send progress-aggregator-chan {:instance-id "i1" :progress-message (str "i1.m" n) :progress-percent n}))
-                (send progress-aggregator-chan {:instance-id "i1" :progress-message "i1.m100" :progress-percent 100} :sync true)
+                  (send progress-aggregator-chan (progress-entry (str "i1.m" n) n n :instance-id "i1")))
+                (send progress-aggregator-chan (progress-entry "i1.m100" 100 100 :instance-id "i1") :sync true)
 
                 (is (< @progress-aggregator-counter 100))
-                (is (= {"i1" {:progress-message "i1.m100", :progress-percent 100}}
+                (is (= {"i1" (progress-entry "i1.m100" 100 100)}
                        (async/<!! progress-state-chan)))
                 (is (= {} (async/<!! progress-state-chan)))
 
@@ -1790,7 +1818,7 @@
             response-chan (async/promise-chan)]
         ;; publish the data
         (async/>!! publish-progress-trigger-chan response-chan)
-        (async/>!! progress-state-chan {i1 {:progress-message "i1.m1" :progress-percent 10}})
+        (async/>!! progress-state-chan {i1 (progress-entry "i1.m1" 10 1)})
         ;; force db transactions
         (async/<!! response-chan)
         ;; assert the state of the db

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -120,7 +120,8 @@
          gpu-enabled?# (or (:gpus-enabled? ~scheduler-config) false)
          progress-config# {:batch-size 100
                            :pending-threshold 1000
-                           :publish-interval-ms 2000}
+                           :publish-interval-ms 2000
+                           :sequence-cache-threshold 1000}
          rebalancer-config# (merge default-rebalancer-config (:rebalancer-config ~scheduler-config))
          framework-id# "cool-framework-id"
          host-settings# {:server-port 12321 :hostname "localhost"}

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -4,7 +4,6 @@
             [chime :refer [chime-ch]]
             [clj-time.core :as t]
             [clj-time.coerce :as tc]
-            [clj-time.periodic :as periodic]
             [clojure.core.async :as async]
             [clojure.core.cache :as cache]
             [clojure.edn :as edn]
@@ -19,17 +18,13 @@
             [cook.mesos :as c]
             [cook.mesos.mesos-mock :as mm]
             [cook.mesos.share :as share]
-            [cook.mesos.scheduler :as sched]
             [cook.mesos.util :as util]
             [cook.test.testutil :refer (restore-fresh-database! poll-until)]
             [datomic.api :as d]
-            [mesomatic.scheduler :as mesos]
-            [mesomatic.types :as mesos-types]
             [plumbing.core :refer (map-vals map-keys map-from-vals)])
   (:import org.apache.curator.framework.CuratorFrameworkFactory
            org.apache.curator.framework.state.ConnectionStateListener
-           org.apache.curator.retry.BoundedExponentialBackoffRetry
-           org.joda.time.DateTimeUtils)
+           org.apache.curator.retry.BoundedExponentialBackoffRetry)
   (:gen-class))
 
 ;;; This namespace contains a simulator for cook scheduler that accepts a trace file
@@ -131,8 +126,8 @@
                             (c/make-trigger-chans rebalancer-config# progress-config# task-constraints#))]
      (try
        (let [additional-config# {:executor-config executor-config#
-                                :rebalancer-config rebalancer-config#
-                                :progress-config progress-config#}
+                                 :rebalancer-config rebalancer-config#
+                                 :progress-config progress-config#}
              scheduler# (c/start-mesos-scheduler ~make-mesos-driver-fn get-mesos-utilization#
                                                  curator-framework# ~conn
                                                  mesos-mult# zk-prefix#


### PR DESCRIPTION
Cook executor: Add support for sequence numbers while sending progress status messages.

Cook scheduler: `progress-aggregator` respects the sequence number in-memory while performing local aggregation of progress messages as it is possible for them to arrive out-of-order.