### PR TITLE
Disable Marathon in Travis tests

### DIFF
--- a/travis/minimesos
+++ b/travis/minimesos
@@ -2,9 +2,9 @@
 
 set -e
 
-MINIMESOS_TAG="0.13.0"
-PARAMS="$@"
-MINIMESOS_CLI_IMAGE="containersol/minimesos-cli"
+MINIMESOS_TAG="0.13.1"
+PARAMS="--debug $@"
+MINIMESOS_CLI_IMAGE="daowen/minimesos-cli"
 
 command_exists() {
     command -v "$@" > /dev/null 2>&1

--- a/travis/minimesosFile
+++ b/travis/minimesosFile
@@ -284,13 +284,6 @@ minimesos {
         loggingLevel = "# INHERIT FROM CLUSTER"
     }
 
-    // Minimesos currently has an NPE without marathon
-    // https://github.com/ContainerSolutions/minimesos/issues/532
-    marathon {
-        imageName = "mesosphere/marathon"
-        imageTag = "v1.3.5"
-    }
-
     zookeeper {
         imageName = "jplock/zookeeper"
         imageTag = "3.4.6"


### PR DESCRIPTION
Requires using a custom-patched minimesos docker image until minimesos
version 0.14 is released, which fixes a NPE bug.

## Changes proposed in this PR

- Disable Marathon in the Travis minimesosFile.
- Use custom-patched minimesos-cli image to fix NPE when Marathon is disabled.

## Why are we making these changes?

Disabling Marathon should speed up our integration tests a bit, and use fewer resources in the restricted Travis VM environment.