### PR TITLE
Removes needs for stdout and stderr tracker threads

### DIFF
--- a/executor/cook/__init__.py
+++ b/executor/cook/__init__.py
@@ -7,7 +7,6 @@ For more information on Mesos executors, see the "Working with Executors"
 section at http://mesos.apache.org/documentation/latest/app-framework-development-guide/
 """
 
-RUNNING_POLL_INTERVAL_SECS = 1
 DAEMON_GRACE_SECS = 1
 TERMINATE_GRACE_SECS = 0.1
 

--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -39,7 +39,7 @@ def main(args=None):
         print(__version__)
         sys.exit(0)
 
-    cio.print_out('Cook Executor version {}'.format(__version__))
+    cio.print_out('Cook Executor version {}'.format(__version__), flush=True)
 
     environment = os.environ
     executor_id = environment.get('MESOS_EXECUTOR_ID', '1')

--- a/executor/cook/config.py
+++ b/executor/cook/config.py
@@ -32,7 +32,6 @@ class ExecutorConfig(object):
             return 1000
 
     def __init__(self,
-                 flush_interval_secs=2,
                  max_bytes_read_per_line=1024,
                  max_message_length=512,
                  memory_usage_interval_secs=15,
@@ -42,7 +41,6 @@ class ExecutorConfig(object):
                  progress_sample_interval_ms=100,
                  sandbox_directory='',
                  shutdown_grace_period='1secs'):
-        self.flush_interval_secs = flush_interval_secs
         self.max_bytes_read_per_line = max_bytes_read_per_line
         self.max_message_length = max_message_length
         self.memory_usage_interval_secs = memory_usage_interval_secs
@@ -82,7 +80,6 @@ def initialize_config(environment):
     if progress_output_env_variable not in environment:
         logging.info('No entry found for {} in the environment'.format(progress_output_env_variable))
 
-    flush_interval_secs = max(int(environment.get('EXECUTOR_FLUSH_INTERVAL_SECS', 10)), 2)
     max_bytes_read_per_line = max(int(environment.get('EXECUTOR_MAX_BYTES_READ_PER_LINE', 4 * 1024)), 128)
     max_message_length = max(int(environment.get('EXECUTOR_MAX_MESSAGE_LENGTH', 512)), 64)
     memory_usage_interval_secs = max(int(environment.get('EXECUTOR_MEMORY_USAGE_INTERVAL_SECS', 3600)), 30)
@@ -92,7 +89,6 @@ def initialize_config(environment):
     sandbox_directory = environment.get('MESOS_SANDBOX', '')
     shutdown_grace_period = environment.get('MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD', '2secs')
 
-    logging.info('stdout/stderr flush interval is {} seconds'.format(flush_interval_secs))
     logging.info('Max bytes read per line is {}'.format(max_bytes_read_per_line))
     logging.info('Max message length is {}'.format(max_message_length))
     logging.info('Memory usage will be logged every {} secs'.format(memory_usage_interval_secs))
@@ -102,8 +98,7 @@ def initialize_config(environment):
     logging.info('Sandbox location is {}'.format(sandbox_directory))
     logging.info('Shutdown grace period is {}'.format(shutdown_grace_period))
 
-    return ExecutorConfig(flush_interval_secs=flush_interval_secs,
-                          max_bytes_read_per_line=max_bytes_read_per_line,
+    return ExecutorConfig(max_bytes_read_per_line=max_bytes_read_per_line,
                           max_message_length=max_message_length,
                           memory_usage_interval_secs=memory_usage_interval_secs,
                           progress_output_env_variable=progress_output_env_variable,

--- a/executor/cook/io_helper.py
+++ b/executor/cook/io_helper.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 
-"""This module ensures atomic writes to stdout and stderr.
-"""
+"""This module ensures atomic writes to stdout."""
 
 import logging
-import os
 import sys
-from threading import Event, Lock, Thread, Timer
+from threading import Lock
+
+import os
 
 __stdout_lock__ = Lock()
-__stderr_lock__ = Lock()
 
 
 def print_to_buffer(lock, buffer, data, flush=False, newline=True):
@@ -62,16 +61,14 @@ def print_out(data, flush=False, newline=True):
     print_to_buffer(__stdout_lock__, sys.stdout.buffer, data, flush=flush, newline=newline)
 
 
-def print_and_log(string_data, flush=False, newline=True):
-    """Wrapper function that prints to stdout in a thread-safe manner ensuring newline at the start.
+def print_and_log(string_data, newline=True):
+    """Wrapper function that prints and flushes to stdout in a locally thread-safe manner ensuring newline at the start.
     The function also outputs the same message via logging.info().
 
     Parameters
     ----------
     string_data: string
         The string to output
-    flush: boolean
-        Flag determining whether to trigger a sys.stdout.flush()
     newline: boolean
         Flag determining whether to output a newline at the end
 
@@ -79,120 +76,5 @@ def print_and_log(string_data, flush=False, newline=True):
     -------
     Nothing.
     """
