### PR TITLE
WIP: togglable sandbox syncer

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -32,15 +32,15 @@ class CookTest(unittest.TestCase):
         self.assertEqual(False, job['disable_mea_culpa_retries'])
         self.assertTrue(len(util.wait_for_output_url(self.cook_url, job_uuid)['output_url']) > 0)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
     def test_no_cook_executor_on_subsequent_instances(self):
         job_uuid, resp = util.submit_job(self.cook_url, command='exit 1', max_retries=10)
@@ -120,15 +120,15 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('failed', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(1, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
     def test_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)
@@ -144,17 +144,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -177,17 +177,17 @@ class CookTest(unittest.TestCase):
         self.assertEqual('success', job['instances'][0]['status'], message)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -211,17 +211,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -243,17 +243,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -304,16 +304,16 @@ class CookTest(unittest.TestCase):
             self.assertGreater(actual_running_time_ms, max_runtime_ms, job_details)
             self.assertGreater(job_sleep_ms, actual_running_time_ms, job_details)
 
+            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+            message = json.dumps(job['instances'][0], sort_keys=True)
+            self.assertIsNotNone(job['instances'][0]['output_url'], message)
+            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
             # verify additional fields set when the cook executor is used
             if job_executor_type == 'cook':
                 job = util.wait_for_exit_code(self.cook_url, job_uuid)
                 message = json.dumps(job['instances'][0], sort_keys=True)
                 self.assertNotEqual(0, job['instances'][0]['exit_code'], message)
-
-                job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-                message = json.dumps(job['instances'][0], sort_keys=True)
-                self.assertIsNotNone(job['instances'][0]['output_url'], message)
-                self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid])
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -32,15 +32,15 @@ class CookTest(unittest.TestCase):
         self.assertEqual(False, job['disable_mea_culpa_retries'])
         self.assertTrue(len(util.wait_for_output_url(self.cook_url, job_uuid)['output_url']) > 0)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
-
         if job_executor_type == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
+
+            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+            message = json.dumps(job['instances'][0], sort_keys=True)
+            self.assertIsNotNone(job['instances'][0]['output_url'], message)
+            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
     def test_no_cook_executor_on_subsequent_instances(self):
         job_uuid, resp = util.submit_job(self.cook_url, command='exit 1', max_retries=10)
@@ -120,15 +120,15 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('failed', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
-
         if job_executor_type == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(1, job['instances'][0]['exit_code'], message)
+
+            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+            message = json.dumps(job['instances'][0], sort_keys=True)
+            self.assertIsNotNone(job['instances'][0]['output_url'], message)
+            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
     def test_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)
@@ -144,17 +144,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
-
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
+
+            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+            message = json.dumps(job['instances'][0], sort_keys=True)
+            self.assertIsNotNone(job['instances'][0]['output_url'], message)
+            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -177,17 +177,17 @@ class CookTest(unittest.TestCase):
         self.assertEqual('success', job['instances'][0]['status'], message)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
-
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
+
+            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+            message = json.dumps(job['instances'][0], sort_keys=True)
+            self.assertIsNotNone(job['instances'][0]['output_url'], message)
+            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -211,17 +211,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
-
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
+
+            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+            message = json.dumps(job['instances'][0], sort_keys=True)
+            self.assertIsNotNone(job['instances'][0]['output_url'], message)
+            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -243,17 +243,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
-
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
+
+            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+            message = json.dumps(job['instances'][0], sort_keys=True)
+            self.assertIsNotNone(job['instances'][0]['output_url'], message)
+            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -304,16 +304,16 @@ class CookTest(unittest.TestCase):
             self.assertGreater(actual_running_time_ms, max_runtime_ms, job_details)
             self.assertGreater(job_sleep_ms, actual_running_time_ms, job_details)
 
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
-
             # verify additional fields set when the cook executor is used
             if job_executor_type == 'cook':
                 job = util.wait_for_exit_code(self.cook_url, job_uuid)
                 message = json.dumps(job['instances'][0], sort_keys=True)
                 self.assertNotEqual(0, job['instances'][0]['exit_code'], message)
