### PR TITLE
Job Client: adds support for configuring progress output and progress regex on a Job

### DIFF
--- a/executor/cook/progress.py
+++ b/executor/cook/progress.py
@@ -133,7 +133,7 @@ class ProgressWatcher(object):
         ----------
         progress_regex_string: string
             The progress regex to match against, it must return one or two capture groups.
-            The first capture group represent the progress percentage.
+            The first capture group represents the progress percentage.
             The second capture group, if present, represents the progress message.
         """
         self.target_file = output_name

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -98,6 +98,8 @@ final public class Job {
         // Use LinkedHashSet to ensure the insertion order will be kept.
         private Set<Constraint> _constraints = new LinkedHashSet<>();
         private Application _application;
+        private String _progressOutputFile;
+        private String _progressRegexString;
 
         /**
          * Prior to {@code build()}, command, memory and cpus for a job must be provided.<br>
@@ -136,7 +138,7 @@ final public class Job {
             }
             return new Job(_uuid, _name, _command, _executor, _memory, _cpus, _retries, _maxRuntime, _expectedRuntime, _status,
                     _priority, _isMeaCulpaRetriesDisabled, _instances, _env, _uris, _container, _labels, _constraints,
-                    _groups, _application);
+                    _groups, _application, _progressOutputFile, _progressRegexString);
         }
 
         /**
@@ -528,6 +530,28 @@ final public class Job {
             _application = application;
             return this;
         }
+
+        /**
+         * Set the progress output file of the job expected to build.
+         *
+         * @param progressOutputFile {@link String} specifies the progress output file for the job.
+         * @return this builder.
+         */
+        public Builder setProgressOutputFile(String progressOutputFile) {
+            _progressOutputFile = progressOutputFile;
+            return this;
+        }
+
+        /**
+         * Set the progress regex string of the job expected to build.
+         *
+         * @param progressRegexString {@link String} specifies the progress regex string for the job.
+         * @return this builder.
+         */
+        public Builder setProgressRegexString(String progressRegexString) {
+            _progressRegexString = progressRegexString;
+            return this;
+        }
     }
 
     final private UUID _uuid;
@@ -552,11 +576,14 @@ final public class Job {
     // the future, jobs will be allowed to belong to multiple groups.
     final private List<UUID> _groups;
     final private Application _application;
+    final private String _progressOutputFile;
+    final private String _progressRegexString;
 
     private Job(UUID uuid, String name, String command, Executor executor, Double memory, Double cpus, Integer retries,
                 Long maxRuntime, Long expectedRuntime, Status status, Integer priority, Boolean isMeaCulpaRetriesDisabled,
                 List<Instance> instances, Map<String, String> env, List<FetchableURI> uris, JSONObject container,
-                Map<String, String> labels, Set<Constraint> constraints, List<UUID> groups, Application application) {
+                Map<String, String> labels, Set<Constraint> constraints, List<UUID> groups, Application application,
+                String progressOutputFile, String progressRegexString) {
         _uuid = uuid;
         _name = name;
         _command = command;
@@ -573,6 +600,8 @@ final public class Job {
         _env = ImmutableMap.copyOf(env);
         _uris = ImmutableList.copyOf(uris);
         _application = application;
+        _progressOutputFile = progressOutputFile;
+        _progressRegexString = progressRegexString;
         // This take the string representation of the JSON object and then parses it again which is inefficient but
         // that is most convenient way to deep copy a JSONObject and make this Job instance immutable.
         if (container != null) {
@@ -734,6 +763,20 @@ final public class Job {
     }
 
     /**
+     * @return the progress output file configured for the job. It returns null if not configured.
+     */
+    public String getProgressOutputFile() {
+        return _progressOutputFile;
+    }
+
+    /**
+     * @return the progress regex string configured for the job. It returns null if not configured.
+     */
+    public String getProgressRegexString() {
+        return _progressRegexString;
+    }
+
+    /**
      * @return the job instance with the running state or {@code null} if can't find one.
      */
     public Instance getRunningInstance() {
@@ -817,6 +860,12 @@ final public class Job {
         }
         if (job._application != null) {
             object.put("application", Application.jsonizeApplication(job._application));
+        }
+        if (job._progressOutputFile != null) {
+            object.put("progress_output_file", job._progressOutputFile);
+        }
+        if (job._progressRegexString != null) {
+            object.put("progress_regex_string", job._progressRegexString);
         }
         if (job._expectedRuntime != null) {
             object.put("expected_runtime", job._expectedRuntime);
@@ -973,6 +1022,12 @@ final public class Job {
             if (json.has("expected_runtime")) {
                 jobBuilder.setExpectedRuntime(json.getLong("expected_runtime"));
             }
+            if (json.has("progress_output_file")) {
+                jobBuilder.setProgressOutputFile(json.getString("progress_output_file"));
+            }
+            if (json.has("progress_regex_string")) {
+                jobBuilder.setProgressRegexString(json.getString("progress_regex_string"));
+            }
             jobs.add(jobBuilder.build());
         }
         return jobs;
@@ -995,9 +1050,10 @@ final public class Job {
         StringBuilder stringBuilder = new StringBuilder(512);
         stringBuilder
                 .append("Job [_uuid=" + _uuid + ", _name=" + _name + ", _command=" + _command + ", _executor=" + _executor
-                        + ", _memory=" + _memory + ", _cpus=" + _cpus + ", _retries=" + _retries
-                        + ", _maxRuntime=" + _maxRuntime + ", _status=" + _status + ", _priority=" + _priority
-                        + ", _isMeaCulpaRetriesDisabled" + _isMeaCulpaRetriesDisabled + "]");
+                    + ", _memory=" + _memory + ", _cpus=" + _cpus + ", _retries=" + _retries
+                    + ", _maxRuntime=" + _maxRuntime + ", _status=" + _status + ", _priority=" + _priority
+                    + ", _progressOutputFile=" + _progressOutputFile + ", _progressRegexString=" + _progressRegexString
+                    + ", _isMeaCulpaRetriesDisabled" + _isMeaCulpaRetriesDisabled + "]");
         stringBuilder.append('\n');
         for (Instance instance : getInstances()) {
             stringBuilder.append(instance.toString()).append('\n');

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -533,6 +533,7 @@ final public class Job {
 
         /**
          * Set the progress output file of the job expected to build.
+         * It can be an absolute path or a path relative to the sandbox directory.
          *
          * @param progressOutputFile {@link String} specifies the progress output file for the job.
          * @return this builder.
@@ -544,6 +545,9 @@ final public class Job {
 
         /**
          * Set the progress regex string of the job expected to build.
+         * The progress regex to match against, it must return one or two capture groups.
+         * The first capture group represents the progress percentage.
+         * The second capture group, if present, represents the progress message.
          *
          * @param progressRegexString {@link String} specifies the progress regex string for the job.
          * @return this builder.
@@ -763,6 +767,9 @@ final public class Job {
     }
 
     /**
+     * The progress output file configured for the job.
+     * It is either an absolute path or a path relative to the sandbox directory.
+     *
      * @return the progress output file configured for the job. It returns null if not configured.
      */
     public String getProgressOutputFile() {
@@ -770,6 +777,10 @@ final public class Job {
     }
 
     /**
+     * The progress regex to match against, it must return one or two capture groups.
+     * The first capture group represents the progress percentage.
+     * The second capture group, if present, represents the progress message.
+     *
      * @return the progress regex string configured for the job. It returns null if not configured.
      */
     public String getProgressRegexString() {

--- a/jobclient/src/test/java/com/twosigma/cook/jobclient/JobTest.java
+++ b/jobclient/src/test/java/com/twosigma/cook/jobclient/JobTest.java
@@ -16,16 +16,20 @@
 
 package com.twosigma.cook.jobclient;
 
-import java.util.*;
-
-import com.twosigma.cook.jobclient.constraint.Constraints;
 import com.twosigma.cook.jobclient.constraint.Constraint;
+import com.twosigma.cook.jobclient.constraint.Constraints;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Unit tests for {@link Job}.
@@ -34,19 +38,19 @@ import org.junit.Test;
  */
 public class JobTest {
 
-    // A job which could be used for any test.
-    private Job _initializedJob;
-
-    // Constraints will be applied to the job.
+    // Constraints which could be used for any test.
     private Constraint _constraint1;
     private Constraint _constraint2;
 
     @Before
     public void setup() {
-        final Job.Builder jobBuilder = new Job.Builder();
+        _constraint1 = Constraints.buildEqualsConstraint("bar1", "foo1");
+        _constraint2 = Constraints.buildEqualsConstraint("bar2", "foo2");
+    }
+
+    private void populateBuilder(Job.Builder jobBuilder) {
         jobBuilder.setUUID(UUID.randomUUID());
         jobBuilder.setCommand("sleep 10s");
-        jobBuilder.setExecutor("cook");
         jobBuilder.setMemory(100.0);
         jobBuilder.setCpus(1.0);
         jobBuilder.addEnv("FOO", "test");
@@ -56,21 +60,32 @@ public class JobTest {
         jobBuilder.addUri(new FetchableURI.Builder().setValue("http://example.com/my_resource").build());
         jobBuilder.setApplication(new Application("baz-app", "1.2.3"));
         jobBuilder.setExpectedRuntime(500L);
-        _constraint1 = Constraints.buildEqualsConstraint("bar1", "foo1");
-        _constraint2 = Constraints.buildEqualsConstraint("bar2", "foo2");
         jobBuilder.addConstraint(_constraint1);
         jobBuilder.addConstraint(Collections.singletonList(_constraint2));
-        _initializedJob = jobBuilder.build();
+    }
+
+    private JSONObject convertJobToJsonObject(Job basicJob) {
+        final JSONObject json = Job.jsonizeJob(basicJob);
+        if (!json.has("instances")) {
+            json.put("instances", new JSONArray());
+        }
+        if (!json.has("status")) {
+            json.put("status", "INITIALIZED");
+        }
+        return json;
     }
 
     @Test
-    public void testJsonizeJob() throws JSONException {
-        final JSONObject jsonJob = Job.jsonizeJob(_initializedJob);
-        Assert.assertEquals(jsonJob.getString("uuid"), _initializedJob.getUUID().toString());
-        Assert.assertEquals(jsonJob.getString("executor"), _initializedJob.getExecutor().displayName());
+    public void testJsonizeJobBasic() throws JSONException {
+        final Job.Builder jobBuilder = new Job.Builder();
+        populateBuilder(jobBuilder);
+        final Job basicJob = jobBuilder.build();
+
+        final JSONObject jsonJob = Job.jsonizeJob(basicJob);
+        Assert.assertEquals(jsonJob.getString("uuid"), basicJob.getUUID().toString());
         Assert.assertEquals(
-                jsonJob.getJSONObject("application").toString(),
-                new JSONObject().put("name", "baz-app").put("version", "1.2.3").toString());
+            jsonJob.getJSONObject("application").toString(),
+            new JSONObject().put("name", "baz-app").put("version", "1.2.3").toString());
         Assert.assertEquals(500L, jsonJob.getLong("expected_runtime"));
         Assert.assertEquals(true, jsonJob.getBoolean("disable_mea_culpa_retries"));
         JSONArray constraints = jsonJob.getJSONArray("constraints");
@@ -80,16 +95,18 @@ public class JobTest {
     }
 
     @Test
-    public void testParseFromJSON() throws JSONException {
-        final JSONObject json = Job.jsonizeJob(_initializedJob);
-        json.put("instances", new JSONArray());
-        json.put("status", "INITIALIZED");
+    public void testParseFromJsonBasic() throws JSONException {
+        final Job.Builder jobBuilder = new Job.Builder();
+        populateBuilder(jobBuilder);
+        final Job basicJob = jobBuilder.build();
+
+        final JSONObject json = convertJobToJsonObject(basicJob);
         final String jsonString = new JSONArray().put(json).toString();
         final List<Job> jobs = Job.parseFromJSON(jsonString);
         Assert.assertEquals(jobs.size(), 1);
         final Job job = jobs.get(0);
-        Assert.assertEquals(_initializedJob, job);
-        Assert.assertEquals(_initializedJob.getExecutor(), job.getExecutor());
+        Assert.assertEquals(basicJob, job);
+        Assert.assertEquals(basicJob.getExecutor(), job.getExecutor());
         Assert.assertEquals(job.getMaxRuntime(), new Long(1000L));
         Assert.assertEquals(job.getApplication().getName(), "baz-app");
         Assert.assertEquals(job.getApplication().getVersion(), "1.2.3");
@@ -102,5 +119,101 @@ public class JobTest {
         Assert.assertEquals(constraint, _constraint1);
         constraint = iter.next();
         Assert.assertEquals(constraint, _constraint2);
+    }
+
+    @Test
+    public void testJsonizeJobExecutor() throws JSONException {
+        for (Executor executor : Executor.values()) {
+            final Job.Builder jobBuilder = new Job.Builder();
+            populateBuilder(jobBuilder);
+            jobBuilder.setExecutor(executor.displayName());
+
+            final Job basicJob = jobBuilder.build();
+            final JSONObject jsonJob = Job.jsonizeJob(basicJob);
+
+            Assert.assertEquals(executor.displayName(), basicJob.getExecutor().displayName());
+            Assert.assertEquals(executor.displayName(), jsonJob.getString("executor"));
+        }
+    }
+
+    @Test
+    public void testParseFromJsonExecutor() throws JSONException {
+        for (Executor executor : Executor.values()) {
+            final Job.Builder jobBuilder = new Job.Builder();
+            populateBuilder(jobBuilder);
+            jobBuilder.setExecutor(executor.displayName());
+
+            final JSONObject json = convertJobToJsonObject(jobBuilder.build());
+            final String jsonString = new JSONArray().put(json).toString();
+            final List<Job> jobs = Job.parseFromJSON(jsonString);
+            Assert.assertEquals(jobs.size(), 1);
+            final Job actualJob = jobs.get(0);
+
+            Assert.assertEquals(executor, actualJob.getExecutor());
+        }
+    }
+
+    @Test
+    public void testJsonizeJobProgressOutputFile() throws JSONException {
+        final String progressOutputFile = "/path/to/progress/output";
+
+        final Job.Builder jobBuilder = new Job.Builder();
+        populateBuilder(jobBuilder);
+        jobBuilder.setProgressOutputFile(progressOutputFile);
+
+        final Job basicJob = jobBuilder.build();
+        final JSONObject jsonJob = Job.jsonizeJob(basicJob);
+
+        Assert.assertEquals(progressOutputFile, basicJob.getProgressOutputFile());
+        Assert.assertEquals(progressOutputFile, jsonJob.getString("progress_output_file"));
+    }
+
+    @Test
+    public void testParseFromJsonProgressOutputFile() throws JSONException {
+        final String progressOutputFile = "/path/to/progress/output";
+
+        final Job.Builder jobBuilder = new Job.Builder();
+        populateBuilder(jobBuilder);
+        jobBuilder.setProgressOutputFile(progressOutputFile);
+
+        final JSONObject json = convertJobToJsonObject(jobBuilder.build());
+        final String jsonString = new JSONArray().put(json).toString();
+        final List<Job> jobs = Job.parseFromJSON(jsonString);
+        Assert.assertEquals(jobs.size(), 1);
+        final Job actualJob = jobs.get(0);
+
+        Assert.assertEquals(progressOutputFile, actualJob.getProgressOutputFile());
+    }
+
+    @Test
+    public void testJsonizeJobProgressRegexString() throws JSONException {
+        final String progressOutputFile = "/path/to/progress/output";
+
+        final Job.Builder jobBuilder = new Job.Builder();
+        populateBuilder(jobBuilder);
+        jobBuilder.setProgressRegexString(progressOutputFile);
+
+        final Job basicJob = jobBuilder.build();
+        final JSONObject jsonJob = Job.jsonizeJob(basicJob);
+
+        Assert.assertEquals(progressOutputFile, basicJob.getProgressRegexString());
+        Assert.assertEquals(progressOutputFile, jsonJob.getString("progress_regex_string"));
+    }
+
+    @Test
+    public void testParseFromJsonProgressRegexString() throws JSONException {
+        final String progressOutputFile = "SomeProgressRegex";
+
+        final Job.Builder jobBuilder = new Job.Builder();
+        populateBuilder(jobBuilder);
+        jobBuilder.setProgressRegexString(progressOutputFile);
+
+        final JSONObject json = convertJobToJsonObject(jobBuilder.build());
+        final String jsonString = new JSONArray().put(json).toString();
+        final List<Job> jobs = Job.parseFromJSON(jsonString);
+        Assert.assertEquals(jobs.size(), 1);
+        final Job actualJob = jobs.get(0);
+
+        Assert.assertEquals(progressOutputFile, actualJob.getProgressRegexString());
     }
 }


### PR DESCRIPTION

## Changes proposed in this PR

- adds support for configuring progress output and progress regex on a Job

## Why are we making these changes?

Allow users of the `JobClient` to set the progress output file and regex String on a per Job basis.
