### PR TITLE
Makes several CLI tests more reliable / faster

### DIFF
--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -289,3 +289,18 @@ def cat_with_logging(uuid, path, cook_url):
     s = stdout(cp)
     logging.info(f'cat of {path}: {s}')
     return cp
+
+
+def wait_for_output_file(cook_url, job_uuid, name):
+    """Waits for a file with the given name for the given job to exist"""
+
+    def query():
+        cp, _ = ls(job_uuid, cook_url, parse_json=False)
+        return json.loads(stdout(cp)) if cp.returncode == 0 else []
+
+    def predicate(entries):
+        logging.debug(f'Job {job_uuid} has entries {entries}')
+        return ls_entry_by_name(entries, name)
+
+    response = util.wait_until(query, predicate)
+    return response

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -722,6 +722,7 @@ class CookCliTest(unittest.TestCase):
             self.cook_url, submit_flags=f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_instance(self.cook_url, uuids[0])
+        util.wait_for_output_url(self.cook_url, uuids[0])
         proc = cli.tail(uuids[0], 'bar', self.cook_url,
                         f'--follow --sleep-interval {sleep_seconds_between_lines}',
                         wait_for_exit=False)

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -586,7 +586,7 @@ class CookCliTest(unittest.TestCase):
     def test_ssh_job_uuid(self):
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
-        instance = util.wait_for_instance(self.cook_url, uuids[0])
+        instance = util.wait_for_output_url(self.cook_url, uuids[0])
         hostname = instance['hostname']
         env = os.environ
         env['CS_SSH'] = 'echo'
@@ -635,7 +635,7 @@ class CookCliTest(unittest.TestCase):
     def test_ssh_instance_uuid(self):
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
-        instance = util.wait_for_instance(self.cook_url, uuids[0])
+        instance = util.wait_for_output_url(self.cook_url, uuids[0])
         hostname = instance['hostname']
         env = os.environ
         env['CS_SSH'] = 'echo'

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -16,6 +16,11 @@ from tests.cook import cli, util
 class CookCliTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 
+    def current_test(self):
+        """Returns the name of the currently running test function"""
+        test_id = self.id()
+        return test_id.split('.')[-1]
+
     def setUp(self):
         self.cook_url = util.retrieve_cook_url()
         self.logger = logging.getLogger(__name__)
@@ -414,7 +419,7 @@ class CookCliTest(unittest.TestCase):
         return cp, jobs
 
     def test_list_by_state(self):
-        name = str(uuid.uuid4())
+        name = f'{self.current_test()}_{uuid.uuid4()}'
 
         # Submit a job that will never run
         raw_job = {'command': 'ls', 'name': name, 'constraints': [['HOSTNAME', 'EQUALS', 'will not get scheduled']]}
@@ -579,7 +584,7 @@ class CookCliTest(unittest.TestCase):
         self.assertIn(uuids[0], jobs[0]['uuid'])
 
     def test_ssh_job_uuid(self):
-        cp, uuids = cli.submit('ls', self.cook_url)
+        cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         instance = util.wait_for_instance(self.cook_url, uuids[0])
         hostname = instance['hostname']
@@ -587,7 +592,7 @@ class CookCliTest(unittest.TestCase):
         env['CS_SSH'] = 'echo'
         cp = cli.ssh(uuids[0], self.cook_url, env=env)
         stdout = cli.stdout(cp)
-        self.assertEqual(0, cp.returncode, stdout)
+        self.assertEqual(0, cp.returncode, cli.decode(cp.stderr))
         self.assertIn(f'Attempting ssh for job instance {instance["task_id"]}', stdout)
         self.assertIn('Executing ssh', stdout)
         self.assertIn(hostname, stdout)
@@ -628,7 +633,7 @@ class CookCliTest(unittest.TestCase):
         self.assertIn('You provided a job group uuid', cli.decode(cp.stderr))
 
     def test_ssh_instance_uuid(self):
