### PR TITLE
Filters the clusters of interest from the provided entity refs

### DIFF
--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -290,6 +290,8 @@ def parse_entity_refs(clusters, ref_strings):
     Throws if an invalid entity ref string is encountered.
     """
     entity_refs = []
+    cluster_names_of_interest = set()
+    all_cluster_names = set(c['name'] for c in clusters)
     for ref_string in ref_strings:
         result = urlparse(ref_string)
 
@@ -301,11 +303,12 @@ def parse_entity_refs(clusters, ref_strings):
                 raise Exception(f'{result.path} is not a valid UUID.')
 
             entity_refs.append({'cluster': Clusters.ALL, 'type': Types.ALL, 'uuid': result.path})
+            cluster_names_of_interest = all_cluster_names
         else:
             path_parts = result.path.split('/')
             num_path_parts = len(path_parts)
             cluster_url = (f'{result.scheme}://' if result.scheme else '') + result.netloc
-            cluster_names = [c['name'] for c in clusters if c['url'].lower().rstrip('/') == cluster_url.lower()]
+            matched_clusters = [c for c in clusters if c['url'].lower().rstrip('/') == cluster_url.lower()]
 
             if num_path_parts < 2:
                 raise Exception(f'Unable to determine entity type and UUID from {ref_string}.')
@@ -313,11 +316,12 @@ def parse_entity_refs(clusters, ref_strings):
             if num_path_parts == 2 and not result.query:
                 raise Exception(f'Unable to determine UUID from {ref_string}.')
 
-            if len(cluster_names) == 0:
+            if len(matched_clusters) == 0:
                 raise Exception(f'There is no configured cluster that matches {ref_string}.')
 
-            cluster_name = cluster_names[0]
+            cluster_name = matched_clusters[0]['name']
             entity_type = resource_to_entity_type(path_parts[1])
+            cluster_names_of_interest.add(cluster_name)
 
             if num_path_parts > 2:
                 entity_refs.append({'cluster': cluster_name, 'type': entity_type, 'uuid': path_parts[2]})
@@ -330,7 +334,8 @@ def parse_entity_refs(clusters, ref_strings):
                 for uuid in query_args['uuid']:
                     entity_refs.append({'cluster': cluster_name, 'type': entity_type, 'uuid': uuid})
 
-    return entity_refs
+    clusters_of_interest = [c for c in clusters if c['name'] in cluster_names_of_interest]
+    return entity_refs, clusters_of_interest
 
 
 def query_with_stdin_support(clusters, entity_refs, pred_jobs=None, pred_instances=None,
@@ -347,6 +352,7 @@ def query_with_stdin_support(clusters, entity_refs, pred_jobs=None, pred_instanc
     if entity_refs and stdin_from_pipe:
         raise Exception(f'You cannot supply entity references both as arguments and from stdin.')
 
+    clusters_of_interest = clusters
     if not entity_refs:
         if not stdin_from_pipe:
             print_info('Enter the UUIDs or URLs, one per line (press Ctrl+D on a blank line to submit)')
@@ -356,7 +362,7 @@ def query_with_stdin_support(clusters, entity_refs, pred_jobs=None, pred_instanc
             raise Exception('You must specify at least one UUID or URL.')
 
         ref_strings = stdin.splitlines()
-        entity_refs = parse_entity_refs(clusters, ref_strings)
+        entity_refs, clusters_of_interest = parse_entity_refs(clusters, ref_strings)
 
-    query_result = query(clusters, entity_refs, pred_jobs, pred_instances, pred_groups, timeout, interval)
-    return query_result
+    query_result = query(clusters_of_interest, entity_refs, pred_jobs, pred_instances, pred_groups, timeout, interval)
+    return query_result, clusters_of_interest

--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -265,8 +265,11 @@ def resource_to_entity_type(resource):
 
 def parse_entity_refs(clusters, ref_strings):
     """
-    Given a collection of entity ref strings, returns a list of entity ref maps, where each map has
-    the following shape:
+    Given the collection of configured clusters and a collection of entity ref strings, returns a pair
+    where the first element is a list of corresponding entity ref maps, and the second element is the
+    subset of clusters that are of interest.
+
+    In the list of entity ref maps, each map has the following shape:
 
       {'cluster': ..., 'type': ..., 'uuid': ...}
 
