### PR TITLE
Adds /jobs resource for retrieving jobs

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -608,7 +608,7 @@ class CookTest(unittest.TestCase):
             util.kill_jobs(self.cook_url, [job_uuid])
 
             def instance_query():
-                return util.query_jobs(self.cook_url, True, job=[job_uuid])
+                return util.query_jobs(self.cook_url, True, uuid=[job_uuid])
 
             # wait for the job (and its instances) to die
             util.wait_until(instance_query, util.all_instances_killed)
@@ -622,7 +622,6 @@ class CookTest(unittest.TestCase):
         finally:
             util.kill_jobs(self.cook_url, [job_uuid])
 
-
     def test_change_retries_deprecated_post(self):
         job_uuid, _ = util.submit_job(self.cook_url, command='sleep 60')
         try:
@@ -630,7 +629,7 @@ class CookTest(unittest.TestCase):
             util.kill_jobs(self.cook_url, [job_uuid])
 
             def instance_query():
-                return util.query_jobs(self.cook_url, True, job=[job_uuid])
+                return util.query_jobs(self.cook_url, True, uuid=[job_uuid])
 
             # wait for the job (and its instances) to die
             util.wait_until(instance_query, util.all_instances_killed)
@@ -655,7 +654,7 @@ class CookTest(unittest.TestCase):
             util.kill_jobs(self.cook_url, [job_uuid])
 
             def instance_query():
-                return util.query_jobs(self.cook_url, True, job=[job_uuid])
+                return util.query_jobs(self.cook_url, True, uuid=[job_uuid])
 
             # Wait for the job (and its instances) to die
             util.wait_until(instance_query, util.all_instances_killed)
@@ -664,7 +663,7 @@ class CookTest(unittest.TestCase):
             # retry both jobs, but with the failed_only=true flag
             resp = util.retry_jobs(self.cook_url, retries=4, failed_only=True, jobs=jobs)
             self.assertEqual(201, resp.status_code, resp.text)
-            jobs = util.query_jobs(self.cook_url, True, job=jobs).json()
+            jobs = util.query_jobs(self.cook_url, True, uuid=jobs).json()
             # We expect both jobs to be running now.
             # The first job (which we killed and retried) should have 3 retries remaining
             # (the attempt before resetting the total retries count is still included).
@@ -693,7 +692,7 @@ class CookTest(unittest.TestCase):
         job_spec = {'group': group_uuid}
         jobs, resp = util.submit_jobs(self.cook_url, job_spec, 2)
         self.assertEqual(resp.status_code, 201)
-        job_data = util.query_jobs(self.cook_url, job=jobs)
+        job_data = util.query_jobs(self.cook_url, uuid=jobs)
         self.assertEqual(200, job_data.status_code)
         job_data = job_data.json()
         self.assertEqual(group_uuid, job_data[0]['groups'][0])
@@ -707,7 +706,7 @@ class CookTest(unittest.TestCase):
         job_spec = {'group': group_uuid}
         jobs, resp = util.submit_jobs(self.cook_url, job_spec, 2, groups=[group_spec])
         self.assertEqual(resp.status_code, 201)
-        job_data = util.query_jobs(self.cook_url, job=jobs)
+        job_data = util.query_jobs(self.cook_url, uuid=jobs)
         self.assertEqual(200, job_data.status_code)
         job_data = job_data.json()
         self.assertEqual(group_uuid, job_data[0]['groups'][0])
@@ -734,7 +733,7 @@ class CookTest(unittest.TestCase):
         util.wait_for_job(self.cook_url, job_fast['uuid'], 'completed')
         util.wait_for_job(self.cook_url, job_slow['uuid'], 'completed',
                           slow_job_wait_seconds * 1000)
-        jobs = util.query_jobs(self.cook_url, True, job=[job_fast, job_slow]).json()
+        jobs = util.query_jobs(self.cook_url, True, uuid=[job_fast, job_slow]).json()
         self.logger.debug('Loaded jobs %s', jobs)
         self.assertEqual('success', jobs[0]['state'], 'Job details: %s' % (json.dumps(jobs[0], sort_keys=True)))
         self.assertEqual('failed', jobs[1]['state'])
@@ -822,20 +821,20 @@ class CookTest(unittest.TestCase):
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
         # Only valid job uuids
-        resp = util.query_jobs(self.cook_url, job=[job_uuid_1, job_uuid_2])
+        resp = util.query_jobs(self.cook_url, uuid=[job_uuid_1, job_uuid_2])
         self.assertEqual(200, resp.status_code, msg=resp.content)
 
         # Mixed valid, invalid job uuids
         bogus_uuid = str(uuid.uuid4())
