### PR TITLE
CS: Revert "disable triggering syncing agent sandbox entries into datomic

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -51,15 +51,15 @@ class CookTest(unittest.TestCase):
         self.assertEqual(False, job['disable_mea_culpa_retries'])
         self.assertTrue(len(util.wait_for_output_url(self.cook_url, job_uuid)['output_url']) > 0)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
     def test_no_cook_executor_on_subsequent_instances(self):
         job_uuid, resp = util.submit_job(self.cook_url, command='exit 1',
@@ -141,15 +141,15 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('failed', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(1, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
     def test_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)
@@ -166,17 +166,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -199,17 +199,17 @@ class CookTest(unittest.TestCase):
         self.assertEqual('success', job['instances'][0]['status'], message)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -233,17 +233,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -265,17 +265,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
+        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        message = json.dumps(job['instances'][0], sort_keys=True)
+        self.assertIsNotNone(job['instances'][0]['output_url'], message)
+        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
         if job_executor_type == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
 
             job = util.load_job(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
@@ -326,16 +326,16 @@ class CookTest(unittest.TestCase):
             self.assertGreater(actual_running_time_ms, max_runtime_ms, job_details)
             self.assertGreater(job_sleep_ms, actual_running_time_ms, job_details)
 
+            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+            message = json.dumps(job['instances'][0], sort_keys=True)
+            self.assertIsNotNone(job['instances'][0]['output_url'], message)
+            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+
             # verify additional fields set when the cook executor is used
             if job_executor_type == 'cook':
                 job = util.wait_for_exit_code(self.cook_url, job_uuid)
                 message = json.dumps(job['instances'][0], sort_keys=True)
                 self.assertNotEqual(0, job['instances'][0]['exit_code'], message)
-
-                job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-                message = json.dumps(job['instances'][0], sort_keys=True)
-                self.assertIsNotNone(job['instances'][0]['output_url'], message)
-                self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid])
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -624,7 +624,8 @@ def wait_for_sandbox_directory(cook_url, job_id):
 
     cook_settings = settings(cook_url)
     cache_ttl_ms = cook_settings['agent-query-cache']['ttl-ms']
-    max_wait_ms = min(4 * cache_ttl_ms, 4 * 60 * 1000)
+    sync_interval_ms = cook_settings['sandbox-syncer']['sync-interval-ms']
+    max_wait_ms = min(4 * max(cache_ttl_ms, sync_interval_ms), 4 * 60 * 1000)
 
     def query():
         response = query_jobs(cook_url, True, uuid=[job_id])

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -34,6 +34,7 @@
             :environment {"EXECUTOR_DEFAULT_PROGRESS_OUTPUT_NAME" "stdout"}
             :portion #config/env-int-default ["COOK_EXECUTOR_PORTION" 0]}
  :agent-query-cache {:ttl-ms 1000}
+ :sandbox-syncer {:sync-interval-ms 1000}
  :unhandled-exceptions {:log-level :error}
  :metrics {:jmx true}
  :nrepl {:enabled? false}

--- a/scheduler/container-config.edn
+++ b/scheduler/container-config.edn
@@ -22,6 +22,7 @@
                                 :retry-limit 15
                                 :cpus 6}}
  :agent-query-cache {:ttl-ms 1000}
+ :sandbox-syncer {:sync-interval-ms 1000}
  :rate-limit {:user-limit-per-m 1000000}
  :rebalancer {:dru-scale 1}
  :mesos {:master #config/env "MESOS_MASTER"

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -89,11 +89,16 @@ If need it to bind to another port, you can specify that with the `:local-port` 
 `:sandbox-syncer`::
   The Cook scheduler throttles the rate at which it publishes task sandbox directories.
   This allows us to handle high rate of incoming progress messages in a graceful manner.
-  `sandbox-syncer` is a map with two possible keys, `publish-batch-size` and `publish-interval-ms`.
+  `sandbox-syncer` is a map with the following possible keys: `max-consecutive-sync-failure`, `publish-batch-size`, `publish-interval-ms` and `sync-interval-ms`.
+  The `max-consecutive-sync-failure` represents the maximum number of failures before sandbox sync is not retried on that agent.
+  The default value is  15.
   The `publish-batch-size` is an integer representing the number of facts that are updated in individual datomic instance sandbox directory update transactions.
   The default value is 100.
   The `publish-interval-ms` is an integer representing the number of millisecond intervals at which sandbox directories updates will be published to datomic.
   The default value is 2500.
+  The `sync-interval-ms` represents the intervals at which the sandbox syncer triggers state lookup on pending mesos agents.
+  This value should ideally be lower than the agent-query-cache ttl-ms.
+  The default value is 15000, i.e. 15 seconds.
 
 
 [[mesos_config]]

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -86,14 +86,15 @@ If need it to bind to another port, you can specify that with the `:local-port` 
   `max-size` is the maximum number of elements in the cache before the LRU eviction semantics apply. The default is 1000.
   `ttl-ms` is the default time in milliseconds that entries are allowed to reside in the cache. The default is 60000, i.e. 1 minute.
 
-`:sandbox-publisher`::
+`:sandbox-syncer`::
   The Cook scheduler throttles the rate at which it publishes task sandbox directories.
   This allows us to handle high rate of incoming progress messages in a graceful manner.
-  `sandbox-publisher` is a map with the following possible keys: `publish-batch-size` and `publish-interval-ms`.
+  `sandbox-syncer` is a map with two possible keys, `publish-batch-size` and `publish-interval-ms`.
   The `publish-batch-size` is an integer representing the number of facts that are updated in individual datomic instance sandbox directory update transactions.
   The default value is 100.
   The `publish-interval-ms` is an integer representing the number of millisecond intervals at which sandbox directories updates will be published to datomic.
   The default value is 2500.
+
 
 [[mesos_config]]
 ==== Mesos Configuration

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -292,11 +292,12 @@
                                     (cache/lru-cache-factory :threshold max-size)
                                     (cache/ttl-cache-factory :ttl ttl-ms)
                                     atom))