+
+                job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+                message = json.dumps(job['instances'][0], sort_keys=True)
+                self.assertIsNotNone(job['instances'][0]['output_url'], message)
+                self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid])
 

--- a/integration/travis/scheduler_config.edn
+++ b/integration/travis/scheduler_config.edn
@@ -24,7 +24,8 @@
             :environment {"EXECUTOR_DEFAULT_PROGRESS_OUTPUT_NAME" "stdout"}
             :portion 0.25}
  :agent-query-cache {:ttl-ms 1000}
- :sandbox-syncer {:sync-interval-ms 1000}
+ :sandbox-syncer {:agent-state-sandbox-sync true
+                  :sync-interval-ms 1000}
  :unhandled-exceptions {:log-level :error}
  :metrics {:jmx true}
  :nrepl {:enabled? false}

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -89,17 +89,17 @@ If need it to bind to another port, you can specify that with the `:local-port` 
 `:sandbox-syncer`::
   The Cook scheduler throttles the rate at which it publishes task sandbox directories.
   This allows us to handle high rate of incoming progress messages in a graceful manner.
-  `sandbox-syncer` is a map with the following possible keys, `max-consecutive-sync-failure`, ``publish-batch-size`, `publish-interval-ms`, `sandbox-sync-enabled` and `sync-interval-ms`.
+  `sandbox-syncer` is a map with the following possible keys: `agent-state-sandbox-sync`, `max-consecutive-sync-failure`, ``publish-batch-size`, `publish-interval-ms`, and `sync-interval-ms`.
+  The `agent-state-sandbox-sync` configured whether to sync sandbox directories from mesos agent state for tasks in the background.
+  The default value is false.
+  The `max-consecutive-sync-failure` is an integer representing the number of consecutive failures before which the syncer stops querying the mesos agent for its state.
+  The default value is 15.
   The `publish-batch-size` is an integer representing the number of facts that are updated in individual datomic instance sandbox directory update transactions.
   The default value is 100.
   The `publish-interval-ms` is an integer representing the number of millisecond intervals at which sandbox directories updates will be published to datomic.
   The default value is 2500.
-  The `sandbox-sync-enabled` configured whether to sync sandbox directories for instance in the background.
-  The default value is false.
   The `sync-interval-ms` is an integer representing the number of millisecond intervals at which the sandbox syncer will trigger state queries on pending mesos agents.
   The default value is 15000.
-  The `max-consecutive-sync-failure` is an integer representing the number of consecutive failures before which the syncer stops querying the mesos agent for its state.
-  The default value is 15.
 
 
 [[mesos_config]]

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -89,11 +89,17 @@ If need it to bind to another port, you can specify that with the `:local-port` 
 `:sandbox-syncer`::
   The Cook scheduler throttles the rate at which it publishes task sandbox directories.
   This allows us to handle high rate of incoming progress messages in a graceful manner.
