### PR TITLE
Add /info endpoint (unauthenticated)

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1,3 +1,4 @@
+import dateutil.parser
 import json
 import logging
 import operator
@@ -22,6 +23,19 @@ class CookTest(unittest.TestCase):
         self.mesos_url = util.retrieve_mesos_url()
         self.logger = logging.getLogger(__name__)
         util.wait_for_cook(self.cook_url)
+
+    def test_scheduler_info(self):
+        info = util.scheduler_info(self.cook_url)
+        info_details = json.dumps(info, sort_keys=True)
+        self.assertIn('authentication-scheme', info, info_details)
+        self.assertIn('commit', info, info_details)
+        self.assertIn('start-time', info, info_details)
+        self.assertIn('version', info, info_details)
+        self.assertEqual(len(info), 4, info_details)
+        try:
+            timestamp = dateutil.parser.parse(info['start-time'])
+        except:
+            self.fail(f"Unable to parse start time: {info_details}")
 
     def test_basic_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -88,7 +88,13 @@ def wait_for_cook(cook_url):
 
 
 def settings(cook_url):
-    return session.get('%s/settings' % cook_url).json()
+    return session.get(f'{cook_url}/settings').json()
+
+
+def scheduler_info(cook_url):
+    resp = session.get(f'{cook_url}/info', auth=None)
+    assert resp.status_code == 200
+    return resp.json()
 
 
 def minimal_job(**kwargs):


### PR DESCRIPTION
## Changes proposed in this PR

Add unauthenticated `/info` endpoint that includes:
- Cook version
- Cook build commit hash
- Cook scheduler instance start time
- Current authentication scheme

Sample JSON response:
```javascript
{
    "authorization-scheme": "one-user",
    "commit": "dev",
    "start-time": "2017-12-15T01:22:12.956Z",
    "version": "1.8.4-SNAPSHOT"
}
```

## Why are we making these changes?

Having the authentication scheme queryable on an unauthenticated endpoint will be helpful for determining the current authentication scheme when performing setup for our multi-user integration tests. The other information is helpful for checking the status of an update deployment.