### PR TITLE
Use pre-installed Python 3.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ jdk:
 services:
   - docker
 before_install:
+  - source ~/virtualenv/python3.6.2/bin/activate
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
   - echo "deb https://repos.mesosphere.io/ubuntu/ trusty main" | sudo tee /etc/apt/sources.list.d/mesosphere.list
   - sudo apt-get update -qq
   - sudo apt-get install mesos -y </dev/null
-  - pyenv install 3.6.2
-  - pyenv global 3.6.2
 branches:
   only:
     - master


### PR DESCRIPTION
Since pyenv has been failing to download and install python3.6.2 all morning, I think making this switch is worthwhile.