-        resp = util.query_jobs(self.cook_url, job=[job_uuid_1, job_uuid_2, bogus_uuid])
+        resp = util.query_jobs(self.cook_url, uuid=[job_uuid_1, job_uuid_2, bogus_uuid])
         self.assertEqual(404, resp.status_code, msg=resp.content)
         self.assertEqual([bogus_uuid], absent_uuids(resp))
-        resp = util.query_jobs(self.cook_url, job=[job_uuid_1, job_uuid_2, bogus_uuid], partial='false')
+        resp = util.query_jobs(self.cook_url, uuid=[job_uuid_1, job_uuid_2, bogus_uuid], partial='false')
         self.assertEqual(404, resp.status_code, resp.json())
         self.assertEqual([bogus_uuid], absent_uuids(resp))
 
         # Partial results with mixed valid, invalid job uuids
-        resp = util.query_jobs(self.cook_url, job=[job_uuid_1, job_uuid_2, bogus_uuid], partial='true')
+        resp = util.query_jobs(self.cook_url, uuid=[job_uuid_1, job_uuid_2, bogus_uuid], partial='true')
         self.assertEqual(200, resp.status_code, resp.json())
         self.assertEqual(2, len(resp.json()))
         self.assertEqual([job_uuid_1, job_uuid_2].sort(), [job['uuid'] for job in resp.json()].sort())
@@ -845,19 +844,20 @@ class CookTest(unittest.TestCase):
         instance_uuid_1 = job['instances'][0]['task_id']
         job = util.wait_for_job(self.cook_url, job_uuid_2, 'completed')
         instance_uuid_2 = job['instances'][0]['task_id']
-        resp = util.query_jobs(self.cook_url, instance=[instance_uuid_1, instance_uuid_2])
+        resp = util.query_jobs_via_rawscheduler_endpoint(self.cook_url, instance=[instance_uuid_1, instance_uuid_2])
         self.assertEqual(200, resp.status_code, msg=resp.content)
 
         # Mixed valid, invalid instance uuids
-        resp = util.query_jobs(self.cook_url, instance=[instance_uuid_1, instance_uuid_2, bogus_uuid])
+        instance_uuids = [instance_uuid_1, instance_uuid_2, bogus_uuid]
+        resp = util.query_jobs_via_rawscheduler_endpoint(self.cook_url, instance=instance_uuids)
         self.assertEqual(404, resp.status_code, msg=resp.content)
         self.assertEqual([bogus_uuid], absent_uuids(resp))
-        resp = util.query_jobs(self.cook_url, instance=[instance_uuid_1, instance_uuid_2, bogus_uuid], partial='false')
+        resp = util.query_jobs_via_rawscheduler_endpoint(self.cook_url, instance=instance_uuids, partial='false')
         self.assertEqual(404, resp.status_code, msg=resp.content)
         self.assertEqual([bogus_uuid], absent_uuids(resp))
 
         # Partial results with mixed valid, invalid instance uuids
-        resp = util.query_jobs(self.cook_url, instance=[instance_uuid_1, instance_uuid_2, bogus_uuid], partial='true')
+        resp = util.query_jobs_via_rawscheduler_endpoint(self.cook_url, instance=instance_uuids, partial='true')
         self.assertEqual(200, resp.status_code, msg=resp.content)
         self.assertEqual(2, len(resp.json()))
         self.assertEqual([job_uuid_1, job_uuid_2].sort(), [job['uuid'] for job in resp.json()].sort())
@@ -940,11 +940,11 @@ class CookTest(unittest.TestCase):
 
             # Wait for the slow job (and its instance) to die
             def query():
-                return util.query_jobs(self.cook_url, True, job=[job_slow])
+                return util.query_jobs(self.cook_url, True, uuid=[job_slow])
 
             util.wait_until(query, util.all_instances_killed)
             # The fast job should have Success, slow job Failed (because we killed it)
-            jobs = util.query_jobs(self.cook_url, True, job=[job_fast, job_slow]).json()
+            jobs = util.query_jobs(self.cook_url, True, uuid=[job_fast, job_slow]).json()
             self.assertEqual('success', jobs[0]['state'], f"Job details: {json.dumps(jobs[0], sort_keys=True)}")
             slow_job_details = f"Job details: {json.dumps(jobs[1], sort_keys=True)}"
             self.assertEqual('failed', jobs[1]['state'], slow_job_details)
@@ -988,7 +988,7 @@ class CookTest(unittest.TestCase):
             # Wait for all the jobs to die
             # Ensure that each job Failed (because we killed it)
             def query():
