### PR TITLE
supports presence of binary data while processing file for progress messages

### DIFF
--- a/executor/cook/_version.py
+++ b/executor/cook/_version.py
@@ -1,4 +1,4 @@
 # This file is read by setup.py to obtain the version.
 # Be aware that changing the format may break the parsing logic.
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -668,7 +668,7 @@ class ExecutorTest(unittest.TestCase):
             self.assertEqual(3, len(driver.statuses))
 
             logging.info('Messages: {}'.format(driver.messages))
-            self.assertEqual(4, len(driver.messages))
+            self.assertEqual(5, len(driver.messages))
 
             actual_encoded_message_0 = driver.messages[0]
             expected_message_0 = {'sandbox-directory': sandbox_directory, 'task-id': task_id, 'type': 'directory'}
@@ -679,9 +679,13 @@ class ExecutorTest(unittest.TestCase):
                                            'progress-percent': 25,
                                            'progress-sequence': 1,
                                            'task-id': task_id},
+                                          {'progress-message': '',
+                                           'progress-percent': 50,
+                                           'progress-sequence': 2,
+                                           'task-id': task_id},
                                           {'progress-message': 'Fifty-five percent in stdout',
                                            'progress-percent': 55,
-                                           'progress-sequence': 2,
+                                           'progress-sequence': 3,
                                            'task-id': task_id}]
             assert_messages(self, driver.messages, expected_exit_messages, expected_progress_messages)
 
@@ -693,10 +697,14 @@ class ExecutorTest(unittest.TestCase):
         sleep_and_set_stop_signal_task(stop_signal, 60)
 
         # progress string in file with binary data will be ignored
-        command = 'echo "Hello"' \
+        command = 'echo "Hello"; ' \
                   'echo "^^^^JOB-PROGRESS: 25 Twenty-five percent in stdout"; ' \
                   'head -c 1000 /dev/random; ' \
+                  'echo "force newline"; ' \
+                  'sleep 2; ' \
                   'echo "^^^^JOB-PROGRESS: 50 `head -c 100 /dev/random`"; ' \
+                  'echo "force newline"; ' \
+                  'sleep 2; ' \
                   'head -c 1000 /dev/random; ' \
                   'echo "force newline"; ' \
                   'echo "^^^^JOB-PROGRESS: 55 Fifty-five percent in stdout"; ' \

--- a/executor/tests/test_progress.py
+++ b/executor/tests/test_progress.py
@@ -50,7 +50,7 @@ class ProgressTest(unittest.TestCase):
             return len(message_string) <= max_message_length
 
         progress_updater = cp.ProgressUpdater(task_id, max_message_length, poll_interval_ms, send_progress_message)
-        progress_data_0 = {'progress-message': 'Progress message-0'}
+        progress_data_0 = {'progress-message': b'Progress message-0'}
         progress_updater.send_progress_update(progress_data_0)
 
         self.assertEqual(1, len(driver.messages))
@@ -58,13 +58,13 @@ class ProgressTest(unittest.TestCase):
         expected_message_0 = {'progress-message': 'Progress message-0', 'task-id': task_id}
         assert_message(self, expected_message_0, actual_encoded_message_0)
 
-        progress_data_1 = {'progress-message': 'Progress message-1'}
+        progress_data_1 = {'progress-message': b'Progress message-1'}
         progress_updater.send_progress_update(progress_data_1)
 
         self.assertEqual(1, len(driver.messages))
 
         time.sleep(poll_interval_ms / 1000.0)
-        progress_data_2 = {'progress-message': 'Progress message-2'}
+        progress_data_2 = {'progress-message': b'Progress message-2'}
         progress_updater.send_progress_update(progress_data_2)
 
         self.assertEqual(2, len(driver.messages))
@@ -85,7 +85,7 @@ class ProgressTest(unittest.TestCase):
             return len(message_string) <= max_message_length
 
         progress_updater = cp.ProgressUpdater(task_id, max_message_length, poll_interval_ms, send_progress_message)
-        progress_data_0 = {'progress-message': 'Progress message-0 is really long lorem ipsum dolor sit amet text'}
+        progress_data_0 = {'progress-message': b'Progress message-0 is really long lorem ipsum dolor sit amet text'}
         progress_updater.send_progress_update(progress_data_0)
 
         self.assertEqual(1, len(driver.messages))
@@ -107,7 +107,8 @@ class ProgressTest(unittest.TestCase):
             return len(message_string) <= max_message_length
 
         progress_updater = cp.ProgressUpdater(task_id, max_message_length, poll_interval_ms, send_progress_message)
