### PR TITLE
Wait for jobs to start before killing in test_group_kill_simple

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -802,12 +802,13 @@ class CookTest(unittest.TestCase):
         group_spec = self.minimal_group()
         group_uuid = group_spec['uuid']
         try:
-            job_fast = util.minimal_job(group=group_uuid)
+            job_fast = util.minimal_job(group=group_uuid, priority=99)
             job_slow = util.minimal_job(group=group_uuid, command=f'sleep {slow_job_wait_seconds}')
             _, resp = util.submit_jobs(self.cook_url, [job_fast, job_slow], groups=[group_spec])
             self.assertEqual(resp.status_code, 201, resp.text)
-            # Wait for the fast job to finish
+            # Wait for the fast job to finish, and the slow job to start
             util.wait_for_job(self.cook_url, job_fast, 'completed')
+            util.wait_for_job(self.cook_url, job_slow, 'running')
             # Now try to cancel the group (just the long job)
             util.kill_groups(self.cook_url, [group_uuid])
 


### PR DESCRIPTION
This patch fixes a bug in the `test_group_kill_simple` integration test where the `slow_job` might be killed before it starts running, which breaks one of the assertions since the test expects both jobs to have one instance.