### PR TITLE
Sandbox sync for pending hosts

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -37,14 +37,15 @@ class CookTest(unittest.TestCase):
         self.assertEqual(False, job['disable_mea_culpa_retries'])
         self.assertTrue(len(util.wait_for_output_url(self.cook_url, job_uuid)['output_url']) > 0)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
     def test_no_cook_executor_on_subsequent_instances(self):
         job_uuid, resp = util.submit_job(self.cook_url, command='exit 1', max_retries=10)
@@ -124,14 +125,15 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('failed', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(1, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
     def test_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)
@@ -146,16 +148,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -178,16 +181,17 @@ class CookTest(unittest.TestCase):
         self.assertEqual('success', job['instances'][0]['status'], message)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -209,16 +213,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -238,16 +243,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -297,15 +303,16 @@ class CookTest(unittest.TestCase):
             self.assertGreater(actual_running_time_ms, max_runtime_ms, job_details)
             self.assertGreater(job_sleep_ms, actual_running_time_ms, job_details)
 
+            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+            message = json.dumps(job['instances'][0], sort_keys=True)
+            self.assertIsNotNone(job['instances'][0]['output_url'], message)
+            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
             # verify additional fields set when the cook executor is used
             if job_executor_type == 'cook':
                 job = util.wait_for_exit_code(self.cook_url, job_uuid)
                 message = json.dumps(job['instances'][0], sort_keys=True)
                 self.assertNotEqual(0, job['instances'][0]['exit_code'], message)
-
-                job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-                message = json.dumps(job['instances'][0], sort_keys=True)
-                self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid])
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -333,13 +333,18 @@ def wait_for_exit_code(cook_url, job_id, max_delay_ms=2000):
     return response.json()[0]
 
 
-def wait_for_sandbox_directory(cook_url, job_id, max_delay_ms=4000):
+def wait_for_sandbox_directory(cook_url, job_id):
     """
     Wait for the given job's sandbox_directory field to appear.
     Returns an up-to-date job description object on success,
     and raises an exception if the max_delay_ms wait time is exceeded.
     """
     job_id = unpack_uuid(job_id)
+
+    cook_settings = settings(cook_url)
+    cache_ttl_ms = get_in(cook_settings, 'agent-query-cache', 'ttl-ms')
+    sync_interval_ms = get_in(cook_settings, 'sandbox-syncer', 'sync-interval-ms')
+    max_delay_ms = min(4 * max(cache_ttl_ms, sync_interval_ms), 4 * 60 * 1000)
 
     def query():
         response = query_jobs(cook_url, True, job=[job_id])

--- a/integration/travis/scheduler_config.edn
+++ b/integration/travis/scheduler_config.edn
@@ -23,6 +23,8 @@
  :executor {:command #config/env "COOK_EXECUTOR_COMMAND"
             :environment {"EXECUTOR_DEFAULT_PROGRESS_OUTPUT_NAME" "stdout"}
             :portion 0.25}
+ :agent-query-cache {:ttl-ms 1000}
+ :sandbox-syncer {:sync-interval-ms 1000}
  :unhandled-exceptions {:log-level :error}
  :metrics {:jmx true}
  :nrepl {:enabled? false}

--- a/scheduler/container-config.edn
+++ b/scheduler/container-config.edn
@@ -17,6 +17,8 @@
                   :executable true
                   :extract false
                   :value #config/env "COOK_EXECUTOR"}}
+ :agent-query-cache {:ttl-ms 1000}
+ :sandbox-syncer {:sync-interval-ms 1000}
  :rate-limit {:user-limit-per-m 1000000}
  :rebalancer {:dru-scale 1}
  :mesos {:master #config/env "MESOS_MASTER"

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -280,11 +280,11 @@
                                     (cache/lru-cache-factory :threshold max-size)
                                     (cache/ttl-cache-factory :ttl ttl-ms)
                                     atom))