-        progress_data_0 = {'unknown': 'Unknown field has a really long lorem ipsum dolor sit amet exceed limit text'}
+        progress_data_0 = {'unknown': 'Unknown field has a really long lorem ipsum dolor sit amet exceed limit text',
+                           'progress-message': b'pm'}
         progress_updater.send_progress_update(progress_data_0)
 
         self.assertEqual(0, len(driver.messages))
@@ -140,7 +141,7 @@ class ProgressTest(unittest.TestCase):
                 collected_data.append(line.strip())
 
             self.assertEqual(items_to_write, len(collected_data))
-            self.assertEqual(list(map(lambda x: str(x), range(items_to_write))), collected_data)
+            self.assertEqual(list(map(lambda x: str.encode(str(x)), range(items_to_write))), collected_data)
         finally:
             if os.path.isfile(file_name):
                 os.remove(file_name)
@@ -177,7 +178,7 @@ class ProgressTest(unittest.TestCase):
                 for index in range(len(collected_data)):
                     logging.info('{}: {}'.format(index, collected_data[index]))
             self.assertEqual(items_to_write, len(collected_data))
-            expected_data = list(map(lambda x: 'line-{}'.format(x), range(items_to_write)))
+            expected_data = list(map(lambda x: str.encode('line-{}'.format(x)), range(items_to_write)))
             self.assertEqual(expected_data, collected_data)
         finally:
             if os.path.isfile(file_name):
@@ -215,9 +216,9 @@ class ProgressTest(unittest.TestCase):
                 collected_data.append(line.strip())
 
             logging.debug('collected_data = {}'.format(collected_data))
-            expected_data = ['abcd',
-                             'abcdefghij', 'kl',
-                             'abcdefghij', 'klmnopqrst', 'uvwxyz']
+            expected_data = [b'abcd',
+                             b'abcdefghij', b'kl',
+                             b'abcdefghij', b'klmnopqrst', b'uvwxyz']
             self.assertEqual(expected_data, collected_data)
         finally:
             if os.path.isfile(file_name):
@@ -251,28 +252,28 @@ class ProgressTest(unittest.TestCase):
             file.flush()
 
             time.sleep(0.10)
