### PR TITLE
Mimic Mesos CommandExecutor kill logic of killing process tree

### DIFF
--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -333,7 +333,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
     finally:
         # ensure completed_signal is set so driver can stop
         completed_signal.set()
-        if launched_process is not None and cs.is_process_running(launched_process):
+        if launched_process and cs.is_process_running(launched_process):
             cs.send_signal(launched_process.pid, signal.SIGKILL)
 
 

--- a/executor/cook/subprocess.py
+++ b/executor/cook/subprocess.py
@@ -1,0 +1,168 @@
+import logging
+import signal
+import subprocess
+import time
+
+import os
+
+import cook
+import cook.io_helper as cio
+
+
+def launch_process(command, environment):
+    """Launches the process using the command and specified environment.
+
+    Parameters
+    ----------
+    command: string
+        The command to execute.
+    environment: dictionary
+        The environment.
+
+    Returns
+    -------
+    The launched process.
+    """
+    if not command:
+        logging.warning('No command provided!')
+        return None
+    # The preexec_fn is run after the fork() but before exec() to run the shell.
+    return subprocess.Popen(command,
+                            env=environment,
+                            preexec_fn=os.setpgrp,
+                            shell=True,
+                            stderr=subprocess.PIPE,
+                            stdout=subprocess.PIPE)
+
+
+def is_process_running(process):
+    """Checks whether the process is still running.
+
+    Parameters
+    ----------
+    process: subprocess.Popen
+        The process to query
+
+    Returns
+    -------
+    whether the process is still running.
+    """
+    return process.poll() is None
+
+
+def find_process_group(process_id):
+    """Return the process group id of the process with process id process_id.
+    Parameters
+    ----------
+    process_id: int
+        The process id.
+    Returns
+    -------
+    The process group id of the process with process id process_id or None.
+    """
+    try:
+        group_id = os.getpgid(process_id)
+        logging.info('Process (pid: {}) belongs to group (id: {})'.format(process_id, group_id))
+        return group_id
+    except ProcessLookupError:
+        logging.info('Unable to find group for process (pid: {})'.format(process_id))
+    except Exception:
+        logging.exception('Error in finding group for process (pid: {})'.format(process_id))
+
+
+def send_signal_to_process(process_id, signal_to_send):
+    """Send the signal_to_send signal to the process with process_id.
+    Parameters
+    ----------
+    process_id: int
+        The id of the process whose group to kill.
+    signal_to_send: signal.Signals enum
+        The signal to send to the process group.
+    Returns
+    -------
+    Nothing
+    """
+    signal_name = signal_to_send.name
+    try:
+        logging.info('Sending signal {} to process (id: {})'.format(signal_name, process_id))
+        os.kill(process_id, signal_to_send)
+        return True
+    except ProcessLookupError:
+        logging.info('Unable to send signal {} as could not find process (id: {})'.format(signal_name, process_id))
+    except Exception:
+        logging.exception('Error in sending signal {} to process (id: {})'.format(signal_name, process_id))
+    return False
+
+
+def send_signal_to_process_group(process_id, signal_to_send):
+    """Send the signal_to_send signal to the process group with group_id.
+    Parameters
+    ----------
+    process_id: int
+        The id of the process whose group to kill.
+    signal_to_send: signal.Signals enum
+        The signal to send to the process group.
+    Returns
+    -------
+    Nothing
+    """
+    signal_name = signal_to_send.name
+    try:
+        group_id = find_process_group(process_id)
+        if group_id:
+            logging.info('Sending signal {} to group (id: {})'.format(signal_name, group_id))
+            os.killpg(group_id, signal_to_send)
+            return True
+    except ProcessLookupError:
+        logging.info('Unable to send signal {} as could not find group (id: {})'.format(signal_name, group_id))
+    except Exception:
+        logging.exception('Error in sending signal {} to group (id: {})'.format(signal_name, group_id))
+    return False
+
+
+def send_signal(process_id, signal_to_send):
+    """Send the signal_to_send signal to the process with process_id.
+    The function uses a two-step mechanism:
+    1. It sends the signal to the process group,
+    2. If unsuccessful, it sends the signal directly to the process"""
+    if process_id:
+        if send_signal_to_process_group(process_id, signal_to_send):
+            logging.info('Successfully killed group for process (id: {})'.format(process_id))
+        else:
+            send_signal_to_process(process_id, signal_to_send)
+
+
+def kill_process(process, shutdown_grace_period_ms):
+    """Attempts to kill a process.
+     First attempt is made by sending the process a SIGTERM.
+     If the process does not terminate inside (shutdown_grace_period_ms - 100) ms, it is then sent a SIGKILL.
+     The 100 ms grace period is allocated for the executor to perform its other cleanup actions.
+
+    Parameters
+    ----------
+    process: subprocess.Popen
+        The process to kill
+    shutdown_grace_period_ms: int
+        Grace period before forceful kill
+
+    Returns
+    -------
+    Nothing
+    """
+    shutdown_grace_period_ms = max(shutdown_grace_period_ms - (1000 * cook.TERMINATE_GRACE_SECS), 0)
+    if is_process_running(process):
+        logging.info('Waiting up to {} ms for process to terminate'.format(shutdown_grace_period_ms))
+        send_signal(process.pid, signal.SIGTERM)
+
+        loop_limit = int(shutdown_grace_period_ms / 10)
+        for i in range(loop_limit):
+            time.sleep(0.01)
+            if not is_process_running(process):
+                cio.print_and_log('Command terminated with signal Terminated (pid: {})'.format(process.pid),
+                                  flush=True)
+                break
+        if is_process_running(process):
+            logging.info('Process did not terminate, forcefully killing it')
+            send_signal(process.pid, signal.SIGKILL)
+            cio.print_and_log('Command terminated with signal Killed (pid: {})'.format(process.pid),
+                              flush=True)