-     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer publish-batch-size publish-interval-ms]]
-                                 mesos-agent-query-cache mesos-datomic]
+     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer publish-batch-size publish-interval-ms sync-interval-ms]]
+                                 framework-id mesos-agent-query-cache mesos-datomic]
                              (let [prepare-sandbox-publisher (lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)]
-                               (prepare-sandbox-publisher mesos-datomic publish-batch-size publish-interval-ms
-                                                          mesos-agent-query-cache)))
+                               (prepare-sandbox-publisher framework-id mesos-datomic publish-batch-size publish-interval-ms
+                                                          sync-interval-ms mesos-agent-query-cache)))
      :mesos-leadership-atom (fnk [] (atom false))
      :mesos-pending-jobs-atom (fnk [] (atom {}))
      :mesos-offer-cache (fnk [[:settings [:offer-cache max-size ttl-ms]]]
@@ -345,7 +345,8 @@
      :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
                        (merge
                          {:publish-batch-size 100
-                          :publish-interval-ms 2500}
+                          :publish-interval-ms 2500
+                          :sync-interval-ms (t/in-millis (t/minutes 15))}
                          sandbox-syncer))
      :server-port (fnk [[:config port]]
                     port)

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -280,11 +280,11 @@
                                     (cache/lru-cache-factory :threshold max-size)
                                     (cache/ttl-cache-factory :ttl ttl-ms)
                                     atom))
-     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer publish-batch-size publish-interval-ms sync-interval-ms]]
+     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure publish-batch-size publish-interval-ms sync-interval-ms]]
                                  framework-id mesos-agent-query-cache mesos-datomic]
                              (let [prepare-sandbox-publisher (lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)]
                                (prepare-sandbox-publisher framework-id mesos-datomic publish-batch-size publish-interval-ms
-                                                          sync-interval-ms mesos-agent-query-cache)))
+                                                          sync-interval-ms max-consecutive-sync-failure mesos-agent-query-cache)))
      :mesos-leadership-atom (fnk [] (atom false))
      :mesos-pending-jobs-atom (fnk [] (atom {}))
      :mesos-offer-cache (fnk [[:settings [:offer-cache max-size ttl-ms]]]
@@ -344,7 +344,8 @@
                             agent-query-cache))
      :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
                        (merge
-                         {:publish-batch-size 100
+                         {:max-consecutive-sync-failure 15
+                          :publish-batch-size 100
                           :publish-interval-ms 2500
                           :sync-interval-ms (t/in-millis (t/minutes 15))}
                          sandbox-syncer))

--- a/scheduler/src/cook/mesos/sandbox.clj
+++ b/scheduler/src/cook/mesos/sandbox.clj
@@ -221,7 +221,7 @@
         (let [{:keys [framework-id host->consecutive-failures pending-sync-hosts]} @pending-sync-agent
               num-pending-sync-hosts (count pending-sync-hosts)]
           (log/info num-pending-sync-hosts "hosts have pending syncs")
-          (loop [[hostname & remaining-hostnames] (vec pending-sync-hosts)
+          (loop [[hostname & remaining-hostnames] (seq pending-sync-hosts)
                  pending-sync-agent-send-performed false]
             (let [consecutive-failures (get host->consecutive-failures hostname 0)]
               (cond

--- a/scheduler/src/cook/mesos/sandbox.clj
+++ b/scheduler/src/cook/mesos/sandbox.clj
@@ -108,19 +108,6 @@
             (log/error e "sandbox batch update error")))))
     {}))
 
-(defn start-sandbox-publisher
-  "Launches a timer task that triggers publishing of the task-id->sandbox state to datomic.
-   The task is invoked at intervals of publish-interval-ms ms."
-  [task-id->sandbox-agent datomic-conn publish-batch-size publish-interval-ms]
-  (log/info "Starting sandbox publisher at intervals of" publish-interval-ms "ms")
-  (chime/chime-at
-    (periodic/periodic-seq (time/now) (time/millis publish-interval-ms))
-    (fn sandbox-publisher-task [_]
-      (log/info "Requesting publishing of instance sandbox directories")
-      (publish-sandbox-to-datomic! datomic-conn publish-batch-size task-id->sandbox-agent))
-    {:error-handler (fn sandbox-publisher-error-handler [ex]
-                      (log/error ex "instance sandbox directory publish failed"))}))
-
 (defn retrieve-sandbox-directories-on-agent
   "Builds an indexed version of all task-id to sandbox directory on the specified agent.
    Usually takes 100-500ms to run."
@@ -147,12 +134,26 @@
                 [id directory]))
          (into {}))))
 