-  `sandbox-syncer` is a map with two possible keys, `publish-batch-size` and `publish-interval-ms`.
+  `sandbox-syncer` is a map with the following possible keys, `max-consecutive-sync-failure`, ``publish-batch-size`, `publish-interval-ms`, `sandbox-sync-enabled` and `sync-interval-ms`.
   The `publish-batch-size` is an integer representing the number of facts that are updated in individual datomic instance sandbox directory update transactions.
   The default value is 100.
   The `publish-interval-ms` is an integer representing the number of millisecond intervals at which sandbox directories updates will be published to datomic.
   The default value is 2500.
+  The `sandbox-sync-enabled` configured whether to sync sandbox directories for instance in the background.
+  The default value is false.
+  The `sync-interval-ms` is an integer representing the number of millisecond intervals at which the sandbox syncer will trigger state queries on pending mesos agents.
+  The default value is 15000.
+  The `max-consecutive-sync-failure` is an integer representing the number of consecutive failures before which the syncer stops querying the mesos agent for its state.
+  The default value is 15.
 
 
 [[mesos_config]]

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -66,14 +66,16 @@
     (resolve var-sym)))
 
 (def raw-scheduler-routes
-  {:scheduler (fnk [mesos mesos-datomic mesos-leadership-atom mesos-pending-jobs-atom framework-id settings]
+  {:scheduler (fnk [mesos mesos-datomic mesos-leadership-atom mesos-pending-jobs-atom framework-id
+                    sandbox-syncer-state settings]
                 ((lazy-load-var 'cook.mesos.api/main-handler)
                   mesos-datomic
                   framework-id
                   (fn [] @mesos-pending-jobs-atom)
                   settings
                   (get-in mesos [:mesos-scheduler :leader-selector])
-                  mesos-leadership-atom))
+                  mesos-leadership-atom
+                  (:hostname->task-id->sandbox-directory-fn sandbox-syncer-state)))
    :view (fnk [scheduler]
            scheduler)})
 

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -282,13 +282,13 @@
                                     (cache/lru-cache-factory :threshold max-size)
                                     (cache/ttl-cache-factory :ttl ttl-ms)
                                     atom))
-     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure publish-batch-size
-                                             publish-interval-ms sandbox-sync-enabled sync-interval-ms]]
+     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer agent-state-sandbox-sync max-consecutive-sync-failure
+                                             publish-batch-size publish-interval-ms sync-interval-ms]]
                                  framework-id mesos-agent-query-cache mesos-datomic]
                              (let [prepare-sandbox-publisher (lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)]
                                (prepare-sandbox-publisher framework-id mesos-datomic publish-batch-size publish-interval-ms
                                                           sync-interval-ms max-consecutive-sync-failure mesos-agent-query-cache
-                                                          sandbox-sync-enabled)))
+                                                          agent-state-sandbox-sync)))
      :mesos-leadership-atom (fnk [] (atom false))
      :mesos-pending-jobs-atom (fnk [] (atom {}))
      :mesos-offer-cache (fnk [[:settings [:offer-cache max-size ttl-ms]]]
@@ -348,10 +348,10 @@
                             agent-query-cache))
      :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
                        (merge
-                         {:max-consecutive-sync-failure 15
+                         {:agent-state-sandbox-sync false
+                          :max-consecutive-sync-failure 15
                           :publish-batch-size 100
                           :publish-interval-ms 2500
-                          :sandbox-sync-enabled false
                           ;; The default should ideally be lower than the agent-query-cache ttl-ms
                           :sync-interval-ms (* 15 1000)}
                          sandbox-syncer))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -282,11 +282,13 @@
                                     (cache/lru-cache-factory :threshold max-size)
                                     (cache/ttl-cache-factory :ttl ttl-ms)
                                     atom))
-     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure publish-batch-size publish-interval-ms sync-interval-ms]]
+     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure publish-batch-size
+                                             publish-interval-ms sandbox-sync-enabled sync-interval-ms]]
                                  framework-id mesos-agent-query-cache mesos-datomic]
                              (let [prepare-sandbox-publisher (lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)]
                                (prepare-sandbox-publisher framework-id mesos-datomic publish-batch-size publish-interval-ms
-                                                          sync-interval-ms max-consecutive-sync-failure mesos-agent-query-cache)))
+                                                          sync-interval-ms max-consecutive-sync-failure mesos-agent-query-cache
+                                                          sandbox-sync-enabled)))
      :mesos-leadership-atom (fnk [] (atom false))
      :mesos-pending-jobs-atom (fnk [] (atom {}))
      :mesos-offer-cache (fnk [[:settings [:offer-cache max-size ttl-ms]]]
@@ -349,6 +351,7 @@
                          {:max-consecutive-sync-failure 15
                           :publish-batch-size 100
                           :publish-interval-ms 2500
+                          :sandbox-sync-enabled false
                           ;; The default should ideally be lower than the agent-query-cache ttl-ms
                           :sync-interval-ms (* 15 1000)}
                          sandbox-syncer))

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -978,7 +978,7 @@
 
 ;;; On DELETE; use repeated job argument
 (defn destroy-jobs-handler
-  [conn framework-id is-authorized-fn hostname->task-id->sandbox-directory-fn]
+  [conn is-authorized-fn]
   (base-cook-handler
     {:allowed-methods [:delete]
      :malformed? check-job-params-present
@@ -1914,7 +1914,7 @@
                                   400 {:description "Non-UUID values were passed as jobs."}
                                   403 {:description "The supplied UUIDs don't correspond to valid jobs."}}
                       :parameters {:query-params JobOrInstanceIds}
-                      :handler (destroy-jobs-handler conn framework-id is-authorized-fn hostname->task-id->sandbox-directory-fn)}}))
+                      :handler (destroy-jobs-handler conn is-authorized-fn)}}))
 
         (c-api/context
           "/share" []

--- a/scheduler/src/cook/mesos/sandbox.clj
+++ b/scheduler/src/cook/mesos/sandbox.clj
@@ -200,8 +200,8 @@
 
 (defn hostname->task-id->sandbox-directory
   "Retrieves the sandbox directory of a task on a specific mesos agent."
-  [publisher-state framework-id agent-hostname task-id]
-  (let [{:keys [data]} (refresh-agent-cache-entry publisher-state framework-id agent-hostname)]
+  [publisher-state framework-id hostname task-id]
+  (let [{:keys [data]} (refresh-agent-cache-entry publisher-state framework-id hostname)]
     (get data task-id)))
 
 (defn update-sandbox

--- a/scheduler/src/cook/mesos/sandbox.clj
+++ b/scheduler/src/cook/mesos/sandbox.clj
@@ -159,13 +159,13 @@
    - After the indexed version is built, the tasks which have sandbox directories are removed;
    - The filtered version of tasks without sandbox directories is then synced into the task-id->sandbox-agent.
    The function call is a no-op if the specified agent already exists in the cache."
-  [{:keys [datomic-conn mesos-agent-query-cache pending-sync-agent sandbox-sync-enabled task-id->sandbox-agent]} 
+  [{:keys [agent-state-sandbox-sync datomic-conn mesos-agent-query-cache pending-sync-agent task-id->sandbox-agent]}
    framework-id agent-hostname]
   (try
     (let [run (delay
                 (try
                   (let [task-id->sandbox-directory (retrieve-sandbox-directories-on-agent framework-id agent-hostname)]
-                    (when sandbox-sync-enabled
+                    (when agent-state-sandbox-sync
                       (let [filtered-task-id->sandbox-directory (remove-task-ids-with-sandbox datomic-conn task-id->sandbox-directory)]
                         (log/info "Found" (count filtered-task-id->sandbox-directory) "tasks without sandbox directories on"
                                   agent-hostname "after retrieving" (count task-id->sandbox-directory) "tasks")
@@ -175,14 +175,14 @@
                      :data task-id->sandbox-directory})
                   (catch Exception e
                     (log/error e "Failed to get mesos agent state on" agent-hostname)
-                    (when sandbox-sync-enabled
+                    (when agent-state-sandbox-sync
                       (send pending-sync-agent aggregate-pending-sync-hostname agent-hostname :error))
                     {:result :error})))
           cs (swap! mesos-agent-query-cache
                     (fn mesos-agent-query-cache-swap-fn [c]
                       (if (cache/has? c agent-hostname)
                         (do
-                          (when sandbox-sync-enabled
+                          (when agent-state-sandbox-sync
                             (send pending-sync-agent aggregate-pending-sync-hostname agent-hostname :pending))
                           (cache/hit c agent-hostname))
                         (cache/miss c agent-hostname run))))
@@ -268,19 +268,19 @@
    :publisher-cancel-fn - fn that take no arguments and that terminates the publisher.
    :task-id->sandbox-agent - The agent that manages the task-id->sandbox aggregation and publishing."
   [framework-id datomic-conn publish-batch-size publish-interval-ms sync-interval-ms max-consecutive-sync-failure
-   mesos-agent-query-cache sandbox-sync-enabled]
+   mesos-agent-query-cache agent-state-sandbox-sync]
   (let [pending-sync-agent (agent {:framework-id framework-id
                                    :host->consecutive-failures {}
                                    :pending-sync-hosts #{}}) ;; stores the names of hosts pending sync
         task-id->sandbox-agent (agent {}) ;; stores all the pending task-id->sandbox state
-        publisher-state {:datomic-conn datomic-conn
+        publisher-state {:agent-state-sandbox-sync agent-state-sandbox-sync
+                         :datomic-conn datomic-conn
                          :mesos-agent-query-cache mesos-agent-query-cache
                          :pending-sync-agent pending-sync-agent
-                         :sandbox-sync-enabled sandbox-sync-enabled
                          :task-id->sandbox-agent task-id->sandbox-agent}
         publisher-cancel-fn (start-sandbox-publisher
                               task-id->sandbox-agent datomic-conn publish-batch-size publish-interval-ms)
-        syncer-cancel-fn (if sandbox-sync-enabled
+        syncer-cancel-fn (if agent-state-sandbox-sync
                            (start-host-sandbox-syncer publisher-state sync-interval-ms max-consecutive-sync-failure)
                            (do
                              (log/info "Not starting sandbox syncer as it has been disabled")

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1213,10 +1213,8 @@
 
 (deftest test-destroy-jobs
   (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
-        framework-id #mesomatic.types.FrameworkID{:value "framework-id"}
         is-authorized-fn (partial auth/is-authorized? {:authorization-fn 'cook.authorization/configfile-admins-auth-open-gets})
-        hostname->task-id->sandbox-directory-fn (constantly nil)
-        handler (api/destroy-jobs-handler conn framework-id is-authorized-fn hostname->task-id->sandbox-directory-fn)]
+        handler (api/destroy-jobs-handler conn is-authorized-fn)]
     (testing "should be able to destroy own jobs"
       (let [{:keys [uuid user] :as job} (minimal-job)
             _ (api/create-jobs! conn {::api/jobs [job]})

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -2009,8 +2009,10 @@
             publish-interval-ms 20
             sync-interval-ms 20
             agent-query-cache (-> {} (cache/ttl-cache-factory :ttl cache-timeout-ms) atom)
+            sandbox-sync-enabled true
             {:keys [pending-sync-agent publisher-cancel-fn syncer-cancel-fn task-id->sandbox-agent] :as sandbox-syncer-state}
-            (sandbox/prepare-sandbox-publisher framework-id db-conn 10 publish-interval-ms sync-interval-ms 5 agent-query-cache)
+            (sandbox/prepare-sandbox-publisher framework-id db-conn 10 publish-interval-ms sync-interval-ms 5
+                                               agent-query-cache sandbox-sync-enabled)
             sync-agent-sandboxes-fn
             (fn [hostname]
               (sandbox/sync-agent-sandboxes sandbox-syncer-state framework-id hostname))]

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -2009,10 +2009,10 @@
             publish-interval-ms 20
             sync-interval-ms 20
             agent-query-cache (-> {} (cache/ttl-cache-factory :ttl cache-timeout-ms) atom)
-            sandbox-sync-enabled true
+            agent-state-sandbox-sync true
             {:keys [pending-sync-agent publisher-cancel-fn syncer-cancel-fn task-id->sandbox-agent] :as sandbox-syncer-state}
             (sandbox/prepare-sandbox-publisher framework-id db-conn 10 publish-interval-ms sync-interval-ms 5
-                                               agent-query-cache sandbox-sync-enabled)
+                                               agent-query-cache agent-state-sandbox-sync)
             sync-agent-sandboxes-fn
             (fn [hostname]
               (sandbox/sync-agent-sandboxes sandbox-syncer-state framework-id hostname))]

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -40,7 +40,8 @@
                                          :mesos-gpu-enabled false
                                          :task-constraints {:cpus 12 :memory-gb 100 :retry-limit 200}}
                                         (Object.)
-                                        (atom true)))
+                                        (atom true)
+                                        (constantly nil)))
         ; Mock kerberization, not testing that
         api-handler-kerb (fn [req]
                            (api-handler (assoc req :authorization/user (System/getProperty "user.name"))))


### PR DESCRIPTION
This PR builds on top of https://github.com/twosigma/Cook/pull/563 

It introduces a `sandbox-sync-enabled` flag to disable sandbox syncing from agent host updates. It also re-enables looking up the agent state to retrieve the `sandbox-directory` while loading an instance.