### PR TITLE
makes message length config responsible only for progress messages

### DIFF
--- a/executor/cook/config.py
+++ b/executor/cook/config.py
@@ -90,8 +90,8 @@ def initialize_config(environment):
     shutdown_grace_period = environment.get('MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD', '2secs')
 
     logging.info('Max bytes read per line is {}'.format(max_bytes_read_per_line))
-    logging.info('Max message length is {}'.format(max_message_length))
     logging.info('Memory usage will be logged every {} secs'.format(memory_usage_interval_secs))
+    logging.info('Progress message length is limited to {}'.format(max_message_length))
     logging.info('Progress output file is {}'.format(progress_output_name))
     logging.info('Progress regex is {}'.format(progress_regex_string))
     logging.info('Progress sample interval is {}'.format(progress_sample_interval_ms))

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -121,8 +121,8 @@ def send_message(driver, message):
         encoded_message = pm.encode_data(message_string)
         driver.sendFrameworkMessage(encoded_message)
         return True
-    except OSError as os_error:
-        raise os_error
+    except OSError:
+        raise
     except Exception:
         logging.exception('Error in sending message {}'.format(message))
         return False

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -99,7 +99,7 @@ class StatusUpdater(object):
                 return False
 
 
-def send_message(driver, message, max_message_length):
+def send_message(driver, message):
     """Sends the message, if it is smaller than the max length, using the driver.
 
     Parameters
@@ -108,24 +108,20 @@ def send_message(driver, message, max_message_length):
         The driver to send the message to.
     message: object
         The raw message to send.
-    max_message_length: int
-        The allowed max message length after encoding.
 
     Returns
     -------
     whether the message was successfully sent
     """
-    logging.info('Sending framework message {}'.format(message))
-    message_string = str(message).encode('utf8')
-    if len(message_string) <= max_message_length:
+    try:
+        logging.info('Sending framework message {}'.format(message))
+        message_string = str(message).encode('utf8')
         encoded_message = pm.encode_data(message_string)
         driver.sendFrameworkMessage(encoded_message)
         return True
-    else:
-        log_message_template = 'Unable to send message as its length of {} exceeds allowed max length of {}'
-        logging.warning(log_message_template.format(len(message_string), max_message_length))
+    except Exception:
+        logging.exception('Error in sending message {}'.format(message))
         return False
