### PR TITLE
Cook executor progress message processing early termination

### DIFF
--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -61,12 +61,14 @@ def main(args=None):
     print_memory_usage_task()
 
     stop_signal = Event()
+    non_zero_exit_signal = Event()
 
     def handle_interrupt(interrupt_code, _):
         logging.info('Executor interrupted with code {}'.format(interrupt_code))
         cio.print_and_log('Received kill for task {} with grace period of {}'.format(
             executor_id, config.shutdown_grace_period))
         stop_signal.set()
+        non_zero_exit_signal.set()
         print_memory_usage()
 
     signal.signal(signal.SIGINT, handle_interrupt)
@@ -89,9 +91,10 @@ def main(args=None):
     except Exception:
         logging.exception('Error in __main__')
         stop_signal.set()
+        non_zero_exit_signal.set()
 
     print_memory_usage()
-    exit_code = 1 if stop_signal.isSet() else 0
+    exit_code = 1 if non_zero_exit_signal.isSet() else 0
     logging.info('Executor exiting with code {}'.format(exit_code))
     sys.exit(exit_code)
 

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -204,17 +204,22 @@ class ProgressWatcher(object):
             linesep_bytes = os.linesep.encode()
             fragment_index = 0
             line_index = 0
+
+            def log_tail_summary():
+                log_message = '%s fragments and %s lines read while processing progress messages [tag=%s]'
+                logging.info(log_message, fragment_index, line_index, self.location_tag)
+
             with open(self.target_file, 'rb') as target_file_obj:
                 while not self.stop_signal.isSet():
                     if self.progress_termination_signal.isSet():
                         logging.info('tail short-circuiting due to progress termination [tag=%s]', self.location_tag)
+                        log_tail_summary()
                         break
                     line = target_file_obj.readline(self.max_bytes_read_per_line)
                     if not line:
                         # exit if program has completed and there are no more lines to read
                         if self.task_completed_signal.isSet():
-                            log_message = '%s fragments and %s lines read while processing progress messages [tag=%s]'
-                            logging.info(log_message, fragment_index, line_index, self.location_tag)
+                            log_tail_summary()
                             break
                         # no new line available, sleep before trying again
                         time.sleep(sleep_param)

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -274,13 +274,11 @@ class ProgressWatcher(object):
             for line in self.tail(sleep_time_ms):
                 try:
                     progress_report = ProgressWatcher.match_progress_update(self.progress_regex_pattern, line)
-                    if progress_report is None:
-                        continue
-                    if self.task_completed_signal.isSet():
-                        last_unprocessed_report = progress_report
-                        continue
-                    if self.__update_progress(progress_report):
-                        yield self.progress
+                    if progress_report is not None:
+                        if self.task_completed_signal.isSet():
+                            last_unprocessed_report = progress_report
+                        elif self.__update_progress(progress_report):
+                            yield self.progress
                 except Exception:
                     logging.exception('Skipping "%s" as a progress entry', line)
         if last_unprocessed_report is not None:

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -565,12 +565,8 @@ class ExecutorTest(unittest.TestCase):
 
             expected_core_messages = [{'sandbox-directory': sandbox_directory, 'task-id': task_id, 'type': 'directory'},
                                       {'exit-code': 0, 'task-id': task_id}]
-            expected_progress_messages = [{'progress-message': 'Twenty-five percent in stdout',
-                                           'progress-percent': 25, 'progress-sequence': 1, 'task-id': task_id},
-                                          {'progress-message': '',
-                                           'progress-percent': 50, 'progress-sequence': 2, 'task-id': task_id},
-                                          {'progress-message': 'Fifty-five percent in stdout',
-                                           'progress-percent': 55, 'progress-sequence': 3, 'task-id': task_id}]
+            expected_progress_messages = [{'progress-message': '',
+                                           'progress-percent': 50, 'progress-sequence': 1, 'task-id': task_id}]
             tu.assert_messages(self, expected_core_messages, expected_progress_messages, driver.messages)
 
             stdout_name = tu.ensure_directory('build/stdout.' + str(task_id))
@@ -582,16 +578,10 @@ class ExecutorTest(unittest.TestCase):
 
         # progress string in file with binary data will be ignored
         command = 'echo "Hello"; ' \
-                  'echo "^^^^JOB-PROGRESS: 25 Twenty-five percent in stdout"; ' \
                   'head -c 1000 /dev/random; ' \
-                  'echo "force newline"; ' \
-                  'sleep 2; ' \
-                  'echo "^^^^JOB-PROGRESS: 50 `head -c 100 /dev/random`"; ' \
-                  'echo "force newline"; ' \
-                  'sleep 2; ' \
-                  'head -c 1000 /dev/random; ' \
-                  'echo "force newline"; ' \
-                  'echo "^^^^JOB-PROGRESS: 55 Fifty-five percent in stdout"; ' \
+                  'echo "force newline stage-1"; ' \
+                  'echo "^^^^JOB-PROGRESS: 50 `head -c 20 /dev/random`"; ' \
+                  'echo "force newline stage-2"; ' \
                   'echo "Done"'
         self.manage_task_runner(command, assertions, stop_signal=stop_signal)
         stop_signal.set()