-                return util.query_jobs(self.cook_url, True, job=jobs)
+                return util.query_jobs(self.cook_url, True, uuid=jobs)
 
             util.wait_until(query, util.all_instances_killed)
         finally:
@@ -1029,7 +1029,7 @@ class CookTest(unittest.TestCase):
             # expect the behavior described above in our usual scaled-down testing environments
             # (i.e., Travis-CI VMs and minimesos using local docker instances).
             util.wait_until(group_query, util.group_some_job_done)
-            job_data = util.query_jobs(self.cook_url, job=jobs).json()
+            job_data = util.query_jobs(self.cook_url, uuid=jobs).json()
             # retry all jobs in the group
             util.retry_jobs(self.cook_url, retries=12, groups=[group_uuid], failed_only=False)
             # wait for the previously-completed jobs to restart
@@ -1037,7 +1037,7 @@ class CookTest(unittest.TestCase):
             assert len(prev_completed_jobs) >= 1
 
             def jobs_query():
-                return util.query_jobs(self.cook_url, True, job=prev_completed_jobs)
+                return util.query_jobs(self.cook_url, True, uuid=prev_completed_jobs)
 
             def all_completed_restarted(response):
                 for job in response.json():
@@ -1049,7 +1049,7 @@ class CookTest(unittest.TestCase):
 
             util.wait_until(jobs_query, all_completed_restarted)
             # ensure that all of the jobs have an updated retries count (set to 12 above)
-            job_data = util.query_jobs(self.cook_url, job=jobs)
+            job_data = util.query_jobs(self.cook_url, uuid=jobs)
             self.assertEqual(200, job_data.status_code)
             for job in job_data.json():
                 job_details = f'Job details: {json.dumps(job, sort_keys=True)}'
@@ -1254,7 +1254,7 @@ class CookTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 201, resp.content)
         try:
             def query():
-                return util.query_jobs(self.cook_url, job=uuids).json()
+                return util.query_jobs(self.cook_url, uuid=uuids).json()
 
             def num_running_predicate(response):
                 num_jobs_total = len(response)
@@ -1316,7 +1316,7 @@ class CookTest(unittest.TestCase):
         uuids, resp = util.submit_jobs(self.cook_url, job_spec, num_jobs, groups=[group])
         try:
             def query_list():
-                return util.query_jobs(self.cook_url, job=uuids).json()
+                return util.query_jobs(self.cook_url, uuid=uuids).json()
 
             def num_running_predicate(response):
                 num_running = len([j for j in response if j['status'] == 'running'])
@@ -1394,7 +1394,7 @@ class CookTest(unittest.TestCase):
         jobs = [util.minimal_job(group=group['uuid'],
                                  priority=1,
                                  cpus=max_cpus)
-                    for _ in range(num_big_jobs)]
+                for _ in range(num_big_jobs)]
         jobs.append(canary)
         uuids, resp = util.submit_jobs(self.cook_url, jobs, groups=[group])
         self.assertEqual(201, resp.status_code, resp.content)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -695,8 +695,8 @@ class CookTest(unittest.TestCase):
         job_data = util.query_jobs(self.cook_url, uuid=jobs)
         self.assertEqual(200, job_data.status_code)
         job_data = job_data.json()
-        self.assertEqual(group_uuid, job_data[0]['groups'][0])
-        self.assertEqual(group_uuid, job_data[1]['groups'][0])
+        self.assertEqual(group_uuid, job_data[0]['groups'][0]['uuid'])
+        self.assertEqual(group_uuid, job_data[1]['groups'][0]['uuid'])
         util.wait_for_job(self.cook_url, jobs[0], 'completed')
         util.wait_for_job(self.cook_url, jobs[1], 'completed')
 
@@ -709,8 +709,8 @@ class CookTest(unittest.TestCase):
         job_data = util.query_jobs(self.cook_url, uuid=jobs)
         self.assertEqual(200, job_data.status_code)
         job_data = job_data.json()
-        self.assertEqual(group_uuid, job_data[0]['groups'][0])
-        self.assertEqual(group_uuid, job_data[1]['groups'][0])
+        self.assertEqual(group_uuid, job_data[0]['groups'][0]['uuid'])
+        self.assertEqual(group_uuid, job_data[1]['groups'][0]['uuid'])
         util.wait_for_job(self.cook_url, jobs[0], 'completed')
         util.wait_for_job(self.cook_url, jobs[1], 'completed')
 

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -881,7 +881,7 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(0, bar['size'])
 
     def test_ls_empty_root_directory(self):
