### PR TITLE
Simplify the integration tests docker image

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,11 +1,5 @@
 FROM python:3.6
 
-RUN apt-get update && apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
-
-RUN apt-get update && apt-get -y install docker-ce
-
 RUN mkdir -p /opt/cook/cli
 WORKDIR /opt/cook/cli
 COPY cli.tar.gz /opt/cook/cli

--- a/integration/bin/run-integration.sh
+++ b/integration/bin/run-integration.sh
@@ -51,7 +51,6 @@ docker create \
        -e "USER=root" \
        ${COOK_MULTICLUSTER_ENV} \
        -v ${INTEGRATION_DIR}:/opt/cook/integration \
-       -v /var/run/docker.sock:/var/run/docker.sock \
        cook-integration:latest
 
 # Connect to the default bridge network (for talking to minimesos)


### PR DESCRIPTION
## Changes proposed in this PR

Removes unused docker support within the integration test docker image

## Why are we making these changes?

Since we don't use docker within the integration tests docker image (we probably did at some point, but we don't anymore), deleting these docker-support-specific items from the integration docker image setup significantly simplifies the build process when using docker to build and run the integration tests.