-        cp, uuids = cli.submit('ls', self.cook_url)
+        cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         instance = util.wait_for_instance(self.cook_url, uuids[0])
         hostname = instance['hostname']
@@ -636,7 +641,7 @@ class CookCliTest(unittest.TestCase):
         env['CS_SSH'] = 'echo'
         cp = cli.ssh(instance['task_id'], self.cook_url, env=env)
         stdout = cli.stdout(cp)
-        self.assertEqual(0, cp.returncode, stdout)
+        self.assertEqual(0, cp.returncode, cli.decode(cp.stderr))
         self.assertIn('Executing ssh', stdout)
         self.assertIn(hostname, stdout)
         self.assertIn(f'-t {hostname} cd', stdout)
@@ -713,8 +718,8 @@ class CookCliTest(unittest.TestCase):
     def test_tail_follow(self):
         sleep_seconds_between_lines = 0.5
         cp, uuids = cli.submit(
-            f'bash -c \'for i in {{1..30}}; do echo $i >> bar; sleep {sleep_seconds_between_lines}; done\'',
-            self.cook_url)
+            f'bash -c \'for i in {{1..300}}; do echo $i >> bar; sleep {sleep_seconds_between_lines}; done\'',
+            self.cook_url, submit_flags=f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_instance(self.cook_url, uuids[0])
         proc = cli.tail(uuids[0], 'bar', self.cook_url,
@@ -756,9 +761,10 @@ class CookCliTest(unittest.TestCase):
         def entry(name):
             return cli.ls_entry_by_name(entries, name)
 
-        cp, uuids = cli.submit('"mkdir foo; echo 123 > foo/bar; echo 45678 > baz; mkdir empty"', self.cook_url)
+        cp, uuids = cli.submit('"mkdir foo; echo 123 > foo/bar; echo 45678 > baz; mkdir empty"',
+                               self.cook_url, submit_flags=f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
-        util.wait_for_job(self.cook_url, uuids[0], 'completed')
+        cli.wait_for_output_file(self.cook_url, uuids[0], 'empty')
 
         # Path that doesn't exist
         cp, entries = cli.ls(uuids[0], self.cook_url, 'qux', parse_json=False)
@@ -825,10 +831,10 @@ class CookCliTest(unittest.TestCase):
         def entry(name):
             return cli.ls_entry_by_name(entries, name)
 
-        cp, uuids = cli.submit('"touch t?.sh; touch [ab]*; touch {b,c,est}; touch \'*\'; touch \'t*\'"', self.cook_url)
+        cp, uuids = cli.submit('"touch t?.sh; touch [ab]*; touch {b,c,est}; touch \'*\'; touch \'t*\'; touch done"',
+                               self.cook_url, submit_flags=f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
-        util.wait_for_job(self.cook_url, uuids[0], 'completed')
-        self.assertEqual(0, cp.returncode, cp.stderr)
+        cli.wait_for_output_file(self.cook_url, uuids[0], 'done')
 
         path = 't?.sh'
         cp, _ = cli.ls(uuids[0], self.cook_url, path, parse_json=False)
@@ -896,7 +902,7 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(0, bar['size'])
 
     def test_ls_empty_root_directory(self):
-        cp, uuids = cli.submit("'rm -r * && rm -r .*'", self.cook_url)
+        cp, uuids = cli.submit("'rm -r * && rm -r .*'", self.cook_url, submit_flags=f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_job(self.cook_url, uuids[0], 'completed')
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -924,10 +930,10 @@ class CookCliTest(unittest.TestCase):
     def test_show_progress_message(self):
         executor = util.get_job_executor_type(self.cook_url)
         line = util.progress_line(self.cook_url, 99, 'We are so close!')
-        cp, uuids = cli.submit(f'echo "{line}"', self.cook_url, submit_flags=f'--executor {executor}')
+        cp, uuids = cli.submit(f'echo "{line}"', self.cook_url, submit_flags=f'--executor {executor} '
+                                                                             f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
-        util.wait_for_job(self.cook_url, uuids[0], 'completed')
-        self.assertEqual(0, cp.returncode, cp.stderr)
+        util.wait_for_instance(self.cook_url, uuids[0])
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(executor, jobs[0]['instances'][0]['executor'])
@@ -960,10 +966,10 @@ class CookCliTest(unittest.TestCase):
                                'echo "Done" >> progress.txt\'',
                                self.cook_url,
                                submit_flags=f'--executor {executor} '
-                                            f'--env {progress_file_env}=progress.txt')
+                                            f'--env {progress_file_env}=progress.txt '
+                                            f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
-        util.wait_for_job(self.cook_url, uuids[0], 'completed')
-        self.assertEqual(0, cp.returncode, cp.stderr)
+        util.wait_for_instance(self.cook_url, uuids[0])
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(executor, jobs[0]['instances'][0]['executor'])
@@ -1123,7 +1129,8 @@ class CookCliTest(unittest.TestCase):
 
     def test_submit_with_command_prefix(self):
         # Specifying command prefix
-        cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, submit_flags='--command-prefix "FOO=0; "')
+        cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, submit_flags=f'--command-prefix "FOO=0; " '
+                                                                               f'--name {self.current_test()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp = cli.wait(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -1135,7 +1142,8 @@ class CookCliTest(unittest.TestCase):
         config = {'defaults': {'submit': {}}}
         with cli.temp_config_file(config) as path:
             flags = '--config %s' % path
-            cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, flags=flags)
+            cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, flags=flags,
+                                   submit_flags=f'--name {self.current_test()}')
             self.assertEqual(0, cp.returncode, cp.stderr)
             cp = cli.wait(uuids, self.cook_url)
             self.assertEqual(0, cp.returncode, cp.stderr)
@@ -1147,7 +1155,8 @@ class CookCliTest(unittest.TestCase):
         config = {'defaults': {'submit': {'command-prefix': 'export FOO=0; '}}}
         with cli.temp_config_file(config) as path:
             flags = '--config %s' % path
-            cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, flags=flags)
+            cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, flags=flags,
+                                   submit_flags=f'--name {self.current_test()}')
             self.assertEqual(0, cp.returncode, cp.stderr)
             cp = cli.wait(uuids, self.cook_url)
             self.assertEqual(0, cp.returncode, cp.stderr)

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -16,7 +16,7 @@ from tests.cook import cli, util
 class CookCliTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 
