### PR TITLE
Re-enable group constraints

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1,6 +1,7 @@
 import dateutil.parser
 import json
 import logging
+import math
 import operator
 import pytest
 import subprocess
@@ -1419,7 +1420,7 @@ class CookTest(unittest.TestCase):
         finally:
             util.kill_jobs(self.cook_url, uuids)
 
-    @attr('explicit')
+    @pytest.mark.xfail
     def test_balanced_host_constraint_cannot_place(self):
         """
         Marked as explicit due to broken constraints handling.

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1365,6 +1365,187 @@ class CookTest(unittest.TestCase):
         finally:
             util.kill_jobs(self.cook_url, [job_uuid_1])
 
+    def test_unique_host_constraint(self):
+        state = util.get_mesos_state(self.mesos_url)
+        num_hosts = len(state['slaves'])
+        group = {'uuid': str(uuid.uuid4()),
+                 'host-placement': {'type': 'unique'}}
+        job_spec = {'group': group['uuid'], 'command': 'sleep 600'}
+        # Don't submit too many jobs for the test. If the cluster is larger than 19 hosts, only submit 20 jobs.
+        num_jobs = min(num_hosts + 1, 20)
+        uuids, resp = util.submit_jobs(self.cook_url, job_spec, num_jobs, groups=[group])
+        self.assertEqual(resp.status_code, 201, resp.content)
+        try:
+            def query():
+                return util.query_jobs(self.cook_url, uuid=uuids).json()
+
+            def num_running_predicate(response):
+                num_jobs_total = len(response)
+                num_running = len([j for j in response if j['status'] == 'running'])
+                num_waiting = len([j for j in response if j['status'] == 'waiting'])
+                if num_jobs_total == num_hosts + 1:
+                    # One job should not be scheduled
+                    return (num_running == num_jobs_total - 1) and (num_waiting == 1)
+                else:
+                    # All of the jobs should be running
+                    return num_running == num_jobs_total
+
+            jobs = util.wait_until(query, num_running_predicate, max_wait_ms=60000)
+            hosts = [job['instances'][0]['hostname'] for job in jobs
+                     if job['status'] == 'running']
+            # Only one job should run on each host
+            self.assertEqual(len(set(hosts)), len(hosts))
+            # If one job was not running, check the output of unscheduled_jobs
+            if num_jobs == num_hosts + 1:
+                waiting_jobs = [j for j in jobs if j['status'] == 'waiting']
+                self.assertEqual(1, len(waiting_jobs))
+                waiting_job = waiting_jobs[0]
+
+                def query():
+                    unscheduled = util.unscheduled_jobs(self.cook_url, waiting_job['uuid'])[0][0]
+                    self.logger.info(f"unscheduled_jobs response: {unscheduled}")
+                    return unscheduled
+
+                def check_unique_constraint(response):
+                    self.logger.debug('unscheduled_jobs response: %s' % response)
+                    return any([r['reason'] == reasons.COULD_NOT_PLACE_JOB for r in response['reasons']])
+
+                unscheduled_jobs = util.wait_until(query, check_unique_constraint)
+                unique_reason = [r for r in unscheduled_jobs['reasons'] if r['reason'] ==
+                                 reasons.COULD_NOT_PLACE_JOB][0]
+                self.assertEqual("unique-host-placement-group-constraint",
+                                 unique_reason['data']['reasons'][0]['reason'],
+                                 unique_reason)
+        finally:
+            util.kill_jobs(self.cook_url, uuids)
+
+    @attr('explicit')
+    def test_balanced_host_constraint_cannot_place(self):
+        """
+        Marked as explicit due to broken constraints handling.
+        See GitHub issue #579.
+        """
+        state = util.get_mesos_state(self.mesos_url)
+        num_hosts = len(state['slaves'])
+        if num_hosts > 10:
+            # Skip this test on large clusters
+            self.logger.info(f"Skipping test due to cluster size of {num_hosts} greater than 10")
+            return
+        minimum_hosts = num_hosts + 1
+        group = {'uuid': str(uuid.uuid4()),
+                 'host-placement': {'type': 'balanced',
+                                    'parameters': {'attribute': 'HOSTNAME',
+                                                   'minimum': minimum_hosts}}}
+        job_spec = {'command': 'sleep 600',
+                    'cpus': 0.1,
+                    'group': group['uuid'],
+                    'mem': 100}
+        num_jobs = minimum_hosts
+        uuids, resp = util.submit_jobs(self.cook_url, job_spec, num_jobs, groups=[group])
+        try:
+            def query_list():
+                return util.query_jobs(self.cook_url, uuid=uuids).json()
+
+            def num_running_predicate(response):
+                num_running = len([j for j in response if j['status'] == 'running'])
+                num_waiting = len([j for j in response if j['status'] == 'waiting'])
+                return num_running == num_hosts and num_waiting == 1
+
+            jobs = util.wait_until(query_list, num_running_predicate)
+            waiting_jobs = [j for j in jobs if j['status'] == 'waiting']
+            self.assertEqual(1, len(waiting_jobs), waiting_jobs)
+            waiting_job = waiting_jobs[0]
+
+            def query_unscheduled():
+                resp = util.unscheduled_jobs(self.cook_url, waiting_job['uuid'])[0][0]
+                placement_reasons = [reason for reason in resp['reasons']
+                                     if reason['reason'] == reasons.COULD_NOT_PLACE_JOB]
+                self.logger.info(f"unscheduled_jobs response: {resp}")
+                return placement_reasons
+
+            placement_reasons = util.wait_until(query_unscheduled, lambda r: len(r) > 0)
+            self.assertEqual(1, len(placement_reasons), placement_reasons)
+            reason = placement_reasons[0]
+            balanced_reasons = [r for r in reason['data']['reasons']
+                                if r['reason'] == 'balanced-host-placement-group-constraint']
+            self.assertEqual(1, len(balanced_reasons), balanced_reasons)
+        finally:
+            util.kill_jobs(self.cook_url, uuids)
+
+    def test_balanced_host_constraint(self):
+        state = util.get_mesos_state(self.mesos_url)
+        num_hosts = len(state['slaves'])
+        minimum_hosts = min(10, num_hosts)
+        group = {'uuid': str(uuid.uuid4()),
+                 'host-placement': {'type': 'balanced',
+                                    'parameters': {'attribute': 'HOSTNAME',
+                                                   'minimum': minimum_hosts}}}
+        job_spec = {'group': group['uuid'],
+                    'command': 'sleep 600',
+                    'mem': 100,
+                    'cpus': 0.1}
+        max_jobs_per_host = 3
+        num_jobs = minimum_hosts * max_jobs_per_host
+        uuids, resp = util.submit_jobs(self.cook_url, job_spec, num_jobs, groups=[group])
+        self.assertEqual(201, resp.status_code, resp.content)
+        try:
+            jobs = util.wait_for_jobs(self.cook_url, uuids, 'running')
+            hosts = [j['instances'][0]['hostname'] for j in jobs]
+            host_count = Counter(hosts)
+            self.assertGreaterEqual(len(host_count), minimum_hosts, hosts)
+            self.assertLessEqual(max(host_count.values()), max_jobs_per_host, host_count)
+        finally:
+            util.kill_jobs(self.cook_url, uuids)
+
+    def test_attribute_equals_hostname_constraint(self):
+        slaves = util.get_mesos_state(self.mesos_url)['slaves']
+        max_slave_cpus = max([s['resources']['cpus'] for s in slaves])
+        task_constraint_cpus = util.settings(self.cook_url)['task-constraints']['cpus']
+        # The largest job we can submit that actually fits on a slave
+        max_cpus = min(max_slave_cpus, task_constraint_cpus)
+        # The number of "big" jobs we need to submit before one will not be scheduled
+        num_big_jobs = max(1, math.floor(max_cpus / task_constraint_cpus))
+        # Use the rest of the machine, plus one half CPU so one of the large jobs won't fit
+        canary_cpus = max_slave_cpus - (num_big_jobs * max_cpus) + 0.5
+        group = {'uuid': str(uuid.uuid4()),
+                 'host-placement': {'type': 'attribute-equals',
+                                    'parameters': {'attribute': 'HOSTNAME'}}}
+        # First job - a canary job with high priority which uses canary_cpus cpus
+        canary = util.minimal_job(group=group['uuid'],
+                                  priority=100,
+                                  cpus=canary_cpus,
+                                  command='sleep 600')
+        # Second job - a big job with low priority using max_cpus cpus
+        # Based on the priority, canary should be scheduled ahead of big_job, but because
+        # of the host-placement constraint they have to be scheduled on the same host.
+        # The canary should be able to be scheduled, but big_job should never be scheduled.
+        jobs = [util.minimal_job(group=group['uuid'],
+                                 priority=1,
+                                 cpus=max_cpus)
+                for _ in range(num_big_jobs)]
+        jobs.append(canary)
+        uuids, resp = util.submit_jobs(self.cook_url, jobs, groups=[group])
+        self.assertEqual(201, resp.status_code, resp.content)
+        try:
+            util.wait_for_job(self.cook_url, canary['uuid'], 'running')
+
+            def query():
+                unscheduled_jobs, _ = util.unscheduled_jobs(self.cook_url, *[j['uuid'] for j in jobs])
+                self.logger.info(f"unscheduled_jobs response: {unscheduled_jobs}")
+                no_hosts = [reason for job in unscheduled_jobs for reason in job['reasons']
+                            if reason['reason'] == "The job couldn't be placed on any available hosts."]
+                for no_hosts_reason in no_hosts:
+                    for sub_reason in no_hosts_reason['data']['reasons']:
+                        if sub_reason['reason'] == "Host had a different attribute than other jobs in the group.":
+                            return sub_reason
+                return None
+
+            reason = util.wait_until(query, lambda r: r is not None)
+            self.assertEqual(reason['reason'],
+                             "Host had a different attribute than other jobs in the group.")
+        finally:
+            util.kill_jobs(self.cook_url, uuids)
+
     def test_retrieve_jobs_with_deprecated_api(self):
         job_uuid_1, resp = util.submit_job(self.cook_url)
         self.assertEqual(201, resp.status_code, msg=resp.content)

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -187,6 +187,8 @@
 ;; Group host placement constraints
 
 (defn- get-running-cotasks-from-cache
+  "Looks up the currently running tasks in group from group-uuid->running-cotask-cache
+   and loads them from db if missing."
   [db group-uuid->running-cotask-cache group]
   (let [group-uuid (:group/uuid group)]
     (cache/lookup (swap! group-uuid->running-cotask-cache

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -575,16 +575,17 @@
    given a job, its resources, its task-id and a function assigned-cotask-getter. assigned-cotask-getter should be a
    function that takes a group uuid and returns a set of task-ids, which correspond to the tasks that will be assigned
    during the same Fenzo scheduling cycle as the newly created TaskRequest."
-  [db job & {:keys [resources task-id assigned-resources guuid->considerable-cotask-ids]
+  [db job & {:keys [resources task-id assigned-resources guuid->considerable-cotask-ids running-cotask-cache]
           :or {resources (util/job-ent->resources job)
                task-id (str (java.util.UUID/randomUUID))
                assigned-resources (atom nil)
-               guuid->considerable-cotask-ids (constantly #{})}}]
+               guuid->considerable-cotask-ids (constantly #{})
+               running-cotask-cache (atom (cache/fifo-cache-factory {} :threshold 1))}}]
   (let [constraints (into (constraints/make-fenzo-job-constraints job)
                           (remove nil?
                                   (mapv (fn make-group-constraints [group]
                                           (constraints/make-fenzo-group-constraint
-                                           db group #(guuid->considerable-cotask-ids (:group/uuid group))))
+                                           db group #(guuid->considerable-cotask-ids (:group/uuid group)) running-cotask-cache))
                                         (:group/_job job))))
         needs-gpus? (constraints/job-needs-gpus? job)
         scalar-requests (reduce (fn [result resource]
@@ -613,9 +614,11 @@
         leases (mapv #(->VirtualMachineLeaseAdapter % t) offers)
         considerable->task-id (plumbing.core/map-from-keys (fn [_] (str (java.util.UUID/randomUUID))) considerable)
         guuid->considerable-cotask-ids (util/make-guuid->considerable-cotask-ids considerable->task-id)
+        running-cotask-cache (atom (cache/fifo-cache-factory {} :threshold (max 1 (count considerable))))
         ; Important that requests maintains the same order as considerable
         requests (mapv (fn [job]
-                         (make-task-request db job :task-id (considerable->task-id job) :guuid->considerable-cotask-ids guuid->considerable-cotask-ids))
+                         (make-task-request db job :task-id (considerable->task-id job) :guuid->considerable-cotask-ids guuid->considerable-cotask-ids
+                                            :running-cotask-cache running-cotask-cache))
                        considerable)
         ;; Need to lock on fenzo when accessing scheduleOnce because scheduleOnce and
         ;; task assigner can not be called at the same time.

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -580,7 +580,12 @@
                task-id (str (java.util.UUID/randomUUID))
                assigned-resources (atom nil)
                guuid->considerable-cotask-ids (constantly #{})}}]
-  (let [constraints (constraints/make-fenzo-job-constraints job)
+  (let [constraints (into (constraints/make-fenzo-job-constraints job)
+                          (remove nil?
+                                  (mapv (fn make-group-constraints [group]
+                                          (constraints/make-fenzo-group-constraint
+                                           db group #(guuid->considerable-cotask-ids (:group/uuid group))))
+                                        (:group/_job job))))
         needs-gpus? (constraints/job-needs-gpus? job)
         scalar-requests (reduce (fn [result resource]
                                   (if-let [value (:resource/amount resource)]

--- a/scheduler/test/cook/test/mesos/rebalancer.clj
+++ b/scheduler/test/cook/test/mesos/rebalancer.clj
@@ -15,7 +15,8 @@
 ;;
 (ns cook.test.mesos.rebalancer
   (:use clojure.test)
-  (:require [clojure.data.priority-map :as pm]
+  (:require [clojure.core.cache :as cache]
+            [clojure.data.priority-map :as pm]
             [clojure.test.check.generators :as gen]
             [cook.mesos :as mesos]
             [cook.mesos.dru :as dru]
@@ -208,6 +209,7 @@
   (testing "test without group constraints"
     (let [datomic-uri "datomic:mem://test-compute-preemption-decision"
           conn (restore-fresh-database! datomic-uri)
+          cotask-cache (atom (cache/fifo-cache-factory {} :threshold 100))
           job1 (create-dummy-job conn :user "ljin" :memory 10.0 :ncpus 10.0)
           job2 (create-dummy-job conn :user "ljin" :memory 5.0  :ncpus 5.0)
           job3 (create-dummy-job conn :user "ljin" :memory 15.0 :ncpus 25.0)
@@ -291,7 +293,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                                     (d/entity db job9))))
+                                                     (d/entity db job9)
+                                                     cotask-cache)))
 
       (is (= {:hostname "hostB" :dru Double/MAX_VALUE :task nil :mem 15.0 :cpus 15.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision db offer-cache
@@ -302,7 +305,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
-                                                     (d/entity db job9))))
+                                                     (d/entity db job9)
+                                                     cotask-cache)))
 
       (is (= {:hostname "hostA" :dru Double/MAX_VALUE :task nil :mem 20.0 :cpus 20.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision db offer-cache
@@ -314,7 +318,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
-                                                     (d/entity db job9))))
+                                                     (d/entity db job9)
+                                                     cotask-cache)))
 
       (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 35.0 :cpus 25.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision db offer-cache
@@ -326,7 +331,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.0 :safe-dru-threshold 1.0}
-                                                     (d/entity db job9))))
+                                                     (d/entity db job9)
+                                                     cotask-cache)))
 
       (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 25.0 :cpus 15.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision db offer-cache
@@ -337,7 +343,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
-                                                     (d/entity db job10))))
+                                                     (d/entity db job10)
+                                                     cotask-cache)))
 
       (is (= nil
              (rebalancer/compute-preemption-decision db offer-cache
@@ -348,7 +355,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
-                                                     (d/entity db job11))))
+                                                     (d/entity db job11)
+                                                     cotask-cache)))
 
       (is (= nil
              (rebalancer/compute-preemption-decision db offer-cache
@@ -359,7 +367,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.0 :safe-dru-threshold 1.0}
-                                                     (d/entity db job12))))
+                                                     (d/entity db job12)
+                                                     cotask-cache)))
 
       (is (= {:hostname "hostA" :dru Double/MAX_VALUE :task nil :mem 40.0 :cpus 40.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision db offer-cache
@@ -370,7 +379,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
-                                                     (d/entity db job12))))
+                                                     (d/entity db job12)
+                                                     cotask-cache)))
 
       (is (= nil
              (rebalancer/compute-preemption-decision db offer-cache
@@ -381,7 +391,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.0 :safe-dru-threshold 1.0}
-                                                     (d/entity db job12))))
+                                                     (d/entity db job12)
+                                                     cotask-cache)))
 
       (is (= {:hostname "hostB" :dru 2.2 :task [task-ent4] :mem 55.0 :cpus 45.0 :gpus 0.0}
              (rebalancer/compute-preemption-decision db offer-cache
@@ -393,7 +404,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
-                                                     (d/entity db job12))))
+                                                     (d/entity db job12)
+                                                     cotask-cache)))
 
       (is (= nil
              (rebalancer/compute-preemption-decision db offer-cache
@@ -404,7 +416,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
-                                                     (d/entity db job13))))
+                                                     (d/entity db job13)
+                                                     cotask-cache)))
 
       (is (= nil
              (rebalancer/compute-preemption-decision db offer-cache
@@ -415,7 +428,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 2.0 :safe-dru-threshold 1.0}
-                                                     (d/entity db job13))))
+                                                     (d/entity db job13)
+                                                     cotask-cache)))
 
       (is (= nil
              (rebalancer/compute-preemption-decision db offer-cache
@@ -426,7 +440,8 @@
                                                               rebalancer/compute-pending-normal-job-dru
                                                               [])
                                                      {:min-dru-diff 0.5 :safe-dru-threshold 1.0}
-                                                     (d/entity db job14))))))
+                                                     (d/entity db job14)
+                                                     cotask-cache)))))
   (testing "test preemption with novel-host job constraint"
     (let [datomic-uri "datomic:mem://test-compute-preemption-decision"
           conn (restore-fresh-database! datomic-uri)
@@ -438,7 +453,8 @@
                        "sticks" {"HOSTNAME" "sticks"}
                        "bricks" {"HOSTNAME" "bricks"}
                        "rebar" {"HOSTNAME" "rebar"}}
-          offer-cache (init-offer-cache)]
+          offer-cache (init-offer-cache)
+          cotask-cache (atom (cache/fifo-cache-factory {} :threshold 100))]
       (share/set-share! conn "default" "new cluster settings"
                         :mem 10.0 :cpus 10.0 :gpus 10.0)
       ; Fill up hosts with preemptable tasks
@@ -464,7 +480,8 @@
                                                                             rebalancer/compute-pending-normal-job-dru
                                                                             [])
                                                                    {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                                                   (d/entity db pending-job)))))))
+                                                                   (d/entity db pending-job)
+                                                                   cotask-cache))))))
 
       (testing "try placing a job that has been preempted everywhere, but not failed on rebar"
         (let [pending-job (create-dummy-job conn :user "diego" :ncpus 1.0)
@@ -489,7 +506,8 @@
                                                                             rebalancer/compute-pending-normal-job-dru
                                                                             [])
                                                                    {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                                                   (d/entity db pending-job)))))))
+                                                                   (d/entity db pending-job)
+                                                                   cotask-cache))))))
       (testing "try placing an unconstrained job"
         (let [pending-job (create-dummy-job conn :user "diego" :ncpus 1.0)
               db (d/db conn)
@@ -504,7 +522,8 @@
                                                                           rebalancer/compute-pending-normal-job-dru
                                                                           [])
                                                                  {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                                                 (d/entity db pending-job))))))))))
+                                                                 (d/entity db pending-job)
+                                                                 cotask-cache)))))))))
 
   (testing "test preemption with unique host-placement group constraint"
     (let [datomic-uri "datomic:mem://test-compute-preemption-decision"
@@ -517,7 +536,8 @@
                        "sticks" {"HOSTNAME" "sticks"}
                        "bricks" {"HOSTNAME" "bricks"}
                        "rebar" {"HOSTNAME" "rebar"}}
-          offer-cache (init-offer-cache)]
+          offer-cache (init-offer-cache)
+          cotask-cache (atom (cache/fifo-cache-factory {} :threshold 100))]
       (share/set-share! conn "default" "new cluster settings"
                         :mem 10.0 :cpus 10.0 :gpus 1.0)
       ; Fill up hosts with preemptable tasks
@@ -541,7 +561,8 @@
                                                                             rebalancer/compute-pending-normal-job-dru
                                                                             [])
                                                                    {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                                                   (d/entity db pending-job)))))))
+                                                                   (d/entity db pending-job)
+                                                                   cotask-cache))))))
 
       (testing "try placing job with no unconstrained-hosts available"
         (let [; Make a group with all available hosts occupied
@@ -561,7 +582,8 @@
                                                                  rebalancer/compute-pending-normal-job-dru
                                                                  [])
                                                         {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                                        (d/entity db pending-job))))))))
+                                                        (d/entity db pending-job)
+                                                        cotask-cache)))))))
 
   (testing "test preemption with attribute-equals host-placement group constraint"
     (let [datomic-uri "datomic:mem://test-compute-preemption-decision"
@@ -576,7 +598,8 @@
                            "sticks" {"az" "east" "HOSTNAME" "sticks"}
                            "bricks" {"az" "east" "HOSTNAME" "bricks"}
                            "rebar" {"az" "west" "HOSTNAME" "rebar"}}
-          offer-cache (init-offer-cache)]
+          offer-cache (init-offer-cache)
+          cotask-cache (atom (cache/fifo-cache-factory {} :threshold 100))]
       (share/set-share! conn "default" "new cluster limits"
                         :mem 10.0 :cpus 10.0 :gpus 1.0)
       ; Fill up hosts with preemptable tasks
@@ -604,7 +627,8 @@
                                                                             rebalancer/compute-pending-normal-job-dru
                                                                             [])
                                                                    {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                                                   (d/entity db pending-job)))))))
+                                                                   (d/entity db pending-job)
+                                                                   cotask-cache))))))
 
       (testing "try placing job with no unconstrained-hosts available"
         (let [group-id (create-dummy-group conn :host-placement
@@ -627,7 +651,8 @@
                                                                  rebalancer/compute-pending-normal-job-dru
                                                                  [])
                                                         {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                                        (d/entity db pending-job))))))))
+                                                        (d/entity db pending-job)
+                                                        cotask-cache)))))))
 
   (testing "test preemption with balanced host-placement group constraint"
     (let [datomic-uri "datomic:mem://test-compute-preemption-decision"
@@ -648,7 +673,8 @@
                            "concrete" {"az" "east" "HOSTNAME" "concrete"}
                            "steel" {"az" "west" "HOSTNAME" "steel"}
                            "gold" {"az" "south" "HOSTNAME" "gold"}
-                           "titanium" {"az" "north" "HOSTNAME" "titanium"}}]
+                           "titanium" {"az" "north" "HOSTNAME" "titanium"}}
+          cotask-cache (atom (cache/fifo-cache-factory {} :threshold 100))]
 
       (testing "try placing job with one unconstrained-host available"
         (let [conn (restore-fresh-database! datomic-uri)
@@ -682,7 +708,8 @@
                                                       rebalancer/compute-pending-normal-job-dru
                                                       [])
                                              {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                             (d/entity db pending-job)))]
+                                             (d/entity db pending-job)
+                                             cotask-cache))]
             (is (true? (or (= "titanium" preempted-host) (= "rebar" preempted-host)))))))
 
       (testing "try placing job with two unconstrained hosts available, but one has already been preempted this cycle"
@@ -720,7 +747,8 @@
                                                       rebalancer/compute-pending-normal-job-dru
                                                       [task-preempted-this-cycle])
                                              {:min-dru-diff 0.05 :safe-dru-threshold 1.0}
-                                             (d/entity db pending-job)))]
+                                             (d/entity db pending-job)
+                                             cotask-cache))]
             (is (true? (or (= "bricks" preempted-host) (= "gold" preempted-host))))))))))
 
 (deftest test-next-state


### PR DESCRIPTION
This change has two commits:
1. Reverts the commit removing fenzo group constraints
2. Adds explicit caching for each group's running cotasks (for rebalancing) and running cotask ids (for matching)

Both of these cases don't necessarily need a `core.cache` cache since they have a fixed number of elements, but I think it's more appropriate as an API than a map or something else.