-
 
 def launch_task(task, environment):
     """Launches the task using the command available in the json map from the data field.
@@ -288,7 +284,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         sandbox_message = json.dumps({'sandbox-directory': config.sandbox_directory,
                                       'task-id': task_id,
                                       'type': 'directory'})
-        send_message(driver, sandbox_message, config.max_message_length)
+        send_message(driver, sandbox_message)
 
         environment = retrieve_process_environment(config, os.environ)
         launched_process = launch_task(task, environment)
@@ -305,12 +301,11 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         task_completed_signal = Event() # event to track task execution completion
         sequence_counter = cp.ProgressSequenceCounter()
 
-        def send_progress_message(message):
-            return send_message(driver, message, config.max_message_length)
-
+        send_progress_message = functools.partial(send_message, driver)
+        max_message_length = config.max_message_length
+        sample_interval_ms = config.progress_sample_interval_ms
+        progress_updater = cp.ProgressUpdater(task_id, max_message_length, sample_interval_ms, send_progress_message)
         progress_termination_signal = Event()
-        progress_updater = cp.ProgressUpdater(task_id, config.max_message_length, config.progress_sample_interval_ms,
-                                              send_progress_message)
 
         def launch_progress_tracker(progress_location, location_tag):
             logging.info('Location {} tagged as [tag={}]'.format(progress_location, location_tag))
@@ -338,7 +333,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         cio.print_and_log('Command exited with status {} (pid: {})'.format(exit_code, launched_process.pid))
 
         exit_message = json.dumps({'exit-code': exit_code, 'task-id': task_id})
-        send_message(driver, exit_message, config.max_message_length)
+        send_message(driver, exit_message)
 
         # await progress updater termination if executor is terminating normally
         if not stop_signal.isSet():

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -112,13 +112,12 @@ class ProgressUpdater(object):
                     logging.info('Progress message trimmed to {}'.format(new_progress_str))
                     message_dict['progress-message'] = new_progress_str
 
-                progress_message = json.dumps(message_dict)
-                send_success = self.send_progress_message(progress_message)
+                send_success = self.send_progress_message(message_dict)
                 if send_success:
                     self.last_progress_data_sent = progress_data
                     self.last_reported_time = time.time()
                 else:
-                    logging.info('Unable to send progress message {}'.format(progress_message))
+                    logging.info('Unable to send progress message {}'.format(message_dict))
 
 
 class ProgressWatcher(object):

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -284,8 +284,8 @@ class ProgressWatcher(object):
                             last_unprocessed_report = progress_report
                         elif self.__update_progress(progress_report):
                             yield self.progress
-                except OSError as os_error:
-                    raise os_error
+                except OSError:
+                    raise
                 except Exception:
                     logging.exception('Skipping "%s" as a progress entry', line)
         if last_unprocessed_report is not None:

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -103,17 +103,16 @@ class ProgressUpdater(object):
                 except UnicodeDecodeError:
                     logging.info('Unable to decode progress message in ascii, using empty string instead')
                     progress_str = ''
-                message_dict['progress-message'] = progress_str
 
-                progress_message = json.dumps(message_dict)
-                if len(progress_message) > self.max_message_length:
-                    num_extra_chars = len(progress_message) - self.max_message_length
-                    allowed_progress_message_length = max(len(progress_str) - num_extra_chars - 3, 0)
+                if len(progress_str) <= self.max_message_length:
+                    message_dict['progress-message'] = progress_str
+                else:
+                    allowed_progress_message_length = max(self.max_message_length - 3, 0)
                     new_progress_str = progress_str[:allowed_progress_message_length].strip() + '...'
                     logging.info('Progress message trimmed to {}'.format(new_progress_str))
                     message_dict['progress-message'] = new_progress_str
-                    progress_message = json.dumps(message_dict)
 
+                progress_message = json.dumps(message_dict)
                 send_success = self.send_progress_message(progress_message)
                 if send_success:
                     self.last_progress_data_sent = progress_data

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -70,23 +70,13 @@ class ExecutorTest(unittest.TestCase):
         task_id = tu.get_random_task_id()
         expected_message = {'task-id': task_id, 'message': 'test-message'}
         message = json.dumps(expected_message)
-        max_message_length = 512
 
-        result = ce.send_message(driver, message, max_message_length)
+        result = ce.send_message(driver, message)
 
         self.assertTrue(result)
         self.assertEqual(1, len(driver.messages))
         actual_encoded_message = driver.messages[0]
         tu.assert_message(self, expected_message, actual_encoded_message)
-
-    def test_send_message_max_length_exceeded(self):
-        driver = object()
-        task_id = tu.get_random_task_id()
-        message = json.dumps({'task-id': task_id, 'message': 'test-message'})
-        max_message_length = 1
-
-        result = ce.send_message(driver, message, max_message_length)
-        self.assertFalse(result)
 
     def test_os_error_handler_functools_partial(self):
         driver = tu.FakeMesosExecutorDriver()
@@ -621,7 +611,7 @@ class ExecutorTest(unittest.TestCase):
         self.run_command_in_manage_task_runner(command, assertions, 60)
 
     def test_manage_task_progress_in_progress_stderr_and_stdout_progress(self):
-        max_message_length = 130
+        max_message_length = 35
 
         def assertions(driver, task_id, sandbox_directory):
             expected_statuses = [{'task_id': {'value': task_id}, 'state': cook.TASK_STARTING},
@@ -637,13 +627,9 @@ class ExecutorTest(unittest.TestCase):
                                            'progress-percent': 55, 'progress-sequence': 2, 'task-id': task_id},
                                           {'progress-message': 'Sixty percent in stderr',
                                            'progress-percent': 60, 'progress-sequence': 3, 'task-id': task_id},
-                                          {'progress-message': 'Sixty-five percent in stdout with...',
+                                          {'progress-message': 'Sixty-five percent in stdout wit...',
                                            'progress-percent': 65, 'progress-sequence': 4, 'task-id': task_id}]
             tu.assert_messages(self, expected_core_messages, expected_progress_messages, driver.messages)
-            for i in range(0, len(driver.messages)):
-                actual_message = tu.parse_message(driver.messages[i])
-                actual_message_string = str(actual_message).encode('utf8')
-                self.assertLessEqual(len(actual_message_string), max_message_length)
 
         stop_signal = Event()
         sleep_and_set_stop_signal_task(stop_signal, 60)

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -69,9 +69,8 @@ class ExecutorTest(unittest.TestCase):
         driver = tu.FakeMesosExecutorDriver()
         task_id = tu.get_random_task_id()
         expected_message = {'task-id': task_id, 'message': 'test-message'}
-        message = json.dumps(expected_message)
 
-        result = ce.send_message(driver, message)
+        result = ce.send_message(driver, expected_message)
 
         self.assertTrue(result)
         self.assertEqual(1, len(driver.messages))

--- a/executor/tests/test_progress.py
+++ b/executor/tests/test_progress.py
@@ -50,18 +50,24 @@ class ProgressTest(unittest.TestCase):
         self.assertEqual((b'2.0', b'\tTwo percent complete'),
                          match_progress_update(b'^^^^JOB-PROGRESS: 2.0\tTwo percent complete'))
 
+    def send_progress_message_helper(self, driver, max_message_length):
+
+        def send_progress_message(message):
+            ce.send_message(driver, message)
+            message_dict = json.loads(message)
+            self.assertTrue('progress-message' in message_dict)
+            self.assertLessEqual(len(message_dict['progress-message']), max_message_length)
+            return len(message_dict['progress-message']) <= max_message_length
+
+        return send_progress_message
+
     def test_send_progress_update(self):
         driver = tu.FakeMesosExecutorDriver()
         task_id = tu.get_random_task_id()
-        max_message_length = 100
+        max_message_length = 30
         poll_interval_ms = 100
 
-        def send_progress_message(message):
-            ce.send_message(driver, message, max_message_length)
-            message_string = str(message).encode('utf8')
-            self.assertLessEqual(len(message_string), max_message_length)
-            return len(message_string) <= max_message_length
-
+        send_progress_message = self.send_progress_message_helper(driver, max_message_length)
         progress_updater = cp.ProgressUpdater(task_id, max_message_length, poll_interval_ms, send_progress_message)
         progress_data_0 = {'progress-message': b' Progress message-0', 'progress-sequence': 1}
         progress_updater.send_progress_update(progress_data_0)
@@ -70,7 +76,6 @@ class ProgressTest(unittest.TestCase):
         actual_encoded_message_0 = driver.messages[0]
         expected_message_0 = {'progress-message': 'Progress message-0', 'progress-sequence': 1, 'task-id': task_id}
         tu.assert_message(self, expected_message_0, actual_encoded_message_0)
-        self.assertLess(len(json.dumps(tu.parse_message(actual_encoded_message_0))), max_message_length)
 
         progress_data_1 = {'progress-message': b' Progress message-1', 'progress-sequence': 2}
         progress_updater.send_progress_update(progress_data_1)
@@ -85,20 +90,14 @@ class ProgressTest(unittest.TestCase):
         actual_encoded_message_2 = driver.messages[1]
         expected_message_2 = {'progress-message': 'Progress message-2', 'progress-sequence': 3, 'task-id': task_id}
         tu.assert_message(self, expected_message_2, actual_encoded_message_2)
-        self.assertLess(len(json.dumps(tu.parse_message(actual_encoded_message_2))), max_message_length)
 
     def test_send_progress_update_trims_progress_message(self):
         driver = tu.FakeMesosExecutorDriver()
         task_id = tu.get_random_task_id()
-        max_message_length = 100
+        max_message_length = 30
         poll_interval_ms = 10
 
-        def send_progress_message(message):
-            ce.send_message(driver, message, max_message_length)
-            message_string = str(message).encode('utf8')
-            self.assertLessEqual(len(message_string), max_message_length)
-            return len(message_string) <= max_message_length
-
+        send_progress_message = self.send_progress_message_helper(driver, max_message_length)
         progress_updater = cp.ProgressUpdater(task_id, max_message_length, poll_interval_ms, send_progress_message)
         progress_data_0 = {'progress-message': b' Progress message-0 is really long lorem ipsum dolor sit amet text',
                            'progress-sequence': 1}
@@ -106,31 +105,31 @@ class ProgressTest(unittest.TestCase):
 
         self.assertEqual(1, len(driver.messages))
         actual_encoded_message_0 = driver.messages[0]
-        expected_message_0 = {'progress-message': 'Progress message-0 is really...',
+        expected_message_0 = {'progress-message': 'Progress message-0 is reall...',
                               'progress-sequence': 1,
                               'task-id': task_id}
         tu.assert_message(self, expected_message_0, actual_encoded_message_0)
-        self.assertEqual(len(json.dumps(tu.parse_message(actual_encoded_message_0))), max_message_length)
 
     def test_send_progress_does_not_trim_unknown_field(self):
         driver = tu.FakeMesosExecutorDriver()
         task_id = tu.get_random_task_id()
-        max_message_length = 100
+        max_message_length = 30
         poll_interval_ms = 10
 
-        def send_progress_message(message):
-            ce.send_message(driver, message, max_message_length)
-            message_string = str(message).encode('utf8')
-            self.assertGreater(len(message_string), max_message_length)
-            return len(message_string) <= max_message_length
-
+        send_progress_message = self.send_progress_message_helper(driver, max_message_length)
         progress_updater = cp.ProgressUpdater(task_id, max_message_length, poll_interval_ms, send_progress_message)
         progress_data_0 = {'progress-message': b' pm',
                            'progress-sequence': 1,
                            'unknown': 'Unknown field has a really long lorem ipsum dolor sit amet exceed limit text'}
         progress_updater.send_progress_update(progress_data_0)
 
-        self.assertEqual(0, len(driver.messages))
+        self.assertEqual(1, len(driver.messages))
+        actual_encoded_message_0 = driver.messages[0]
+        expected_message_0 = {'progress-message': 'pm',
+                              'progress-sequence': 1,
+                              'task-id': task_id,
+                              'unknown': 'Unknown field has a really long lorem ipsum dolor sit amet exceed limit text'}
+        tu.assert_message(self, expected_message_0, actual_encoded_message_0)
 
     def test_watcher_tail(self):
         file_name = tu.ensure_directory('build/tail_progress_test.' + tu.get_random_task_id())

--- a/executor/tests/test_progress.py
+++ b/executor/tests/test_progress.py
@@ -54,10 +54,9 @@ class ProgressTest(unittest.TestCase):
 
         def send_progress_message(message):
             ce.send_message(driver, message)
-            message_dict = json.loads(message)
-            self.assertTrue('progress-message' in message_dict)
-            self.assertLessEqual(len(message_dict['progress-message']), max_message_length)
-            return len(message_dict['progress-message']) <= max_message_length
+            self.assertTrue('progress-message' in message)
+            self.assertLessEqual(len(message['progress-message']), max_message_length)
+            return len(message['progress-message']) <= max_message_length
 
         return send_progress_message
 


### PR DESCRIPTION
## Changes proposed in this PR

- make `max_message_length` config only affect length of progress messages
- refactoring: make `send_message` expect a dictionary instead of a string

## Why are we making these changes?

It simplifies the code to make the max message length directly apply to the progress message length. Since the length check only applies to the progress messages, we are still backward compatible in terms of consumption of the config.