-        cp, uuids = cli.submit("'rm *'", self.cook_url)
+        cp, uuids = cli.submit("'rm -r * && rm -r .*'", self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_job(self.cook_url, uuids[0], 'completed')
         self.assertEqual(0, cp.returncode, cp.stderr)

--- a/integration/tests/cook/test_multi_cluster.py
+++ b/integration/tests/cook/test_multi_cluster.py
@@ -28,13 +28,13 @@ class MultiClusterTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 201)
 
         # Ask for both jobs from cluster #1, expect to get the first
-        resp = util.query_jobs(self.cook_url_1, job=[job_uuid_1, job_uuid_2], partial='true')
+        resp = util.query_jobs(self.cook_url_1, uuid=[job_uuid_1, job_uuid_2], partial='true')
         self.assertEqual(200, resp.status_code, resp.json())
         self.assertEqual(1, len(resp.json()))
         self.assertEqual([job_uuid_1], [job['uuid'] for job in resp.json()])
 
         # Ask for both jobs from cluster #2, expect to get the second
-        resp = util.query_jobs(self.cook_url_2, job=[job_uuid_1, job_uuid_2], partial='true')
+        resp = util.query_jobs(self.cook_url_2, uuid=[job_uuid_1, job_uuid_2], partial='true')
         self.assertEqual(200, resp.status_code, resp.json())
         self.assertEqual(1, len(resp.json()))
         self.assertEqual([job_uuid_2], [job['uuid'] for job in resp.json()])

--- a/integration/tests/cook/test_multi_cluster.py
+++ b/integration/tests/cook/test_multi_cluster.py
@@ -28,13 +28,13 @@ class MultiClusterTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 201)
 
         # Ask for both jobs from cluster #1, expect to get the first
-        resp = util.query_jobs(self.cook_url_1, uuid=[job_uuid_1, job_uuid_2], partial='true')
+        resp = util.query_jobs(self.cook_url_1, uuid=[job_uuid_1, job_uuid_2], partial=True)
         self.assertEqual(200, resp.status_code, resp.json())
         self.assertEqual(1, len(resp.json()))
         self.assertEqual([job_uuid_1], [job['uuid'] for job in resp.json()])
 
         # Ask for both jobs from cluster #2, expect to get the second
-        resp = util.query_jobs(self.cook_url_2, uuid=[job_uuid_1, job_uuid_2], partial='true')
+        resp = util.query_jobs(self.cook_url_2, uuid=[job_uuid_1, job_uuid_2], partial=True)
         self.assertEqual(200, resp.status_code, resp.json())
         self.assertEqual(1, len(resp.json()))
         self.assertEqual([job_uuid_2], [job['uuid'] for job in resp.json()])

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -193,6 +193,8 @@ def query_jobs_via_rawscheduler_endpoint(cook_url, assert_response=False, **kwar
     for key in ('job', 'instance'):
         if key in kwargs:
             kwargs[key] = map(unpack_uuid, kwargs[key])
+    if 'partial' in kwargs:
+        kwargs['partial'] = 'true' if (kwargs['partial'] in [True, 'true', '1']) else 'false'
     response = session.get(f'{cook_url}/rawscheduler', params=kwargs)
     if assert_response:
         assert 200 == response.status_code
@@ -208,6 +210,8 @@ def query_jobs(cook_url, assert_response=False, **kwargs):
     automatically unpacked to get their UUIDs.
     """
     kwargs['uuid'] = [unpack_uuid(u) for u in kwargs['uuid']]
+    if 'partial' in kwargs:
+        kwargs['partial'] = 'true' if (kwargs['partial'] in [True, 'true', '1']) else 'false'
     response = session.get(f'{cook_url}/jobs', params=kwargs)
     if assert_response:
         assert 200 == response.status_code

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1135,7 +1135,7 @@
               job-resp (api/fetch-job-map (db conn) framework-id retrieve-sandbox-directory-from-agent uuid)]
           (is (= (expected-job-map job framework-id)
                  (dissoc job-resp :submit_time)))
-          (s/validate api/JobResponse
+          (s/validate api/JobResponseDeprecated
                       ; fetch-job-map returns a FrameworkID object instead of a string
                       (assoc job-resp :framework_id (str (:framework_id job-resp))))))
 


### PR DESCRIPTION
This PR introduces `/jobs`. This can be used in two different ways:

- `/jobs/<uuid>` returns a single job
- `/jobs?uuid=<uuid>&uuid=<uuid>&...` returns a list of jobs

Future PRs will add `/instances` and `/groups`.
