### PR TITLE
Allows for specifying the CLI command to use in integration tests

### DIFF
--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -46,11 +46,16 @@ def sh(command, stdin=None, env=None, wait_for_exit=True):
         return proc
 
 
+def command():
+    """If the COOK_CLI_COMMAND environment variable is set, returns its value, otherwise 'cs'"""
+    return os.environ['COOK_CLI_COMMAND'] if 'COOK_CLI_COMMAND' in os.environ else 'cs'
+
+
 def cli(args, cook_url=None, flags=None, stdin=None, env=None, wait_for_exit=True):
     """Runs a CLI command with the given URL, flags, and stdin"""
     url_flag = f'--url {cook_url} ' if cook_url else ''
     other_flags = f'{flags} ' if flags else ''
-    cp = sh(f'cs {url_flag}{other_flags}{args}', stdin, env, wait_for_exit)
+    cp = sh(f'{command()} {url_flag}{other_flags}{args}', stdin, env, wait_for_exit)
     return cp
 
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -633,6 +633,7 @@ def group_submit_retry(cook_url, command, predicate_statuses, retry_failed_jobs_
         # ensure that we don't leave a bunch of jobs running/waiting
         kill_groups(cook_url, [group_uuid])
 
+
 def user_current_usage(cook_url, **kwargs):
     """
     Queries cook for a user's current resource usage


### PR DESCRIPTION
## Changes proposed in this PR

- The integration tests will check if the `COOK_CLI_COMMAND` environment variable is set, and use its value as the CLI command to test against (if not set, it will default to simply `cs`)

## Why are we making these changes?

To allow for testing versions of the CLI other than whatever `cs` happens to resolve to.
