### PR TITLE
Refactor test_progress_update_submit and test_show_progress_message_custom_progress_file

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -133,9 +133,7 @@ class CookTest(unittest.TestCase):
 
     def test_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)
-        settings = util.settings(self.cook_url)
-        progress_file_env = (util.get_in(settings, 'executor', 'environment', 'EXECUTOR_PROGRESS_OUTPUT_FILE_ENV') or
-                             'EXECUTOR_PROGRESS_OUTPUT_FILE')
+        progress_file_env = util.retrieve_progress_file_env(self.cook_url)
 
         line = util.progress_line(self.cook_url, 25, f'Twenty-five percent in ${{{progress_file_env}}}')
         command = f'echo "{line}" >> ${{{progress_file_env}}}; sleep 1; exit 0'

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -133,11 +133,14 @@ class CookTest(unittest.TestCase):
 
     def test_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)
-        line = util.progress_line(self.cook_url, 25, 'Twenty-five percent in ${PROGRESS_FILE}')
-        command = f'echo "{line}" >> ${{PROGRESS_FILE}}; sleep 1; exit 0'
+        settings = util.settings(self.cook_url)
+        progress_file_env = (util.get_in(settings, 'executor', 'environment', 'EXECUTOR_PROGRESS_OUTPUT_FILE_ENV') or
+                             'EXECUTOR_PROGRESS_OUTPUT_FILE')
+
+        line = util.progress_line(self.cook_url, 25, f'Twenty-five percent in ${{{progress_file_env}}}')
+        command = f'echo "{line}" >> ${{{progress_file_env}}}; sleep 1; exit 0'
         job_uuid, resp = util.submit_job(self.cook_url, command=command,
-                                         env={'EXECUTOR_PROGRESS_OUTPUT_FILE_ENV': 'PROGRESS_FILE',
-                                              'PROGRESS_FILE': 'progress.txt'},
+                                         env={progress_file_env: 'progress.txt'},
                                          executor=job_executor_type, max_runtime=60000)
         self.assertEqual(201, resp.status_code, msg=resp.content)
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -936,9 +936,7 @@ class CookCliTest(unittest.TestCase):
 
     def test_show_progress_message_custom_progress_file(self):
         executor = util.get_job_executor_type(self.cook_url)
-        settings = util.settings(self.cook_url)
-        progress_file_env = (util.get_in(settings, 'executor', 'environment', 'EXECUTOR_PROGRESS_OUTPUT_FILE_ENV') or
-                             'EXECUTOR_PROGRESS_OUTPUT_FILE')
+        progress_file_env = util.retrieve_progress_file_env(self.cook_url)
 
         line = util.progress_line(self.cook_url, 99, 'We are so close!')
         cp, uuids = cli.submit('\'touch progress.txt && '

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -936,6 +936,10 @@ class CookCliTest(unittest.TestCase):
 
     def test_show_progress_message_custom_progress_file(self):
         executor = util.get_job_executor_type(self.cook_url)
+        settings = util.settings(self.cook_url)
+        progress_file_env = (util.get_in(settings, 'executor', 'environment', 'EXECUTOR_PROGRESS_OUTPUT_FILE_ENV') or
+                             'EXECUTOR_PROGRESS_OUTPUT_FILE')
+
         line = util.progress_line(self.cook_url, 99, 'We are so close!')
         cp, uuids = cli.submit('\'touch progress.txt && '
                                'echo "Hello World" >> progress.txt && '
@@ -943,8 +947,7 @@ class CookCliTest(unittest.TestCase):
                                'echo "Done" >> progress.txt\'',
                                self.cook_url,
                                submit_flags=f'--executor {executor} '
-                                            '--env EXECUTOR_PROGRESS_OUTPUT_FILE_ENV=PROGRESS_OUTPUT_FILE '
-                                            '--env PROGRESS_OUTPUT_FILE=progress.txt')
+                                            f'--env {progress_file_env}=progress.txt')
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_job(self.cook_url, uuids[0], 'completed')
         self.assertEqual(0, cp.returncode, cp.stderr)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -640,3 +640,10 @@ def user_current_usage(cook_url, **kwargs):
     based on their currently running jobs.
     """
     return session.get('%s/usage' % cook_url, params=kwargs)
+
+
+def retrieve_progress_file_env(cook_url):
+    """Retrieves the environment variable used by the cook executor to lookup the progress file."""
+    cook_settings = settings(cook_url)
+    default_value = 'EXECUTOR_PROGRESS_OUTPUT_FILE'
+    return get_in(cook_settings, 'executor', 'environment', 'EXECUTOR_PROGRESS_OUTPUT_FILE_ENV') or default_value


### PR DESCRIPTION
## Changes proposed in this PR

- Chooses the EXECUTOR_PROGRESS_OUTPUT_FILE_ENV dynamically in `test_progress_update_submit` and `test_show_progress_message_custom_progress_file`

## Why are we making these changes?

Allows the test respect the `EXECUTOR_PROGRESS_OUTPUT_FILE_ENV` variable value when configured in the scheduler
