### PR TITLE
Fixes entity ref parsing when configured cluster has trailing /

### DIFF
--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -302,7 +302,7 @@ def parse_entity_refs(clusters, ref_strings):
             path_parts = result.path.split('/')
             num_path_parts = len(path_parts)
             cluster_url = (f'{result.scheme}://' if result.scheme else '') + result.netloc
-            cluster_names = [c['name'] for c in clusters if c['url'].lower() == cluster_url.lower()]
+            cluster_names = [c['name'] for c in clusters if c['url'].lower().rstrip('/') == cluster_url.lower()]
 
             if num_path_parts < 2:
                 raise Exception(f'Unable to determine entity type and UUID from {ref_string}.')

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1363,3 +1363,15 @@ class CookCliTest(unittest.TestCase):
         _, instance_job_pairs = cli.show_instances([instance_url], self.cook_url)
         self.assertIn(instance_uuid_1, (i['task_id'] for i, _ in instance_job_pairs))
         self.assertIn(instance_uuid_2, (i['task_id'] for i, _ in instance_job_pairs))
+
+    def test_entity_refs_trailing_slash_on_cluster(self):
+        config = {'clusters': [{'name': 'Foo', 'url': f'{self.cook_url}/'}]}
+        with cli.temp_config_file(config) as path:
+            flags = f'--config {path}'
+            cp, uuids = cli.submit('ls', flags=flags)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            uuid = uuids[0]
+            _, jobs = cli.show_jobs([f'{self.cook_url}/jobs/{uuid}'], flags=flags)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            self.assertEqual(1, len(jobs))
+            self.assertEqual(uuid, jobs[0]['uuid'])


### PR DESCRIPTION
## Changes proposed in this PR

- Strips trailing slash from configured clusters (e.g. `http://localhost:12321/`) when parsing an entity ref URL and matching to determine the target cluster
- Adds an integration test to confirm the behavior

## Why are we making these changes?

If the user has a cluster configured with a trailing slash, they need to be able to match against that cluster when passing an entity ref URL as input.