### PR TITLE
Fewer resources for default integration test job

### DIFF
--- a/integration/bin/single-test.sh
+++ b/integration/bin/single-test.sh
@@ -24,4 +24,4 @@ fi
 
 echo "Found $test_name in $test_file:$test_class"
 
-time nosetests --verbosity 3 --nologcapture --tests "$test_file:$test_class.$test_name"
+time nosetests --processes=0 --verbosity 3 --nologcapture --tests "$test_file:$test_class.$test_name"

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -93,11 +93,11 @@ def settings(cook_url):
 
 def minimal_job(**kwargs):
     job = {
-        'command': 'echo hello',
-        'cpus': 1,
+        'command': 'echo Default Test Command',
+        'cpus': 0.1,
         'max_retries': 1,
-        'mem': 256,
-        'name': 'echo',
+        'mem': 128,
+        'name': 'default_test_job',
         'priority': 1,
         'uuid': str(uuid.uuid4())
     }


### PR DESCRIPTION
## Changes proposed in this PR

- Fewer CPUs and less RAM requested for default job spec used by our integration tests.
- Disable nosetest multiprocessing when using the `single-test.sh` test launcher script.

## Why are we making these changes?

I think I get fewer timeout errors with *cpus=0.1*, probably because Mesos can schedule more jobs simultaneously. I think `0.1` is actually a more accurate estimation of the default job's CPU usage (it's not particularly compute intensive). Disabling multiprocessing with the single-test script also makes it easier to kill a job that *is* timing out (only need one <kbd>Ctrl</kbd>+<kbd>C</kbd> instead of three).