### PR TITLE
User-friendly JSON values for auth-middleware

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -361,19 +361,25 @@
                                          user-password-valid?
                                          ((lazy-load-var 'cook.basic-auth/make-user-password-valid?) validation http-basic)]
                                      (log/info "Using http basic authorization with validation" validation)
-                                     ((lazy-load-var 'cook.basic-auth/create-http-basic-middleware) user-password-valid?))
+                                     (with-meta
+                                       ((lazy-load-var 'cook.basic-auth/create-http-basic-middleware) user-password-valid?)
+                                       {:json-value "HttpBasicAuthMiddleware"}))
 
                                    one-user
                                    (do
                                      (log/info "Using single user authorization")
-                                     (fn one-user-middleware [h]
-                                       (fn one-user-auth-wrapper [req]
-                                         (h (assoc req :authorization/user one-user)))))
+                                     (with-meta
+                                       (fn one-user-middleware [h]
+                                         (fn one-user-auth-wrapper [req]
+                                           (h (assoc req :authorization/user one-user))))
+                                       {:json-value "OneUserAuthMiddleware"}))
 
                                    kerberos
                                    (do
                                      (log/info "Using kerberos middleware")
-                                     (lazy-load-var 'cook.spnego/require-gss))
+                                     (with-meta
+                                       (lazy-load-var 'cook.spnego/require-gss)
+                                       {:json-value "KerberosAuthMiddleware"}))
                                    :else (throw (ex-info "Missing authorization configuration" {}))))
      :rate-limit (fnk [[:config {rate-limit nil}]]
                    (let [{:keys [user-limit-per-m]

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1881,6 +1881,7 @@
   "Converts values to strings as needed for conversion to JSON"
   [v]
   (cond
+    (contains? (meta v) :json-value) (-> v meta :json-value str)
     (fn? v) (str v)
     (map? v) (map-vals stringify v)
     (instance? Atom v) (stringify (deref v))


### PR DESCRIPTION
## Changes proposed in this PR

This is what the Cook /settings endpoint's JSON response looks like now:
`{...,"authorization-middleware":"cook.components$fn__30710$fnk30707_positional__30711$one_user_middleware__30712@19910f02",...}`
This is what the Cook /settings endpoint's JSON response looks like after this patch:
`{...,"authorization-middleware":"OneUserAuthMiddleware",...}`

## Why are we making these changes?

This both makes the settings more readable, and makes it easier to check which auth-scheme we're using during integration testing. I'm planning to use this feature to enable certain multi-user tests only when using BasicAuth or Kerberos.