-    def current_test(self):
+    def current_name(self):
         """Returns the name of the currently running test function"""
         test_id = self.id()
         return test_id.split('.')[-1]
@@ -419,7 +419,7 @@ class CookCliTest(unittest.TestCase):
         return cp, jobs
 
     def test_list_by_state(self):
-        name = f'{self.current_test()}_{uuid.uuid4()}'
+        name = f'{self.current_name()}_{uuid.uuid4()}'
 
         # Submit a job that will never run
         raw_job = {'command': 'ls', 'name': name, 'constraints': [['HOSTNAME', 'EQUALS', 'will not get scheduled']]}
@@ -584,7 +584,7 @@ class CookCliTest(unittest.TestCase):
         self.assertIn(uuids[0], jobs[0]['uuid'])
 
     def test_ssh_job_uuid(self):
-        cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_test()}')
+        cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         instance = util.wait_for_output_url(self.cook_url, uuids[0])
         hostname = instance['hostname']
@@ -633,7 +633,7 @@ class CookCliTest(unittest.TestCase):
         self.assertIn('You provided a job group uuid', cli.decode(cp.stderr))
 
     def test_ssh_instance_uuid(self):
-        cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_test()}')
+        cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         instance = util.wait_for_output_url(self.cook_url, uuids[0])
         hostname = instance['hostname']
