### PR TITLE
Deref Kerberos middleware fn var before adding meta-data

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -388,7 +388,7 @@
                                    (do
                                      (log/info "Using kerberos middleware")
                                      (with-meta
-                                       (lazy-load-var 'cook.spnego/require-gss)
+                                       @(lazy-load-var 'cook.spnego/require-gss)
                                        {:json-value "kerberos"}))
                                    :else (throw (ex-info "Missing authorization configuration" {}))))
      :rate-limit (fnk [[:config {rate-limit nil}]]


### PR DESCRIPTION
## Changes proposed in this PR

Fix error caused by trying to attach meta-data to the Kerberos middlewar *Var* instead of the *Fn*.

## Why are we making these changes?

Clojure doesn't magically dereference Vars for you when calling `with-meta` like it does when you try to call them like a function.