-     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure publish-batch-size publish-interval-ms sync-interval-ms]]
+     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure publish-batch-size
+                                             publish-interval-ms sync-interval-ms]]
                                  framework-id mesos-agent-query-cache mesos-datomic]
-                             (let [prepare-sandbox-publisher (lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)]
-                               (prepare-sandbox-publisher framework-id mesos-datomic publish-batch-size publish-interval-ms
-                                                          sync-interval-ms max-consecutive-sync-failure mesos-agent-query-cache)))
+                             ((lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)
+                               framework-id mesos-datomic publish-batch-size publish-interval-ms sync-interval-ms
+                               max-consecutive-sync-failure mesos-agent-query-cache))
      :mesos-leadership-atom (fnk [] (atom false))
      :mesos-pending-jobs-atom (fnk [] (atom {}))
      :mesos-offer-cache (fnk [[:settings [:offer-cache max-size ttl-ms]]]
@@ -354,11 +355,6 @@
                             {:max-size 5000
                              :ttl-ms (* 60 1000)}
                             agent-query-cache))
-     :sandbox-publisher (fnk [[:config {sandbox-publisher nil}]]
-                          (merge
-                            {:publish-batch-size 100
-                             :publish-interval-ms 2500}
-                            sandbox-publisher))
      :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
                        (merge
                          {:max-consecutive-sync-failure 15

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -193,7 +193,7 @@
   [{:keys [curator-framework executor-config fenzo-config framework-id get-mesos-utilization gpu-enabled? make-mesos-driver-fn
            mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom mesos-pending-jobs-atom
            offer-cache offer-incubate-time-ms progress-config rebalancer-config riemann-host riemann-port
-           sandbox-publisher-state server-config task-constraints trigger-chans zk-prefix]}]
+           sandbox-syncer-state server-config task-constraints trigger-chans zk-prefix]}]
   (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
                 fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness]} fenzo-config
         {:keys [cancelled-task-trigger-chan lingering-task-trigger-chan rebalancer-trigger-chan
@@ -232,7 +232,7 @@
                                           gpu-enabled?
                                           good-enough-fitness
                                           framework-id
-                                          sandbox-publisher-state
+                                          sandbox-syncer-state
                                           executor-config
                                           progress-config
                                           trigger-chans)

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -189,7 +189,8 @@
    rebalancer-config        -- map, config for rebalancer. See scheduler/docs/rebalancer-config.adoc for details
    progress-config          -- map, config for progress publishing. See scheduler/docs/configuration.adoc for more details
    framework-id             -- str, the Mesos framework id from the cook settings
-   fenzo-config             -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details"
+   fenzo-config             -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details
+   sandbox-syncer-state     -- map, representing the sandbox syncer object"
   [{:keys [curator-framework executor-config fenzo-config framework-id get-mesos-utilization gpu-enabled? make-mesos-driver-fn
            mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom mesos-pending-jobs-atom
            offer-cache offer-incubate-time-ms progress-config rebalancer-config riemann-host riemann-port

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -173,7 +173,7 @@
 
 (defn handle-status-update
   "Takes a status update from mesos."
-  [conn driver ^TaskScheduler fenzo status]
+  [conn driver ^TaskScheduler fenzo sync-agent-sandboxes-fn status]
   (log/info "Mesos status is:" status)
   (timers/time!
     handle-status-update-duration
@@ -249,6 +249,8 @@
              (meters/mark! tasks-killed-in-status-update)
              (mesos/kill-task! driver {:value task-id}))
            (when-not (nil? instance)
+             (when (#{:task-starting :task-running} task-state)
+               (sync-agent-sandboxes-fn (:instance/hostname instance-ent)))
              ;; (println "update:" task-id task-state job instance instance-status prior-job-state)
              (log/debug "Transacting updated state for instance" instance "to status" instance-status)
              ;; The database can become inconsistent if we make multiple calls to :instance/update-state in a single
@@ -1490,81 +1492,82 @@
 (defn create-mesos-scheduler
   "Creates the mesos scheduler which processes status updates asynchronously but in order of receipt."
   [configured-framework-id gpu-enabled? conn heartbeat-ch fenzo offers-chan match-trigger-chan handle-progress-message
-   sandbox-publisher-state]
-  (mesos/scheduler
-    (registered
-      [this driver framework-id master-info]
-      (log/info "Registered with mesos with framework-id " framework-id)
-      (let [value (-> framework-id mesomatic.types/pb->data :value)]
-        (when (not= configured-framework-id value)
-          (let [message (str "The framework-id provided by Mesos (" value ") "
-                             "does not match the one Cook is configured with (" configured-framework-id ")")]
-            (log/error message)
-            (throw (ex-info message {:framework-id-mesos value :framework-id-cook configured-framework-id})))))
-      (when (and gpu-enabled? (not (re-matches #"1\.\d+\.\d+" (:version master-info))))
-        (binding [*out* *err*]
-          (println "Cannot enable GPU support on pre-mesos 1.0. The version we found was " (:version master-info)))
-        (log/error "Cannot enable GPU support on pre-mesos 1.0. The version we found was " (:version master-info))
-        (Thread/sleep 1000)
-        (System/exit 1))
-      ;; Use future because the thread that runs mesos/scheduler doesn't load classes correctly. for reasons.
-      ;; As Sophie says, you want to future proof your code.
-      (future
+   sandbox-syncer-state]
+  (let [sync-agent-sandboxes-fn #(sandbox/sync-agent-sandboxes sandbox-syncer-state configured-framework-id %)]
+    (mesos/scheduler
+      (registered
+        [this driver framework-id master-info]
+        (log/info "Registered with mesos with framework-id " framework-id)
+        (let [value (-> framework-id mesomatic.types/pb->data :value)]
+          (when (not= configured-framework-id value)
+            (let [message (str "The framework-id provided by Mesos (" value ") "
+                               "does not match the one Cook is configured with (" configured-framework-id ")")]
+              (log/error message)
+              (throw (ex-info message {:framework-id-mesos value :framework-id-cook configured-framework-id})))))
+        (when (and gpu-enabled? (not (re-matches #"1\.\d+\.\d+" (:version master-info))))
+          (binding [*out* *err*]
+            (println "Cannot enable GPU support on pre-mesos 1.0. The version we found was " (:version master-info)))
+          (log/error "Cannot enable GPU support on pre-mesos 1.0. The version we found was " (:version master-info))
+          (Thread/sleep 1000)
+          (System/exit 1))
+        ;; Use future because the thread that runs mesos/scheduler doesn't load classes correctly. for reasons.
+        ;; As Sophie says, you want to future proof your code.
+        (future
+          (try
+            (reconcile-jobs conn)
+            (reconcile-tasks (db conn) driver configured-framework-id fenzo)
+            (catch Exception e
+              (log/error e "Reconciliation error")))))
+      (reregistered
+        [this driver master-info]
+        (log/info "Reregistered with new master")
+        (future
+          (try
+            (reconcile-jobs conn)
+            (reconcile-tasks (db conn) driver configured-framework-id fenzo)
+            (catch Exception e
+              (log/error e "Reconciliation error")))))
+      ;; Ignore this--we can just wait for new offers
+      (offer-rescinded
+        [this driver offer-id]
+        (comment "TODO: Rescind the offer in fenzo"))
+      (framework-message
+        [this driver executor-id slave-id message]
+        (meters/mark! handle-framework-message-rate)
         (try
-          (reconcile-jobs conn)
-          (reconcile-tasks (db conn) driver configured-framework-id fenzo)
+          (let [{:strs [task-id type] :as parsed-message} (json/read-str (String. ^bytes message "UTF-8"))]
+            (case type
+              "directory" (sandbox/update-sandbox sandbox-syncer-state parsed-message)
+              "heartbeat" (heartbeat/notify-heartbeat heartbeat-ch executor-id slave-id parsed-message)
+              (async-in-order-processing
+                task-id #(handle-framework-message conn handle-progress-message parsed-message))))
           (catch Exception e
-            (log/error e "Reconciliation error")))))
-    (reregistered
-      [this driver master-info]
-      (log/info "Reregistered with new master")
-      (future
-        (try
-          (reconcile-jobs conn)
-          (reconcile-tasks (db conn) driver configured-framework-id fenzo)
-          (catch Exception e
-            (log/error e "Reconciliation error")))))
-    ;; Ignore this--we can just wait for new offers
-    (offer-rescinded
-      [this driver offer-id]
-      (comment "TODO: Rescind the offer in fenzo"))
-    (framework-message
-      [this driver executor-id slave-id message]
-      (meters/mark! handle-framework-message-rate)
-      (try
-        (let [{:strs [task-id type] :as parsed-message} (json/read-str (String. ^bytes message "UTF-8"))]
-          (case type
-            "directory" (sandbox/update-sandbox sandbox-publisher-state parsed-message)
-            "heartbeat" (heartbeat/notify-heartbeat heartbeat-ch executor-id slave-id parsed-message)
-            (async-in-order-processing
-              task-id #(handle-framework-message conn handle-progress-message parsed-message))))
-        (catch Exception e
-          (log/error e "Unable to process framework message"
-                     {:executor-id executor-id, :message message, :slave-id slave-id}))))
-    (disconnected
-      [this driver]
-      (log/error "Disconnected from the previous master"))
-    ;; We don't care about losing slaves or executors--only tasks
-    (slave-lost [this driver slave-id])
-    (executor-lost [this driver executor-id slave-id status])
-    (error
-      [this driver message]
-      (meters/mark! mesos-error)
-      (log/error "Got a mesos error!!!!" message))
-    (resource-offers
-      [this driver offers]
-      (receive-offers offers-chan match-trigger-chan driver offers))
-    (status-update
-      [this driver status]
-      (meters/mark! handle-status-update-rate)
-      (let [task-id (-> status :task-id :value)]
-        (async-in-order-processing
-          task-id #(handle-status-update conn driver fenzo status))))))
+            (log/error e "Unable to process framework message"
+                       {:executor-id executor-id, :message message, :slave-id slave-id}))))
+      (disconnected
+        [this driver]
+        (log/error "Disconnected from the previous master"))
+      ;; We don't care about losing slaves or executors--only tasks
+      (slave-lost [this driver slave-id])
+      (executor-lost [this driver executor-id slave-id status])
+      (error
+        [this driver message]
+        (meters/mark! mesos-error)
+        (log/error "Got a mesos error!!!!" message))
+      (resource-offers
+        [this driver offers]
+        (receive-offers offers-chan match-trigger-chan driver offers))
+      (status-update
+        [this driver status]
+        (meters/mark! handle-status-update-rate)
+        (let [task-id (-> status :task-id :value)]
+          (async-in-order-processing
+            task-id #(handle-status-update conn driver fenzo sync-agent-sandboxes-fn status)))))))
 
 (defn create-datomic-scheduler
   [conn driver-atom pending-jobs-atom offer-cache heartbeat-ch offer-incubate-time-ms mea-culpa-failure-limit
    fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset
-   fenzo-fitness-calculator task-constraints gpu-enabled? good-enough-fitness framework-id sandbox-publisher-state
+   fenzo-fitness-calculator task-constraints gpu-enabled? good-enough-fitness framework-id sandbox-syncer-state
    executor-config progress-config trigger-chans]
 
   (persist-mea-culpa-failure-limit! conn mea-culpa-failure-limit)
@@ -1581,5 +1584,5 @@
                                   (handle-progress-message! progress-aggregator-chan progress-message-map))]
     (start-jobs-prioritizer! conn pending-jobs-atom task-constraints rank-trigger-chan)
     {:scheduler (create-mesos-scheduler framework-id gpu-enabled? conn heartbeat-ch fenzo offers-chan
-                                        match-trigger-chan handle-progress-message sandbox-publisher-state)
+                                        match-trigger-chan handle-progress-message sandbox-syncer-state)
      :view-incubating-offers (fn get-resources-atom [] @resources-atom)}))

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -249,7 +249,9 @@
              (meters/mark! tasks-killed-in-status-update)
              (mesos/kill-task! driver {:value task-id}))
            (when-not (nil? instance)
-             (when (#{:task-starting :task-running} task-state)
+             (when (and (#{:task-starting :task-running} task-state)
+                        (not= :executor/cook (:instance/executor instance-ent)))
+               ;; cook executor tasks should automatically get sandbox directory updates
                (sync-agent-sandboxes-fn (:instance/hostname instance-ent)))
              ;; (println "update:" task-id task-state job instance instance-status prior-job-state)
              (log/debug "Transacting updated state for instance" instance "to status" instance-status)

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1239,7 +1239,8 @@
           (is (= {::api/results (str "submitted jobs " uuid)}
                  (api/create-jobs! conn {::api/jobs [job]})))
           (is (= (expected-job-map job framework-id)
-                 (dissoc (api/fetch-job-map (db conn) framework-id uuid) :submit_time)))))
+                 (-> (api/fetch-job-map (db conn) framework-id uuid)
+                     (dissoc :submit_time))))))
 
       (testing "should work when the job specifies disable-mea-culpa-retries"
         (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1248,7 +1249,8 @@
           (is (= {::api/results (str "submitted jobs " uuid)}
                  (api/create-jobs! conn {::api/jobs [job]})))
           (is (= (expected-job-map job framework-id)
-                 (dissoc (api/fetch-job-map (db conn) framework-id uuid) :submit_time)))))
+                 (-> (api/fetch-job-map (db conn) framework-id uuid)
+                     (dissoc :submit_time))))))
 
       (testing "should work when the job specifies cook-executor"
         (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1400,8 +1402,7 @@
 
 (deftest test-fetch-instance-map
   (let [conn (restore-fresh-database! "datomic:mem://test-fetch-instance-map")]
-    (let [job-entity-id (create-dummy-job conn :user "test-user"
-                                          :job-state :job.state/completed)
+    (let [job-entity-id (create-dummy-job conn :user "test-user" :job-state :job.state/completed)
           basic-instance-properties {:executor-id (str job-entity-id "-executor-1")
                                      :slave-id "slave-1"
                                      :task-id (str job-entity-id "-executor-1")}
@@ -1582,7 +1583,7 @@
     @(d/transact conn [job-txn-no-name])
     (let [db (db conn)
           job-entity (d/entity db [:job/uuid job-uuid])
-          job-map-for-api (api/fetch-job-map db nil nil job-uuid)]
+          job-map-for-api (api/fetch-job-map db nil job-uuid)]
       (is (= job-uuid (:job/uuid job-entity)))
       (is (nil? (:job/name job-entity)))
       (is (= job-uuid (:uuid job-map-for-api)))

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -86,8 +86,7 @@
                        :mesos-gpu-enabled gpus-enabled
                        :task-constraints {:cpus cpus :memory-gb memory-gb :retry-limit retry-limit}}
                       (Object.)
-                      (atom true)
-                      (constantly nil))))
+                      (atom true))))
 
 (defn response->body-data [{:keys [body]}]
   (let [baos (ByteArrayOutputStream.)
@@ -1141,8 +1140,7 @@
         (is (thrown? Exception (s/validate api/Job (assoc min-job :expected-runtime 3 :max-runtime 2))))))))
 
 (deftest test-create-jobs!
-  (let [retrieve-sandbox-directory-from-agent (constantly nil)
-        expected-job-map
+  (let [expected-job-map
         (fn
           ; Converts the provided job and framework-id (framework-id) to the job-map we expect to get back from
           ; api/fetch-job-map. Note that we don't include the submit_time field here, so assertions below
@@ -1199,7 +1197,7 @@
                                       {:resource/type :resource.type/mem
                                        :resource/amount (:mem job)}]}
               _ @(d/transact conn [job-ent])
-              job-resp (api/fetch-job-map (db conn) framework-id retrieve-sandbox-directory-from-agent uuid)]
+              job-resp (api/fetch-job-map (db conn) framework-id uuid)]
           (is (= (expected-job-map job framework-id)
                  (dissoc job-resp :submit_time)))
           (s/validate api/JobResponseDeprecated
@@ -1213,8 +1211,7 @@
           (is (= {::api/results (str "submitted jobs " uuid)}
                  (api/create-jobs! conn {::api/jobs [job]})))
           (is (= (expected-job-map job framework-id)
-                 (-> (api/fetch-job-map (db conn) framework-id retrieve-sandbox-directory-from-agent uuid)
-                     (dissoc :submit_time))))))
+                 (dissoc (api/fetch-job-map (db conn) framework-id uuid) :submit_time)))))
 
       (testing "should fail on a duplicate uuid"
         (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1233,8 +1230,7 @@
           (is (= {::api/results (str "submitted jobs " uuid)}
                  (api/create-jobs! conn {::api/jobs [job]})))
           (is (= (expected-job-map job framework-id)
-                 (-> (api/fetch-job-map (db conn) framework-id retrieve-sandbox-directory-from-agent uuid)
-                     (dissoc :submit_time))))))
+                 (dissoc (api/fetch-job-map (db conn) framework-id uuid) :submit_time)))))
 
       (testing "should work when the job specifies the expected runtime"
         (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1243,8 +1239,7 @@
           (is (= {::api/results (str "submitted jobs " uuid)}
                  (api/create-jobs! conn {::api/jobs [job]})))
           (is (= (expected-job-map job framework-id)
-                 (-> (api/fetch-job-map (db conn) framework-id retrieve-sandbox-directory-from-agent uuid)
-                     (dissoc :submit_time))))))
+                 (dissoc (api/fetch-job-map (db conn) framework-id uuid) :submit_time)))))
 
       (testing "should work when the job specifies disable-mea-culpa-retries"
         (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1253,8 +1248,7 @@
           (is (= {::api/results (str "submitted jobs " uuid)}
                  (api/create-jobs! conn {::api/jobs [job]})))
           (is (= (expected-job-map job framework-id)
-                 (-> (api/fetch-job-map (db conn) framework-id retrieve-sandbox-directory-from-agent uuid)
-                     (dissoc :submit_time))))))
+                 (dissoc (api/fetch-job-map (db conn) framework-id uuid) :submit_time)))))
 
       (testing "should work when the job specifies cook-executor"
         (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1263,7 +1257,7 @@
           (is (= {::api/results (str "submitted jobs " uuid)}
                  (api/create-jobs! conn {::api/jobs [job]})))
           (is (= (expected-job-map job framework-id)
-                 (-> (api/fetch-job-map (db conn) framework-id retrieve-sandbox-directory-from-agent uuid)
+                 (-> (api/fetch-job-map (db conn) framework-id uuid)
                      (dissoc :submit_time)
                      (update :executor name))))))
 
@@ -1274,7 +1268,7 @@
           (is (= {::api/results (str "submitted jobs " uuid)}
                  (api/create-jobs! conn {::api/jobs [job]})))
           (is (= (expected-job-map job framework-id)
-                 (-> (api/fetch-job-map (db conn) framework-id retrieve-sandbox-directory-from-agent uuid)
+                 (-> (api/fetch-job-map (db conn) framework-id uuid)
                      (dissoc :submit_time)
                      (update :executor name)))))))))
 