@@ -345,7 +348,8 @@ def query_with_stdin_support(clusters, entity_refs, pred_jobs=None, pred_instanc
 
       $ cs jobs --user sally --running --waiting -1 | cs wait
 
-    The above example would wait for all of sally's running and waiting jobs to complete.
+    The above example would wait for all of sally's running and waiting jobs to complete. Returns a pair where the
+    first element is the query result map, and the second element is the subset of clusters that are of interest.
     """
     stdin_from_pipe = not sys.stdin.isatty()
 

--- a/cli/cook/subcommands/kill.py
+++ b/cli/cook/subcommands/kill.py
@@ -98,17 +98,17 @@ def kill_entities(query_result, clusters):
 def kill(clusters, args, _):
     """Attempts to kill the jobs / instances / groups with the given UUIDs."""
     guard_no_cluster(clusters)
-    uuids = parse_entity_refs(clusters, args.get('uuid'))
-    query_result = query_with_stdin_support(clusters, uuids)
+    entity_refs, _ = parse_entity_refs(clusters, args.get('uuid'))
+    query_result, clusters_of_interest = query_with_stdin_support(clusters, entity_refs)
     if query_result['count'] == 0:
-        print_no_data(clusters)
+        print_no_data(clusters_of_interest)
         return 1
 
     # If the user provides UUIDs that map to more than one entity,
     # we will raise an Exception that contains the details
     guard_against_duplicates(query_result)
 
-    return kill_entities(query_result, clusters)
+    return kill_entities(query_result, clusters_of_interest)
 
 
 def register(add_parser, _):

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -103,13 +103,13 @@ def ls_for_instance(instance, sandbox_dir, path, long_format, as_json):
 def ls(clusters, args, _):
     """Lists contents of the corresponding Mesos sandbox path by job or instance uuid."""
     guard_no_cluster(clusters)
-    uuids = parse_entity_refs(clusters, args.get('uuid'))
+    entity_refs, clusters_of_interest = parse_entity_refs(clusters, args.get('uuid'))
     path = args.get('path')
     long_format = args.get('long_format')
     as_json = args.get('json')
     literal = args.get('literal')
 
-    if len(uuids) > 1:
+    if len(entity_refs) > 1:
         # argparse should prevent this, but we'll be defensive anyway
         raise Exception(f'You can only provide a single uuid.')
 
@@ -117,16 +117,16 @@ def ls(clusters, args, _):
         message = 'It looks like you are trying to glob, but ls does not support globbing. ' \
                   f'You can use the {colors.bold("ssh")} command instead:\n' \
                   '\n' \
-                  f'  cs ssh {uuids[0]}\n' \
+                  f'  cs ssh {entity_refs[0]}\n' \
                   '\n' \
                   f'Or, if you want the literal path {colors.bold(path)}, add {colors.bold("--literal")}:\n' \
                   '\n' \
-                  f'  cs ls {colors.bold("--literal")} {uuids[0]} {path}'
+                  f'  cs ls {colors.bold("--literal")} {entity_refs[0]} {path}'
         print(message)
         return 1
 
     command_fn = partial(ls_for_instance, path=path, long_format=long_format, as_json=as_json)
-    query_unique_and_run(clusters, uuids[0], command_fn)
+    query_unique_and_run(clusters_of_interest, entity_refs[0], command_fn)
 
 
 def register(add_parser, _):

--- a/cli/cook/subcommands/show.py
+++ b/cli/cook/subcommands/show.py
@@ -147,8 +147,8 @@ def show(clusters, args, _):
     """Prints info for the jobs / instances / groups with the given UUIDs."""
     guard_no_cluster(clusters)
     as_json = args.get('json')
-    uuids = parse_entity_refs(clusters, args.get('uuid'))
-    query_result = query_with_stdin_support(clusters, uuids)
+    entity_refs, _ = parse_entity_refs(clusters, args.get('uuid'))
+    query_result, clusters_of_interest = query_with_stdin_support(clusters, entity_refs)
     if as_json:
         print(json.dumps(query_result))
     else:
@@ -166,7 +166,7 @@ def show(clusters, args, _):
         return 0
     else:
         if not as_json:
-            print_no_data(clusters)
+            print_no_data(clusters_of_interest)
         return 1
 
 

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -19,12 +19,12 @@ def ssh_to_instance(instance, sandbox_dir):
 def ssh(clusters, args, _):
     """Attempts to ssh (using os.execlp) to the Mesos agent corresponding to the given job or instance uuid."""
     guard_no_cluster(clusters)
-    uuids = parse_entity_refs(clusters, args.get('uuid'))
-    if len(uuids) > 1:
+    entity_refs, clusters_of_interest = parse_entity_refs(clusters, args.get('uuid'))
+    if len(entity_refs) > 1:
         # argparse should prevent this, but we'll be defensive anyway
         raise Exception(f'You can only provide a single uuid.')
 
-    query_unique_and_run(clusters, uuids[0], ssh_to_instance)
+    query_unique_and_run(clusters_of_interest, entity_refs[0], ssh_to_instance)
 
 
 def register(add_parser, _):

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -141,13 +141,13 @@ def tail_for_instance(instance, sandbox_dir, path, num_lines_to_print, follow, f
 def tail(clusters, args, _):
     """Tails the contents of the corresponding Mesos sandbox path by job or instance uuid."""
     guard_no_cluster(clusters)
-    uuids = parse_entity_refs(clusters, args.get('uuid'))
+    entity_refs, clusters_of_interest = parse_entity_refs(clusters, args.get('uuid'))
     paths = args.get('path')
     lines = args.get('lines')
     follow = args.get('follow')
     sleep_interval = args.get('sleep-interval')
 
-    if len(uuids) > 1:
+    if len(entity_refs) > 1:
         # argparse should prevent this, but we'll be defensive anyway
         raise Exception(f'You can only provide a single uuid.')
 
@@ -157,7 +157,7 @@ def tail(clusters, args, _):
 
     command_fn = partial(tail_for_instance, path=paths[0], num_lines_to_print=lines,
                          follow=follow, follow_sleep_seconds=sleep_interval)
-    query_unique_and_run(clusters, uuids[0], command_fn)
+    query_unique_and_run(clusters_of_interest, entity_refs[0], command_fn)
 
 
 def register(add_parser, add_defaults):

--- a/cli/cook/subcommands/wait.py
+++ b/cli/cook/subcommands/wait.py
@@ -31,15 +31,16 @@ def wait(clusters, args, _):
     guard_no_cluster(clusters)
     timeout = args.get('timeout')
     interval = args.get('interval')
-    uuids = parse_entity_refs(clusters, args.get('uuid'))
+    entity_refs, _ = parse_entity_refs(clusters, args.get('uuid'))
     timeout_text = ('up to %s' % seconds_to_timedelta(timeout)) if timeout else 'indefinitely'
     print_info('Will wait %s.' % timeout_text)
-    query_result = query_with_stdin_support(clusters, uuids, all_jobs_completed, all_instances_completed,
-                                            all_groups_completed, timeout, interval)
+    query_result, clusters_of_interest = query_with_stdin_support(clusters, entity_refs, all_jobs_completed,
+                                                                  all_instances_completed, all_groups_completed,
+                                                                  timeout, interval)
     if query_result['count'] > 0:
         return 0
     else:
-        print_no_data(clusters)
+        print_no_data(clusters_of_interest)
         return 1
 
 

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.2.0'
+VERSION = '1.2.1'

--- a/integration/bin/single-test.sh
+++ b/integration/bin/single-test.sh
@@ -24,4 +24,5 @@ fi
 
 echo "Found $test_name in $test_file:$test_class"
 
+export COOK_MULTI_CLUSTER=
 time nosetests --processes=0 --verbosity 3 --nologcapture --tests "$test_file:$test_class.$test_name"

--- a/integration/tests/cook/test_cli_multi_cook.py
+++ b/integration/tests/cook/test_cli_multi_cook.py
@@ -27,7 +27,7 @@ class MultiCookCliTest(unittest.TestCase):
         return {'clusters': [{'name': 'cook1', 'url': self.cook_url_1},
                              {'name': 'cook2', 'url': self.cook_url_2}]}
 
-    def test_federated_query(self):
+    def test_federated_show(self):
         # Submit to cluster #1
         cp, uuids = cli.submit('ls', self.cook_url_1)
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -41,16 +41,12 @@ class MultiCookCliTest(unittest.TestCase):
         # Single query for both jobs, federated across clusters
         config = self.__two_cluster_config()
         with cli.temp_config_file(config) as path:
-            cp = cli.wait([uuid_1, uuid_2], flags='--config %s' % path)
-            self.assertEqual(0, cp.returncode, cp.stderr)
             cp, jobs = cli.show_jobs([uuid_1, uuid_2], flags='--config %s' % path)
             uuids = [job['uuid'] for job in jobs]
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertEqual(2, len(jobs), jobs)
             self.assertIn(str(uuid_1), uuids)
             self.assertIn(str(uuid_2), uuids)
-            self.assertEqual('completed', jobs[0]['status'])
-            self.assertEqual('completed', jobs[1]['status'])
 
     def test_ssh(self):
         # Submit to cluster #2

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -94,9 +94,9 @@ def settings(cook_url):
 def minimal_job(**kwargs):
     job = {
         'command': 'echo Default Test Command',
-        'cpus': 0.1,
+        'cpus': float(os.getenv('COOK_DEFAULT_JOB_CPUS', 1.0)),
         'max_retries': 1,
-        'mem': 128,
+        'mem': int(os.getenv('COOK_DEFAULT_JOB_MEM_MB', 256)),
         'name': 'default_test_job',
         'priority': 1,
         'uuid': str(uuid.uuid4())


### PR DESCRIPTION
## Changes proposed in this PR

- `parse_entity_refs` now returns a second value, which is the list of only the clusters of interest
- `query_with_stdin_support` now returns the same second value
- sub-commands use the clusters of interest in downstream functions instead of all configured clusters

## Why are we making these changes?

The issue that exposed this is that if a user passes an entity ref URL with the wrong base cluster URL, the "No matching data found" message was claiming that no data was found in all configured clusters, when in reality only the clusters from the provided URLs were queried.