@@ -719,7 +719,7 @@ class CookCliTest(unittest.TestCase):
         sleep_seconds_between_lines = 0.5
         cp, uuids = cli.submit(
             f'bash -c \'for i in {{1..300}}; do echo $i >> bar; sleep {sleep_seconds_between_lines}; done\'',
-            self.cook_url, submit_flags=f'--name {self.current_test()}')
+            self.cook_url, submit_flags=f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_instance(self.cook_url, uuids[0])
         proc = cli.tail(uuids[0], 'bar', self.cook_url,
@@ -762,7 +762,7 @@ class CookCliTest(unittest.TestCase):
             return cli.ls_entry_by_name(entries, name)
 
         cp, uuids = cli.submit('"mkdir foo; echo 123 > foo/bar; echo 45678 > baz; mkdir empty"',
-                               self.cook_url, submit_flags=f'--name {self.current_test()}')
+                               self.cook_url, submit_flags=f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         cli.wait_for_output_file(self.cook_url, uuids[0], 'empty')
 
@@ -832,7 +832,7 @@ class CookCliTest(unittest.TestCase):
             return cli.ls_entry_by_name(entries, name)
 
         cp, uuids = cli.submit('"touch t?.sh; touch [ab]*; touch {b,c,est}; touch \'*\'; touch \'t*\'; touch done"',
-                               self.cook_url, submit_flags=f'--name {self.current_test()}')
+                               self.cook_url, submit_flags=f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         cli.wait_for_output_file(self.cook_url, uuids[0], 'done')
 
@@ -902,7 +902,7 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(0, bar['size'])
 
     def test_ls_empty_root_directory(self):
-        cp, uuids = cli.submit("'rm -r * && rm -r .*'", self.cook_url, submit_flags=f'--name {self.current_test()}')
+        cp, uuids = cli.submit("'rm -r * && rm -r .*'", self.cook_url, submit_flags=f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_job(self.cook_url, uuids[0], 'completed')
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -931,7 +931,7 @@ class CookCliTest(unittest.TestCase):
         executor = util.get_job_executor_type(self.cook_url)
         line = util.progress_line(self.cook_url, 99, 'We are so close!')
         cp, uuids = cli.submit(f'echo "{line}"', self.cook_url, submit_flags=f'--executor {executor} '
-                                                                             f'--name {self.current_test()}')
+                                                                             f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_instance(self.cook_url, uuids[0])
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
@@ -967,7 +967,7 @@ class CookCliTest(unittest.TestCase):
                                self.cook_url,
                                submit_flags=f'--executor {executor} '
                                             f'--env {progress_file_env}=progress.txt '
-                                            f'--name {self.current_test()}')
+                                            f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_instance(self.cook_url, uuids[0])
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
@@ -1130,7 +1130,7 @@ class CookCliTest(unittest.TestCase):
     def test_submit_with_command_prefix(self):
         # Specifying command prefix
         cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, submit_flags=f'--command-prefix "FOO=0; " '
-                                                                               f'--name {self.current_test()}')
+                                                                               f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp = cli.wait(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -1143,7 +1143,7 @@ class CookCliTest(unittest.TestCase):
         with cli.temp_config_file(config) as path:
             flags = '--config %s' % path
             cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, flags=flags,
-                                   submit_flags=f'--name {self.current_test()}')
+                                   submit_flags=f'--name {self.current_name()}')
             self.assertEqual(0, cp.returncode, cp.stderr)
             cp = cli.wait(uuids, self.cook_url)
             self.assertEqual(0, cp.returncode, cp.stderr)
@@ -1156,7 +1156,7 @@ class CookCliTest(unittest.TestCase):
         with cli.temp_config_file(config) as path:
             flags = '--config %s' % path
             cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, flags=flags,
-                                   submit_flags=f'--name {self.current_test()}')
+                                   submit_flags=f'--name {self.current_name()}')
             self.assertEqual(0, cp.returncode, cp.stderr)
             cp = cli.wait(uuids, self.cook_url)
             self.assertEqual(0, cp.returncode, cp.stderr)


### PR DESCRIPTION
## Changes proposed in this PR

- making several tests submit jobs with the name of the job being the name of the test
- making tweaks to several tests to make them more reliable and/or faster to complete

## Why are we making these changes?

To reduce flakiness and increase our ability to troubleshoot it.