### PR TITLE
Add user agent to requests in python scripts

### DIFF
--- a/cli/cook/http.py
+++ b/cli/cook/http.py
@@ -5,6 +5,8 @@ from urllib.parse import urljoin
 
 import requests
 
+import cook
+
 session = None
 timeouts = None
 
@@ -29,6 +31,7 @@ def configure(config):
     http_adapter = adapters_module.HTTPAdapter(max_retries=retries)
     session = session_module.Session()
     session.mount('http://', http_adapter)
+    session.headers['User-Agent'] = f"cs/{cook.version.VERSION} ({session.headers['User-Agent']})"
 
 
 def __post(url, json_body):

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.7.1'
+VERSION = '0.7.2'

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -10,6 +10,7 @@ from retrying import retry
 
 logger = logging.getLogger(__name__)
 session = importlib.import_module(os.getenv('COOK_SESSION_MODULE', 'requests')).Session()
+session.headers['User-Agent'] = f"Cook-Scheduler-Integration-Tests ({session.headers['User-Agent']})"
 
 
 def get_in(dct, *keys):


### PR DESCRIPTION
Clarifies the origin of some requests in the cook scheduler access logs.