--- a/executor/tests/test_progress.py
+++ b/executor/tests/test_progress.py
@@ -541,9 +541,9 @@ class ProgressTest(unittest.TestCase):
 
             target_file.close()
             time.sleep(0.15)
-            completed.set()
 
         write_thread = Thread(target=write_to_file, args=())
+        write_thread.daemon = True
         write_thread.start()
 
         counter = cp.ProgressSequenceCounter()
@@ -558,6 +558,8 @@ class ProgressTest(unittest.TestCase):
                 expected_progress_state = progress_states.pop(0)
                 self.assertEqual(expected_progress_state, actual_progress_state)
                 self.assertEqual(expected_progress_state, watcher.current_progress())
+                if not progress_states:
+                    completed.set()
             self.assertFalse(progress_states)
 
             write_thread.join()

--- a/executor/tests/test_progress.py
+++ b/executor/tests/test_progress.py
@@ -270,7 +270,6 @@ class ProgressTest(unittest.TestCase):
                 file.write("^^^^JOB-PROGRESS: 198.8\n")
                 file.flush()
                 file.close()
-                completed_signal.set()
 
             print_thread = Thread(target=print_to_file, args=())
             print_thread.start()
@@ -284,6 +283,8 @@ class ProgressTest(unittest.TestCase):
                 expected_progress_state = progress_states.pop(0)
                 self.assertEqual(expected_progress_state, actual_progress_state)
                 self.assertEqual(expected_progress_state, watcher.current_progress())
+                if not progress_states:
+                    completed_signal.set()
             self.assertFalse(progress_states)
 
             print_thread.join()
@@ -316,7 +317,6 @@ class ProgressTest(unittest.TestCase):
                 file.write("^^^^JOB-PROGRESS: 100.1 Over a hundred\n")
                 file.flush()
                 file.close()
-                completed_signal.set()
 
             print_thread = Thread(target=print_to_file, args=())
             print_thread.start()
@@ -330,6 +330,8 @@ class ProgressTest(unittest.TestCase):
                 expected_progress_state = progress_states.pop(0)
                 self.assertEqual(expected_progress_state, actual_progress_state)
                 self.assertEqual(expected_progress_state, watcher.current_progress())
+                if not progress_states:
+                    completed_signal.set()
             self.assertFalse(progress_states)
 
             print_thread.join()


### PR DESCRIPTION
## Changes proposed in this PR

- skips processing of intervening progress reports when task has completed
- triggers termination of progress trackers when process completes execution
- makes cook executor exit non-zero only when interrupted or handling exception

## Why are we making these changes?

Running commands that generate lots of output (e.g. `for i in ``seq 1 10000000``; do echo "progress: 5 five percent" ; done`) can cause significant delays in the executor completion. This is inconvenient as it holds up the Mesos agent resources trying to extract the progress message even after the actual command has run to completion.

On my mac this is noticed to be around 
- 110 seconds for processing 1 million progress lines, vs 
- 36 seconds for processing 1 million lines that do not satisfy the progress regex, vs 
- 24 seconds for tailing 1 million lines.

This change triggers early termination of the progress watcher thread in two ways:

1. It skips further processing (and hence sending to the scheduler) of all progress messages except the last one after the process has completed execution.
1. It trigger termination of the `tail` mechanism after a grace period to stop the progress message reading.

## Relevant output:

Before the change:
```
2017-12-04 22:23:51,636 INFO Command: for i in `seq 1 10000000`; do echo "progress: 5 five percent" ; done
...
2017-12-04 22:23:51,651 INFO Forked command at 42763
...
2017-12-04 22:25:36,781 INFO Command exited with status 0 (pid: 42763)
...
2017-12-04 22:28:07,056 INFO 10000007 fragments and 10000007 lines read while processing progress messages [tag=stdout]
2017-12-04 22:28:07,057 INFO Progress monitoring from complete [tag=stdout]
2017-12-04 22:28:07,057 INFO Progress updaters completed
...
2017-12-04 22:28:07,058 INFO Sending progress message {'progress-sequence': 10000000, 'progress-percent': 5, 'progress-message': b' five percent'}
...
2017-12-04 22:28:07,075 INFO Executor exiting with code 1
```

After the change:

```
2017-12-04 22:32:16,668 INFO Command: for i in `seq 1 10000000`; do echo "progress: 5 five percent" ; done
...
2017-12-04 22:32:16,680 INFO Forked command at 43435    
...
2017-12-04 22:34:17,935 INFO Command exited with status 0 (pid: 43435)
...
2017-12-04 22:34:22,939 INFO tail short-circuiting due to progress termination [tag=stdout]                           
2017-12-04 22:34:22,940 INFO 3286437 fragments and 3286437 lines read while processing progress messages [tag=stdout]
2017-12-04 22:34:22,940 INFO Progress monitoring complete [tag=stdout]           
...                                                                  
2017-12-04 22:34:22,940 INFO Sending progress message {'progress-percent': 5, 'progress-sequence': 2141358, 'progress-message': b' five percent'}
...                                  
2017-12-04 22:34:22,946 INFO Executor exiting with code 0
```

**Note** that after the change the executor terminates around 5 seconds (the shutdown grace period) after the command has exited.