### PR TITLE
Fixes grammar when there is 1 cs kill failure

### DIFF
--- a/cli/cook/subcommands/kill.py
+++ b/cli/cook/subcommands/kill.py
@@ -83,8 +83,10 @@ def kill_entities(query_result, clusters):
                 for group_uuid in group_uuids:
                     print(colors.failed(f'Failed to kill job group {group_uuid} on {cluster_name}.'))
 
-    if num_failures > 0:
+    if num_failures > 1:
         print_info(f'There were {colors.failed(str(num_failures))} kill failures.')
+    elif num_failures == 1:
+        print_info(f'There was {colors.failed("1")} kill failure.')
 
     return num_failures
 

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.1.0'
+VERSION = '1.1.1'


### PR DESCRIPTION
## Changes proposed in this PR

- Fixes grammar of error message you get when there is 1 failure during a `cs kill`

## Why are we making these changes?

To make the grammar correct.

New error message when there is a single failure:

```bash
$ cs kill 6533d1bf-fa89-4ab1-ad90-f6266bc76901
Failed to kill job 6533d1bf-fa89-4ab1-ad90-f6266bc76901 on dev0.
There was 1 kill failure.
```
