### PR TITLE
Cook Executor:  narrows OSError handler to only trigger task exit only for out of memory

### DIFF
--- a/executor/cook/_version.py
+++ b/executor/cook/_version.py
@@ -1,4 +1,4 @@
 # This file is read by setup.py to obtain the version.
 # Be aware that changing the format may break the parsing logic.
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -98,7 +98,7 @@ class StatusUpdater(object):
                 return False
 
 
-def send_message(driver, message):
+def send_message(driver, error_handler, message):
     """Sends the message, if it is smaller than the max length, using the driver.
 
     Note: This function must rethrow any OSError exceptions that it encounters.
@@ -107,6 +107,8 @@ def send_message(driver, message):
     ----------
     driver: MesosExecutorDriver
         The driver to send the message to.
+    error_handler: fn(os_error)
+        OSError exception handler for out of memory situations.
     message: dictionary
         The raw message to send.
 
@@ -120,10 +122,11 @@ def send_message(driver, message):
         encoded_message = pm.encode_data(message_string)
         driver.sendFrameworkMessage(encoded_message)
         return True
-    except OSError:
-        raise
-    except Exception:
-        logging.exception('Error in sending message {}'.format(message))
+    except Exception as exception:
+        if cu.is_out_of_memory_error(exception):
+            error_handler(exception)
+        else:
+            logging.exception('Exception while sending message {}'.format(message))
         return False
 
 def launch_task(task, environment):
@@ -284,7 +287,8 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         # not yet started to run the task
         status_updater.update_status(cook.TASK_STARTING)
 
-        send_message(driver, {'sandbox-directory': config.sandbox_directory, 'task-id': task_id, 'type': 'directory'})
+        sandbox_message = {'sandbox-directory': config.sandbox_directory, 'task-id': task_id, 'type': 'directory'}
+        send_message(driver, inner_os_error_handler, sandbox_message)
 
         environment = retrieve_process_environment(config, os.environ)
         launched_process = launch_task(task, environment)
@@ -301,7 +305,7 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         task_completed_signal = Event() # event to track task execution completion
         sequence_counter = cp.ProgressSequenceCounter()
 
-        send_progress_message = functools.partial(send_message, driver)
+        send_progress_message = functools.partial(send_message, driver, inner_os_error_handler)
         max_message_length = config.max_message_length
         sample_interval_ms = config.progress_sample_interval_ms
         progress_updater = cp.ProgressUpdater(task_id, max_message_length, sample_interval_ms, send_progress_message)
@@ -332,7 +336,8 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         exit_code = launched_process.returncode
         cio.print_and_log('Command exited with status {} (pid: {})'.format(exit_code, launched_process.pid))
 
-        send_message(driver, {'exit-code': exit_code, 'task-id': task_id})
+        exit_message = {'exit-code': exit_code, 'task-id': task_id}
+        send_message(driver, inner_os_error_handler, exit_message)
 
         # await progress updater termination if executor is terminating normally
         if not stop_signal.isSet():

--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -318,7 +318,7 @@ class ProgressTracker(object):
         location_tag: string
             A tag to identify the target location.
         os_error_handler: fn(os_error)
-            OSError exception handler."""
+            OSError exception handler for out of memory situations."""
         self.location_tag = location_tag
         self.os_error_handler = os_error_handler
         self.progress_complete_event = Event()

--- a/executor/cook/util.py
+++ b/executor/cook/util.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import resource
 import sys
@@ -15,3 +16,8 @@ def print_memory_usage():
         logging.info('Executor Memory usage: {} MB'.format(max_rss / __rusage_denom_mb))
     except Exception:
         logging.exception('Error in logging memory usage')
+
+
+def is_out_of_memory_error(exception):
+    """Returns true iff exception is an instance of OSError and error code represents an out of memory error."""
+    return isinstance(exception, OSError) and exception.errno == errno.ENOMEM

--- a/executor/tests/test_progress.py
+++ b/executor/tests/test_progress.py
@@ -53,7 +53,7 @@ class ProgressTest(unittest.TestCase):
     def send_progress_message_helper(self, driver, max_message_length):
 
         def send_progress_message(message):
-            ce.send_message(driver, message)
+            ce.send_message(driver, tu.fake_os_error_handler, message)
             self.assertTrue('progress-message' in message)
             self.assertLessEqual(len(message['progress-message']), max_message_length)
             return len(message['progress-message']) <= max_message_length


### PR DESCRIPTION
## Changes proposed in this PR

- narrows OSError handler to only trigger task exit only for out of memory OSErrors
- adds exception handling logic to send_message

## Why are we making these changes?

There are a few error classes (e.g. `socker.error`) that extend `OSError` and are currently incorrectly being treated as out of memory errors. This PR fixes this bug.

In addition, we are adding exception handling logic to sending of messages to correctly treat network error as transient errors and allow the executor to chug along.

