### PR TITLE
Job Client: adds support for configuring the executor field on a job and populating the executor field on an instance

### DIFF
--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/Executor.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/Executor.java
@@ -1,0 +1,23 @@
+package com.twosigma.cook.jobclient;
+
+/**
+ * Enum representing valid options for the executor field in a job and instance.
+ */
+
+public enum Executor {
+    COOK,
+    EXECUTOR;
+
+    public static Executor fromString(final String name) {
+        for (final Executor executor : values()) {
+            if (executor.name().toLowerCase().equals(name)) {
+                return executor;
+            }
+        }
+        return null;
+    }
+
+    public String displayName() {
+        return name().toLowerCase();
+    }
+}

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/Instance.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/Instance.java
@@ -73,7 +73,7 @@ final public class Instance {
         private Boolean _preempted;
         private String _outputURL;
         private String _hostName;
-        private String _executor;
+        private Executor _executor;
 
         /**
          * The task id must be provided prior to {@code build()}. If the instance status is not
@@ -198,12 +198,22 @@ final public class Instance {
         }
 
         /**
-         * Set the executor for the instance expected to build.
+         * Set the executor of the instance expected to build.
          *
-         * @param executor {@link String} specifies the executor used to run this task.
+         * @param executor {@link String} specifies executor for a job.
          * @return this builder.
          */
         public Builder setExecutor(String executor) {
+            return setExecutor(Executor.fromString(executor));
+        }
+
+        /**
+         * Set the executor of the instance expected to build.
+         *
+         * @param executor {@link Executor} specifies executor for a job.
+         * @return this builder.
+         */
+        public Builder setExecutor(Executor executor) {
             _executor = executor;
             return this;
         }
@@ -240,7 +250,7 @@ final public class Instance {
             return _hostName;
         }
 
-        public String getExecutor() {
+        public Executor getExecutor() {
             return _executor;
         }
     }
@@ -258,11 +268,11 @@ final public class Instance {
     final private Boolean _preempted;
     final private String _outputURL;
     final private String _hostName;
-    private String _executor;
+    private Executor _executor;
 
     private Instance(UUID taskID, String slaveID, String executorID, Long startTime, Long endTime,
                      Status status, Long reasonCode, Boolean preempted, String outputURL, String hostName,
-                     String executor) {
+                     Executor executor) {
         _taskID = taskID;
         _slaveID = slaveID;
         _executorID = executorID;
@@ -410,7 +420,7 @@ final public class Instance {
         return _hostName;
     }
 
-    public String getExecutor() {
+    public Executor getExecutor() {
         return _executor;
     }
 

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/Instance.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/Instance.java
@@ -73,6 +73,7 @@ final public class Instance {
         private Boolean _preempted;
         private String _outputURL;
         private String _hostName;
+        private String _executor;
 
         /**
          * The task id must be provided prior to {@code build()}. If the instance status is not
@@ -86,7 +87,7 @@ final public class Instance {
                 _status = Status.UNKNOWN;
             }
             return new Instance(_taskID, _slaveID, _executorID, _startTime, _endTime, _status, _reasonCode,
-                    _preempted, _outputURL, _hostName);
+                    _preempted, _outputURL, _hostName, _executor);
         }
 
         /**
@@ -196,6 +197,17 @@ final public class Instance {
             return this;
         }
 
+        /**
+         * Set the executor for the instance expected to build.
+         *
+         * @param executor {@link String} specifies the executor used to run this task.
+         * @return this builder.
+         */
+        public Builder setExecutor(String executor) {
+            _executor = executor;
+            return this;
+        }
+
         public UUID getTaskID() {
             return _taskID;
         }
@@ -227,6 +239,10 @@ final public class Instance {
         public String getHostName() {
             return _hostName;
         }
+
+        public String getExecutor() {
+            return _executor;
+        }
     }
 
     /**
@@ -242,9 +258,11 @@ final public class Instance {
     final private Boolean _preempted;
     final private String _outputURL;
     final private String _hostName;
+    private String _executor;
 
     private Instance(UUID taskID, String slaveID, String executorID, Long startTime, Long endTime,
-                     Status status, Long reasonCode, Boolean preempted, String outputURL, String hostName) {
+                     Status status, Long reasonCode, Boolean preempted, String outputURL, String hostName,
+                     String executor) {
         _taskID = taskID;
         _slaveID = slaveID;
         _executorID = executorID;
@@ -255,6 +273,7 @@ final public class Instance {
         _preempted = preempted;
         _outputURL = outputURL;
         _hostName = hostName;
+        _executor = executor;
     }
 
     /**
@@ -269,6 +288,7 @@ final public class Instance {
      *      "status" : "success",
      *      "start_time" : 1426632249597,
      *      "hostname" : "server1.example.com",
+     *      "executor" : "mesos",
      *      "executor_id" : "f52fbacf-52a1-44a2-bda1-cbfa477cc163",
      *      "task_id" : "f52fbacf-52a1-44a2-bda1-cbfa477cc163",
      *      "preempted": false
@@ -305,6 +325,9 @@ final public class Instance {
             instanceBuilder.setSlaveID(json.getString("slave_id"));
             instanceBuilder.setExecutorID(json.getString("executor_id"));
             instanceBuilder.setHostName(json.getString("hostname"));
+            if (json.has("executor")) {
+                instanceBuilder.setExecutor(json.getString("executor"));
+            }
             instanceBuilder.setStatus(Status.fromString(json.getString("status")));
             instanceBuilder.setPreempted(json.getBoolean("preempted"));
             instanceBuilder.setStartTime(json.getLong("start_time"));
@@ -344,7 +367,7 @@ final public class Instance {
         return "Instance [_taskID=" + _taskID + ", _slaveID=" + _slaveID + ", _executorID="
                 + _executorID + ", _startTime=" + _startTime + ", _endTime=" + _endTime
                 + ", _status=" + _status + ", _reasonCode=" + _reasonCode + ", _preempted=" + _preempted
-                + ", _outputURL=" + _outputURL + ", _hostName=" + _hostName + "]";
+                + ", _outputURL=" + _outputURL + ", _hostName=" + _hostName + ", _executor=" + _executor + "]";
     }
 
     public UUID getTaskID() {
@@ -385,6 +408,10 @@ final public class Instance {
 
     public String getHostName() {
         return _hostName;
+    }
+
+    public String getExecutor() {
+        return _executor;
     }
 
 

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -80,6 +80,7 @@ final public class Job {
         private UUID _uuid;
         private String _name;
         private String _command;
+        private String _executor;
         private Double _memory;
         private Double _cpus;
         private Integer _retries;
@@ -133,7 +134,7 @@ final public class Job {
             if (_isMeaCulpaRetriesDisabled == null) {
                 _isMeaCulpaRetriesDisabled = false;
             }
-            return new Job(_uuid, _name, _command, _memory, _cpus, _retries, _maxRuntime, _expectedRuntime, _status,
+            return new Job(_uuid, _name, _command, _executor, _memory, _cpus, _retries, _maxRuntime, _expectedRuntime, _status,
                     _priority, _isMeaCulpaRetriesDisabled, _instances, _env, _uris, _container, _labels, _constraints,
                     _groups, _application);
         }
@@ -146,6 +147,7 @@ final public class Job {
          */
         public Builder of(Job job) {
             setCommand(job.getCommand());
+            setExecutor(job.getExecutor());
             setMemory(job.getMemory());
             setCpus(job.getCpus());
             setRetries(job.getRetries());
@@ -342,6 +344,17 @@ final public class Job {
         }
 
         /**
+         * Set the executor of the job expected to build.
+         *
+         * @param executor {@link String} specifies executor for a job.
+         * @return this builder.
+         */
+        public Builder setExecutor(String executor) {
+            _executor = executor;
+            return this;
+        }
+
+        /**
          * Set the cpus of the job expected to build.
          *
          * @param cpus {@link Double} specifies cpus for a job.
@@ -510,6 +523,7 @@ final public class Job {
     final private UUID _uuid;
     final private String _name;
     final private String _command;
+    final private String _executor;
     final private Double _memory;
     final private Double _cpus;
     final private Integer _retries;
@@ -529,13 +543,14 @@ final public class Job {
     final private List<UUID> _groups;
     final private Application _application;
 
-    private Job(UUID uuid, String name, String command, Double memory, Double cpus, Integer retries, Long maxRuntime,
-                Long expectedRuntime, Status status, Integer priority, Boolean isMeaCulpaRetriesDisabled,
+    private Job(UUID uuid, String name, String command, String executor, Double memory, Double cpus, Integer retries,
+                Long maxRuntime, Long expectedRuntime, Status status, Integer priority, Boolean isMeaCulpaRetriesDisabled,
                 List<Instance> instances, Map<String, String> env, List<FetchableURI> uris, JSONObject container,
                 Map<String, String> labels, Set<Constraint> constraints, List<UUID> groups, Application application) {
         _uuid = uuid;
         _name = name;
         _command = command;
+        _executor = executor;
         _memory = memory;
         _cpus = cpus;
         _retries = retries;
@@ -576,6 +591,13 @@ final public class Job {
      */
     public String getCommand() {
         return _command;
+    }
+
+    /**
+     * @return the job executor.
+     */
+    public String getExecutor() {
+        return _executor;
     }
 
     /**
@@ -758,6 +780,9 @@ final public class Job {
         object.put("uuid", job.getUUID().toString());
         object.put("name", job.getName());
         object.put("command", job.getCommand());
+        if (job.getExecutor() != null) {
+            object.put("executor", job.getExecutor());
+        }
         object.put("mem", job.getMemory());
         object.put("cpus", job.getCpus());
         object.put("priority", job.getPriority());
@@ -874,6 +899,9 @@ final public class Job {
             jobBuilder.setMemory(json.getDouble("mem"));
             jobBuilder.setCpus(json.getDouble("cpus"));
             jobBuilder.setCommand(json.getString("command"));
+            if (json.has("executor")) {
+                jobBuilder.setExecutor(json.getString("executor"));
+            }
             jobBuilder.setPriority(json.getInt("priority"));
             jobBuilder.setStatus(Status.fromString(json.getString("status")));
             if (json.has("disable_mea_culpa_retries") && json.getBoolean("disable_mea_culpa_retries")) {
@@ -956,9 +984,9 @@ final public class Job {
     public String toString() {
         StringBuilder stringBuilder = new StringBuilder(512);
         stringBuilder
-                .append("Job [_uuid=" + _uuid + ", _name=" + _name + ", _command=" + _command + ", _memory=" + _memory
-                        + ", _cpus=" + _cpus + ", _retries=" + _retries + ", _maxRuntime=" + _maxRuntime
-                        + ", _status=" + _status + ", _priority=" + _priority
+                .append("Job [_uuid=" + _uuid + ", _name=" + _name + ", _command=" + _command + ", _executor=" + _executor
+                        + ", _memory=" + _memory + ", _cpus=" + _cpus + ", _retries=" + _retries
+                        + ", _maxRuntime=" + _maxRuntime + ", _status=" + _status + ", _priority=" + _priority
                         + ", _isMeaCulpaRetriesDisabled" + _isMeaCulpaRetriesDisabled + "]");
         stringBuilder.append('\n');
         for (Instance instance : getInstances()) {

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -80,7 +80,7 @@ final public class Job {
         private UUID _uuid;
         private String _name;
         private String _command;
-        private String _executor;
+        private Executor _executor;
         private Double _memory;
         private Double _cpus;
         private Integer _retries;
@@ -350,6 +350,16 @@ final public class Job {
          * @return this builder.
          */
         public Builder setExecutor(String executor) {
+            return setExecutor(Executor.fromString(executor));
+        }
+
+        /**
+         * Set the executor of the job expected to build.
+         *
+         * @param executor {@link Executor} specifies executor for a job.
+         * @return this builder.
+         */
+        public Builder setExecutor(Executor executor) {
             _executor = executor;
             return this;
         }
@@ -523,7 +533,7 @@ final public class Job {
     final private UUID _uuid;
     final private String _name;
     final private String _command;
-    final private String _executor;
+    final private Executor _executor;
     final private Double _memory;
     final private Double _cpus;
     final private Integer _retries;
@@ -543,7 +553,7 @@ final public class Job {
     final private List<UUID> _groups;
     final private Application _application;
 
-    private Job(UUID uuid, String name, String command, String executor, Double memory, Double cpus, Integer retries,
+    private Job(UUID uuid, String name, String command, Executor executor, Double memory, Double cpus, Integer retries,
                 Long maxRuntime, Long expectedRuntime, Status status, Integer priority, Boolean isMeaCulpaRetriesDisabled,
                 List<Instance> instances, Map<String, String> env, List<FetchableURI> uris, JSONObject container,
                 Map<String, String> labels, Set<Constraint> constraints, List<UUID> groups, Application application) {
@@ -596,7 +606,7 @@ final public class Job {
     /**
      * @return the job executor.
      */
-    public String getExecutor() {
+    public Executor getExecutor() {
         return _executor;
     }
 
@@ -781,7 +791,7 @@ final public class Job {
         object.put("name", job.getName());
         object.put("command", job.getCommand());
         if (job.getExecutor() != null) {
-            object.put("executor", job.getExecutor());
+            object.put("executor", job.getExecutor().displayName());
         }
         object.put("mem", job.getMemory());
         object.put("cpus", job.getCpus());

--- a/jobclient/src/test/java/com/twosigma/cook/jobclient/InstanceTest.java
+++ b/jobclient/src/test/java/com/twosigma/cook/jobclient/InstanceTest.java
@@ -46,6 +46,7 @@ public class InstanceTest {
         instanceBuilder.setStartTime(1426632249597L);
         instanceBuilder.setEndTime(1426632251828L);
         instanceBuilder.setHostName("server1.example.com");
+        instanceBuilder.setExecutor("cook");
         instanceBuilder.setExecutorID("f52fbacf-52a1-44a2-bda1-cbfa477cc163");
         instanceBuilder.setStatus(Instance.Status.SUCCESS);
         instanceBuilder.setPreempted(false);
@@ -61,12 +62,15 @@ public class InstanceTest {
         json.put("status", _successfulInstance.getStatus());
         json.put("preempted", _successfulInstance.getPreempted());
         json.put("hostname", _successfulInstance.getHostName());
+        json.put("executor", _successfulInstance.getExecutor());
         json.put("task_id", _successfulInstance.getTaskID());
         json.put("executor_id", _successfulInstance.getExecutorID());
         final String jsonString = new JSONArray().put(json).toString();
         final List<Instance> instances = Instance.parseFromJSON(jsonString);
         Assert.assertEquals(instances.size(), 1);
-        Assert.assertEquals(instances.get(0), _successfulInstance);
+        final Instance actualInstance = instances.get(0);
+        Assert.assertEquals(_successfulInstance, actualInstance);
+        Assert.assertEquals(_successfulInstance.getExecutor(), actualInstance.getExecutor());
     }
 }
 

--- a/jobclient/src/test/java/com/twosigma/cook/jobclient/InstanceTest.java
+++ b/jobclient/src/test/java/com/twosigma/cook/jobclient/InstanceTest.java
@@ -62,7 +62,7 @@ public class InstanceTest {
         json.put("status", _successfulInstance.getStatus());
         json.put("preempted", _successfulInstance.getPreempted());
         json.put("hostname", _successfulInstance.getHostName());
-        json.put("executor", _successfulInstance.getExecutor());
+        json.put("executor", _successfulInstance.getExecutor().name().toLowerCase());
         json.put("task_id", _successfulInstance.getTaskID());
         json.put("executor_id", _successfulInstance.getExecutorID());
         final String jsonString = new JSONArray().put(json).toString();

--- a/jobclient/src/test/java/com/twosigma/cook/jobclient/InstanceTest.java
+++ b/jobclient/src/test/java/com/twosigma/cook/jobclient/InstanceTest.java
@@ -16,61 +16,105 @@
 
 package com.twosigma.cook.jobclient;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.util.List;
 import java.util.UUID;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-
-import org.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 /**
  * Unit tests for {@link Job}.
- * 
+ *
  * @author wzhao
  */
 public class InstanceTest {
-    /*
-     * A job which could be used for any test.
-     */
-    private Instance _successfulInstance;
-
-    @Before
-    public void setup() {
-        final Instance.Builder instanceBuilder = new Instance.Builder();
+    private void populateBuilder(Instance.Builder instanceBuilder) {
         instanceBuilder.setTaskID(UUID.randomUUID());
         instanceBuilder.setSlaveID("20150311-033720-1963923116-5050-4084-32");
         instanceBuilder.setStartTime(1426632249597L);
         instanceBuilder.setEndTime(1426632251828L);
         instanceBuilder.setHostName("server1.example.com");
-        instanceBuilder.setExecutor("cook");
         instanceBuilder.setExecutorID("f52fbacf-52a1-44a2-bda1-cbfa477cc163");
         instanceBuilder.setStatus(Instance.Status.SUCCESS);
         instanceBuilder.setPreempted(false);
-        _successfulInstance = instanceBuilder.build();
     }
 
-    @Test
-    public void testParseFromJSON() throws JSONException {
-        final JSONObject json = new JSONObject();
+    private void populateJson(JSONObject json, Instance _successfulInstance) {
         json.put("slave_id", _successfulInstance.getSlaveID());
         json.put("start_time", _successfulInstance.getStartTime());
         json.put("end_time", _successfulInstance.getEndTime());
         json.put("status", _successfulInstance.getStatus());
         json.put("preempted", _successfulInstance.getPreempted());
         json.put("hostname", _successfulInstance.getHostName());
-        json.put("executor", _successfulInstance.getExecutor().name().toLowerCase());
         json.put("task_id", _successfulInstance.getTaskID());
         json.put("executor_id", _successfulInstance.getExecutorID());
+    }
+
+    @Test
+    public void testBuilderBasic() throws JSONException {
+        final Instance.Builder instanceBuilder = new Instance.Builder();
+        populateBuilder(instanceBuilder);
+
+        Instance basicInstance = instanceBuilder.build();
+
+        Assert.assertNull(basicInstance.getExecutor());
+        Assert.assertEquals(Instance.Status.SUCCESS, basicInstance.getStatus());
+        Assert.assertNotNull(basicInstance.getTaskID());
+    }
+
+    @Test
+    public void testParseFromJsonBasic() throws JSONException {
+        final Instance.Builder instanceBuilder = new Instance.Builder();
+        populateBuilder(instanceBuilder);
+        Instance basicInstance = instanceBuilder.build();
+
+        final JSONObject json = new JSONObject();
+        populateJson(json, basicInstance);
+
         final String jsonString = new JSONArray().put(json).toString();
         final List<Instance> instances = Instance.parseFromJSON(jsonString);
+
         Assert.assertEquals(instances.size(), 1);
-        final Instance actualInstance = instances.get(0);
-        Assert.assertEquals(_successfulInstance, actualInstance);
-        Assert.assertEquals(_successfulInstance.getExecutor(), actualInstance.getExecutor());
+        Assert.assertEquals(instances.get(0), basicInstance);
+    }
+
+    @Test
+    public void testBuilderWithExecutor() throws JSONException {
+        for (Executor executor : Executor.values()) {
+            final Instance.Builder instanceBuilder = new Instance.Builder();
+            populateBuilder(instanceBuilder);
+            instanceBuilder.setExecutor(executor.displayName());
+
+            Instance basicInstance = instanceBuilder.build();
+
+            Assert.assertEquals(executor, basicInstance.getExecutor());
+        }
+    }
+
+    @Test
+    public void testParseFromJsonWithExecutor() throws JSONException {
+
+        final Instance.Builder instanceBuilder = new Instance.Builder();
+        populateBuilder(instanceBuilder);
+        Instance basicInstance = instanceBuilder.build();
+
+        Assert.assertNull(basicInstance.getExecutor());
+
+        for (Executor executor : Executor.values()) {
+            final JSONObject json = new JSONObject();
+            populateJson(json, basicInstance);
+            json.put("executor", executor.displayName());
+
+            final String jsonString = new JSONArray().put(json).toString();
+            final List<Instance> instances = Instance.parseFromJSON(jsonString);
+
+            Assert.assertEquals(instances.size(), 1);
+            final Instance actualInstance = instances.get(0);
+            Assert.assertEquals(executor, actualInstance.getExecutor());
+        }
     }
 }
 

--- a/jobclient/src/test/java/com/twosigma/cook/jobclient/JobTest.java
+++ b/jobclient/src/test/java/com/twosigma/cook/jobclient/JobTest.java
@@ -67,7 +67,7 @@ public class JobTest {
     public void testJsonizeJob() throws JSONException {
         final JSONObject jsonJob = Job.jsonizeJob(_initializedJob);
         Assert.assertEquals(jsonJob.getString("uuid"), _initializedJob.getUUID().toString());
-        Assert.assertEquals(jsonJob.getString("executor"), _initializedJob.getExecutor());
+        Assert.assertEquals(jsonJob.getString("executor"), _initializedJob.getExecutor().displayName());
         Assert.assertEquals(
                 jsonJob.getJSONObject("application").toString(),
                 new JSONObject().put("name", "baz-app").put("version", "1.2.3").toString());

--- a/jobclient/src/test/java/com/twosigma/cook/jobclient/JobTest.java
+++ b/jobclient/src/test/java/com/twosigma/cook/jobclient/JobTest.java
@@ -46,6 +46,7 @@ public class JobTest {
         final Job.Builder jobBuilder = new Job.Builder();
         jobBuilder.setUUID(UUID.randomUUID());
         jobBuilder.setCommand("sleep 10s");
+        jobBuilder.setExecutor("cook");
         jobBuilder.setMemory(100.0);
         jobBuilder.setCpus(1.0);
         jobBuilder.addEnv("FOO", "test");
@@ -66,6 +67,7 @@ public class JobTest {
     public void testJsonizeJob() throws JSONException {
         final JSONObject jsonJob = Job.jsonizeJob(_initializedJob);
         Assert.assertEquals(jsonJob.getString("uuid"), _initializedJob.getUUID().toString());
+        Assert.assertEquals(jsonJob.getString("executor"), _initializedJob.getExecutor());
         Assert.assertEquals(
                 jsonJob.getJSONObject("application").toString(),
                 new JSONObject().put("name", "baz-app").put("version", "1.2.3").toString());
@@ -85,13 +87,15 @@ public class JobTest {
         final String jsonString = new JSONArray().put(json).toString();
         final List<Job> jobs = Job.parseFromJSON(jsonString);
         Assert.assertEquals(jobs.size(), 1);
-        Assert.assertEquals(jobs.get(0), _initializedJob);
-        Assert.assertEquals(jobs.get(0).getMaxRuntime(), new Long(1000L));
-        Assert.assertEquals(jobs.get(0).getApplication().getName(), "baz-app");
-        Assert.assertEquals(jobs.get(0).getApplication().getVersion(), "1.2.3");
-        Assert.assertEquals(jobs.get(0).getExpectedRuntime(), new Long(500L));
+        final Job job = jobs.get(0);
+        Assert.assertEquals(_initializedJob, job);
+        Assert.assertEquals(_initializedJob.getExecutor(), job.getExecutor());
+        Assert.assertEquals(job.getMaxRuntime(), new Long(1000L));
+        Assert.assertEquals(job.getApplication().getName(), "baz-app");
+        Assert.assertEquals(job.getApplication().getVersion(), "1.2.3");
+        Assert.assertEquals(job.getExpectedRuntime(), new Long(500L));
 
-        final Set<Constraint> constraints = jobs.get(0).getConstraints();
+        final Set<Constraint> constraints = job.getConstraints();
         Assert.assertEquals(constraints.size(), 2);
         Iterator<Constraint> iter = constraints.iterator();
         Constraint constraint = iter.next();


### PR DESCRIPTION

## Changes proposed in this PR

- adds support for configuring the executor field on a job and populating the executor field on an instance

## Why are we making these changes?

This will enable the `JobClient` to specify the executor to use while submitting/loading a job. Additionally, it also allows displaying the executor used in an instance.

