### PR TITLE
sorts instances by start_time (field expected to be always present on…

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -54,7 +54,7 @@ class CookTest(unittest.TestCase):
             pass
         job = util.load_job(self.cook_url, job_uuid)
         message = json.dumps(job, sort_keys=True)
-        job_instances = sorted(job['instances'], key=lambda instance: instance['end_time'])
+        job_instances = sorted(job['instances'], key=lambda instance: instance['start_time'])
         self.assertTrue(len(job_instances) >= 2, message)  # sort job instances
         for i in range(1, len(job_instances)):
             message = 'Index ' + str(i) + json.dumps(job_instances[i], sort_keys=True)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -61,7 +61,7 @@ class CookTest(unittest.TestCase):
                 self.assertEqual('failed', job_instance['status'], message)
                 self.assertEqual('Command exited non-zero', job_instance['reason_string'], message)
             else:
-                self.assertEqual('unknown', job_instance['status'], message)
+                self.assertIn(job_instance['status'], ['running', 'unknown'], message)
             self.assertEqual('mesos', job_instance['executor'], message)
 
     def test_disable_mea_culpa(self):


### PR DESCRIPTION
… an instance) in test_no_cook_executor_on_subsequent_instances