-    print_out('{}{}'.format(os.linesep, string_data), flush=flush, newline=newline)
+    print_out('{}{}'.format(os.linesep, string_data), flush=True, newline=newline)
     logging.info(string_data)
-
-
-def print_err(data, flush=False, newline=True):
-    """Wrapper function that prints to stderr in a thread-safe manner using the __stderr_lock__ lock.
-
-    Parameters
-    ----------
-    data: string or bytes
-        The data to output
-    flush: boolean
-        Flag determining whether to trigger a sys.stderr.flush()
-    newline: boolean
-        Flag determining whether to output a newline at the end
-
-    Returns
-    -------
-    Nothing.
-    """
-    print_to_buffer(__stderr_lock__, sys.stderr.buffer, data, flush=flush, newline=newline)
-
-
-def process_output(label, out_buffer, out_fn, flush_fn, flush_interval_secs, max_bytes_per_read):
-    """Processes output piped from the out_buffer and prints it using the out_fn function.
-    When done reading the file, calls flush_fn to flush the output.
-
-    Parameters
-    ----------
-    label: string
-        The string to associate in outputs
-    out_buffer: a file object
-        Provides that output from the child process
-    out_fn: function(string)
-        Function to output a string
-    flush_fn: function()
-        Function that flushes the output.
-    flush_interval_secs: number
-        The number of seconds to wait between flushing buffered data
-    max_bytes_per_read: int
-        The maximum number of bytes to read per call to read().
-
-    Returns
-    -------
-    Nothing.
-    """
-    io_lock = Lock()
-    lines_buffered_event = Event()
-    buffering_complete_event = Event()
-
-    def safe_flush():
-        try:
-            if lines_buffered_event.is_set():
-                with io_lock:
-                    if lines_buffered_event.is_set():
-                        logging.info('Flushing contents {}'.format(label))
-                        flush_fn()
-                        lines_buffered_event.clear()
-        except:
-            logging.exception('Error while flushing contents {}'.format(label))
-
-    def trigger_flush_daemon():
-        safe_flush()
-        if not buffering_complete_event.is_set():
-            Timer(flush_interval_secs, trigger_flush_daemon).start()
-
-    try:
-        logging.info('Starting to pipe {}'.format(label))
-        trigger_flush_daemon()
-        while True:
-            line = out_buffer.read1(max_bytes_per_read)
-            if not line:
-                break
-            with io_lock:
-                out_fn(line, newline=False)
-                lines_buffered_event.set()
-        safe_flush()
-    except Exception:
-        logging.exception('Error in process_output of {}'.format(label))
-    finally:
-        buffering_complete_event.set()
-        logging.info('Done piping {}'.format(label))
-
-
-def track_outputs(task_id, process, flush_interval_secs, max_bytes_per_read):
-    """Launches two threads to pipe the stderr/stdout from the subprocess to the system stderr/stdout.
-
-    Parameters
-    ----------
-    task_id: string
-        The ID of the task being executed.
-    process: subprocess.Popen
-        The process whose stderr and stdout to monitor.
-    flush_interval_secs: number
-        The number of seconds to wait between flushing buffered data
-    max_bytes_per_read: int
-        The maximum number of bytes to read per call to read().
-
-    Returns
-    -------
-    A tuple containing the two threads that have been started: stdout_thread, stderr_thread.
-    """
-
-    def launch_tracker_thread(label, out_buffer, out_fn, flush_fn):
-        tracker_thread = Thread(target=process_output,
-                                args=(label, out_buffer, out_fn, flush_fn, flush_interval_secs, max_bytes_per_read))
-        tracker_thread.daemon = True
-        tracker_thread.start()
-        return tracker_thread
-
-    stderr_label = 'stderr (task-id: {}, pid: {})'.format(task_id, process.pid)
-    stderr_thread = launch_tracker_thread(stderr_label, process.stderr, print_err, sys.stderr.flush)
-
-    stdout_label = 'stdout (task-id: {}, pid: {})'.format(task_id, process.pid)
-    stdout_thread = launch_tracker_thread(stdout_label, process.stdout, print_out, sys.stdout.flush)
-
-    return stdout_thread, stderr_thread