--- a/executor/requirements.txt
+++ b/executor/requirements.txt
@@ -1,1 +1,2 @@
+psutil==5.4.1
 pymesos==0.2.15

--- a/executor/setup.py
+++ b/executor/setup.py
@@ -17,7 +17,7 @@ setup(
         'nose>=1.0'
     ],
     setup_requires=['nose>=1.0'],
-    install_requires=['pymesos==0.2.15'],
+    install_requires=['psutil==5.4.1', 'pymesos==0.2.15'],
     entry_points={
         'console_scripts': [
             'cook-executor = cook.__main__:main'

--- a/executor/tests/test_subprocess.py
+++ b/executor/tests/test_subprocess.py
@@ -1,0 +1,132 @@
+import logging
+import signal
+import subprocess
+import time
+import unittest
+
+import collections
+
+import cook.io_helper as cio
+import cook.subprocess as cs
+import tests.utils as tu
+
+
+def find_process_ids_in_group(group_id):
+    group_id_to_process_ids = collections.defaultdict(set)
+    process_id_to_command = collections.defaultdict(lambda: '')
+
+    p = subprocess.Popen('ps -eo pid,pgid,command',
+                         close_fds=True, shell=True,
+                         stderr=subprocess.STDOUT, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    ps_output = p.stdout.read().decode('utf8')
+
+    for line in ps_output.splitlines():
+        line_split = line.split()
+        pid = line_split[0]
+        pgid = line_split[1]
+        command = str.join(' ', line_split[2:])
+        group_id_to_process_ids[pgid].add(pid)
+        process_id_to_command[pid] = command
+
+    group_id_str = str(group_id)
+    logging.info("group_id_to_process_ids[{}]: {}".format(group_id, group_id_to_process_ids[group_id_str]))
+    for pid in group_id_to_process_ids[group_id_str]:
+        logging.info("process (pid: {}) command is {}".format(pid, process_id_to_command[pid]))
+    return group_id_to_process_ids[group_id_str]
+
+
+class SubprocessTest(unittest.TestCase):
+    def test_kill_task_terminate_with_sigterm(self):
+        task_id = tu.get_random_task_id()
+
+        stdout_name = tu.ensure_directory('build/stdout.{}'.format(task_id))
+        stderr_name = tu.ensure_directory('build/stderr.{}'.format(task_id))
+
+        tu.redirect_stdout_to_file(stdout_name)
+        tu.redirect_stderr_to_file(stderr_name)
+
+        try:
+            command = "bash -c 'function handle_term { echo GOT TERM; }; trap handle_term SIGTERM TERM; sleep 100'"
+            process = cs.launch_process(command, {})
+            stdout_thread, stderr_thread = cio.track_outputs(task_id, process, 2, 4096)
+            shutdown_grace_period_ms = 1000
+
+            group_id = cs.find_process_group(process.pid)
+            self.assertGreater(len(find_process_ids_in_group(group_id)), 0)
+
+            cs.kill_process(process, shutdown_grace_period_ms)
+
+            # await process termination
+            while process.poll() is None:
+                time.sleep(0.01)
+            stderr_thread.join()
+            stdout_thread.join()
+
+            self.assertTrue(((-1 * signal.SIGTERM) == process.poll()) or ((128 + signal.SIGTERM) == process.poll()),
+                            'Process exited with code {}'.format(process.poll()))
+            self.assertEqual(0, len(find_process_ids_in_group(group_id)))
+
+            with open(stdout_name) as f:
+                file_contents = f.read()
+                self.assertTrue('GOT TERM' in file_contents)
+
+        finally:
+            tu.cleanup_output(stdout_name, stderr_name)
+
+    def test_kill_task_terminate_with_sigkill(self):
+        task_id = tu.get_random_task_id()
+
+        stdout_name = tu.ensure_directory('build/stdout.{}'.format(task_id))
+        stderr_name = tu.ensure_directory('build/stderr.{}'.format(task_id))
+
+        tu.redirect_stdout_to_file(stdout_name)
+        tu.redirect_stderr_to_file(stderr_name)
+
+        try:
+            command = "trap '' TERM SIGTERM; sleep 100"
+            process = cs.launch_process(command, {})
+            stdout_thread, stderr_thread = cio.track_outputs(task_id, process, 2, 4096)
+            shutdown_grace_period_ms = 1000
+
+            group_id = cs.find_process_group(process.pid)
+            self.assertGreater(len(find_process_ids_in_group(group_id)), 0)
+
+            cs.kill_process(process, shutdown_grace_period_ms)
+
+            # await process termination
+            while process.poll() is None:
+                time.sleep(0.01)
+            stderr_thread.join()
+            stdout_thread.join()
+
+            self.assertTrue(((-1 * signal.SIGKILL) == process.poll()) or ((128 + signal.SIGKILL) == process.poll()),
+                            'Process exited with code {}'.format(process.poll()))
+            self.assertEqual(len(find_process_ids_in_group(group_id)), 0)
+
+        finally:
+            tu.cleanup_output(stdout_name, stderr_name)
+
+    def test_progress_group_assignment_and_killing(self):
+        start_time = time.time()
+
+        command = 'echo "A.$(sleep 30)" & echo "B.$(sleep 30)" & echo "C.$(sleep 30)" &'
+        environment = {}
+        process = cs.launch_process(command, environment)
+
+        group_id = cs.find_process_group(process.pid)
+        self.assertGreater(group_id, 0)
+
+        child_process_ids = tu.wait_for(lambda: find_process_ids_in_group(group_id),
+                                        lambda data: len(data) >= 7,
+                                        default_value=[])
+        self.assertGreaterEqual(len(child_process_ids), 7)
+        self.assertLessEqual(len(child_process_ids), 10)
+
+        cs.send_signal(process.pid, signal.SIGKILL)
+
+        child_process_ids = tu.wait_for(lambda: find_process_ids_in_group(group_id),
+                                        lambda data: len(data) == 0,
+                                        default_value=[])
+        self.assertEqual(0, len(child_process_ids))
+
+        self.assertLess(time.time() - start_time, 30)


### PR DESCRIPTION
## Changes proposed in this PR

- refactors the process management logic to cook/subprocess.py 
- adds support for killing process trees in the executor (uses [psutil](https://github.com/giampaolo/psutil)) using breadth-first ordering and `SIGSTOP` signals before retrieving child processes 

## Why are we making these changes?

We want to align our kill logic with the Mesos [`CommandExecutor`](https://github.com/apache/mesos/blob/master/src/launcher/executor.cpp#L856)
