### PR TITLE
Keep cook-executor binary updated

### DIFF
--- a/executor/bin/check-version.sh
+++ b/executor/bin/check-version.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# USAGE: ./bin/check-version.sh [-q|--quiet]
+#
+# Returns 0 (true) if the currently-installed cook executor version
+# matches the source version, and 1 (false) otherwise.
+#
+# When using the quiet flag (-q|--quiet), no additional output is printed.
+#
+# Note that versions containing the case-insensitive string "SNAPSHOT" never match
+# (i.e., they're considered "unstable", and should always require a rebuild).
+
+case "$1" in
+    -q|--quiet)
+        shift
+        verbose=false
+        ;;
+    '')
+        verbose=true
+        ;;
+    *)
+        echo "USAGE: $0 [-q|--quiet]"
+        exit -1
+esac
+
+source_version=`python3 -c 'from cook._version import __version__; print(__version__)'`
+
+shopt -s nocasematch
+
+if [[ "$source_version" == *SNAPSHOT* ]]; then
+    if $verbose; then
+        echo "Detected snapshot (unstable) version: $source_version"
+    fi
+    exit 1
+fi
+
+binary_app=./dist/cook-executor
+
+if [ -e $binary_app ]; then
+    installed_version="$($binary_app --version)"
+else
+    installed_version=none
+fi
+
+if [ "$installed_version" == "$source_version" ]; then
+    if $verbose; then
+        echo "At most recent version: $installed_version"
+    fi
+    exit 0
+else
+    if $verbose; then
+        echo "Version mismatch: $installed_version installed vs $source_version available"
+    fi
+    exit 1
+fi

--- a/executor/bin/check-version.sh
+++ b/executor/bin/check-version.sh
@@ -7,8 +7,12 @@
 #
 # When using the quiet flag (-q|--quiet), no additional output is printed.
 #
-# Note that versions containing the case-insensitive string "SNAPSHOT" never match
+# Note: versions containing the case-insensitive string "SNAPSHOT" never match
 # (i.e., they're considered "unstable", and should always require a rebuild).
+
+#
+# Parse options
+#
 
 case "$1" in
     -q|--quiet)
@@ -23,7 +27,23 @@ case "$1" in
         exit -1
 esac
 
+#
+# Switch to executor directory
+#
+
+executor_bin_dir="$(dirname ${BASH_SOURCE[0]})"
+
+cd "$executor_bin_dir/.."
+
+#
+# Get source code version
+#
+
 source_version=`python3 -c 'from cook._version import __version__; print(__version__)'`
+
+#
+# Check for source code SNAPSHOT version
+#
 
 shopt -s nocasematch
 
@@ -34,6 +54,10 @@ if [[ "$source_version" == *SNAPSHOT* ]]; then
     exit 1
 fi
 
+#
+# Get installed binary's version
+#
+
 binary_app=./dist/cook-executor
 
 if [ -e $binary_app ]; then
@@ -41,6 +65,10 @@ if [ -e $binary_app ]; then
 else
     installed_version=none
 fi
+
+#
+# Compare source vs installed binary versions
+#
 
 if [ "$installed_version" == "$source_version" ]; then
     if $verbose; then

--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -21,12 +21,13 @@ import cook.executor as ce
 
 
 def main(args=None):
+    from _version import __version__
+
     if len(sys.argv) == 2 and sys.argv[1] == "--version":
-        from _version import __version__
         print(__version__)
         sys.exit(0)
 
-    print('Starting cook executor...')
+    print('Cook Executor version {}'.format(__version__))
 
     environment = os.environ
     executor_id = environment.get('MESOS_EXECUTOR_ID', '1')

--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -21,6 +21,11 @@ import cook.executor as ce
 
 
 def main(args=None):
+    if len(sys.argv) == 2 and sys.argv[1] == "--version":
+        from _version import __version__
+        print(__version__)
+        sys.exit(0)
+
     print('Starting cook executor...')
 
     environment = os.environ

--- a/executor/cook/_version.py
+++ b/executor/cook/_version.py
@@ -1,0 +1,4 @@
+# This file is read by setup.py to obtain the version.
+# Be aware that changing the format may break the parsing logic.
+
+__version__ = "0.1.1"

--- a/executor/setup.py
+++ b/executor/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name='cook-executor',
-    version='0.1.0',
+    version=open("cook/_version.py").readlines()[-1].split('"')[1],
     description='Custom Mesos executor for Cook written in Python',
     url='https://github.com/twosigma/Cook',
     license="Apache Software License 2.0",

--- a/scheduler/bin/build-docker-image.sh
+++ b/scheduler/bin/build-docker-image.sh
@@ -3,5 +3,29 @@
 SCHEDULER_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 NAME=cook-scheduler
 