--- a/executor/tests/test_config.py
+++ b/executor/tests/test_config.py
@@ -20,7 +20,6 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(1000, cc.ExecutorConfig.parse_time_ms('corrupt-value'))
 
     def test_executor_config(self):
-        flush_interval_secs = 1234
         max_bytes_read_per_line = 16 * 1024
         max_message_length = 300
         memory_usage_interval_secs = 150
@@ -30,8 +29,7 @@ class ConfigTest(unittest.TestCase):
         progress_sample_interval_ms = 100
         sandbox_directory = '/location/to/task/sandbox/task_id'
         shutdown_grace_period_secs = '5secs'
-        config = cc.ExecutorConfig(flush_interval_secs=flush_interval_secs,
-                                   max_bytes_read_per_line=max_bytes_read_per_line,
+        config = cc.ExecutorConfig(max_bytes_read_per_line=max_bytes_read_per_line,
                                    max_message_length=max_message_length,
                                    memory_usage_interval_secs=memory_usage_interval_secs,
                                    progress_output_env_variable=progress_output_env_variable,
@@ -41,7 +39,6 @@ class ConfigTest(unittest.TestCase):
                                    sandbox_directory=sandbox_directory,
                                    shutdown_grace_period=shutdown_grace_period_secs)
 
-        self.assertEqual(flush_interval_secs, config.flush_interval_secs)
         self.assertEqual(max_bytes_read_per_line, config.max_bytes_read_per_line)
         self.assertEqual(max_message_length, config.max_message_length)
         self.assertEqual(memory_usage_interval_secs, config.memory_usage_interval_secs)
@@ -59,7 +56,6 @@ class ConfigTest(unittest.TestCase):
         environment = {}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(10, config.flush_interval_secs)
         self.assertEqual(4 * 1024, config.max_bytes_read_per_line)
         self.assertEqual(512, config.max_message_length)
         self.assertEqual('executor.progress', config.progress_output_name)
@@ -69,8 +65,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(2000, config.shutdown_grace_period_ms)
 
     def test_initialize_config_custom(self):
-        environment = {'EXECUTOR_FLUSH_INTERVAL_SECS': '60',
-                       'EXECUTOR_MAX_BYTES_READ_PER_LINE': '1234',
+        environment = {'EXECUTOR_MAX_BYTES_READ_PER_LINE': '1234',
                        'EXECUTOR_MAX_MESSAGE_LENGTH': '1024',
                        'EXECUTOR_MEMORY_USAGE_INTERVAL_SECS': '120',
                        'EXECUTOR_PROGRESS_OUTPUT_FILE': 'progress_file',
@@ -80,7 +75,6 @@ class ConfigTest(unittest.TestCase):
                        'PROGRESS_SAMPLE_INTERVAL_MS': '2500'}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(60, config.flush_interval_secs)
         self.assertEqual(1234, config.max_bytes_read_per_line)
         self.assertEqual(1024, config.max_message_length)
         self.assertEqual(120, config.memory_usage_interval_secs)
@@ -102,7 +96,6 @@ class ConfigTest(unittest.TestCase):
                        'PROGRESS_SAMPLE_INTERVAL_MS': '2500'}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(10, config.flush_interval_secs)
         self.assertEqual(1234, config.max_bytes_read_per_line)
         self.assertEqual(1024, config.max_message_length)
         self.assertEqual(30, config.memory_usage_interval_secs)
@@ -124,7 +117,6 @@ class ConfigTest(unittest.TestCase):
                        'PROGRESS_SAMPLE_INTERVAL_MS': '2500'}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(10, config.flush_interval_secs)
         self.assertEqual(1234, config.max_bytes_read_per_line)
         self.assertEqual(1024, config.max_message_length)
         self.assertEqual(3600, config.memory_usage_interval_secs)
