### PR TITLE
Add sysouts to get output closer to Mesos' CommandExecutor

### DIFF
--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -28,7 +28,7 @@ def main(args=None):
         print(__version__)
         sys.exit(0)
 
-    cio.print_out('Cook Executor version {}'.format(__version__))
+    cio.printline_out('Cook Executor version {}'.format(__version__))
 
     environment = os.environ
     executor_id = environment.get('MESOS_EXECUTOR_ID', '1')
@@ -43,7 +43,7 @@ def main(args=None):
     config = cc.initialize_config(environment)
 
     def handle_interrupt(interrupt_code, _):
-        cio.print_out('Received kill for task {} with grace period of {}'.format(
+        cio.printline_out('Received kill for task {} with grace period of {}'.format(
             executor_id, config.shutdown_grace_period))
         logging.info('Received interrupt code {}, preparing to terminate executor'.format(
             interrupt_code))

--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -18,6 +18,7 @@ import encodings.idna
 
 import cook.config as cc
 import cook.executor as ce
+import cook.io_helper as cio
 
 
 def main(args=None):
@@ -27,7 +28,7 @@ def main(args=None):
         print(__version__)
         sys.exit(0)
 
-    print('Cook Executor version {}'.format(__version__))
+    cio.print_out('Cook Executor version {}'.format(__version__))
 
     environment = os.environ
     executor_id = environment.get('MESOS_EXECUTOR_ID', '1')
@@ -42,6 +43,7 @@ def main(args=None):
     config = cc.initialize_config(environment)
 
     def handle_interrupt(interrupt_code, _):
+        print('Received kill for task {} with grace period of {}'.format(executor_id, config.shutdown_grace_period))
         logging.info('Received interrupt code {}, preparing to terminate executor'.format(interrupt_code))
         stop_signal.set()
     signal.signal(signal.SIGINT, handle_interrupt)
@@ -56,6 +58,7 @@ def main(args=None):
 
     exit_code = 1 if stop_signal.isSet() else 0
     logging.info('Executor exiting with code {}'.format(exit_code))
+    print('Executor completed execution of {}'.format(executor_id))
     sys.exit(exit_code)
 
 if __name__ == '__main__':

--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -28,7 +28,7 @@ def main(args=None):
         print(__version__)
         sys.exit(0)
 
-    cio.print_and_log('Cook Executor version {}'.format(__version__))
+    cio.print_out('Cook Executor version {}'.format(__version__))
 
     environment = os.environ
     executor_id = environment.get('MESOS_EXECUTOR_ID', '1')
@@ -37,7 +37,7 @@ def main(args=None):
     logging.basicConfig(level = log_level,
                         filename = 'executor.log',
                         format='%(asctime)s %(levelname)s %(message)s')
-    logging.info('Starting cook executor {} for executor-id={}'.format(__version__, executor_id))
+    logging.info('Starting Cook Executor {} for executor-id={}'.format(__version__, executor_id))
     logging.info('Log level is {}'.format(log_level))
 
     config = cc.initialize_config(environment)

--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -43,8 +43,10 @@ def main(args=None):
     config = cc.initialize_config(environment)
 
     def handle_interrupt(interrupt_code, _):
-        print('Received kill for task {} with grace period of {}'.format(executor_id, config.shutdown_grace_period))
-        logging.info('Received interrupt code {}, preparing to terminate executor'.format(interrupt_code))
+        cio.print_out('Received kill for task {} with grace period of {}'.format(
+            executor_id, config.shutdown_grace_period))
+        logging.info('Received interrupt code {}, preparing to terminate executor'.format(
+            interrupt_code))
         stop_signal.set()
     signal.signal(signal.SIGINT, handle_interrupt)
     signal.signal(signal.SIGTERM, handle_interrupt)
@@ -57,9 +59,9 @@ def main(args=None):
     logging.info('Driver thread has completed')
 
     exit_code = 1 if stop_signal.isSet() else 0
-    cio.print_out('Executor completed execution of {}'.format(executor_id), flush=True)
-    logging.info('Executor completed execution of {} with code {}'.format(executor_id, exit_code))
+    logging.info('Executor exiting with code {}'.format(exit_code))
     sys.exit(exit_code)
+
 
 if __name__ == '__main__':
     main()

--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -57,8 +57,8 @@ def main(args=None):
     logging.info('Driver thread has completed')
 
     exit_code = 1 if stop_signal.isSet() else 0
-    logging.info('Executor exiting with code {}'.format(exit_code))
-    print('Executor completed execution of {}'.format(executor_id))
+    cio.print_out('Executor completed execution of {}'.format(executor_id), flush=True)
+    logging.info('Executor completed execution of {} with code {}'.format(executor_id, exit_code))
     sys.exit(exit_code)
 
 if __name__ == '__main__':

--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -28,7 +28,7 @@ def main(args=None):
         print(__version__)
         sys.exit(0)
 
-    cio.printline_out('Cook Executor version {}'.format(__version__))
+    cio.print_and_log('Cook Executor version {}'.format(__version__))
 
     environment = os.environ
     executor_id = environment.get('MESOS_EXECUTOR_ID', '1')
@@ -43,10 +43,9 @@ def main(args=None):
     config = cc.initialize_config(environment)
 
     def handle_interrupt(interrupt_code, _):
-        cio.printline_out('Received kill for task {} with grace period of {}'.format(
+        logging.info('Executor interrupted with code {}'.format(interrupt_code))
+        cio.print_and_log('Received kill for task {} with grace period of {}'.format(
             executor_id, config.shutdown_grace_period))
-        logging.info('Received interrupt code {}, preparing to terminate executor'.format(
-            interrupt_code))
         stop_signal.set()
     signal.signal(signal.SIGINT, handle_interrupt)
     signal.signal(signal.SIGTERM, handle_interrupt)

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -192,16 +192,14 @@ def kill_task(process, shutdown_grace_period_ms):
         for i in range(loop_limit):
             time.sleep(0.01)
             if not is_process_running(process):
-                message = 'Command terminated with signal Terminated (pid: {})'.format(process.pid)
-                cio.printline_out(message, flush=True)
-                logging.info(message)
+                cio.print_and_log('Command terminated with signal Terminated (pid: {})'.format(process.pid),
+                                  flush=True)
                 break
         if is_process_running(process):
             logging.info('Process did not terminate, forcefully killing it')
             process.kill()
-            message = 'Command terminated with signal Killed (pid: {})'.format(process.pid)
-            cio.printline_out(message, flush=True)
-            logging.info(message)
+            cio.print_and_log('Command terminated with signal Killed (pid: {})'.format(process.pid),
+                              flush=True)
 
 
 def await_process_completion(stop_signal, process_info, shutdown_grace_period_ms):
@@ -267,7 +265,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
     Nothing
     """
     task_id = get_task_id(task)
-    cio.printline_out('Starting task {}'.format(task_id))
+    cio.print_and_log('Starting task {}'.format(task_id))
     try:
         # not yet started to run the task
         update_status(driver, task_id, cook.TASK_STARTING)
@@ -300,9 +298,8 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         # propagate the exit code
         process, _, _ = process_info
         exit_code = process.returncode
-        message = 'Command exited with status {} (pid: {})'.format(exit_code, process.pid)
-        cio.printline_out(message, flush=True)
-        logging.info(message)
+        cio.print_and_log('Command exited with status {} (pid: {})'.format(exit_code, process.pid),
+                          flush=True)
 
         # await progress updater termination if executor is terminating normally
         if not stop_signal.isSet():
@@ -329,9 +326,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
     finally:
         # ensure completed_signal is set so driver can stop
         completed_signal.set()
-        message = 'Executor completed execution of {}'.format(task_id)
-        cio.printline_out(message, flush=True)
-        logging.info(message)
+        cio.print_and_log('Executor completed execution of {}'.format(task_id), flush=True)
 
 
 def run_mesos_driver(stop_signal, config):

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -106,8 +106,7 @@ def launch_task(task, max_bytes_read_per_line):
 
     Returns
     -------
-    When command is provided and a process can be started, the process launched along
-    with the two threads that are piping the stdout and stderr.
+    When command is provided and a process can be started, the process launched.
     Else it logs the reason and returns None.
     """
     try:
@@ -120,7 +119,7 @@ def launch_task(task, max_bytes_read_per_line):
             return None
 
         process = subprocess.Popen(command,
-                                   bufsize=2*max_bytes_read_per_line,
+                                   bufsize=10*max_bytes_read_per_line,
                                    shell=True,
                                    stderr=subprocess.PIPE,
                                    stdout=subprocess.PIPE)
@@ -297,7 +296,6 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         task_completed_signal.set()
 
         # propagate the exit code
-        process, _, _ = process_info
         exit_code = process.returncode
         cio.print_and_log('Command exited with status {} (pid: {})'.format(exit_code, process.pid),
                           flush=True)

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -301,9 +301,6 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         cio.print_and_log('Command exited with status {} (pid: {})'.format(exit_code, process.pid),
                           flush=True)
 
-        # force send any available latest progress state
-        cp.force_send_progress_update(progress_watcher, progress_updater)
-
         exit_message = json.dumps({'exit-code': exit_code, 'task-id': task_id})
         send_message(driver, exit_message, config.max_message_length)
 
@@ -313,7 +310,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
             progress_complete_event.wait()
             logging.info('Progress updater completed')
 
-        # force send the latest progress state after progress tracking completion
+        # force send any available latest progress state
         cp.force_send_progress_update(progress_watcher, progress_updater)
 
         # task either completed successfully or aborted with an error

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -2,9 +2,7 @@
 
 import json
 import logging
-import os
 import subprocess
-import sys
 import time
 from threading import Event, Thread
 
@@ -312,6 +310,9 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
     finally:
         # ensure completed_signal is set so driver can stop
         completed_signal.set()
+        message = 'Executor completed execution of {}'.format(task_id)
+        cio.print_out(message, flush=True)
+        logging.info(message)
 
 
 def run_mesos_driver(stop_signal, config):

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -225,7 +225,7 @@ def get_task_state(exit_code):
         return cook.TASK_FINISHED
 
 
-def manage_task(driver, task, stop_signal, completed_signal, config, stdout_name, stderr_name):
+def manage_task(driver, task, stop_signal, completed_signal, config):
     """Manages the execution of a task waiting for it to terminate normally or be killed.
        It also sends the task status updates, sandbox location and exit code back to the scheduler.
        Progress updates are tracked on a separate thread and are also sent to the scheduler.
@@ -332,12 +332,10 @@ class CookExecutor(Executor):
     def launchTask(self, driver, task):
         logging.info('Driver {} launching task {}'.format(driver, task))
 
-        stdout_file_path = os.path.join(self.config.sandbox_directory, 'stdout')
-        stderr_file_path = os.path.join(self.config.sandbox_directory, 'stderr')
-        thread = Thread(target=manage_task,
-                        args=(driver, task, self.stop_signal, self.completed_signal, self.config, stdout_file_path,
-                              stderr_file_path))
-        thread.start()
+        stop_signal = self.stop_signal
+        completed_signal = self.completed_signal
+        config = self.config
+        Thread(target=manage_task, args=(driver, task, stop_signal, completed_signal, config)).start()
 
     def killTask(self, driver, task_id):
         logging.info('Task {} has been killed by Mesos'.format(task_id))

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -283,7 +283,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
             update_status(driver, task_id, cook.TASK_ERROR)
             return
 
-        stdout_thread, stderr_thread = cio.track_outputs(process, config.max_bytes_read_per_line)
+        stdout_thread, stderr_thread = cio.track_outputs(task_id, process, config.max_bytes_read_per_line)
         task_completed_signal = Event() # event to track task execution completion
 
         progress_watcher = cp.ProgressWatcher(config, stop_signal, task_completed_signal)

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -119,7 +119,6 @@ def launch_task(task, max_bytes_read_per_line):
             return None
 
         process = subprocess.Popen(command,
-                                   bufsize=10*max_bytes_read_per_line,
                                    shell=True,
                                    stderr=subprocess.PIPE,
                                    stdout=subprocess.PIPE)

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -277,6 +277,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         if process:
             # task has begun running successfully
             update_status(driver, task_id, cook.TASK_RUNNING)
+            cio.print_and_log('Forked command at {}'.format(process.pid))
         else:
             # task launch failed, report an error
             logging.info('Error in launching task')

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -18,7 +18,7 @@ def get_task_id(task):
 
     Parameters
     ----------
-    task: map
+    task: dictionary
         The task
 
     Returns
@@ -52,7 +52,7 @@ def update_status(driver, task_id, task_state):
     ----------
     driver: MesosExecutorDriver
         The driver to send the status update to.
-    task: map
+    task: dictionary
         The task whose status update to send.
     task_state: string
         The state of the task which will be sent to the driver.
@@ -99,7 +99,7 @@ def launch_task(task, max_bytes_read_per_line):
 
     Parameters
     ----------
-    task: map
+    task: dictionary
         The task to execute.
     max_bytes_read_per_line: int
         The maximum number of bytes to read per call to readline().

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -296,8 +296,6 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         message = 'Command exited with status {} (pid: {})'.format(exit_code, process.pid)
         cio.print_out(message, flush=True)
         logging.info(message)
-        exit_message = json.dumps({'exit-code': exit_code, 'task-id': task_id})
-        send_message(driver, exit_message, config.max_message_length)
 
         # await progress updater termination if executor is terminating normally
         if not stop_signal.isSet():
@@ -307,6 +305,10 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
 
         # force send the latest progress state if available
         cp.force_send_progress_update(progress_watcher, progress_updater)
+
+        # send the exit code after the last progress message has been sent
+        exit_message = json.dumps({'exit-code': exit_code, 'task-id': task_id})
+        send_message(driver, exit_message, config.max_message_length)
 
         # task either completed successfully or aborted with an error
         task_state = get_task_state(exit_code)

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -311,7 +311,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
             progress_complete_event.wait()
             logging.info('Progress updater completed')
 
-        # force send any available latest progress state
+        # force send the latest progress state if available
         cp.force_send_progress_update(progress_watcher, progress_updater)
 
         # task either completed successfully or aborted with an error

--- a/executor/cook/io_helper.py
+++ b/executor/cook/io_helper.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+"""This module ensures atomic writes to stdout and stderr.
+"""
+
+import logging
+import sys
+from threading import Lock, Thread
+
+__stdout_lock__ = Lock()
+__stderr_lock__ = Lock()
+
+
+def print_out(string_data, flush=False):
+    """Wrapper function that prints to stdout in a thread-safe manner using the __stdout_lock__ lock.
+
+    Parameters
+    ----------
+    string_data: string
+        The string to output
+
+    Returns
+    -------
+    Nothing.
+    """
+    with __stdout_lock__:
+        print(string_data, file=sys.stdout)
+    if flush:
+        sys.stdout.flush()
+
+
+def print_err(string_data, flush=False):
+    """Wrapper function that prints to stderr in a thread-safe manner using the __stderr_lock__ lock.
+
+    Parameters
+    ----------
+    string_data: string
+        The string to output
+
+    Returns
+    -------
+    Nothing.
+    """
+    with __stderr_lock__:
+        print(string_data, file=sys.stderr)
+    if flush:
+        sys.stdout.flush()
+
+
+def process_output(label, out_file, out_fn, flush_fn):
+    """Processes output piped from the out_file and prints it using the out_fn function.
+    When done reading the file, calls flush_fn to flush the output.
+
+    Parameters
+    ----------
+    label: string
+        The string to associate in outputs
+    out_file: a file object
+        Provides that output from the child process
+    out_fn: function(string)
+        Function to output a string
+    flush_fn: function()
+        Function that flushes the output.
+
+    Returns
+    -------
+    Nothing.
+    """
+    message = 'Starting to pipe {} from launched process'.format(label)
+    print_out(message)
+    logging.info(message)
+    try:
+        for line in out_file:
+            out_fn(line.decode('utf-8').rstrip())
+        flush_fn()
+        message = 'Done piping {} from launched process'.format(label)
+        print_out(message)
+        logging.info(message)
+    except Exception:
+        logging.exception('Error in process_output of {}'.format(label))
+        print_out('Error in process_output of {}'.format(label), flush=True)
+
+
+def track_outputs(process):
+    """Launches two threads to pipe the stderr/stdout from the subprocess to the system stderr/stdout.
+
+    Parameters
+    ----------
+    process: subprocess.Popen
+        The process whose stderr and stdout to monitor.
+
+    Returns
+    -------
+    Nothing.
+    """
+    Thread(target=process_output, args=('stderr', process.stderr, print_err, sys.stderr.flush)).start()
+    Thread(target=process_output, args=('stdout', process.stdout, print_out, sys.stdout.flush)).start()

--- a/executor/cook/io_helper.py
+++ b/executor/cook/io_helper.py
@@ -100,7 +100,7 @@ def process_output(label, out_file, max_bytes_read_per_line, out_fn, flush_fn):
     -------
     Nothing.
     """
-    print_and_log('Starting to pipe {}'.format(label))
+    logging.info('Starting to pipe {}'.format(label))
     try:
         while True:
             line = out_file.readline(max_bytes_read_per_line)
@@ -108,10 +108,9 @@ def process_output(label, out_file, max_bytes_read_per_line, out_fn, flush_fn):
                 break
             out_fn(line.decode('utf-8'), newline=False)
         flush_fn()
-        print_and_log('Done piping {}'.format(label))
+        logging.info('Done piping {}'.format(label))
     except Exception:
         logging.exception('Error in process_output of {}'.format(label))
-        print_out('Error in process_output of {}{}'.format(label, os.linesep), flush=True)
 
 
 def track_outputs(task_id, process, max_bytes_read_per_line):

--- a/executor/cook/io_helper.py
+++ b/executor/cook/io_helper.py
@@ -91,7 +91,12 @@ def track_outputs(process):
 
     Returns
     -------
-    Nothing.
+    A tuple containing the two threads that have been started: stdout_thread, stderr_thread.
     """
-    Thread(target=process_output, args=('stderr', process.stderr, print_err, sys.stderr.flush)).start()
-    Thread(target=process_output, args=('stdout', process.stdout, print_out, sys.stdout.flush)).start()
+    stderr_thread = Thread(target=process_output, args=('stderr', process.stderr, print_err, sys.stderr.flush))
+    stdout_thread = Thread(target=process_output, args=('stdout', process.stdout, print_out, sys.stdout.flush))
+
+    stderr_thread.start()
+    stdout_thread.start()
+
+    return stdout_thread, stderr_thread

--- a/executor/cook/io_helper.py
+++ b/executor/cook/io_helper.py
@@ -35,8 +35,9 @@ def print_out(string_data, flush=False, newline=True):
         sys.stdout.flush()
 
 
-def printline_out(string_data, flush=False, newline=True):
+def print_and_log(string_data, flush=False, newline=True):
     """Wrapper function that prints to stdout in a thread-safe manner ensuring newline at the start.
+    The function also outputs the same message via logging.info().
 
     Parameters
     ----------
@@ -52,6 +53,7 @@ def printline_out(string_data, flush=False, newline=True):
     Nothing.
     """
     print_out('{}{}'.format(os.linesep, string_data), flush=flush, newline=newline)
+    logging.info(string_data)
 
 
 def print_err(string_data, flush=False, newline=True):
@@ -98,9 +100,7 @@ def process_output(label, out_file, max_bytes_read_per_line, out_fn, flush_fn):
     -------
     Nothing.
     """
-    message = 'Starting to pipe {} from launched process'.format(label)
-    printline_out(message)
-    logging.info(message)
+    print_and_log('Starting to pipe {} from launched process'.format(label))
     try:
         while True:
             line = out_file.readline(max_bytes_read_per_line)
@@ -108,12 +108,10 @@ def process_output(label, out_file, max_bytes_read_per_line, out_fn, flush_fn):
                 break
             out_fn(line.decode('utf-8'), newline=False)
         flush_fn()
-        message = 'Done piping {} from launched process'.format(label)
-        printline_out(message)
-        logging.info(message)
+        print_and_log('Done piping {} from launched process'.format(label))
     except Exception:
         logging.exception('Error in process_output of {}'.format(label))
-        printline_out('Error in process_output of {}'.format(label), flush=True)
+        print_out('Error in process_output of {}{}'.format(label, os.linesep), flush=True)
 
 
 def track_outputs(process, max_bytes_read_per_line):

--- a/executor/cook/io_helper.py
+++ b/executor/cook/io_helper.py
@@ -28,9 +28,10 @@ def print_out(string_data, flush=False, newline=True):
     -------
     Nothing.
     """
-    message = '{}{}'.format(string_data, os.linesep) if newline else string_data
     with __stdout_lock__:
-        sys.stdout.write(message)
+        sys.stdout.write(string_data)
+        if newline:
+            sys.stdout.write(os.linesep)
     if flush:
         sys.stdout.flush()
 
@@ -72,9 +73,10 @@ def print_err(string_data, flush=False, newline=True):
     -------
     Nothing.
     """
-    message = '{}{}'.format(string_data, os.linesep) if newline else string_data
     with __stderr_lock__:
-        sys.stderr.write(message)
+        sys.stderr.write(string_data)
+        if newline:
+            sys.stderr.write(os.linesep)
     if flush:
         sys.stderr.flush()
 
@@ -106,7 +108,7 @@ def process_output(label, out_file, max_bytes_read_per_line, out_fn, flush_fn):
             line = out_file.readline(max_bytes_read_per_line)
             if not line:
                 break
-            out_fn(line.decode('utf-8'), newline=False)
+            out_fn(line.decode(), newline=False)
         flush_fn()
         logging.info('Done piping {}'.format(label))
     except Exception:

--- a/executor/cook/io_helper.py
+++ b/executor/cook/io_helper.py
@@ -100,7 +100,7 @@ def process_output(label, out_file, max_bytes_read_per_line, out_fn, flush_fn):
     -------
     Nothing.
     """
-    print_and_log('Starting to pipe {} from launched process'.format(label))
+    print_and_log('Starting to pipe {}'.format(label))
     try:
         while True:
             line = out_file.readline(max_bytes_read_per_line)
@@ -108,7 +108,7 @@ def process_output(label, out_file, max_bytes_read_per_line, out_fn, flush_fn):
                 break
             out_fn(line.decode('utf-8'), newline=False)
         flush_fn()
-        print_and_log('Done piping {} from launched process'.format(label))
+        print_and_log('Done piping {}'.format(label))
     except Exception:
         logging.exception('Error in process_output of {}'.format(label))
         print_out('Error in process_output of {}{}'.format(label, os.linesep), flush=True)

--- a/executor/cook/io_helper.py
+++ b/executor/cook/io_helper.py
@@ -32,8 +32,8 @@ def print_out(string_data, flush=False, newline=True):
         sys.stdout.write(string_data)
         if newline:
             sys.stdout.write(os.linesep)
-    if flush:
-        sys.stdout.flush()
+        if flush:
+            sys.stdout.flush()
 
 
 def print_and_log(string_data, flush=False, newline=True):
@@ -77,8 +77,8 @@ def print_err(string_data, flush=False, newline=True):
         sys.stderr.write(string_data)
         if newline:
             sys.stderr.write(os.linesep)
-    if flush:
-        sys.stderr.flush()
+        if flush:
+            sys.stderr.flush()
 
 
 def process_output(label, out_file, max_bytes_read_per_line, out_fn, flush_fn):

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -148,18 +148,23 @@ class ProgressWatcher(object):
 
             logging.info('{} has been created, reading contents'.format(self.target_file))
             target_file_obj = open(self.target_file, 'r')
+            fragment_index = 0
             line_index = 0
             while not self.stop_signal.isSet():
                 line = target_file_obj.readline(self.max_bytes_read_per_line)
                 if not line:
                     # exit if program has completed and there are no more lines to read
                     if self.task_completed_signal.isSet():
-                        logging.info('Done processing progress messages, {} lines read'.format(line_index))
+                        message = 'Done processing progress messages, {} fragments and {} lines read'
+                        logging.info(message.format(fragment_index, line_index))
                         break
                     # no new line available, sleep before trying again
                     time.sleep(sleep_param)
                     continue
-                line_index += 1
+
+                fragment_index += 1
+                if line.endswith(os.linesep):
+                    line_index += 1
                 yield line
             if self.stop_signal.isSet() and not self.task_completed_signal.isSet():
                 logging.info('Task requested to be killed, may not have processed all progress messages')

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -6,8 +6,6 @@ from threading import Event, Lock, Thread
 import os
 import re
 
-import cook.io_helper as cio
-
 
 class ProgressUpdater(object):
     """This class is responsible for sending progress updates to the scheduler.
@@ -156,8 +154,7 @@ class ProgressWatcher(object):
                 if not line:
                     # exit if program has completed and there are no more lines to read
                     if self.task_completed_signal.isSet():
-                        cio.print_and_log('Done processing progress messages, {} lines read'.format(
-                            line_index))
+                        logging.info('Done processing progress messages, {} lines read'.format(line_index))
                         break
                     # no new line available, sleep before trying again
                     time.sleep(sleep_param)

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -6,7 +6,7 @@ from threading import Event, Lock, Thread
 import os
 import re
 
-import cook
+import cook.io_helper as cio
 
 
 class ProgressUpdater(object):
@@ -150,16 +150,20 @@ class ProgressWatcher(object):
 
             logging.info('{} has been created, reading contents'.format(self.target_file))
             target_file_obj = open(self.target_file, 'r')
+            line_index = 0
             while not self.stop_signal.isSet():
                 line = target_file_obj.readline(self.max_bytes_read_per_line)
                 if not line:
                     # exit if program has completed and there are no more lines to read
                     if self.task_completed_signal.isSet():
-                        logging.info('Done processing file for progress messages')
+                        message = 'Done processing progress messages, {} lines read'.format(line_index)
+                        cio.print_out(message)
+                        logging.info(message)
                         break
                     # no new line available, sleep before trying again
                     time.sleep(sleep_param)
                     continue
+                line_index += 1
                 yield line
             if self.stop_signal.isSet() and not self.task_completed_signal.isSet():
                 logging.info('Task requested to be killed, may not have processed all progress messages')

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -156,9 +156,8 @@ class ProgressWatcher(object):
                 if not line:
                     # exit if program has completed and there are no more lines to read
                     if self.task_completed_signal.isSet():
-                        message = 'Done processing progress messages, {} lines read'.format(line_index)
-                        cio.printline_out(message)
-                        logging.info(message)
+                        cio.print_and_log('Done processing progress messages, {} lines read'.format(
+                            line_index))
                         break
                     # no new line available, sleep before trying again
                     time.sleep(sleep_param)

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -157,7 +157,7 @@ class ProgressWatcher(object):
                     # exit if program has completed and there are no more lines to read
                     if self.task_completed_signal.isSet():
                         message = 'Done processing progress messages, {} lines read'.format(line_index)
-                        cio.print_out(message)
+                        cio.printline_out(message)
                         logging.info(message)
                         break
                     # no new line available, sleep before trying again

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -54,7 +54,7 @@ class ProgressUpdater(object):
         
         Parameters
         ----------
-        progress_data: map 
+        progress_data: dictionary
             The progress data to send.
         force_send: boolean, optional
             Defaults to false.

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -142,11 +142,8 @@ class ExecutorTest(unittest.TestCase):
         try:
             command = 'sleep 100'
             process = subprocess.Popen(command, shell=True)
-            stdout_thread = Thread()
-            stderr_thread = Thread()
-            process_info = process, stdout_thread, stderr_thread
             shutdown_grace_period_ms = 2000
-            ce.kill_task(process_info, shutdown_grace_period_ms)
+            ce.kill_task(process, shutdown_grace_period_ms)
 
             # await process termination
             while process.poll() is None:

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import signal
 import subprocess
 import time
@@ -499,6 +500,16 @@ class ExecutorTest(unittest.TestCase):
             actual_encoded_message_1 = driver.messages[1]
             expected_message_1 = {'exit-code': 0, 'task-id': task_id}
             assert_message(self, expected_message_1, actual_encoded_message_1)
+
+            stdout_name = ensure_directory('build/stdout.' + str(task_id))
+            if os.path.isfile(stdout_name):
+                with open(stdout_name) as f:
+                    file_contents = f.read()
+                    expected_string = 'Hello' * 1000000
+                    self.assertTrue(expected_string in file_contents)
+            else:
+                self.fail('{} does not exist.'.format(stdout_name))
+
 
         stop_signal = Event()
 

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -89,7 +89,7 @@ class ExecutorTest(unittest.TestCase):
         try:
             max_bytes_read_per_line = 4096
             process = ce.launch_task(task, max_bytes_read_per_line)
-            cio.track_outputs(process, max_bytes_read_per_line)
+            cio.track_outputs(task_id, process, max_bytes_read_per_line)
 
             self.assertIsNotNone(process)
 

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -234,7 +234,7 @@ class ExecutorTest(unittest.TestCase):
 
         try:
 
-            ce.manage_task(driver, task, stop_signal, completed_signal, config, stdout_name, stderr_name)
+            ce.manage_task(driver, task, stop_signal, completed_signal, config)
 
             self.assertTrue(completed_signal.isSet())
             assertions_fn(driver, task_id, sandbox_directory)

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -522,6 +522,6 @@ class ExecutorTest(unittest.TestCase):
         thread = Thread(target=sleep_and_set_stop_signal, args=())
         thread.start()
 
-        command = 'for i in {1..1000000}; do printf "Hello"; done; echo "World"'
+        command = 'for i in `seq 1000000`; do printf "Hello"; done; echo "World"'
         self.manage_task_runner(command, assertions, stop_signal=stop_signal)
         stop_signal.set()

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -400,7 +400,7 @@ class ExecutorTest(unittest.TestCase):
                     expected_message = expected_progress_messages.pop(0)
                     self.assertEquals(expected_message, actual_message)
                 else:
-                    self.assertTrue(False, 'Unexpected message: {}'.format(actual_message))
+                    self.fail('Unexpected message: {}'.format(actual_message))
 
         command = 'echo "Hello World"; ' \
                   'echo "^^^^JOB-PROGRESS: 50 Fifty percent"; ' \

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -12,6 +12,7 @@ from pymesos import encode_data
 import cook
 import cook.config as cc
 import cook.executor as ce
+import cook.io_helper as cio
 from tests.utils import assert_message, assert_status, cleanup_output, close_sys_outputs, ensure_directory, \
     get_random_task_id, redirect_stderr_to_file, redirect_stdout_to_file, FakeMesosExecutorDriver
 
@@ -86,11 +87,11 @@ class ExecutorTest(unittest.TestCase):
         redirect_stderr_to_file(stderr_name)
 
         try:
-            process, stdout_thread, stderr_thread = ce.launch_task(task)
+            max_bytes_read_per_line = 4096
+            process = ce.launch_task(task, max_bytes_read_per_line)
+            cio.track_outputs(process, max_bytes_read_per_line)
 
             self.assertIsNotNone(process)
-            self.assertIsNotNone(stdout_thread)
-            self.assertIsNotNone(stderr_thread)
 
             for i in range(100):
                 if process.poll() is None:
@@ -118,7 +119,7 @@ class ExecutorTest(unittest.TestCase):
         task = {'task_id': {'value': task_id},
                 'data': encode_data(json.dumps({'command': ''}).encode('utf8'))}
 
-        process = ce.launch_task(task)
+        process = ce.launch_task(task, 4096)
 
         self.assertIsNone(process)
 
@@ -126,7 +127,7 @@ class ExecutorTest(unittest.TestCase):
         task_id = get_random_task_id()
         task = {'task_id': {'value': task_id}}
 
-        process = ce.launch_task(task)
+        process = ce.launch_task(task, 4096)
 
         self.assertIsNone(process)
 
@@ -472,3 +473,35 @@ class ExecutorTest(unittest.TestCase):
 
         command = 'sleep 100'
         self.manage_task_runner(command, assertions, stop_signal=stop_signal)
+
+    def test_manage_task_long_output(self):
+        def assertions(driver, task_id, sandbox_directory):
+
+            logging.info('Statuses: {}'.format(driver.statuses))
+            self.assertEqual(3, len(driver.statuses))
+
+            logging.info('Messages: {}'.format(driver.messages))
+            self.assertEqual(2, len(driver.messages))
+
+            actual_encoded_message_0 = driver.messages[0]
+            expected_message_0 = {'sandbox-directory': sandbox_directory, 'task-id': task_id}
+            assert_message(self, expected_message_0, actual_encoded_message_0)
+
+            actual_encoded_message_1 = driver.messages[1]
+            expected_message_1 = {'exit-code': 0, 'task-id': task_id}
+            assert_message(self, expected_message_1, actual_encoded_message_1)
+
+        stop_signal = Event()
+
+        def sleep_and_set_stop_signal():
+            # wait upto 1 minute for the task to complete
+            for _ in range(60):
+                if not stop_signal.isSet():
+                    time.sleep(1)
+            stop_signal.set()
+        thread = Thread(target=sleep_and_set_stop_signal, args=())
+        thread.start()
+
+        command = 'for i in {1..1000000}; do printf "Hello"; done; echo "World"'
+        self.manage_task_runner(command, assertions, stop_signal=stop_signal)
+        stop_signal.set()

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -102,11 +102,11 @@ class ExecutorTest(unittest.TestCase):
 
             with open(stdout_name) as f:
                 stdout_content = f.read()
-                self.assertEqual("Hello World\n", stdout_content)
+                self.assertTrue("Hello World\n" in stdout_content)
 
             with open(stderr_name) as f:
                 stderr_content = f.read()
-                self.assertEqual("Error Message\n", stderr_content)
+                self.assertTrue("Error Message\n" in stderr_content)
         finally:
             cleanup_output(stdout_name, stderr_name)
 
@@ -373,14 +373,14 @@ class ExecutorTest(unittest.TestCase):
             assert_message(self, expected_message_1, actual_encoded_message_1)
 
             actual_encoded_message_2 = driver.messages[2]
-            expected_message_2 = {'progress-message': 'Fifty-five percent',
-                                  'progress-percent': 55,
-                                  'progress-sequence': 2,
-                                  'task-id': task_id}
+            expected_message_2 = {'exit-code': 0, 'task-id': task_id}
             assert_message(self, expected_message_2, actual_encoded_message_2)
 
             actual_encoded_message_3 = driver.messages[3]
-            expected_message_3 = {'exit-code': 0, 'task-id': task_id}
+            expected_message_3 = {'progress-message': 'Fifty-five percent',
+                                  'progress-percent': 55,
+                                  'progress-sequence': 2,
+                                  'task-id': task_id}
             assert_message(self, expected_message_3, actual_encoded_message_3)
 
         command = 'echo "Hello World"; ' \

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -382,14 +382,14 @@ class ExecutorTest(unittest.TestCase):
             assert_message(self, expected_message_1, actual_encoded_message_1)
 
             actual_encoded_message_2 = driver.messages[2]
-            expected_message_2 = {'exit-code': 0, 'task-id': task_id}
-            assert_message(self, expected_message_2, actual_encoded_message_2)
-
-            actual_encoded_message_3 = driver.messages[3]
-            expected_message_3 = {'progress-message': 'Fifty-five percent',
+            expected_message_2 = {'progress-message': 'Fifty-five percent',
                                   'progress-percent': 55,
                                   'progress-sequence': 2,
                                   'task-id': task_id}
+            assert_message(self, expected_message_2, actual_encoded_message_2)
+
+            actual_encoded_message_3 = driver.messages[3]
+            expected_message_3 = {'exit-code': 0, 'task-id': task_id}
             assert_message(self, expected_message_3, actual_encoded_message_3)
 
         command = 'echo "Hello World"; ' \

--- a/executor/tests/utils.py
+++ b/executor/tests/utils.py
@@ -47,8 +47,12 @@ def assert_status(testcase, expected_status, actual_status):
     testcase.assertEquals(expected_status, actual_status)
 
 
+def parse_message(encoded_message):
+    return json.loads(decode_data(encoded_message).decode('utf8'))
+
+
 def assert_message(testcase, expected_message, actual_encoded_message):
-    actual_message = json.loads(decode_data(actual_encoded_message).decode('utf8'))
+    actual_message = parse_message(actual_encoded_message)
     testcase.assertEquals(expected_message, actual_message)
 
 


### PR DESCRIPTION
The main change is that we now pipe the output from the subprocess that is launched.
We also wrap the stdout/stderr calls to print in a lock to avoid data races.

Sample output in the `stdout` file:
```
Cook Executor version 0.1.2.dev0

Starting task c8df9002-9a30-4a11-b484-1cc42b83ec1b

progress: 25 Twenty-five percent
progress: 50 Fifty percent
progress: Sixty percent invalid format
progress: 75 Seventy-five percent
progress: Eighty percent invalid format

Command exited with status 0 (pid: 6984)

Executor completed execution of c8df9002-9a30-4a11-b484-1cc42b83ec1b
```