### PR TITLE
Increase default exit code wait for tests to 1 min

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -364,7 +364,7 @@ def wait_for_jobs(cook_url, job_ids, status, max_wait_ms=120000):
     return response.json()
 
 
-def wait_for_exit_code(cook_url, job_id, max_wait_ms=2000):
+def wait_for_exit_code(cook_url, job_id, max_wait_ms=60000):
     """
     Wait for the given job's exit_code field to appear.
     (Only supported by Cook Executor jobs.)


### PR DESCRIPTION
## Changes proposed in this PR

Increase default timeout for the `wait_for_exit_code` utility function to 1 minute.

## Why are we making these changes?

The previous default of 2 seconds was too short, causing flaky tests.