### PR TITLE
Adds batching to queries made from cs

### DIFF
--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -26,21 +26,16 @@ class Clusters:
 
 def __distinct(seq):
     """Remove duplicate entries from a sequence. Maintains original order."""
-    return collections.OrderedDict(zip(seq, seq)).keys()
+    seen = set()
+    seen_add = seen.add
+    return [x for x in seq if not (x in seen or seen_add(x))]
 
 
-def query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, entity_type):
+def __query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, entity_type):
     """
     Queries the given cluster for the given uuids with
     an optional predicate, pred, that must be satisfied
     """
-    if len(uuids) == 0:
-        return []
-
-    # Cook will give us back two copies if the user asks for the same UUID twice, e.g.
-    # $ cs show d38ea6bd-8a26-4ddf-8a93-5926fa2991ce d38ea6bd-8a26-4ddf-8a93-5926fa2991ce
-    # Prevent this by calling distinct:
-    uuids = __distinct(uuids)
 
     def satisfy_pred():
         return pred(http.make_data_request(cluster, lambda: make_request_fn(cluster, uuids)))
@@ -69,6 +64,31 @@ def query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, enti
                 progress.update(index, colors.bold('Done'))
             else:
                 raise TimeoutError('Timeout waiting for response.')
+    return entities
+
+
+def partition(l, n):
+    """Yield successive n-sized chunks from l"""
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
+
+
+def query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, entity_type):
+    """Delegates to __query_cluster in batches of at most 100 UUIDs and combines the results"""
+    if len(uuids) == 0:
+        return []
+
+    # Cook will give us back two copies if the user asks for the same UUID twice, e.g.
+    # $ cs show d38ea6bd-8a26-4ddf-8a93-5926fa2991ce d38ea6bd-8a26-4ddf-8a93-5926fa2991ce
+    # Prevent this by calling distinct:
+    uuids = __distinct(uuids)
+
+    # return __query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, entity_type)
+    entities = []
+    query_batch_size = 100
+    for uuid_batch in partition(uuids, query_batch_size):
+        entity_batch = __query_cluster(cluster, uuid_batch, pred, timeout, interval, make_request_fn, entity_type)
+        entities.extend(entity_batch)
     return entities
 
 

--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -83,7 +83,6 @@ def query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, enti
     # Prevent this by calling distinct:
     uuids = __distinct(uuids)
 
-    # return __query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, entity_type)
     entities = []
     query_batch_size = 100
     for uuid_batch in partition(uuids, query_batch_size):

--- a/cli/cook/util.py
+++ b/cli/cook/util.py
@@ -130,3 +130,16 @@ def guard_no_cluster(clusters):
     """Throws if no clusters have been specified, either via configuration or via the command line"""
     if not clusters:
         raise Exception('You must specify at least one cluster.')
+
+
+def distinct(seq):
+    """Remove duplicate entries from a sequence. Maintains original order."""
+    seen = set()
+    seen_add = seen.add
+    return [x for x in seq if not (x in seen or seen_add(x))]
+
+
+def partition(l, n):
+    """Yield successive n-sized chunks from l"""
+    for i in range(0, len(l), n):
+        yield l[i:i + n]

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -199,7 +199,13 @@ def ls(uuid, cook_url, path=None, parse_json=True):
     """Invokes the ls subcommand"""
     args = f'ls --json {uuid} {path}' if path else f'ls --json {uuid}'
     cp = cli(args, cook_url)
-    entries = json.loads(stdout(cp)) if parse_json else None
+    out = stdout(cp)
+    try:
+        entries = json.loads(out) if parse_json else None
+    except:
+        err = decode(cp.stderr)
+        logging.exception(f'Exception when parsing output from ls (stdout = {out}, stderr = {err})')
+        raise
     return cp, entries
 
 

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1446,31 +1446,35 @@ class CookCliTest(unittest.TestCase):
 
     def test_piping_from_jobs_to_show(self):
         name = uuid.uuid4()
-        cp, uuids = cli.submit_stdin(['ls'] * 3, self.cook_url, submit_flags=f'--name {name}')
+        num_jobs = 200
+        cp, uuids = cli.submit_stdin(['ls'] * num_jobs, self.cook_url,
+                                     submit_flags=f'--name {name} --cpus 0.01 --mem 16')
         self.assertEqual(0, cp.returncode, cp.stderr)
         user = util.get_user(self.cook_url, uuids[0])
-        jobs_flags = f'--user {user} --name {name} --all'
+        jobs_flags = f'--user {user} --name {name} --all --limit {num_jobs}'
         cp, jobs = cli.jobs_json(self.cook_url, jobs_flags)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(3, len(jobs))
+        self.assertEqual(num_jobs, len(jobs))
         cs = f'{cli.command()} --url {self.cook_url}'
         command = f'{cs} jobs {jobs_flags} -1 | {cs} show --json'
         self.logger.info(command)
         cp = subprocess.run(command, shell=True, stdout=subprocess.PIPE)
         self.assertEqual(0, cp.returncode, cp.stderr)
         jobs = json.loads(cli.stdout(cp))['clusters'][self.cook_url]['jobs']
-        self.assertEqual(3, len(jobs), json.dumps(jobs, indent=2))
+        self.assertEqual(num_jobs, len(jobs))
         self.assertEqual(sorted(uuids), sorted([j['uuid'] for j in jobs]))
 
     def test_piping_from_jobs_to_wait(self):
         name = uuid.uuid4()
-        cp, uuids = cli.submit_stdin(['ls'] * 3, self.cook_url, submit_flags=f'--name {name}')
+        num_jobs = 200
+        cp, uuids = cli.submit_stdin(['ls'] * num_jobs, self.cook_url,
+                                     submit_flags=f'--name {name} --cpus 0.01 --mem 16')
         self.assertEqual(0, cp.returncode, cp.stderr)
         user = util.get_user(self.cook_url, uuids[0])
-        jobs_flags = f'--user {user} --name {name} --all'
+        jobs_flags = f'--user {user} --name {name} --all --limit {num_jobs}'
         cp, jobs = cli.jobs_json(self.cook_url, jobs_flags)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(3, len(jobs))
+        self.assertEqual(num_jobs, len(jobs))
         cs = f'{cli.command()} --url {self.cook_url}'
         command = f'{cs} jobs {jobs_flags} -1 | {cs} wait'
         self.logger.info(command)

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1446,7 +1446,7 @@ class CookCliTest(unittest.TestCase):
 
     def test_piping_from_jobs_to_show_and_wait(self):
         name = uuid.uuid4()
-        num_jobs = 200
+        num_jobs = 101
         # Submit a batch of jobs
         cp, uuids = cli.submit_stdin(['ls'] * num_jobs, self.cook_url,
                                      submit_flags=f'--name {name} --cpus 0.01 --mem 16')


### PR DESCRIPTION
## Changes proposed in this PR

- groups UUIDs into batches of at most 100 when querying
- modifies 2 integration tests (`show`, `wait`) to query for 200 jobs each

## Why are we making these changes?

We discovered a bug where querying for too many UUIDs in the same request was failing due to hitting the limit of the query string length. This change allows us to ask for as many UUIDs as needed, but in batches.