+(defn- aggregate-pending-sync-hostname
+  "Aggregates the hostname as a pending sync item into pending-sync-state."
+  [pending-sync-state agent-hostname reason]
+  ;; TODO Shams use reason to track consecutive failures
+  (-> pending-sync-state
+      (update :pending-sync-hosts conj agent-hostname)))
+
+(defn- clear-pending-sync-hostname
+  "Clears the hostname as a pending sync item from pending-sync-state."
+  [pending-sync-state agent-hostname reason]
+  ;; TODO Shams use reason to track consecutive failures
+  (-> pending-sync-state
+      (update :pending-sync-hosts disj agent-hostname)))
+
 (defn refresh-agent-cache-entry
   "If the entry for the specified agent is not cached:
    - Triggers building an indexed version of all task-id to sandbox directory for the specified agent;
    - After the indexed version is built, it is synced into the task-id->sandbox-agent.
    The function call is a no-op if the specified agent already exists in the cache."
-  [framework-id mesos-agent-query-cache task-id->sandbox-agent agent-hostname]
+  [framework-id mesos-agent-query-cache pending-sync-agent task-id->sandbox-agent agent-hostname]
   (try
     (let [run (delay
                 (try
@@ -160,14 +161,18 @@
                         (retrieve-sandbox-directories-on-agent framework-id agent-hostname)]
                     (log/info "Found sandbox directories for" (count task-id->sandbox-directory) "tasks on" agent-hostname)
                     (send task-id->sandbox-agent aggregate-sandbox task-id->sandbox-directory)
+                    (send pending-sync-agent clear-pending-sync-hostname agent-hostname :success)
                     :success)
                   (catch Exception e
                     (log/debug e "Failed to get mesos agent state on" agent-hostname)
+                    (send pending-sync-agent aggregate-pending-sync-hostname agent-hostname :error)
                     :error)))
           cs (swap! mesos-agent-query-cache
                     (fn mesos-agent-query-cache-swap-fn [c]
                       (if (cache/has? c agent-hostname)
-                        (cache/hit c agent-hostname)
+                        (do
+                          (send pending-sync-agent aggregate-pending-sync-hostname agent-hostname :pending)
+                          (cache/hit c agent-hostname))
                         (cache/miss c agent-hostname run))))
           val (cache/lookup cs agent-hostname)]
       (if val @val @run))
