### PR TITLE
Batches kill requests from cs

### DIFF
--- a/cli/cook/subcommands/kill.py
+++ b/cli/cook/subcommands/kill.py
@@ -87,9 +87,6 @@ def kill_entities(query_result, clusters):
 
     def __kill(cluster, uuids, kill_fn):
         if len(uuids) > 0:
-            # success = kill_fn(cluster, uuids)
-            # if not success:
-            #     failed.extend(uuids)
             for uuid_batch in partition(uuids, kill_batch_size):
                 success = kill_fn(cluster, uuid_batch)
                 (succeeded if success else failed).extend(uuid_batch)

--- a/cli/cook/subcommands/kill.py
+++ b/cli/cook/subcommands/kill.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from cook import http, colors
 from cook.querying import print_no_data, parse_entity_refs, query_with_stdin_support
-from cook.util import print_info, guard_no_cluster
+from cook.util import print_info, guard_no_cluster, partition
 
 
 def guard_against_duplicates(query_result):
@@ -48,51 +48,65 @@ def guard_against_duplicates(query_result):
         raise Exception(message)
 
 
+def __kill_entities(cluster, uuids, endpoint, param, entity_type):
+    """Attempts to kill the jobs / instances / groups with the given UUIDs on the given cluster"""
+    success_status_code = 204
+    cluster_name = cluster['name']
+    resp = http.delete(cluster, endpoint, params={param: uuids})
+    if resp.status_code == success_status_code:
+        for uuid in uuids:
+            print_info(f'Killed {entity_type} {colors.bold(uuid)} on {colors.bold(cluster_name)}.')
+        return True
+    else:
+        for uuid in uuids:
+            print(colors.failed(f'Failed to kill {entity_type} {uuid} on {cluster_name}.'))
+        return False
+
+
+def kill_jobs(cluster, uuids):
+    """Attempts to kill the jobs with the given UUIDs"""
+    return __kill_entities(cluster, uuids, 'rawscheduler', 'job', 'job')
+
+
+def kill_instances(cluster, uuids):
+    """Attempts to kill the job instsances with the given UUIDs"""
+    return __kill_entities(cluster, uuids, 'rawscheduler', 'instance', 'job instance')
+
+
+def kill_groups(cluster, uuids):
+    """Attempts to kill the job groups with the given UUIDs"""
+    return __kill_entities(cluster, uuids, 'group', 'uuid', 'job group')
+
+
 def kill_entities(query_result, clusters):
     """Attempts to kill the jobs / instances / groups with the given UUIDs"""
-    num_failures = 0
-    success_status_code = 204
+    kill_batch_size = 100
+    failed = []
+    succeeded = []
     clusters_by_name = {c['name']: c for c in clusters}
+
+    def __kill(cluster, uuids, kill_fn):
+        if len(uuids) > 0:
+            # success = kill_fn(cluster, uuids)
+            # if not success:
+            #     failed.extend(uuids)
+            for uuid_batch in partition(uuids, kill_batch_size):
+                success = kill_fn(cluster, uuid_batch)
+                (succeeded if success else failed).extend(uuid_batch)
+
     for cluster_name, entities in query_result['clusters'].items():
         cluster = clusters_by_name[cluster_name]
-
         job_uuids = [j['uuid'] for j in entities['jobs']] if 'jobs' in entities else []
         instance_uuids = [i['task_id'] for i, _ in entities['instances']] if 'instances' in entities else []
-        num_jobs = len(job_uuids)
-        num_instances = len(instance_uuids)
-        if num_jobs > 0 or num_instances > 0:
-            resp = http.delete(cluster, 'rawscheduler', params={'job': job_uuids, 'instance': instance_uuids})
-            if resp.status_code == success_status_code:
-                for job_uuid in job_uuids:
-                    print_info(f'Killed job {colors.bold(job_uuid)} on {colors.bold(cluster_name)}.')
-                for instance_uuid in instance_uuids:
-                    print_info(f'Killed job instance {colors.bold(instance_uuid)} on {colors.bold(cluster_name)}.')
-            else:
-                num_failures += (num_jobs + num_instances)
-                for job_uuid in job_uuids:
-                    print(colors.failed(f'Failed to kill job {job_uuid} on {cluster_name}.'))
-                for instance_uuid in instance_uuids:
-                    print(colors.failed(f'Failed to kill job instance {instance_uuid} on {cluster_name}.'))
+        group_uuids = [g['uuid'] for g in entities['groups']] if 'groups' in entities else []
+        __kill(cluster, job_uuids, kill_jobs)
+        __kill(cluster, instance_uuids, kill_instances)
+        __kill(cluster, group_uuids, kill_groups)
 
-        if 'groups' in entities:
-            group_uuids = [g['uuid'] for g in entities['groups']]
-            num_groups = len(group_uuids)
-            if num_groups > 0:
-                resp = http.delete(cluster, 'group', params={'uuid': group_uuids})
-                if resp.status_code == success_status_code:
-                    for group_uuid in group_uuids:
-                        print_info(f'Killed job group {colors.bold(group_uuid)} on {colors.bold(cluster_name)}.')
-                else:
-                    num_failures += num_groups
-                    for group_uuid in group_uuids:
-                        print(colors.failed(f'Failed to kill job group {group_uuid} on {cluster_name}.'))
-
-    if num_failures > 1:
-        print_info(f'There were {colors.failed(str(num_failures))} kill failures.')
-    elif num_failures == 1:
-        print_info(f'There was {colors.failed("1")} kill failure.')
-
-    return num_failures
+    num_succeeded = len(succeeded)
+    num_failed = len(failed)
+    print_info(f'Successful: {num_succeeded}, Failed: {num_failed}')
+    return num_failed
 
 
 def kill(clusters, args, _):

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.3.0'
+VERSION = '1.3.1'

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1434,7 +1434,7 @@ class CookCliTest(unittest.TestCase):
 
         # List the jobs
         user = util.get_user(self.cook_url, uuids[0])
-        jobs_flags = f'--user {user} --name {name} --running --waiting --limit {num_jobs}'
+        jobs_flags = f'--user {user} --name {name} --all --limit {num_jobs}'
         cp, jobs = cli.jobs_json(self.cook_url, jobs_flags)
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(num_jobs, len(jobs))
@@ -1447,9 +1447,6 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(0, cp.returncode, cp.stderr)
 
         # All jobs should now be failed
-        cp, jobs = cli.jobs_json(self.cook_url, jobs_flags)
-        self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(0, len(jobs))
         cp, jobs = cli.jobs_json(self.cook_url, f'--user {user} --name {name} --failed --limit {num_jobs}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(num_jobs, len(jobs))


### PR DESCRIPTION
## Changes proposed in this PR

- batches kill requests coming from `cs` to avoid hitting the query string length limit

## Why are we making these changes?

Now that you can pipe from `cs jobs` to `cs kill`, it's possible that users will want to, for example, kill 1000 running jobs with something like:

```bash
$ cs jobs --all --user root --name test01 --limit 1000 -1 | cs kill
```

If we don't batch the kill requests, we end up constructing a query string that is too long.