+EXECUTOR_DIR="$(dirname ${SCHEDULER_DIR})/executor"
+COOK_EXECUTOR_FILE=${EXECUTOR_DIR}/dist/cook-executor
+SCHEDULER_EXECUTOR_DIR=${SCHEDULER_DIR}/resources/public
+
+if [ ! -f ${COOK_EXECUTOR_FILE} ]; then
+    echo "cook-executor not found at ${COOK_EXECUTOR_FILE}"
+    DO_EXECUTOR_REBUILD=true
+elif ! (cd ../executor && ./bin/check-version.sh -q); then
+    echo "cook-executor appears to be out of date"
+    DO_EXECUTOR_REBUILD=true
+else
+    DO_EXECUTOR_REBUILD=false
+fi
+
+if $DO_EXECUTOR_REBUILD; then
+    echo "Triggering build of cook-executor before proceeding."
+    ${EXECUTOR_DIR}/bin/build-cook-executor.sh
+fi
+
+echo "Copying cook-executor from ${COOK_EXECUTOR_FILE} to ${SCHEDULER_EXECUTOR_DIR}"
+mkdir -p ${SCHEDULER_EXECUTOR_DIR}
+cp -f ${COOK_EXECUTOR_FILE} ${SCHEDULER_EXECUTOR_DIR}
+
+
 echo "Building docker images for ${NAME}"
 docker build -t ${NAME} ${SCHEDULER_DIR}

--- a/scheduler/bin/build-docker-image.sh
+++ b/scheduler/bin/build-docker-image.sh
@@ -6,11 +6,12 @@ NAME=cook-scheduler
 EXECUTOR_DIR="$(dirname ${SCHEDULER_DIR})/executor"
 COOK_EXECUTOR_FILE=${EXECUTOR_DIR}/dist/cook-executor
 SCHEDULER_EXECUTOR_DIR=${SCHEDULER_DIR}/resources/public
+SCHEDULER_EXECUTOR_FILE=${SCHEDULER_EXECUTOR_DIR}/cook-executor
 
 if [ ! -f ${COOK_EXECUTOR_FILE} ]; then
     echo "cook-executor not found at ${COOK_EXECUTOR_FILE}"
     DO_EXECUTOR_REBUILD=true
-elif ! (cd ../executor && ./bin/check-version.sh -q); then
+elif ! ../executor/bin/check-version.sh -q; then
     echo "cook-executor appears to be out of date"
     DO_EXECUTOR_REBUILD=true
 else
@@ -22,10 +23,11 @@ if $DO_EXECUTOR_REBUILD; then
     ${EXECUTOR_DIR}/bin/build-cook-executor.sh
 fi
 
-echo "Copying cook-executor from ${COOK_EXECUTOR_FILE} to ${SCHEDULER_EXECUTOR_DIR}"
-mkdir -p ${SCHEDULER_EXECUTOR_DIR}
-cp -f ${COOK_EXECUTOR_FILE} ${SCHEDULER_EXECUTOR_DIR}
-
+if [ "$COOK_EXECUTOR_FILE" -nt "$SCHEDULER_EXECUTOR_FILE" ]; then
+    echo "Copying cook-executor from ${COOK_EXECUTOR_FILE} to ${SCHEDULER_EXECUTOR_DIR}"
+    mkdir -p ${SCHEDULER_EXECUTOR_DIR}
+    cp -f ${COOK_EXECUTOR_FILE} ${SCHEDULER_EXECUTOR_FILE}
+fi
 
 echo "Building docker images for ${NAME}"
 docker build -t ${NAME} ${SCHEDULER_DIR}

--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -26,18 +26,7 @@ else
 fi
 
 SCHEDULER_DIR="$( dirname ${DIR} )"
-EXECUTOR_DIR="$(dirname ${SCHEDULER_DIR})/executor"
-COOK_EXECUTOR_FILE=${EXECUTOR_DIR}/dist/cook-executor
 SCHEDULER_EXECUTOR_DIR=${SCHEDULER_DIR}/resources/public
-
-if [ ! -f ${COOK_EXECUTOR_FILE} ]; then
-    echo "cook-executor not found at ${COOK_EXECUTOR_FILE}"
-    echo "Triggering build of cook-executor before proceeding."
-    ${EXECUTOR_DIR}/bin/build-cook-executor.sh
-fi
-echo "Copying cook-executor from ${COOK_EXECUTOR_FILE} to ${SCHEDULER_EXECUTOR_DIR}"
-mkdir -p ${SCHEDULER_EXECUTOR_DIR}
-cp -f ${COOK_EXECUTOR_FILE} ${SCHEDULER_EXECUTOR_DIR}
 
 if [ -z "$(docker network ls -q -f name=cook_nw)" ];
 then
@@ -67,6 +56,9 @@ docker create \
     --name=${NAME} \
     --publish=${COOK_NREPL_PORT}:${COOK_NREPL_PORT} \
     --publish=${COOK_PORT}:${COOK_PORT} \
+    # NOTE: since the cook scheduler directory is mounted as a volume
+    # by the minimesos agents, they have access to the cook-executor binary
+    # using the absolute file path URI below.
     -e "COOK_EXECUTOR=file://${SCHEDULER_EXECUTOR_DIR}/cook-executor" \
     -e "COOK_PORT=${COOK_PORT}" \
     -e "COOK_NREPL_PORT=${COOK_NREPL_PORT}" \


### PR DESCRIPTION
Ensure cook-executor binary is rebuilt when sources change, and always
copy the newest version when building the scheduler docker image.