### PR TITLE
Softens the UUID validity check

### DIFF
--- a/cli/cook/util.py
+++ b/cli/cook/util.py
@@ -76,11 +76,10 @@ def is_valid_uuid(uuid_to_test, version=4):
     False
     """
     try:
-        uuid_obj = uuid.UUID(uuid_to_test, version=version)
+        uuid.UUID(uuid_to_test, version=version)
+        return True
     except:
         return False
-
-    return str(uuid_obj) == uuid_to_test
 
 
 silent = False

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.2.0'
+VERSION = '1.2.1'

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1374,7 +1374,7 @@ class CookCliTest(unittest.TestCase):
             cp, uuids = cli.submit('ls', flags=flags)
             self.assertEqual(0, cp.returncode, cp.stderr)
             uuid = uuids[0]
-            _, jobs = cli.show_jobs([f'{self.cook_url}/jobs/{uuid}'], flags=flags)
+            cp, jobs = cli.show_jobs([f'{self.cook_url}/jobs/{uuid}'], flags=flags)
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertEqual(1, len(jobs))
             self.assertEqual(uuid, jobs[0]['uuid'])
@@ -1460,3 +1460,8 @@ class CookCliTest(unittest.TestCase):
         self.logger.info(command)
         cp = subprocess.run(command, shell=True)
         self.assertEqual(0, cp.returncode, cp.stderr)
+
+    def test_show_interesting_uuid(self):
+        cp = cli.show(['019c34c3-13b3-b370-01a5-d1ecc9071249'], self.cook_url)
+        self.assertEqual(1, cp.returncode, cp.stderr)
+        self.assertIn('No matching data found', cli.stdout(cp), cp.stderr)


### PR DESCRIPTION
## Changes proposed in this PR

- changing `is_valid_uuid` to no longer check if the string representation of the parsed UUID is equal to the input string
- adding an integration test for a UUID that exposes this: `019c34c3-13b3-b370-01a5-d1ecc9071249`

## Why are we making these changes?

The UUID above, and others, parse as valid UUIDs, but for some reason have a different string representation:

```bash
>>> uuid_str = '019c34c3-13b3-b370-01a5-d1ecc9071249'
>>> import uuid
>>> uuid_obj = uuid.UUID(uuid_str, version=4)
>>> str(uuid_obj)
'019c34c3-13b3-4370-81a5-d1ecc9071249'
>>> str(uuid_obj) == uuid_str
False
```

At the end of the day, all we care is that Cook Scheduler accepts these UUIDs, and it does.