### PR TITLE
Bump rate limit for Travis tests up to 1M/minute

### DIFF
--- a/integration/travis/scheduler_config.edn
+++ b/integration/travis/scheduler_config.edn
@@ -11,6 +11,7 @@
                                 :memory-gb 48
                                 :retry-limit 200
                                 :cpus 6}}
+ :rate-limit {:user-limit-per-m 1000000}
  :rebalancer {:dru-scale 1}
 
  :mesos {:master #config/env "MINIMESOS_ZOOKEEPER"


### PR DESCRIPTION
This *might* fix some of the failures we've been seeing in Travis.