@@ -1377,8 +1371,9 @@
                                            :data (ByteString/copyFrom (.getBytes (pr-str {:percent progress}) "UTF-8"))}]
                                  task))
           job-id (create-dummy-job conn :user "user" :job-state :job.state/running)
+          sync-agent-sandboxes-fn (constantly true)
           send-status-update #(->> (make-status-update "task1" :unknown :task-running %)
-                                   (sched/handle-status-update conn driver fenzo)
+                                   (sched/handle-status-update conn driver fenzo sync-agent-sandboxes-fn)
                                    async/<!!)
           instance-id (create-dummy-instance conn job-id
                                              :instance-status :instance.status/running
@@ -1389,7 +1384,7 @@
                                          [?i :instance/progress ?p]]
                                        (db conn) instance-id))
           job-uuid (:job/uuid (d/entity (db conn) job-id))
-          progress-from-api #(:progress (first (:instances (api/fetch-job-map (db conn) nil (constantly nil) job-uuid))))]
+          progress-from-api #(:progress (first (:instances (api/fetch-job-map (db conn) nil job-uuid))))]
       (send-status-update 0)
       (is (= 0 (progress-from-db)))
       (is (= 0 (progress-from-api)))
@@ -1405,23 +1400,22 @@
 
 (deftest test-fetch-instance-map
   (let [conn (restore-fresh-database! "datomic:mem://test-fetch-instance-map")]
-    (let [basic-instance-properties (fn [job-entity-id]
-                                      {:executor-id (str job-entity-id "-executor-1")
-                                       :slave-id "slave-1"
-                                       :task-id (str job-entity-id "-executor-1")})
-          basic-instance-map (fn [job-entity-id]
-                               {:executor_id (str job-entity-id "-executor-1")
-                                :slave_id "slave-1"
-                                :task_id (str job-entity-id "-executor-1")})]
+    (let [job-entity-id (create-dummy-job conn :user "test-user"
+                                          :job-state :job.state/completed)
+          basic-instance-properties {:executor-id (str job-entity-id "-executor-1")
+                                     :slave-id "slave-1"
+                                     :task-id (str job-entity-id "-executor-1")}
+          basic-instance-map {:executor_id (str job-entity-id "-executor-1")
+                              :slave_id "slave-1"
+                              :task_id (str job-entity-id "-executor-1")}]
 
       (testing "basic-instance-without-sandbox"
-        (let [job-entity-id (create-dummy-job conn :user "test-user" :job-state :job.state/completed)
-              instance-entity-id (apply create-dummy-instance conn job-entity-id
+        (let [instance-entity-id (apply create-dummy-instance conn job-entity-id
                                         :instance-status :instance.status/success
-                                        (mapcat seq (basic-instance-properties job-entity-id)))
+                                        (mapcat seq basic-instance-properties))
               instance-entity (d/entity (db conn) instance-entity-id)
-              instance-map (api/fetch-instance-map (db conn) instance-entity (constantly nil))
-              expected-map (assoc (basic-instance-map job-entity-id)
+              instance-map (api/fetch-instance-map (db conn) instance-entity)
+              expected-map (assoc basic-instance-map
                              :backfilled false
                              :hostname "localhost"
                              :ports []
@@ -1430,15 +1424,14 @@
                              :status "success")]
           (is (= expected-map (dissoc instance-map :start_time)))))
 
-      (testing "basic-instance-with-sandbox-url-from-datomic"
-        (let [job-entity-id (create-dummy-job conn :user "test-user" :job-state :job.state/completed)
-              instance-entity-id (apply create-dummy-instance conn job-entity-id
+      (testing "basic-instance-with-sandbox-url"
+        (let [instance-entity-id (apply create-dummy-instance conn job-entity-id
                                         :instance-status :instance.status/success
                                         :sandbox-directory "/path/to/working/directory"
-                                        (mapcat seq (basic-instance-properties job-entity-id)))
+                                        (mapcat seq basic-instance-properties))
               instance-entity (d/entity (db conn) instance-entity-id)
-              instance-map (api/fetch-instance-map (db conn) instance-entity (constantly nil))
-              expected-map (assoc (basic-instance-map job-entity-id)
+              instance-map (api/fetch-instance-map (db conn) instance-entity)
+              expected-map (assoc basic-instance-map
                              :backfilled false
                              :hostname "localhost"
                              :output_url "http://localhost:5051/files/read.json?path=%2Fpath%2Fto%2Fworking%2Fdirectory"
@@ -1449,28 +1442,8 @@
                              :status "success")]
           (is (= expected-map (dissoc instance-map :start_time)))))
 
-      (testing "basic-instance-with-sandbox-url-from-agent"
-        (let [job-entity-id (create-dummy-job conn :user "test-user" :job-state :job.state/completed)
-              instance-entity-id (apply create-dummy-instance conn job-entity-id
-                                        :instance-status :instance.status/success
-                                        (mapcat seq (basic-instance-properties job-entity-id)))
-              instance-entity (d/entity (db conn) instance-entity-id)
-              retrieve-sandbox-directory-from-agent (constantly "/sandbox/directory")
-              instance-map (api/fetch-instance-map (db conn) instance-entity retrieve-sandbox-directory-from-agent)
-              expected-map (assoc (basic-instance-map job-entity-id)
-                             :backfilled false
-                             :hostname "localhost"
-                             :output_url "http://localhost:5051/files/read.json?path=%2Fsandbox%2Fdirectory"
-                             :ports []
-                             :preempted false
-                             :progress 0
-                             :sandbox_directory "/sandbox/directory"
-                             :status "success")]
-          (is (= expected-map (dissoc instance-map :start_time)))))
-
       (testing "detailed-instance"
-        (let [job-entity-id (create-dummy-job conn :user "test-user" :job-state :job.state/completed)
-              instance-entity-id (apply create-dummy-instance conn job-entity-id
+        (let [instance-entity-id (apply create-dummy-instance conn job-entity-id
                                         :exit-code 2
                                         :hostname "agent-hostname"
                                         :instance-status :instance.status/success
@@ -1479,10 +1452,10 @@
                                         :progress-message "seventy-eight percent done"
                                         :reason :preempted-by-rebalancer
                                         :sandbox-directory "/path/to/working/directory"
-                                        (mapcat seq (basic-instance-properties job-entity-id)))
+                                        (mapcat seq basic-instance-properties))
               instance-entity (d/entity (db conn) instance-entity-id)
-              instance-map (api/fetch-instance-map (db conn) instance-entity (constantly nil))
-              expected-map (assoc (basic-instance-map job-entity-id)
+              instance-map (api/fetch-instance-map (db conn) instance-entity)
+              expected-map (assoc basic-instance-map
                              :backfilled false
                              :exit_code 2
                              :hostname "agent-hostname"

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -892,7 +892,10 @@
                                    (let [task {:task-id {:value task-id}
                                                :reason reason
                                                :state state}]
-                                     task))]
+                                     task))
+        synced-agents-atom (atom [])
+        sync-agent-sandboxes-fn (fn sync-agent-sandboxes-fn [hostname]
+                                  (swap! synced-agents-atom conj hostname))]
 
     (testing "Mesos task death"
       (let [job-id (create-dummy-job conn :user "tsram" :job-state :job.state/running)
@@ -902,7 +905,7 @@
                                                :task-id task-id)]
         ; Wait for async database transaction inside handle-status-update
         (->> (make-dummy-status-update task-id :reason-gc-error :task-killed)
-             (sched/handle-status-update conn driver fenzo)
+             (sched/handle-status-update conn driver fenzo sync-agent-sandboxes-fn)
              async/<!!)
 
         (is (= :instance.status/failed
@@ -927,7 +930,7 @@
               original-end-time (get-end-time)]
           (Thread/sleep 100)
           (->> (make-dummy-status-update task-id :reason-gc-error :task-killed)
-               (sched/handle-status-update conn driver fenzo)
+               (sched/handle-status-update conn driver fenzo sync-agent-sandboxes-fn)
                async/<!!)
           (is (= original-end-time (get-end-time))))))
 
@@ -952,7 +955,7 @@
                                                :reason :max-runtime-exceeded)] ; Previous reason is not mea-culpa
         ; Status update says slave got restarted (mea-culpa)
         (->> (make-dummy-status-update task-id :mesos-slave-restarted :task-killed)
-             (sched/handle-status-update conn driver fenzo)
+             (sched/handle-status-update conn driver fenzo sync-agent-sandboxes-fn)
              async/<!!)
         ; Assert old reason persists
         (is (= :max-runtime-exceeded
@@ -987,10 +990,12 @@
                                :instance-status :instance.status/success
                                :task-id task-id-b
                                :reason :unknown)
+        (reset! synced-agents-atom [])
         (->> (make-dummy-status-update task-id-a :mesos-slave-restarted :task-running)
-             (sched/handle-status-update conn driver fenzo)
+             (sched/handle-status-update conn driver fenzo sync-agent-sandboxes-fn)
              async/<!!)
-        (is (true? (contains? @tasks-killed task-id-a)))))
+        (is (true? (contains? @tasks-killed task-id-a)))
+        (is (= ["www.test-host.com"] @synced-agents-atom))))
 
     (testing "instance persists mesos-start-time when task is first known to be starting or running"
       (let [job-id (create-dummy-job conn
@@ -1009,17 +1014,19 @@
                                :task-id task-id)
         (is (nil? (mesos-start-time)))
         (->> (make-dummy-status-update task-id :unknown :task-staging)
-             (sched/handle-status-update conn driver fenzo)
+             (sched/handle-status-update conn driver fenzo sync-agent-sandboxes-fn)
              async/<!!)
         (is (nil? (mesos-start-time)))
+        (reset! synced-agents-atom [])
         (->> (make-dummy-status-update task-id :unknown :task-running)
-             (sched/handle-status-update conn driver fenzo)
+             (sched/handle-status-update conn driver fenzo sync-agent-sandboxes-fn)
              async/<!!)
+        (is (= ["www.test-host.com"] @synced-agents-atom))
         (is (not (nil? (mesos-start-time))))
         (let [first-observed-start-time (.getTime (mesos-start-time))]
           (is (not (nil? first-observed-start-time)))
           (->> (make-dummy-status-update task-id :unknown :task-running)
-               (sched/handle-status-update conn driver fenzo)
+               (sched/handle-status-update conn driver fenzo sync-agent-sandboxes-fn)
                async/<!!)
           (is (= first-observed-start-time (.getTime (mesos-start-time)))))))))
 
@@ -1646,7 +1653,7 @@
   (let [status-store (atom {})
         latch (CountDownLatch. 11)]
     (with-redefs [sched/handle-status-update
-                  (fn [_ _ _ status]
+                  (fn [_ _ _ _ status]
                     (let [task-id (-> status :task-id :value str)]
                       (swap! status-store update task-id
                              (fn [statuses] (conj (or statuses [])
@@ -2000,6 +2007,62 @@
 
         (cancel-handle)
         (async/close! progress-state-chan)))))
+
+(deftest test-sandbox-directory-population
+  (let [db-conn (restore-fresh-database! "datomic:mem://test-sandbox-directory-population")
+        executing-tasks-atom (atom #{})
+        num-jobs 25
+        cache-timeout-ms 65
+        get-task-id #(str "task-test-sandbox-directory-population-" %)]
+    (dotimes [n num-jobs]
+      (let [task-id (get-task-id n)
+            job (create-dummy-job db-conn :task-id task-id)]
+        (create-dummy-instance db-conn job :executor-id task-id :task-id task-id)))
+
+    (with-redefs [sandbox/retrieve-sandbox-directories-on-agent
+                  (fn [_ _]
+                    (pc/map-from-keys #(str "/sandbox/for/" %) @executing-tasks-atom))]
+      (let [framework-id "test-framework-id"
+            publish-interval-ms 20
+            sync-interval-ms 20
+            agent-query-cache (-> {} (cache/ttl-cache-factory :ttl cache-timeout-ms) atom)
+            {:keys [pending-sync-agent publisher-cancel-fn syncer-cancel-fn task-id->sandbox-agent] :as sandbox-syncer-state}
+            (sandbox/prepare-sandbox-publisher framework-id db-conn 10 publish-interval-ms sync-interval-ms 5 agent-query-cache)
+            sync-agent-sandboxes-fn
+            (fn [hostname]
+              (sandbox/sync-agent-sandboxes sandbox-syncer-state framework-id hostname))]
+        (try
+          (-> (dotimes [n num-jobs]
+                (let [task-id (get-task-id n)]
+                  (swap! executing-tasks-atom conj task-id)
+                  (->> {:task-id {:value task-id}, :state :task-running}
+                       (sched/handle-status-update db-conn nil nil sync-agent-sandboxes-fn)))
+                (Thread/sleep 5))
+              async/thread
+              async/<!!)
+
+          (Thread/sleep (+ cache-timeout-ms sync-interval-ms))
+          (await pending-sync-agent)
+          (Thread/sleep (* 2 publish-interval-ms))
+          (await task-id->sandbox-agent)
+
+          ;; verify the sandbox-directory stored into the db
+          (let [datomic-db (d/db db-conn)]
+            (dotimes [n num-jobs]
+              (let [task-id (get-task-id n)
+                    sandbox-directory (->> task-id
+                                           (d/q '[:find ?i
+                                                  :in $ ?task-id
+                                                  :where [?i :instance/task-id ?task-id]]
+                                                datomic-db)
+                                           ffirst
+                                           (d/entity (d/db db-conn))
+                                           :instance/sandbox-directory)]
+                (is (= (str "/sandbox/for/" task-id) sandbox-directory)))))
+
+          (finally
+            (publisher-cancel-fn)
+            (syncer-cancel-fn)))))))
 
 (comment
   (run-tests))

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -116,7 +116,7 @@
                            :sequence-cache-threshold 1000}
          rebalancer-config# (merge default-rebalancer-config (:rebalancer-config ~scheduler-config))
          framework-id# "cool-framework-id"
-         sandbox-publisher-state# {:task-id->sandbox-agent (agent {})}
+         sandbox-syncer-state# {:task-id->sandbox-agent (agent {})}
          host-settings# {:server-port 12321 :hostname "localhost"}
          mesos-leadership-atom# (atom false)
          fenzo-config# (merge default-fenzo-config (:fenzo-config ~scheduler-config))
@@ -142,7 +142,7 @@
           :rebalancer-config rebalancer-config#
           :riemann-host (:riemann-host ~scheduler-config)
           :riemann-port (:riemann-port ~scheduler-config)
-          :sandbox-publisher-state sandbox-publisher-state#
+          :sandbox-syncer-state sandbox-syncer-state#
           :server-config host-settings#
           :task-constraints task-constraints#
           :trigger-chans trigger-chans#

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -41,8 +41,7 @@
                                          :mesos-gpu-enabled false
                                          :task-constraints {:cpus 12 :memory-gb 100 :retry-limit 200}}
                                         (Object.)
-                                        (atom true)
-                                        (constantly nil)))
+                                        (atom true)))
         ; Mock kerberization, not testing that
         api-handler-kerb (fn [req]
                            (api-handler (assoc req :authorization/user (System/getProperty "user.name"))))


### PR DESCRIPTION
## Changes proposed in this PR

- This reverts commit f2b5847 enabling the sandbox syncing for non-cook-executor instances

The PR is split into two commits. The first commit reverts a previous commit that disabled the syncer. The second commit handles merge conflicts and adds metrics.

## Why are we making these changes?

We would like timely sandbox directory updates for tasks that are not executed via the cook executor. This can significantly save the load time on the list pages as they do not trigger the sandbox syncing logic. Additionally, saving the sandbox directory into datomic means once the directory is available, it is consistently always rendered instead of relying on the availability of the data from the Mesos agent state.