@@ -182,11 +187,44 @@
 
 (defn sync-agent-sandboxes
   "Asynchronously triggers state syncing from the mesos agent."
-  [{:keys [mesos-agent-query-cache task-id->sandbox-agent]} framework-id agent-hostname]
+  [{:keys [mesos-agent-query-cache pending-sync-agent task-id->sandbox-agent]} framework-id agent-hostname]
   (when (and mesos-agent-query-cache task-id->sandbox-agent framework-id agent-hostname)
     (future
       (refresh-agent-cache-entry
-        framework-id mesos-agent-query-cache task-id->sandbox-agent agent-hostname))))
+        framework-id mesos-agent-query-cache pending-sync-agent task-id->sandbox-agent agent-hostname))))
+
+(defn start-sandbox-publisher
+  "Launches a timer task that triggers publishing of the task-id->sandbox state to datomic.
+   The task is invoked at intervals of publish-interval-ms ms."
+  [task-id->sandbox-agent datomic-conn publish-batch-size publish-interval-ms]
+  (log/info "Starting sandbox publisher at intervals of" publish-interval-ms "ms")
+  (chime/chime-at
+    (periodic/periodic-seq (time/now) (time/millis publish-interval-ms))
+    (fn sandbox-publisher-task [_]
+      (log/info "Requesting publishing of instance sandbox directories")
+      (publish-sandbox-to-datomic! datomic-conn publish-batch-size task-id->sandbox-agent))
+    {:error-handler (fn sandbox-publisher-error-handler [ex]
+                      (log/error ex "Instance sandbox directory publish failed"))}))
+
+(defn start-host-sandbox-syncer
+  "Launches a timer task that triggers syncing of sandbox directories of any pending hosts."
+  [mesos-agent-query-cache pending-sync-agent task-id->sandbox-agent sync-interval-ms]
+  (log/info "Starting sandbox syncer at intervals of" sync-interval-ms "ms")
+  (let [syncer-state {:mesos-agent-query-cache mesos-agent-query-cache
+                      :pending-sync-agent pending-sync-agent
+                      :task-id->sandbox-agent task-id->sandbox-agent}]
+    (chime/chime-at
+      (periodic/periodic-seq (time/now) (time/millis sync-interval-ms))
+      (fn host-sandbox-syncer-task [_]
+        (let [{:keys [framework-id pending-sync-hosts]} @pending-sync-agent]
+          (log/info (count pending-sync-hosts) "hosts have pending syncs")
+          (doseq [agent-hostname pending-sync-hosts]
+            (when-not (cache/has? @mesos-agent-query-cache agent-hostname)
+              (log/info "Triggering pending sandbox sync of" agent-hostname)
+              (send pending-sync-agent clear-pending-sync-hostname agent-hostname :sync)
+              (sync-agent-sandboxes syncer-state framework-id agent-hostname)))))
+      {:error-handler (fn sandbox-publisher-error-handler [ex]
+                        (log/error ex "Sync of sandbox directories on pending hosts failed"))})))
 
 (defn prepare-sandbox-publisher
   "This function initializes the sandbox publisher as well as helper functions to send individual
@@ -195,10 +233,16 @@
    :mesos-agent-query-cache - the cache that throttles the state sync calls to the mesos agents.
    :publisher-cancel-fn - fn that take no arguments and that terminates the publisher.
    :task-id->sandbox-agent - The agent that manages the task-id->sandbox aggregation and publishing."
-  [datomic-conn publish-batch-size publish-interval-ms mesos-agent-query-cache]
-  (let [task-id->sandbox-agent (agent {}) ;; stores all the pending task-id->sandbox state
+  [framework-id datomic-conn publish-batch-size publish-interval-ms sync-interval-ms mesos-agent-query-cache]
+  (let [pending-sync-agent (agent {:framework-id framework-id
+                                   :pending-sync-hosts #{}}) ;; stores the names of hosts pending sync
+        task-id->sandbox-agent (agent {}) ;; stores all the pending task-id->sandbox state
         publisher-cancel-fn (start-sandbox-publisher
-                              task-id->sandbox-agent datomic-conn publish-batch-size publish-interval-ms)]
+                              task-id->sandbox-agent datomic-conn publish-batch-size publish-interval-ms)
+        syncer-cancel-fn (start-host-sandbox-syncer
+                           mesos-agent-query-cache pending-sync-agent task-id->sandbox-agent sync-interval-ms)]
     {:mesos-agent-query-cache mesos-agent-query-cache
+     :pending-sync-agent pending-sync-agent
      :publisher-cancel-fn publisher-cancel-fn
+     :syncer-cancel-fn syncer-cancel-fn
      :task-id->sandbox-agent task-id->sandbox-agent}))

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -195,7 +195,6 @@
                                                               db task-id))
                job-ent (d/entity db job)
                instance-ent (d/entity db instance)
