### PR TITLE
CS: Treats :mesos-executor-terminated as mea-culpa failures

### DIFF
--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -1194,8 +1194,10 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :reason/code 99002
     :reason/string "Mesos executor terminated"
     :reason/name :mesos-executor-terminated
-    :reason/mea-culpa? false
-    :reason/mesos-reason :reason-executor-terminated}
+    :reason/mea-culpa? true
+    :reason/mesos-reason :reason-executor-terminated
+    ;; unless configured otherwise, start counting more than 3 failures against the job's retry limit
+    :reason/failure-limit 3}
    {:db/id (d/tempid :db.part/user)
     :reason/code 99003
     :reason/string "Command exited non-zero"


### PR DESCRIPTION
## Changes proposed in this PR

- treat `mesos-executor-terminated` as mea-culpa failures with a failure limit of 3

## Why are we making these changes?

It is possible that the executor command configured on a Mesos agent is invalid as it has not been deployed there yet. This change allows us to tolerate such failures on potentially multiple hosts before treating the job as failed. In addition, since our current implementation requires subsequent instances to use the Mesos executor, we account for avoiding repeated failures (on potentially the same host) due to missing deployments.