-            self.assertEqual({'progress-message': 'Fifty percent', 'progress-percent': 50, 'progress-sequence': 2},
+            self.assertEqual({'progress-message': b'Fifty percent', 'progress-percent': 50, 'progress-sequence': 2},
                              watcher.current_progress())
 
             file.write("Stage Three complete\n")
             file.flush()
 
             time.sleep(0.10)
-            self.assertEqual({'progress-message': 'Fifty percent', 'progress-percent': 50, 'progress-sequence': 2},
+            self.assertEqual({'progress-message': b'Fifty percent', 'progress-percent': 50, 'progress-sequence': 2},
                              watcher.current_progress())
 
             file.write("^^^^JOB-PROGRESS: 55.0 Fifty-five percent\n")
             file.flush()
 
             time.sleep(0.10)
-            self.assertEqual({'progress-message': 'Fifty-five percent', 'progress-percent': 55, 'progress-sequence': 3},
+            self.assertEqual({'progress-message': b'Fifty-five percent', 'progress-percent': 55, 'progress-sequence': 3},
                              watcher.current_progress())
 
             file.write("^^^^JOB-PROGRESS: 65.8 Sixty-six percent\n")
             file.flush()
 
             time.sleep(0.10)
-            self.assertEqual({'progress-message': 'Sixty-six percent', 'progress-percent': 66, 'progress-sequence': 4},
+            self.assertEqual({'progress-message': b'Sixty-six percent', 'progress-percent': 66, 'progress-sequence': 4},
                              watcher.current_progress())
 
             file.write("Stage Four complete\n")
@@ -281,7 +282,7 @@ class ProgressTest(unittest.TestCase):
             file.flush()
 
             time.sleep(0.10)
-            self.assertEqual({'progress-message': 'Hundred percent', 'progress-percent': 100, 'progress-sequence': 5},
+            self.assertEqual({'progress-message': b'Hundred percent', 'progress-percent': 100, 'progress-sequence': 5},
                              watcher.current_progress())
 
         finally:
@@ -326,7 +327,7 @@ class ProgressTest(unittest.TestCase):
             file.write("^^^^JOB-PROGRESS: 075 75% percent\n")
             file.flush()
             time.sleep(0.10)
-            self.assertEqual({'progress-message': '75% percent', 'progress-percent': 75, 'progress-sequence': 1},
+            self.assertEqual({'progress-message': b'75% percent', 'progress-percent': 75, 'progress-sequence': 1},
                              watcher.current_progress())
 
         finally:
@@ -371,7 +372,7 @@ class ProgressTest(unittest.TestCase):
             file.write("^^^^JOB-PROGRESS: 75 75% percent\n")
             file.flush()
             time.sleep(0.10)
-            self.assertEqual({'progress-message': '75% percent', 'progress-percent': 75, 'progress-sequence': 1},
+            self.assertEqual({'progress-message': b'75% percent', 'progress-percent': 75, 'progress-sequence': 1},
                              watcher.current_progress())
 
         finally:
@@ -408,7 +409,7 @@ class ProgressTest(unittest.TestCase):
 
             time.sleep(0.10)
             self.assertIsNone(dn_watcher.current_progress())
-            self.assertEqual({'progress-message': 'Hundred percent', 'progress-percent': 100, 'progress-sequence': 1},
+            self.assertEqual({'progress-message': b'Hundred percent', 'progress-percent': 100, 'progress-sequence': 1},
                              out_watcher.current_progress())
 
         finally:
@@ -460,7 +461,7 @@ class ProgressTest(unittest.TestCase):
 
             read_progress_states_thread.join()
 
-            expected_data = list(map(lambda x: {'progress-message': 'completed-{}-percent'.format(x),
+            expected_data = list(map(lambda x: {'progress-message': 'completed-{}-percent'.format(x).encode(),
                                                 'progress-percent': x,
                                                 'progress-sequence': x},
                                      range(1, 101)))

--- a/executor/tests/utils.py
+++ b/executor/tests/utils.py
@@ -106,7 +106,7 @@ def cleanup_output(stdout_name, stderr_name):
                     read_and_print_contents(f, file_name)
             except UnicodeDecodeError:
                 try:
-                    with open(file_name, 'r', encoding='utf-8') as f:
+                    with open(file_name, 'r', encoding='cp437') as f:
                         read_and_print_contents(f, file_name)
                 except UnicodeDecodeError:
                     with open(file_name, 'rb') as f:


### PR DESCRIPTION
Example message in the logs:

```
root: DEBUG: Unable to decode line b'\x16npb\x14\x9c<%\x9c3^\xf3\xb1F\xcai\xcd\xdd\x8c_G\xc2\x19\xd2,H\xc9\xe9\x86\x8f\xe2\xe2!1\xfe\xe8yP@\x83\xf0\xbe\xdc\x041\xaaW\xdc\x1e\xe9W\xcb\x1c\xc7\xc4+x\xc4\x9b\xb4\x835D\xa0\x1f\xc7\xc6c,\xfb\xe6\xeb\xba5x\xed\x81Nv\x1a\xa4-"\xe5\x94D\x98R\xd8\x84\xb7\x01\x1f\x8b\x83H\xe3\r\x9b&\x10\x93\x8dJh\xf5\xf5x\xfd\xce\xf2\xe0\xe0\x95\xc0\x9d\xae\xfe\xed\xaf@\xb0\x00\xeb\xc0\xb8>\x8fL\x90\xbb\xd0\xb5\x14(t\x80\xb1\x0eH\x96\x98\x0c\x06*\xd4\r\x8b}@\x8fl\xea\x03\xab\x06v\x8a\xa5\xc7\x17\xf4j\x80j)\xd6\xa6.!\xf6\xd7\xc3\xca\xf4D\x1e6\xc7\xbb\x1b\xb5\xdfm\xc2a\xeb\x07\xf6\xa0\x02w\xce\xe8\x12>\xd0\xd9;\xb3\xd2L\x91+ew\xfb[[\x08c}y\xe5\x16\x12\x87\xc8T\x08i\x9c\x83\rw\x93\x9aK9\xd32\x0e\xb1\x08*\x86\xa9\x0f\xe6\x01\xcf\x04\x1b\xd0\x8a\x8ca\x05{j\xbc\xda\xcct\xd8D\xddI3\xb2\x0eb\xffbn\xce\xd1_\x1d\x90\x11|\xad@\xd8\xf6G>\xc0aC\xf7@y\xa2\x1e4\xd9\xa8\x01\xa9\x07"\xc6\xb0\x9ae`\xae6\x8b\xf6\xa3\xb2x<\xaa\x8e\xfdn\x1a\xba\x0e6\xf5\xd2\xb0\xe9\x12\xa6;\x8e-AF\xa5+\x08\xcb\x95\x1d9\xc9\x8f\xf76\x8c\xb3\xa6\x9b\x95\x8f\xd1 \xf8_\x0e;*\xf4&M\xf1 \xb6 \x9b\xb8dV\xf6\xad\x91\xe6/0\xb9\x80|\xe5\x18o>\x90\xd9\x16(\xfe\x17\xd2\x17\xb8\t\x96\xfdQ?h\x89/\xe1p\x16a\xe5FV\x11J\xba\x97s\xcd*\xb2\x1e\xa3\x0f.\x05\xba\x1d{\x8f\xdf\xaa\x1f\xc0\xcc\x18Ykr=\xf5\x00O\xa8V\xa2\xf0\x93\xacq@\x97_\x9f\xfd\xb8qPC\xac\x1b\x9b*\xa7\x17\xa1\x1a\xc1\xd8\xd7d\xbf\xe0\xca\xe3\xdf\xb6\xe2\xa4\x11\xd4\xdfI\x1c_<!\n' [tag=progress]
root: DEBUG: Unable to decode line b'\xbc\xe1\x82UE\x1a\x8e#\xa3,N\x84\x96ZbZ\xe4{\xd9\xf2\x95<1\xb0\xc8 \x90\x05\xf3\xfe\xff\xcd\x1f\xb0\xcb<\xddIu\x1a\x0eTN\xd30_\x9c,b\x03\x1b^\x08\xaf\xe5\xa7\x8c\xf9\x06\xab\xb0\xe7\x94\xa1\xed\xbf\xfcl_@=\xe0\xda\xf2\x824\xd1\x9b\xc95j\xa1\x8d\xb1\xcc\x02up0\x8c\xfc\xc4\xcf\xb2w\xe5\xf5\xae\'\xa8<\xd4\x9aK\x84\x91@\x06\x11\xb4"<\xf8\xd9\xaa\xaf\x9a\xe1on\x89\xf9A\x1d\xe2\xffh6\xca\xb0\xcfS\xa1m\x06\xeb\xcfb \x81\xb2 |\x8fH\xb9\xec\x16\xad\xef\x7f\x9f\xee\x9f\xba\xa8w\x12\x1d\xcc\xc8&\xe3J@\r\xcb\xcaSU\xfc&\xaf\xc8\\\x8b\x9e\xdb\xea\x00\xd3\x85\x1a\x1e\xc3\xd9F:l\x9b\xee\xdf]\xe8\xad\xa9,\x043\xbaBP\xa1\xf1\xb1\xfa\x8e\xa8JJ\x05w\xf30 \x89$\xd0y\xa0\x87\xc2\x8e^\xe8\xd6\xda\xde\x86\xac\xcc\xf9\xaduk\x0c?y\x9d\x81\xdb\xa4\xfe\x0f\xefo\xa8\xc7\xe8\xba\x01\x93\xcdk\xf0PE&\x17O\xc8\xf8\n' [tag=progress]
root: DEBUG: Unable to decode line b'cP\x14z\x05\xca\x89\xd9\x0b\xcct\xaf\xb2X\x83p\x830D\xf8\xfb\xe2\xdd\x1b`\xe8{\x11M\xf6\t\x91V>\xba\x04\xc3\xb17z\xaa[\x9d\xd5\x8f\xac\xc1\xb0_I\x06Pnu\xa3\x97\x02q^B\xb5\xac\x89\\\xcap\xe6l\x93}\xbb\xdf\xd2\x90\x83\x06\xffO\x19\x92\xf4\xa894!ki\xdc+\xeb\x93\xacI1\x9cC\xda\x9bf\x82\xf48[\x9fG\xebT\xbam\xe0\xd2+\xae\x87\x9b\xc5\xeb\xc9\x9d\x02\xa4\x8d\xe7Ku\x1b\xb8[j\xf1\x90\x18\x11\x16\xb6\xd9Lp9\x11\xb6\x9ab\x05\xccf\\I\xa4)\xfa0\xe2i\xdb W\x16\xe7\xf0\xd5\x90\x89t\xf9\x91\x91r\xe6uZ\xde\x08k3i\xeb\xdc\xcf\xdd\x88\xde\xadVmQ\xb7$}\xf4\xd4\xfc\xb6[E"p\xc0T\xc6\x9a\xb7p+\xf3p\xda\xf7PT\x11\xd3\x02\xb6\x0e\xec\xf2\xfb\xa5\x8d\n' [tag=progress]
root: DEBUG: Unable to decode line b'?\x1b\xbdQ3iuR\\\x91s\xbfH\x85o\xf2\x82\xeaI\xdeY>\x93\xe7\xa6\x8d\x89\xbd[\x9c_\x03Q_?d\xb5\xc1\x88<Z\x93IKHelloecho ^^^^JOB-PROGRESS: 50 $\x83F\xbcC\xf4\xfb\xe59\\\xa0X\x08\x0e%j\x8c\xfa\xe3c\x92\x82D\x1f\x05\x0c4\xd1\xcf\xa0N7sC\xbc\xd0\x85\xfa\xc7\xe5\xacO\xffK\xc0\xe8gA\xc0\xed\xa2\x06\x16\xa2\t%\xeb\x81\xac\x7fA\xb0W\x98|\x0f\xe9\xc7\xf1u\x91K\xd6d\x85\x9b\x9c\xd6\xa9J]\x867h\x97\x91C2\xf7\xea\xd1KA\xdc\xc3!2F\x8a\n' [tag=progress]
```