-               retries-so-far (count (:job/instance job-ent))
                previous-reason (reason/instance-entity->reason-entity db instance-ent)
                instance-status (condp contains? task-state
                                  #{:task-staging} :instance.status/unknown
@@ -416,7 +415,7 @@
   "Processes a framework message from Mesos."
   [conn handle-progress-message
    {:strs [exit-code progress-message progress-percent progress-sequence task-id] :as message}]
-  (log/debug "Received framework message:" {:task-id task-id, :message message})
+  (log/info "Received framework message:" {:task-id task-id, :message message})
   (timers/time!
     handle-framework-message-duration
     (try

--- a/scheduler/test/cook/test/mesos/sandbox.clj
+++ b/scheduler/test/cook/test/mesos/sandbox.clj
@@ -202,46 +202,147 @@
 (deftest test-refresh-agent-cache-entry
   (let [framework-id "test-framework-id"
         mesos-agent-query-cache (atom (cache/fifo-cache-factory {} :threshold 2))
+        pending-sync-initial-state {:framework-id framework-id, :pending-sync-hosts #{"host2.com"}}
+        pending-sync-agent (agent pending-sync-initial-state)
         task-id->sandbox-agent (agent {})
-        item-unavailable (future :unavailable)]
+        item-unavailable (future :unavailable)
+        refresh-agent-cache-helper #(sandbox/refresh-agent-cache-entry
+                                      framework-id mesos-agent-query-cache pending-sync-agent task-id->sandbox-agent %)]
     (with-redefs [sandbox/retrieve-sandbox-directories-on-agent
                   (fn [_ hostname]
                     (if (str/includes? hostname "badhost")
                       (throw (Exception. "Exception from test"))
                       {(str "task." hostname) (str "/path/to/" hostname "/sandbox")}))]
 
-      (sandbox/refresh-agent-cache-entry framework-id mesos-agent-query-cache task-id->sandbox-agent "host1.com")
-      (sandbox/refresh-agent-cache-entry framework-id mesos-agent-query-cache task-id->sandbox-agent "host2.com")
-      (await task-id->sandbox-agent)
-      (is (= :success @(cache/lookup @mesos-agent-query-cache "host1.com" item-unavailable)))
-      (is (= :success @(cache/lookup @mesos-agent-query-cache "host2.com" item-unavailable)))
-      (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host3.com" item-unavailable)))
-      (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "badhost.com" item-unavailable)))
-      (is (= {"task.host1.com" "/path/to/host1.com/sandbox"
-              "task.host2.com" "/path/to/host2.com/sandbox"}
-             @task-id->sandbox-agent))
+      (testing "cache population on good hosts"
+        (refresh-agent-cache-helper "host1.com")
+        (refresh-agent-cache-helper "host2.com")
+        (await task-id->sandbox-agent)
+        (await pending-sync-agent)
+        (is (= :success @(cache/lookup @mesos-agent-query-cache "host1.com" item-unavailable)))
+        (is (= :success @(cache/lookup @mesos-agent-query-cache "host2.com" item-unavailable)))
+        (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host3.com" item-unavailable)))
+        (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "badhost.com" item-unavailable)))
+        (is (= {"task.host1.com" "/path/to/host1.com/sandbox"
+                "task.host2.com" "/path/to/host2.com/sandbox"}
+               @task-id->sandbox-agent))
+        (is (= (update pending-sync-initial-state :pending-sync-hosts
+                       (fn [pending-sync-hosts] (-> pending-sync-hosts
+                                                    (disj "host2.com"))))
+               @pending-sync-agent)))
 
-      (sandbox/refresh-agent-cache-entry framework-id mesos-agent-query-cache task-id->sandbox-agent "host3.com")
-      (await task-id->sandbox-agent)
-      (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host1.com" item-unavailable)))
-      (is (= :success @(cache/lookup @mesos-agent-query-cache "host2.com" item-unavailable)))
-      (is (= :success @(cache/lookup @mesos-agent-query-cache "host3.com" item-unavailable)))
-      (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "badhost.com" item-unavailable)))
-      (is (= {"task.host1.com" "/path/to/host1.com/sandbox"
-              "task.host2.com" "/path/to/host2.com/sandbox"
-              "task.host3.com" "/path/to/host3.com/sandbox"}
-             @task-id->sandbox-agent))
+      (testing "cache eviction on good host"
+        (refresh-agent-cache-helper "host3.com")
+        (await task-id->sandbox-agent)
+        (await pending-sync-agent)
+        (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host1.com" item-unavailable)))
+        (is (= :success @(cache/lookup @mesos-agent-query-cache "host2.com" item-unavailable)))
+        (is (= :success @(cache/lookup @mesos-agent-query-cache "host3.com" item-unavailable)))
+        (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "badhost.com" item-unavailable)))
+        (is (= {"task.host1.com" "/path/to/host1.com/sandbox"
+                "task.host2.com" "/path/to/host2.com/sandbox"
+                "task.host3.com" "/path/to/host3.com/sandbox"}
+               @task-id->sandbox-agent))
+        (is (= (update pending-sync-initial-state :pending-sync-hosts
+                       (fn [pending-sync-hosts] (-> pending-sync-hosts
+                                                    (disj "host2.com"))))
+               @pending-sync-agent)))
 
-      (sandbox/refresh-agent-cache-entry framework-id mesos-agent-query-cache task-id->sandbox-agent "badhost.com")
-      (await task-id->sandbox-agent)
-      (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host1.com" item-unavailable)))
-      (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host2.com" item-unavailable)))
-      (is (= :success @(cache/lookup @mesos-agent-query-cache "host3.com" item-unavailable)))
-      (is (= :error @(cache/lookup @mesos-agent-query-cache "badhost.com" item-unavailable)))
-      (is (= {"task.host1.com" "/path/to/host1.com/sandbox"
-              "task.host2.com" "/path/to/host2.com/sandbox"
-              "task.host3.com" "/path/to/host3.com/sandbox"}
-             @task-id->sandbox-agent)))))
+      (testing "cache eviction on bad host"
+        (refresh-agent-cache-helper "badhost.com")
+        (await task-id->sandbox-agent)
+        (await pending-sync-agent)
+        (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host1.com" item-unavailable)))
+        (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host2.com" item-unavailable)))
+        (is (= :success @(cache/lookup @mesos-agent-query-cache "host3.com" item-unavailable)))
+        (is (= :error @(cache/lookup @mesos-agent-query-cache "badhost.com" item-unavailable)))
+        (is (= {"task.host1.com" "/path/to/host1.com/sandbox"
+                "task.host2.com" "/path/to/host2.com/sandbox"
+                "task.host3.com" "/path/to/host3.com/sandbox"}
+               @task-id->sandbox-agent))
+        (is (= (update pending-sync-initial-state :pending-sync-hosts
+                       (fn [pending-sync-hosts] (-> pending-sync-hosts
+                                                    (disj "host2.com")
+                                                    (conj "badhost.com"))))
+               @pending-sync-agent)))
+
+      (testing "syncing of cached host"
+        (refresh-agent-cache-helper "host3.com")
+        (await task-id->sandbox-agent)
+        (await pending-sync-agent)
+        (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host1.com" item-unavailable)))
+        (is (= :unavailable @(cache/lookup @mesos-agent-query-cache "host2.com" item-unavailable)))
+        (is (= :success @(cache/lookup @mesos-agent-query-cache "host3.com" item-unavailable)))
+        (is (= :error @(cache/lookup @mesos-agent-query-cache "badhost.com" item-unavailable)))
+        (is (= {"task.host1.com" "/path/to/host1.com/sandbox"
+                "task.host2.com" "/path/to/host2.com/sandbox"
+                "task.host3.com" "/path/to/host3.com/sandbox"}
+               @task-id->sandbox-agent))
+        (is (= (update pending-sync-initial-state :pending-sync-hosts
+                       (fn [pending-sync-hosts] (-> pending-sync-hosts
+                                                    (disj "host2.com")
+                                                    (conj "badhost.com" "host3.com"))))
+               @pending-sync-agent))))))
+
+(deftest test-start-host-sandbox-syncer
+  (let [framework-id "test-framework-id"
+        mesos-agent-query-cache (-> {"host1" (future :success)
+                                     "host2" (future :success)
+                                     "host3" (future :success)
+                                     "host6" (future :error)}
+                                    (cache/fifo-cache-factory :threshold 10)
+                                    atom)
+        pending-sync-initial-state {:framework-id framework-id
+                                    :pending-sync-hosts #{"host1" "host2" "badhost3" "host4" "badhost5" "host6"}}
+        pending-sync-agent (agent pending-sync-initial-state)
+        task-id->sandbox-agent (agent {})
+        sync-interval-ms 2
+        sync-first-batch-latch (CountDownLatch. 2)
+        total-items-synced-latch (CountDownLatch. 4)
+        synced-hosts-atom (atom [])
+        item-unavailable (future :unavailable)]
+    (with-redefs [sandbox/retrieve-sandbox-directories-on-agent
+                  (fn [_ hostname]
+                    (.countDown sync-first-batch-latch)
+                    (.countDown total-items-synced-latch)
+                    (swap! synced-hosts-atom conj hostname)
+                    (if (str/includes? hostname "badhost")
+                      (throw (Exception. "Exception from test"))
+                      {(str "task." hostname) (str "/path/to/" hostname "/sandbox")}))]
+      (let [syncer-cancel-fn
+            (sandbox/start-host-sandbox-syncer
+              mesos-agent-query-cache pending-sync-agent task-id->sandbox-agent sync-interval-ms)]
+        (try
+          (.await sync-first-batch-latch 10 TimeUnit/SECONDS)
+          (is (zero? (.getCount sync-first-batch-latch)))
+
+          ;; evict items that will get populated during the second run of the syncer
+          (reset! mesos-agent-query-cache
+                  (-> @mesos-agent-query-cache
+                      (cache/evict "host2")
+                      (cache/evict "host3")))
+
+          (.await total-items-synced-latch 10 TimeUnit/SECONDS)
+          (await task-id->sandbox-agent)
+          (await pending-sync-agent)
+
+          (is (zero? (.getCount total-items-synced-latch)))
+          (is (= :success @(cache/lookup @mesos-agent-query-cache "host1" item-unavailable)))
+          (is (= :success @(cache/lookup @mesos-agent-query-cache "host2" item-unavailable)))
+          (is (= :error @(cache/lookup @mesos-agent-query-cache "badhost3" item-unavailable)))
+          (is (= :success @(cache/lookup @mesos-agent-query-cache "host4" item-unavailable)))
+          (is (= :error @(cache/lookup @mesos-agent-query-cache "badhost5" item-unavailable)))
+          (is (= :error @(cache/lookup @mesos-agent-query-cache "host6" item-unavailable)))
+          (is (= #{"host1" "badhost3" "badhost5" "host6"}
+                 (get @pending-sync-agent :pending-sync-hosts)))
+          (is (= {"task.host2" "/path/to/host2/sandbox"
+                  "task.host4" "/path/to/host4/sandbox"}
+                 @task-id->sandbox-agent))
+          (is (= #{"host2" "badhost3" "host4" "badhost5"}
+                 (set @synced-hosts-atom)))
+
+          (finally
+            (syncer-cancel-fn)))))))
 
 (deftest test-prepare-sandbox-publisher
   (with-redefs [sandbox/retrieve-sandbox-directories-on-agent
@@ -249,15 +350,20 @@
     (let [db-conn (tu/restore-fresh-database! "datomic:mem://test-start-sandbox-publisher")
           publish-batch-size 20
           publish-interval-ms 10
+          sync-interval-ms 10000
           framework-id "test-framework-id"
           mesos-agent-query-cache (atom (cache/fifo-cache-factory {} :threshold 2))
-          {:keys [publisher-cancel-fn task-id->sandbox-agent] :as sandbox-state}
-          (sandbox/prepare-sandbox-publisher db-conn publish-batch-size publish-interval-ms mesos-agent-query-cache)]
+          {:keys [publisher-cancel-fn syncer-cancel-fn task-id->sandbox-agent] :as sandbox-state}
+          (sandbox/prepare-sandbox-publisher framework-id db-conn publish-batch-size publish-interval-ms
+                                             sync-interval-ms mesos-agent-query-cache)]
 
-      (sandbox/update-sandbox sandbox-state {"sandbox-directory" "/path/to/sandbox", "task-id" "task-1", "type" "directory"})
-      @(sandbox/sync-agent-sandboxes sandbox-state framework-id "host1")
-      (await task-id->sandbox-agent)
+      (try
+        (sandbox/update-sandbox sandbox-state {"sandbox-directory" "/path/to/sandbox", "task-id" "task-1", "type" "directory"})
+        @(sandbox/sync-agent-sandboxes sandbox-state framework-id "host1")
+        (await task-id->sandbox-agent)
 
-      (is (= {"task-1" "/path/to/sandbox", "task.host1" "/path/to/host1/sandbox"} @task-id->sandbox-agent))
-
-      (publisher-cancel-fn))))
+        (is (= {"task-1" "/path/to/sandbox", "task.host1" "/path/to/host1/sandbox"}
+               @task-id->sandbox-agent))
+        (finally
+          (publisher-cancel-fn)
+          (syncer-cancel-fn))))))

--- a/scheduler/test/cook/test/mesos/sandbox.clj
+++ b/scheduler/test/cook/test/mesos/sandbox.clj
@@ -360,7 +360,6 @@
 (deftest test-prepare-sandbox-publisher
   (with-redefs [sandbox/retrieve-sandbox-directories-on-agent
                 (fn [_ hostname]
-                  (println "retrieve-sandbox-directories-on-agent:" hostname)
                   {(str "task." hostname) (str "/path/to/" hostname "/sandbox")})]
     (let [db-conn (tu/restore-fresh-database! "datomic:mem://test-start-sandbox-publisher")
           publish-batch-size 20


### PR DESCRIPTION
- retries sandbox syncing of hosts when the cache entry expires
- removes bad hosts from the pending sandbox sync process
- asserts for `sandbox_directory` and `output_url` in integration tests