### PR TITLE
Makes several CLI tests more reliable

### DIFF
--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -138,12 +138,12 @@ class temp_config_file:
     """
 
     def __init__(self, config):
-        self.config = config
         session_module = os.getenv('COOK_SESSION_MODULE')
         if session_module:
-            modules_config = {'http': {'modules': {'session-module': session_module,
-                                                   'adapters-module': session_module}}}
-            self.config = {**modules_config, **config}
+            self.config = {'http': {'modules': {'session-module': session_module, 'adapters-module': session_module}}}
+            self.config.update(config)
+        else:
+            self.config = config
 
     def write_temp_json(self):
         path = tempfile.NamedTemporaryFile(delete=False).name

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -245,7 +245,7 @@ def version():
         raise Exception(f'Unable to parse version from {string}')
 
 
-def config_get(key, flags):
+def config_get(key, flags=None):
     """Invokes the config subcommand to get a config value"""
     cp = cli(f'config --get {key}', flags=flags)
     return cp

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -255,3 +255,9 @@ def config_set(key, value, flags):
     """Invokes the config subcommand to set a config value"""
     cp = cli(f'config {key} {value}', flags=flags)
     return cp
+
+
+def command_prefix():
+    """Returns the currently configured command-prefix, if any"""
+    cp = config_get('defaults.submit.command-prefix')
+    return decode(cp.stdout).rstrip('\n') if cp.returncode == 0 else ''

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -139,6 +139,11 @@ class temp_config_file:
 
     def __init__(self, config):
         self.config = config
+        session_module = os.getenv('COOK_SESSION_MODULE')
+        if session_module:
+            modules_config = {'http': {'modules': {'session-module': session_module,
+                                                   'adapters-module': session_module}}}
+            self.config = {**modules_config, **config}
 
     def write_temp_json(self):
         path = tempfile.NamedTemporaryFile(delete=False).name

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -211,9 +211,10 @@ class CookCliTest(unittest.TestCase):
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(3, len(jobs), jobs)
+        cp = cli.config_get('defaults.submit.command-prefix')
+        command_prefix = cli.decode(cp.stdout).rstrip('\n') if cp.returncode == 0 else ''
         for job in jobs:
-            self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertEqual(command, job['command'])
+            self.assertEqual(f'{command_prefix}{command}', job['command'])
             self.assertEqual(name, job['name'])
             self.assertEqual(priority, job['priority'])
             self.assertEqual(max_retries, job['max_retries'])

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -699,7 +699,7 @@ class CookCliTest(unittest.TestCase):
             f'bash -c \'for i in {{1..30}}; do echo $i >> bar; sleep {sleep_seconds_between_lines}; done\'',
             self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        util.wait_for_job(self.cook_url, uuids[0], 'running')
+        util.wait_for_instance(self.cook_url, uuids[0])
         proc = cli.tail(uuids[0], 'bar', self.cook_url,
                         f'--follow --sleep-interval {sleep_seconds_between_lines}',
                         wait_for_exit=False)

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -374,14 +374,15 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(desired_command.replace('"', ''), jobs[0]['command'])
+        expected_command = desired_command.replace('"', '')
+        self.assertEqual(f'{cli.command_prefix()}{expected_command}', jobs[0]['command'])
         # Correctly submitted command
         command = '"(foo -x \'def bar = \\"baz\\"\')"'
         cp, uuids = cli.submit(command, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(desired_command, jobs[0]['command'])
+        self.assertEqual(f'{cli.command_prefix()}{desired_command}', jobs[0]['command'])
 
         desired_command = "export HOME=$MESOS_DIRECTORY; export LOGNAME=$(whoami); JAVA_OPTS='-Xmx15000m' foo"
         # Incorrectly submitted command
@@ -390,14 +391,15 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(desired_command.replace("'", ''), jobs[0]['command'])
+        expected_command = desired_command.replace("'", '')
+        self.assertEqual(f'{cli.command_prefix()}{expected_command}', jobs[0]['command'])
         # Correctly submitted command
         command = "'export HOME=$MESOS_DIRECTORY; export LOGNAME=$(whoami); JAVA_OPTS='\"'\"'-Xmx15000m'\"'\"' foo'"
         cp, uuids = cli.submit(command, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(desired_command, jobs[0]['command'])
+        self.assertEqual(f'{cli.command_prefix()}{desired_command}', jobs[0]['command'])
 
     def test_list_no_matching_jobs(self):
         cp = cli.jobs(self.cook_url, '--name %s' % uuid.uuid4())

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -294,30 +294,27 @@ class CookCliTest(unittest.TestCase):
         cp, uuids = cli.submit('-- ls -al', 'localhost:99999', '--verbose')
         stderr = cli.decode(cp.stderr)
         self.assertEqual(1, cp.returncode, stderr)
-        self.assertIn('Starting new HTTP connection (1)', stderr)
-        self.assertIn('Starting new HTTP connection (2)', stderr)
-        self.assertIn('Starting new HTTP connection (3)', stderr)
-        self.assertNotIn('Starting new HTTP connection (4)', stderr)
+        self.assertIn('Retrying (Retry(total=1', stderr)
+        self.assertIn('Retrying (Retry(total=0', stderr)
+        self.assertNotIn('Retrying (Retry(total=2', stderr)
         # Set retries = 0
         config = {'http': {'retries': 0}}
         with cli.temp_config_file(config) as path:
             cp, uuids = cli.submit('-- ls -al', 'localhost:99999', '--verbose --config %s' % path)
             stderr = cli.decode(cp.stderr)
             self.assertEqual(1, cp.returncode, stderr)
-            self.assertIn('Starting new HTTP connection (1)', stderr)
-            self.assertNotIn('Starting new HTTP connection (2)', stderr)
+            self.assertNotIn('Retrying (Retry(total=0', stderr)
         # Set retries = 4
         config = {'http': {'retries': 4}}
         with cli.temp_config_file(config) as path:
             cp, uuids = cli.submit('-- ls -al', 'localhost:99999', '--verbose --config %s' % path)
             stderr = cli.decode(cp.stderr)
             self.assertEqual(1, cp.returncode, stderr)
-            self.assertIn('Starting new HTTP connection (1)', stderr)
-            self.assertIn('Starting new HTTP connection (2)', stderr)
-            self.assertIn('Starting new HTTP connection (3)', stderr)
-            self.assertIn('Starting new HTTP connection (4)', stderr)
-            self.assertIn('Starting new HTTP connection (5)', stderr)
-            self.assertNotIn('Starting new HTTP connection (6)', stderr)
+            self.assertIn('Retrying (Retry(total=3', stderr)
+            self.assertIn('Retrying (Retry(total=2', stderr)
+            self.assertIn('Retrying (Retry(total=1', stderr)
+            self.assertIn('Retrying (Retry(total=0', stderr)
+            self.assertNotIn('Retrying (Retry(total=4', stderr)
 
     def test_submit_priority(self):
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority 0')

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1116,13 +1116,16 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual('success', jobs[0]['state'])
 
         # Default command prefix (empty)
-        cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url)
-        self.assertEqual(0, cp.returncode, cp.stderr)
-        cp = cli.wait(uuids, self.cook_url)
-        self.assertEqual(0, cp.returncode, cp.stderr)
-        cp, jobs = cli.show_jobs(uuids, self.cook_url)
-        self.assertEqual('exit ${FOO:-1}', jobs[0]['command'])
-        self.assertEqual('failed', jobs[0]['state'])
+        config = {'defaults': {'submit': {}}}
+        with cli.temp_config_file(config) as path:
+            flags = '--config %s' % path
+            cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, flags=flags)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            cp = cli.wait(uuids, self.cook_url)
+            self.assertEqual(0, cp.returncode, cp.stderr)
+            cp, jobs = cli.show_jobs(uuids, self.cook_url)
+            self.assertEqual('exit ${FOO:-1}', jobs[0]['command'])
+            self.assertEqual('failed', jobs[0]['state'])
 
         # User-defined default
         config = {'defaults': {'submit': {'command-prefix': 'export FOO=0; '}}}

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -279,13 +279,13 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual('ls -al', jobs[0]['command'])
+        self.assertEqual(f'{cli.command_prefix()}ls -al', jobs[0]['command'])
         # Double-dash along with other flags
         cp, uuids = cli.submit('-- ls -al', self.cook_url, submit_flags='--name foo --priority 12')
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual('ls -al', jobs[0]['command'])
+        self.assertEqual(f'{cli.command_prefix()}ls -al', jobs[0]['command'])
         self.assertEqual('foo', jobs[0]['name'])
         self.assertEqual(12, jobs[0]['priority'])
 

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -181,7 +181,7 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(str(juuid), uuids[0], uuids)
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(command, jobs[0]['command'])
+        self.assertEqual(f'{cli.command_prefix()}{command}', jobs[0]['command'])
         self.assertEqual(name, jobs[0]['name'])
         self.assertEqual(priority, jobs[0]['priority'])
         self.assertEqual(max_retries, jobs[0]['max_retries'])
@@ -211,10 +211,8 @@ class CookCliTest(unittest.TestCase):
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(3, len(jobs), jobs)
-        cp = cli.config_get('defaults.submit.command-prefix')
-        command_prefix = cli.decode(cp.stdout).rstrip('\n') if cp.returncode == 0 else ''
         for job in jobs:
-            self.assertEqual(f'{command_prefix}{command}', job['command'])
+            self.assertEqual(f'{cli.command_prefix()}{command}', job['command'])
             self.assertEqual(name, job['name'])
             self.assertEqual(priority, job['priority'])
             self.assertEqual(max_retries, job['max_retries'])


### PR DESCRIPTION
## Changes proposed in this PR

- `test_submit_with_command_prefix`: explicitly use a config file with no command-prefix
- `temp_config_file`: use the `COOK_SESSION_MODULE` environment variable if it's set
- `test_submit_raw_multiple`: respect the configured command-prefix
- `test_submit_raw`: respect the configured command-prefix
- `test_retries`: look for the 'Retrying' log message to count the retries
- `test_complex_commands`: respect the configured command-prefix
- `test_double_dash_for_end_of_options`: respect the configured command-prefix
- `test_tail_follow`: use `wait_for_instance` instead of `wait_for_job(..., 'running')`

## Why are we making these changes?

So that the CLI tests can be run in multiple environments without flaking.