@@ -146,7 +138,6 @@ class ConfigTest(unittest.TestCase):
                        'PROGRESS_SAMPLE_INTERVAL_MS': '2500'}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(10, config.flush_interval_secs)
         self.assertEqual(1234, config.max_bytes_read_per_line)
         self.assertEqual(1024, config.max_message_length)
         self.assertEqual(3600, config.memory_usage_interval_secs)
@@ -169,7 +160,6 @@ class ConfigTest(unittest.TestCase):
                        'PROGRESS_SAMPLE_INTERVAL_MS': '2500'}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(10, config.flush_interval_secs)
         self.assertEqual(1234, config.max_bytes_read_per_line)
         self.assertEqual(1024, config.max_message_length)
         self.assertEqual(3600, config.memory_usage_interval_secs)
@@ -193,7 +183,6 @@ class ConfigTest(unittest.TestCase):
                        'PROGRESS_SAMPLE_INTERVAL_MS': '2500'}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(10, config.flush_interval_secs)
         self.assertEqual(1234, config.max_bytes_read_per_line)
         self.assertEqual(1024, config.max_message_length)
         self.assertEqual(3600, config.memory_usage_interval_secs)
@@ -217,7 +206,6 @@ class ConfigTest(unittest.TestCase):
                        'PROGRESS_SAMPLE_INTERVAL_MS': '2500'}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(10, config.flush_interval_secs)
         self.assertEqual(1234, config.max_bytes_read_per_line)
         self.assertEqual(1024, config.max_message_length)
         self.assertEqual(3600, config.memory_usage_interval_secs)


### PR DESCRIPTION
## Changes proposed in this PR

- removes helper methods and threads for stdout/stderr tracking
- uses stdout=sys.stdout and stderr=sys.stderr for subprocess arguments
-- this helps with testability as otherwise the subprocess ends up writing on the console due to stdout/stderr file descriptors
-- I have manually tested that using the file handles does not slow down the stdout syncing when compared to the mesos command executor
- launches a separate thread to perform task killing on stop_signal
- uses timed [`wait()`](https://docs.python.org/3.5/library/subprocess.html#subprocess.Popen.wait) to await process termination on SIGTERM
- uses `wait()` for process termination either normally or via SIGKILL

## Why are we making these changes?

We want to relieve ourselves from having to deal with buffering and memory issues of piping stdout and stderr from the subprocess.


## Example

Command: `python3 -c '[print("loremipsumstringfoobar:",i) for i in range(1000000000)]'`

Output on stdout:
```
Cook Executor version 0.1.6

Starting task 19646813-9dc0-4baa-8431-303f78a59465

Forked command at 41484
loremipsumstringfoobar: 0
loremipsumstringfoobar: 1
loremipsumstringfoobar: 2
...
loremipsumstringfoobar: 44653459
loremipsumstringfoobar: 44653460
Received kill for task 19646813-9dc0-4baa-8431-303f78a59465 with grace period of 5secs

Command exited with status -15 (pid: 41484)

Executor completed execution of 19646813-9dc0-4baa-8431-303f78a59465 (state=TASK_KILLED)
```