### PR TITLE
User Impersonation

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1234,7 +1234,7 @@ class CookTest(unittest.TestCase):
             self.assertEqual(201, resp.status_code, resp.content)
 
             def query_queue():
-                return util.session.get('%s/queue' % self.cook_url)
+                return util.query_queue(self.cook_url)
 
             def queue_predicate(resp):
                 return any([job['job/uuid'] == job_uuid for job in resp.json()['normal']])

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -18,7 +18,6 @@ from tests.cook import util
 
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class CookTest(unittest.TestCase):
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -16,7 +16,6 @@ from tests.cook import cli, util
 @unittest.skipIf(util.http_basic_auth_enabled(), 'Cook CLI does not currently support HTTP Basic Auth')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class CookCliTest(unittest.TestCase):
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/integration/tests/cook/test_cli_multi_cluster.py
+++ b/integration/tests/cook/test_cli_multi_cluster.py
@@ -15,7 +15,6 @@ from tests.cook import cli, util
 @unittest.skipIf(util.http_basic_auth_enabled(), 'Cook CLI does not currently support HTTP Basic Auth')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class MultiCookCliTest(unittest.TestCase):
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/integration/tests/cook/test_impersonation.py
+++ b/integration/tests/cook/test_impersonation.py
@@ -8,7 +8,6 @@ from tests.cook import util
 @pytest.mark.impersonation
 @unittest.skipUnless(util.multi_user_tests_enabled(), 'Requires using multi-user coniguration (e.g., BasicAuth) for Cook Scheduler')
 class ImpersonationCookTest(unittest.TestCase):
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/integration/tests/cook/test_impersonation.py
+++ b/integration/tests/cook/test_impersonation.py
@@ -1,0 +1,117 @@
+import itertools
+import logging
+import pytest
+import unittest
+
+from tests.cook import util
+
+@pytest.mark.impersonation
+@unittest.skipUnless(util.multi_user_tests_enabled(), 'Requires using multi-user coniguration (e.g., BasicAuth) for Cook Scheduler')
+class ImpersonationCookTest(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cook_url = util.retrieve_cook_url()
+        util.init_cook_session(cls.cook_url)
+
+    def setUp(self):
+        self.cook_url = type(self).cook_url
+        self.logger = logging.getLogger(__name__)
+        self.user_factory = util.UserFactory(self)
+        self.poser = util.User('poser')
+
+    def test_impersonated_job_delete(self):
+        user1, user2 = self.user_factory.new_users(2)
+        with user1:
+            job_uuid, resp = util.submit_job(self.cook_url, command='sleep 60')
+            self.assertEqual(resp.status_code, 201, resp.text)
+        try:
+            # authorized impersonator
+            with self.poser:
+                util.kill_jobs(self.cook_url, [job_uuid], expected_status_code=403)
+            with self.poser.impersonating(user2):
+                util.kill_jobs(self.cook_url, [job_uuid], expected_status_code=403)
+            with self.poser.impersonating(user1):
+                util.kill_jobs(self.cook_url, [job_uuid])
+            # unauthorized impersonation attempts by arbitrary user
+            with user2:
+                util.kill_jobs(self.cook_url, [job_uuid], expected_status_code=403)
+            with user2.impersonating(user2):
+                util.kill_jobs(self.cook_url, [job_uuid], expected_status_code=403)
+            with user2.impersonating(user1):
+                util.kill_jobs(self.cook_url, [job_uuid], expected_status_code=403)
+            # unauthorized impersonation attempts by job owner
+            with user1.impersonating(user2):
+                util.kill_jobs(self.cook_url, [job_uuid], expected_status_code=403)
+            with user1.impersonating(user1):
+                util.kill_jobs(self.cook_url, [job_uuid], expected_status_code=403)
+            with user1:
+                util.kill_jobs(self.cook_url, [job_uuid])
+        finally:
+            # default user should be an admin, and can kill all the jobs
+            util.kill_jobs(self.cook_url, [job_uuid])
+
+    def test_admin_cannot_impersonate(self):
+        user1 = self.user_factory.new_user()
+        job_uuids = []
+        # the default user should have admin rights
+        admin = util.default_user
+        try:
+            # admin can create jobs
+            with admin:
+                job_uuid, resp = util.submit_job(self.cook_url, command='sleep 1')
+                self.assertEqual(resp.status_code, 201, resp.text)
+                job_uuids.append(job_uuid)
+            # users can create jobs
+            with user1:
+                job_uuid, resp = util.submit_job(self.cook_url, command='sleep 1')
+                self.assertEqual(resp.status_code, 201, resp.text)
+                job_uuids.append(job_uuid)
+            # admin cannot impersonate others creating jobs (not an authorized impersonator)
+            with admin.impersonating(user1):
+                job_uuid, resp = util.submit_job(self.cook_url, command='sleep 1')
+                self.assertEqual(resp.status_code, 403, resp.text)
+        finally:
+            # default user should be an admin, and can kill all the jobs
+            util.kill_jobs(self.cook_url, [ j for j in job_uuids if j ])
+
+    def test_cannot_impersonate_endpoints(self):
+        user1 = self.user_factory.new_user()
+        job_uuids = []
+        # the default user should have admin rights
+        admin = util.default_user
+        # admin can do admin things
+        with admin:
+            # read queue endpoint
+            resp = util.query_queue(self.cook_url)
+            self.assertEqual(resp.status_code, 200, resp.text)
+            # set user quota
+            resp = util.set_limit(self.cook_url, 'quota', user1.name, cpus=20)
+            self.assertEqual(resp.status_code, 201, resp.text)
+            # reset user quota back to default
+            resp = util.reset_limit(self.cook_url, 'quota', user1.name)
+            self.assertEqual(resp.status_code, 204, resp.text)
+            # set user share
+            resp = util.set_limit(self.cook_url, 'share', user1.name, cpus=10)
+            self.assertEqual(resp.status_code, 201, resp.text)
+            # reset user share back to default
+            resp = util.reset_limit(self.cook_url, 'share', user1.name)
+            self.assertEqual(resp.status_code, 204, resp.text)
+        # impersonator cannot indirectly do admin things
+        with admin.impersonating(user1):
+            # read queue endpoint
+            resp = util.query_queue(self.cook_url)
+            self.assertEqual(resp.status_code, 403, resp.text)
+            # set user quota
+            resp = util.set_limit(self.cook_url, 'quota', user1.name, cpus=20)
+            self.assertEqual(resp.status_code, 403, resp.text)
+            # reset user quota back to default
+            resp = util.reset_limit(self.cook_url, 'quota', user1.name)
+            self.assertEqual(resp.status_code, 403, resp.text)
+            # set user share
+            resp = util.set_limit(self.cook_url, 'share', user1.name, cpus=10)
+            self.assertEqual(resp.status_code, 403, resp.text)
+            # reset user share back to default
+            resp = util.reset_limit(self.cook_url, 'share', user1.name)
+            self.assertEqual(resp.status_code, 403, resp.text)

--- a/integration/tests/cook/test_impersonation.py
+++ b/integration/tests/cook/test_impersonation.py
@@ -73,9 +73,9 @@ class ImpersonationCookTest(unittest.TestCase):
                 self.assertEqual(resp.status_code, 403, resp.text)
         finally:
             # default user should be an admin, and can kill all the jobs
-            util.kill_jobs(self.cook_url, [ j for j in job_uuids if j ])
+            util.kill_jobs(self.cook_url, [j for j in job_uuids if j])
 
-    def test_cannot_impersonate_endpoints(self):
+    def test_cannot_impersonate_admin_endpoints(self):
         user1 = self.user_factory.new_user()
         job_uuids = []
         # the default user should have admin rights
@@ -98,7 +98,7 @@ class ImpersonationCookTest(unittest.TestCase):
             resp = util.reset_limit(self.cook_url, 'share', user1.name)
             self.assertEqual(resp.status_code, 204, resp.text)
         # impersonator cannot indirectly do admin things
-        with admin.impersonating(user1):
+        with self.poser.impersonating(admin):
             # read queue endpoint
             resp = util.query_queue(self.cook_url)
             self.assertEqual(resp.status_code, 403, resp.text)

--- a/integration/tests/cook/test_master_slave.py
+++ b/integration/tests/cook/test_master_slave.py
@@ -11,7 +11,6 @@ from tests.cook import util
                      'Requires setting the COOK_MASTER_SLAVE environment variable')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class MasterSlaveTest(unittest.TestCase):
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/integration/tests/cook/test_multi_cluster.py
+++ b/integration/tests/cook/test_multi_cluster.py
@@ -11,7 +11,6 @@ from tests.cook import util
                      'Requires setting the COOK_MULTI_CLUSTER environment variable')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class MultiClusterTest(unittest.TestCase):
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -8,7 +8,6 @@ from tests.cook import reasons, util
 @unittest.skipUnless(util.multi_user_tests_enabled(), 'Requires using multi-user coniguration (e.g., BasicAuth) for Cook Scheduler')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class MultiUserCookTest(unittest.TestCase):
-    _multiprocess_can_split_ = True
 
     @classmethod
     def setUpClass(cls):

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -24,6 +24,8 @@ DEFAULT_TEST_TIMEOUT_SECS = 600
 # 2 minutes should be more than sufficient on most cases
 DEFAULT_TIMEOUT_MS = 120000
 
+# Name of our custom HTTP header for user impersonation
+IMPERSONATION_HEADER = 'X-Cook-Impersonate'
 
 def continuous_integration():
     """Returns true if the CONTINUOUS_INTEGRATION environment variable is set, as done by Travis-CI."""
@@ -55,8 +57,6 @@ class _AuthenticatedUser(object):
     to conveniently set a user for a sequence of commands.
     """
 
-    __IMPERSONATION_HEADER = 'X-Cook-Impersonate'
-
     def __init__(self, name, impersonatee=None):
         self.name = name
         self.impersonatee = impersonatee
@@ -69,17 +69,17 @@ class _AuthenticatedUser(object):
     def __enter__(self):
         logger.debug(f'Switching to user {self.name}')
         if self.impersonatee:
-            self.previous_impersonatee = session.headers.get(__IMPERSONATION_HEADER)
-            session.headers[__IMPERSONATION_HEADER] = self.impersonatee
+            self.previous_impersonatee = session.headers.get(IMPERSONATION_HEADER)
+            session.headers[IMPERSONATION_HEADER] = self.impersonatee
 
     def __exit__(self, ex_type, ex_val, ex_trace):
         logger.debug(f'Switching back from user {self.name}')
         if self.impersonatee:
             if self.previous_impersonatee:
-                session.headers[__IMPERSONATION_HEADER] = self.previous_impersonatee
+                session.headers[IMPERSONATION_HEADER] = self.previous_impersonatee
                 self.previous_impersonatee = None
             else:
-                del session.headers[__IMPERSONATION_HEADER]
+                del session.headers[IMPERSONATION_HEADER]
 
 
 class _BasicAuthUser(_AuthenticatedUser):

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -55,6 +55,8 @@ class _AuthenticatedUser(object):
     to conveniently set a user for a sequence of commands.
     """
 
+    __IMPERSONATION_HEADER = 'X-Cook-Impersonate'
+
     def __init__(self, name, impersonatee=None):
         self.name = name
         self.impersonatee = impersonatee
@@ -67,17 +69,17 @@ class _AuthenticatedUser(object):
     def __enter__(self):
         logger.debug(f'Switching to user {self.name}')
         if self.impersonatee:
-            self.previous_impersonatee = session.headers.get('X-Cook-Impersonate')
-            session.headers['X-Cook-Impersonate'] = self.impersonatee
+            self.previous_impersonatee = session.headers.get(__IMPERSONATION_HEADER)
+            session.headers[__IMPERSONATION_HEADER] = self.impersonatee
 
     def __exit__(self, ex_type, ex_val, ex_trace):
         logger.debug(f'Switching back from user {self.name}')
         if self.impersonatee:
             if self.previous_impersonatee:
-                session.headers['X-Cook-Impersonate'] = self.previous_impersonatee
+                session.headers[__IMPERSONATION_HEADER] = self.previous_impersonatee
                 self.previous_impersonatee = None
             else:
-                del session.headers['X-Cook-Impersonate']
+                del session.headers[__IMPERSONATION_HEADER]
 
 
 class _BasicAuthUser(_AuthenticatedUser):

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -9,7 +9,9 @@
                         :authorization-fn cook.authorization/configfile-admins-auth-open-gets
                         ;; These users have admin privileges when using configfile-admins-auth;
                         ;; e.g., they can view and modify other users' jobs.
-                        :admins #{"root" "travis"}}
+                        :admins #{"root" "travis"}
+                        ;; users that are allowed to do things on behalf of others
+                        :impersonators #{"poser" "travis"}}
  :database {:datomic-uri #config/env "COOK_DATOMIC"}
  :zookeeper {:connection #config/env "COOK_ZOOKEEPER"
              :local? #config/env-bool "COOK_ZOOKEEPER_LOCAL"

--- a/scheduler/container-config.edn
+++ b/scheduler/container-config.edn
@@ -9,7 +9,9 @@
                         :authorization-fn cook.authorization/configfile-admins-auth-open-gets
                         ;; These users have admin privileges when using configfile-admins-auth;
                         ;; e.g., they can view and modify other users' jobs.
-                        :admins #{"admin" "root"}}
+                        :admins #{"admin" "root"}
+                        ;; users that are allowed to do things on behalf of others
+                        :impersonators #{"poser" "other-impersonator"}}
  :database {:datomic-uri #config/env "COOK_DATOMIC_URI"}
  :zookeeper {:local? #config/env-bool "COOK_ZOOKEEPER_LOCAL"
              :connection #config/env "COOK_ZOOKEEPER"}

--- a/scheduler/docs/scheduler-rest-api.adoc
+++ b/scheduler/docs/scheduler-rest-api.adoc
@@ -559,6 +559,8 @@ You may specify a set of *authorized impersonators* in your Cook Scheduler confi
 The set is placed under `:authorization-config` `:impersonators`.
 An authorized impersonator may perform most Cook Scheduler actions on behalf of other users;
 e.g., create a new job, retrying a group of jobs, or querying current share limits.
+This feature may be useful to services built on top of the Cook Scheduler,
+which would need authorization to manipulate Cook jobs on behalf of its users.
 
 An impersonated request is the same as a normal request, but with the additon of a special header: `X-Cook-Impersonate`.
 The value associated with this header should be the username (or Kerberos principal) of the user to be impersonated.

--- a/scheduler/docs/scheduler-rest-api.adoc
+++ b/scheduler/docs/scheduler-rest-api.adoc
@@ -551,6 +551,22 @@ $ curl -u: --negotiate "$cook_uri/usage?user=$user&group_breakdown=true"
 {"total_usage":{"cpus":2.0,"mem":512.0,"gpus":0.0,"jobs":2},"grouped":[{"group":{"uuid":"d250d3ed-f397-47b6-9a71-173871e81c63","name":"cookgroup","running_jobs":["ba9b69a7-5fce-4047-a484-167290134322"]},"usage":{"cpus":1.0,"mem":256.0,"gpus":0.0,"jobs":1}}],"ungrouped":{"running_jobs":["81a23761-25c8-4714-a72f-3e0057ecbab6"],"usage":{"cpus":1.0,"mem":256.0,"gpus":0.0,"jobs":1}}}
 ----
 
+[impersonation]
+
+=== User Impersonation
+
+You may specify a set of *authorized impersonators* in your Cook Scheduler configuration file.
+The set is placed under `:authorization-config` `:impersonators`.
+An authorized impersonator may perform most Cook Scheduler actions on behalf of other users;
+e.g., create a new job, retrying a group of jobs, or querying current share limits.
+
+An impersonated request is the same as a normal request, but with the additon of a special header: `X-Cook-Impersonate`.
+The value associated with this header should be the username (or Kerberos principal) of the user to be impersonated.
+The scheduler will check both that the impersonating user is authorized to perform impersonated actions,
+and that the impersonated user is allowed to perform the desired action.
+However, some administrative functions are not allowed via impersonation;
+e.g., an impersonator cannot impersonate an admin to change a user's quota.
+
 [swagger]
 
 === Swagger Specification

--- a/scheduler/src/cook/authorization.clj
+++ b/scheduler/src/cook/authorization.clj
@@ -216,6 +216,7 @@
   [settings
    ^String user
    ^Keyword verb
+   ^String impersonator
    {:keys [owner item] :as object}]
   (log/debug "[is-authorized?] Checking whether user" user
              "may perform" verb "on" (str object) "...")

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -26,11 +26,11 @@
             [congestion.middleware :refer (wrap-rate-limit ip-rate-limit)]
             [congestion.storage :as storage]
             [cook.curator :as curator]
-            [cook.util :as util]
             [cook.impersonation :refer (impersonation-authorized-wrapper)]
+            [cook.util :as util]
             [metrics.jvm.core :as metrics-jvm]
             [metrics.ring.instrument :refer (instrument)]
-            [plumbing.core :refer (fnk letk)]
+            [plumbing.core :refer (fnk)]
             [plumbing.graph :as graph]
             [ring.middleware.cookies :refer (wrap-cookies)]
             [ring.middleware.params :refer (wrap-params)]
@@ -397,7 +397,7 @@
                                        {:json-value "kerberos"}))
                                    :else (throw (ex-info "Missing authorization configuration" {}))))
      :impersonation-middleware (fnk [[:config {authorization-config nil}]]
-                                    (letk [[{impersonators nil}] authorization-config]
+                                    (let [{impersonators :impersonators} authorization-config]
                                       (with-meta
                                         ((lazy-load-var 'cook.impersonation/create-impersonation-middleware) impersonators)
                                         {:json-value "config-impersonation"})))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -27,9 +27,10 @@
             [congestion.storage :as storage]
             [cook.curator :as curator]
             [cook.util :as util]
+            [cook.impersonation :refer (impersonation-authorized-wrapper)]
             [metrics.jvm.core :as metrics-jvm]
             [metrics.ring.instrument :refer (instrument)]
-            [plumbing.core :refer (fnk)]
+            [plumbing.core :refer (fnk letk)]
             [plumbing.graph :as graph]
             [ring.middleware.cookies :refer (wrap-cookies)]
             [ring.middleware.params :refer (wrap-params)]
@@ -244,8 +245,8 @@
   (graph/eager-compile
     {:mesos-datomic mesos-datomic
      :route full-routes
-     :http-server (fnk [[:settings server-port authorization-middleware leader-reports-unhealthy [:rate-limit user-limit]] [:route view]
-                        mesos-leadership-atom]
+     :http-server (fnk [[:settings server-port authorization-middleware impersonation-middleware
+                         leader-reports-unhealthy [:rate-limit user-limit]] [:route view] mesos-leadership-atom]
                     (log/info "Launching http server")
                     (let [rate-limit-storage (storage/local-storage)
                           jetty ((lazy-load-var 'qbits.jet.server/run-jetty)
@@ -256,6 +257,7 @@
                                                        tell-jetty-about-usename
                                                        (wrap-rate-limit {:storage rate-limit-storage
                                                                          :limit user-limit})
+                                                       impersonation-middleware
                                                        (conditional-auth-bypass authorization-middleware)
                                                        wrap-stacktrace
                                                        wrap-no-cache
@@ -362,8 +364,11 @@
      :server-port (fnk [[:config port]]
                     port)
      :is-authorized-fn (fnk [[:config {authorization-config default-authorization}]]
-                         (partial (lazy-load-var 'cook.authorization/is-authorized?)
-                                  authorization-config))
+                            (let [auth-fn @(lazy-load-var 'cook.authorization/is-authorized?)]
+                              ; we only wrap the authorization function if we have impersonators configured
+                              (if (-> authorization-config :impersonators seq)
+                                (impersonation-authorized-wrapper auth-fn authorization-config)
+                                (partial auth-fn authorization-config))))
      :authorization-middleware (fnk [[:config [:authorization {one-user false} {kerberos false} {http-basic false}]]]
                                  (cond
                                    http-basic
@@ -391,6 +396,11 @@
                                        @(lazy-load-var 'cook.spnego/require-gss)
                                        {:json-value "kerberos"}))
                                    :else (throw (ex-info "Missing authorization configuration" {}))))
+     :impersonation-middleware (fnk [[:config {authorization-config nil}]]
+                                    (letk [[{impersonators nil}] authorization-config]
+                                      (with-meta
+                                        ((lazy-load-var 'cook.impersonation/create-impersonation-middleware) impersonators)
+                                        {:json-value "config-impersonation"})))
      :rate-limit (fnk [[:config {rate-limit nil}]]
                    (let [{:keys [user-limit-per-m]
                           :or {user-limit-per-m 600}} rate-limit]

--- a/scheduler/src/cook/impersonation.clj
+++ b/scheduler/src/cook/impersonation.clj
@@ -1,0 +1,87 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.impersonation
+  "Support for services impersonating a user, performing Cook actions the user's behalf."
+  (:require [clojure.string]
+            [clojure.tools.logging :as log]
+            [cook.util]
+            [ring.util.response :refer (header status response)])
+  (:import (clojure.lang Keyword)))
+
+(defn- unrestricted-access
+  "Denotes that an impersonator may perform any operation on a given object type."
+  [_]
+  true)
+
+(defn- getter-access
+  "Denotes that an impersonator may only perform gets on a given object type."
+  [verb]
+  (= :get verb))
+
+(def object-type->verb->impersonatable?
+  "Specification of operations that authorized impersonators may perform on behalf of another user."
+  {:job unrestricted-access
+   :quota getter-access
+   :share getter-access
+   :usage getter-access})
+
+(defn impersonation-authorized-wrapper
+  "This function is meant to wrap the authorization/is-authorized? function.
+
+  The resulting function determines whether an authorized impersonator
+  can perform the given operation on the given object, on behalf of the given user.
+
+  Returns true if allowed, else false."
+  [is-authorized-fn settings]
+  (fn is-impersonatable?
+    [^String user
+     ^Keyword verb
+     ^String impersonator
+     {:keys [owner item] :as object}]
+    (log/debug "[is-impersonatable?] Checking whether user" impersonator
+               "may impersonate user" user
+               "performing" verb "on" (str object) "...")
+    (log/debug "[is-impersonatable?] Settings are:" settings)
+    (and (or (nil? impersonator)
+             (if-let [verb->impersonatable? (object-type->verb->impersonatable? item)]
+               (verb->impersonatable? verb)
+               false))
+         (is-authorized-fn settings user verb impersonator object))))
+
+(defn create-impersonation-middleware
+  "Provides user-impersonation middleware.
+  Uses the impersonators set-argument to verify impersonation authorization."
+  [impersonators]
+  (fn impersonation-middleware [h]
+    (if-let [impersonators-set (some-> impersonators seq set)]
+      (fn impersonation-wrapper [{user :authorization/user :as req}]
+        (if-let [impersonated-principal (get-in req [:headers "x-cook-impersonate"])]
+          (let [impersonated-user (cook.util/principal->username impersonated-principal)]
+            (log/debug "User" user "is attempting to impersonate" impersonated-user)
+            (if-not (contains? impersonators-set user)
+              ; Case: this user isn't authorized to impersonate
+              (-> (response (str "User " user " does not have impersonation privileges."))
+                  (status 403)
+                  (header "Content-Type" "text/plain"))
+              ; Case: impersonation looks OK so far
+              ; Note that the is-authorized-fn (via the impersonation-authorized-wrapper function)
+              ; will later look for the :authorization/impersonator value and ensure that
+              ; the target operation is allowed to be impersonated (see components.clj).
+              (h (assoc req :authorization/user impersonated-user :authorization/impersonator user))))
+          ; Case: not attempting to impersonate
+          (h req)))
+      ; we don't add this middleware if no impersonators are configured
+      h)))

--- a/scheduler/src/cook/impersonation.clj
+++ b/scheduler/src/cook/impersonation.clj
@@ -14,7 +14,7 @@
 ;; limitations under the License.
 ;;
 (ns cook.impersonation
-  "Support for services impersonating a user, performing Cook actions the user's behalf."
+  "Support for services impersonating a user, performing Cook actions on the user's behalf."
   (:require [clojure.string]
             [clojure.tools.logging :as log]
             [cook.util]
@@ -56,9 +56,8 @@
                "performing" verb "on" (str object) "...")
     (log/debug "[is-impersonatable?] Settings are:" settings)
     (and (or (nil? impersonator)
-             (if-let [verb->impersonatable? (object-type->verb->impersonatable? item)]
-               (verb->impersonatable? verb)
-               false))
+             (when-let [verb->impersonatable? (object-type->verb->impersonatable? item)]
+               (verb->impersonatable? verb)))
          (is-authorized-fn settings user verb impersonator object))))
 
 (defn create-impersonation-middleware

--- a/scheduler/src/cook/spnego.clj
+++ b/scheduler/src/cook/spnego.clj
@@ -17,6 +17,7 @@
   (:require [clojure.data.codec.base64 :as b64]
             [clojure.string :as str]
             [clojure.string :refer (split lower-case)]
+            [cook.util]
             [ring.util.response :refer (header status response)])
   (:import [org.ietf.jgss GSSManager GSSCredential Oid]))
 
@@ -86,7 +87,7 @@
           (let [princ (gss-get-princ gss_context)]
             (cond-> (-> req
                         (assoc :krb5-authenticated-princ princ
-                               :authorization/user (first (str/split princ #"@" 2)))
+                               :authorization/user (cook.util/principal->username princ))
                         (rh))
               token (header "WWW-Authenticate" token)))
           (response-401-negotiate)))

--- a/scheduler/src/cook/util.clj
+++ b/scheduler/src/cook/util.clj
@@ -280,6 +280,11 @@
                         (System/getProperty "cook.version")
                         "version_unknown")))
 
+(defn principal->username
+ "Convert a Kerberos-style principal to a Mesos username."
+ [principal]
+ (-> principal (split #"[/@]" 2) first))
+
 (defn get-html-stacktrace
   "Returns a string representation of the exception. The 3 argument form fleshes
    out information about the thread, user, and host."

--- a/scheduler/test/cook/test/authorization.clj
+++ b/scheduler/test/cook/test/authorization.clj
@@ -139,22 +139,22 @@
 
 (deftest is-authorized
   (testing "is-authorized? selects the auth function defined in the settings correctly"
-    (is (true? (auth/is-authorized? open-auth-settings "foo" :create test-job)))
-    (is (true? (auth/is-authorized? open-auth-settings "bar" :read test-job)))
-    (is (true? (auth/is-authorized? open-auth-settings "baz" :update test-job)))
-    (is (true? (auth/is-authorized? open-auth-settings "frob" :destroy test-job)))
+    (is (true? (auth/is-authorized? open-auth-settings "foo" :create nil test-job)))
+    (is (true? (auth/is-authorized? open-auth-settings "bar" :read nil test-job)))
+    (is (true? (auth/is-authorized? open-auth-settings "baz" :update nil test-job)))
+    (is (true? (auth/is-authorized? open-auth-settings "frob" :destroy nil test-job)))
 
-    (is (false? (auth/is-authorized? configfile-admins-settings "foo" :create test-job)))
-    (is (false? (auth/is-authorized? configfile-admins-settings "bar" :read test-job)))
-    (is (false? (auth/is-authorized? configfile-admins-settings "baz" :update test-job)))
-    (is (false? (auth/is-authorized? configfile-admins-settings "frob" :destroy test-job)))
+    (is (false? (auth/is-authorized? configfile-admins-settings "foo" :create nil test-job)))
+    (is (false? (auth/is-authorized? configfile-admins-settings "bar" :read nil test-job)))
+    (is (false? (auth/is-authorized? configfile-admins-settings "baz" :update nil test-job)))
+    (is (false? (auth/is-authorized? configfile-admins-settings "frob" :destroy nil test-job)))
 
-    (is (true? (auth/is-authorized? configfile-admins-settings test-job-owner :create test-job)))
-    (is (true? (auth/is-authorized? configfile-admins-settings test-job-owner :read test-job)))
-    (is (true? (auth/is-authorized? configfile-admins-settings test-job-owner :update test-job)))
-    (is (true? (auth/is-authorized? configfile-admins-settings test-job-owner :destroy test-job)))
+    (is (true? (auth/is-authorized? configfile-admins-settings test-job-owner :create nil test-job)))
+    (is (true? (auth/is-authorized? configfile-admins-settings test-job-owner :read nil test-job)))
+    (is (true? (auth/is-authorized? configfile-admins-settings test-job-owner :update nil test-job)))
+    (is (true? (auth/is-authorized? configfile-admins-settings test-job-owner :destroy nil test-job)))
 
-    (is (true? (auth/is-authorized? configfile-admins-settings admin-user :create test-job)))
-    (is (true? (auth/is-authorized? configfile-admins-settings admin-user :read test-job)))
-    (is (true? (auth/is-authorized? configfile-admins-settings admin-user :update test-job)))
-    (is (true? (auth/is-authorized? configfile-admins-settings admin-user :destroy test-job)))))
+    (is (true? (auth/is-authorized? configfile-admins-settings admin-user :create nil test-job)))
+    (is (true? (auth/is-authorized? configfile-admins-settings admin-user :read nil test-job)))
+    (is (true? (auth/is-authorized? configfile-admins-settings admin-user :update nil test-job)))
+    (is (true? (auth/is-authorized? configfile-admins-settings admin-user :destroy nil test-job)))))

--- a/scheduler/test/cook/test/impersonation.clj
+++ b/scheduler/test/cook/test/impersonation.clj
@@ -1,0 +1,115 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.test.impersonation
+  (:use clojure.test)
+  (:require [cook.authorization :as auth]
+            [cook.impersonation :as imp]
+            [cook.mesos.api :as api]))
+
+(def test-job-owner "the-job-owner")
+(def test-job {:owner test-job-owner :item :job})
+
+(def impersonator-user "the-impersonator")
+(def impersonator-job {:owner impersonator-user :item :job})
+
+(def admin-user "admin")
+
+(def auth-settings
+  {:authorization-fn 'cook.authorization/configfile-admins-auth-open-gets
+   :admins #{"admin" "other-admin"}})
+
+(def is-authorized? (imp/impersonation-authorized-wrapper auth/is-authorized? auth-settings))
+
+(deftest impersonated-is-authorized
+  (testing "that is-authorized? function performs correctly with impersonated users"
+
+    ; random users can't touch other's job
+    (is (false? (is-authorized? "foo" :create nil test-job)))
+    (is (false? (is-authorized? "bar" :read nil test-job)))
+    (is (false? (is-authorized? "baz" :update nil test-job)))
+    (is (false? (is-authorized? "frob" :destroy nil test-job)))
+
+    ; but random gets are OK
+    (is (true? (is-authorized? "froo" :get impersonator-user test-job)))
+
+    ; job owner can modify their own job
+    (is (true? (is-authorized? test-job-owner :create nil test-job)))
+    (is (true? (is-authorized? test-job-owner :read nil test-job)))
+    (is (true? (is-authorized? test-job-owner :update nil test-job)))
+    (is (true? (is-authorized? test-job-owner :destroy nil test-job)))
+
+    ; admin can modify other's job
+    (is (true? (is-authorized? admin-user :create nil test-job)))
+    (is (true? (is-authorized? admin-user :read nil test-job)))
+    (is (true? (is-authorized? admin-user :update nil test-job)))
+    (is (true? (is-authorized? admin-user :destroy nil test-job)))
+
+    ; admin can read and write user quotas
+    (is (true? (is-authorized? admin-user :get nil {:item :quota})))
+    (is (true? (is-authorized? admin-user :create nil {:item :quota})))
+    (is (true? (is-authorized? admin-user :update nil {:item :quota})))
+    (is (true? (is-authorized? admin-user :destroy nil {:item :quota})))
+
+    ; admin can read and write user shares
+    (is (true? (is-authorized? admin-user :get nil {:item :share})))
+    (is (true? (is-authorized? admin-user :create nil {:item :share})))
+    (is (true? (is-authorized? admin-user :update nil {:item :share})))
+    (is (true? (is-authorized? admin-user :destroy nil {:item :share})))
+
+    ; admin can read user usage
+    (is (true? (is-authorized? admin-user :get nil {:item :usage})))
+
+    ; admin can read queue endpoint
+    (is (true? (is-authorized? admin-user :read nil {:item :queue})))
+
+    ; impersonated random users can't touch other's job
+    (is (false? (is-authorized? "foo" :create impersonator-user test-job)))
+    (is (false? (is-authorized? "bar" :read impersonator-user test-job)))
+    (is (false? (is-authorized? "baz" :update impersonator-user test-job)))
+    (is (false? (is-authorized? "frob" :destroy impersonator-user test-job)))
+
+    ; but random impersonated gets are OK
+    (is (true? (is-authorized? "froo" :get impersonator-user test-job)))
+
+    ; impersonated job owner can modify their own job
+    (is (true? (is-authorized? test-job-owner :create impersonator-user test-job)))
+    (is (true? (is-authorized? test-job-owner :read impersonator-user test-job)))
+    (is (true? (is-authorized? test-job-owner :update impersonator-user test-job)))
+    (is (true? (is-authorized? test-job-owner :destroy impersonator-user test-job)))
+
+    ; impersonated admin can modify other's job
+    (is (true? (is-authorized? admin-user :create impersonator-user test-job)))
+    (is (true? (is-authorized? admin-user :read impersonator-user test-job)))
+    (is (true? (is-authorized? admin-user :update impersonator-user test-job)))
+    (is (true? (is-authorized? admin-user :destroy impersonator-user test-job)))
+
+    ; impersonated admin can read--but not write--user quotas
+    (is (true? (is-authorized? admin-user :get impersonator-user {:item :quota})))
+    (is (false? (is-authorized? admin-user :create impersonator-user {:item :quota})))
+    (is (false? (is-authorized? admin-user :update impersonator-user {:item :quota})))
+    (is (false? (is-authorized? admin-user :destroy impersonator-user {:item :quota})))
+
+    ; impersonated admin can read--but not write--user shares
+    (is (true? (is-authorized? admin-user :get impersonator-user {:item :share})))
+    (is (false? (is-authorized? admin-user :create impersonator-user {:item :share})))
+    (is (false? (is-authorized? admin-user :update impersonator-user {:item :share})))
+    (is (false? (is-authorized? admin-user :destroy impersonator-user {:item :share})))
+
+    ; impersonated admin can read user usage
+    (is (true? (is-authorized? admin-user :get impersonator-user {:item :usage})))
+
+    ; impersonated admin can't read queue endpoint
+    (is (false? (is-authorized? admin-user :read impersonator-user {:item :queue})))))

--- a/scheduler/test/cook/test/impersonation.clj
+++ b/scheduler/test/cook/test/impersonation.clj
@@ -71,10 +71,10 @@
       (is (true? (is-authorized? admin-user :read nil {:item :queue})))
 
       ; impersonated random users can't touch other's job
-      (is (false? (is-authorized? "foo" :create impersonator-user test-job)))
-      (is (false? (is-authorized? "bar" :read impersonator-user test-job)))
-      (is (false? (is-authorized? "baz" :update impersonator-user test-job)))
-      (is (false? (is-authorized? "frob" :destroy impersonator-user test-job)))
+      (is (not (is-authorized? "foo" :create impersonator-user test-job)))
+      (is (not (is-authorized? "bar" :read impersonator-user test-job)))
+      (is (not (is-authorized? "baz" :update impersonator-user test-job)))
+      (is (not (is-authorized? "frob" :destroy impersonator-user test-job)))
 
       ; but random impersonated gets are OK
       (is (true? (is-authorized? "froo" :get impersonator-user test-job)))
@@ -93,18 +93,18 @@
 
       ; impersonated admin can read--but not write--user quotas
       (is (true? (is-authorized? admin-user :get impersonator-user {:item :quota})))
-      (is (false? (is-authorized? admin-user :create impersonator-user {:item :quota})))
-      (is (false? (is-authorized? admin-user :update impersonator-user {:item :quota})))
-      (is (false? (is-authorized? admin-user :destroy impersonator-user {:item :quota})))
+      (is (not (is-authorized? admin-user :create impersonator-user {:item :quota})))
+      (is (not (is-authorized? admin-user :update impersonator-user {:item :quota})))
+      (is (not (is-authorized? admin-user :destroy impersonator-user {:item :quota})))
 
       ; impersonated admin can read--but not write--user shares
       (is (true? (is-authorized? admin-user :get impersonator-user {:item :share})))
-      (is (false? (is-authorized? admin-user :create impersonator-user {:item :share})))
-      (is (false? (is-authorized? admin-user :update impersonator-user {:item :share})))
-      (is (false? (is-authorized? admin-user :destroy impersonator-user {:item :share})))
+      (is (not (is-authorized? admin-user :create impersonator-user {:item :share})))
+      (is (not (is-authorized? admin-user :update impersonator-user {:item :share})))
+      (is (not (is-authorized? admin-user :destroy impersonator-user {:item :share})))
 
       ; impersonated admin can read user usage
       (is (true? (is-authorized? admin-user :get impersonator-user {:item :usage})))
 
       ; impersonated admin can't read queue endpoint
-      (is (false? (is-authorized? admin-user :read impersonator-user {:item :queue}))))))
+      (is (not (is-authorized? admin-user :read impersonator-user {:item :queue}))))))

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -32,7 +32,7 @@
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."
   [conn port]
-  (let [authorized-fn (fn [x y z] true)
+  (let [authorized-fn (fn [w x y z] true)
         api-handler (wrap-params
                       (api/main-handler conn
                                         "my-framework-id"


### PR DESCRIPTION
## Changes proposed in this PR

Add support for explicitly-authorized users to impersonate other users (i.e., execute commands on another user's behalf). The set of actions that can be impersonated is also restricted.

## Why are we making these changes?

Services built on top of cook can use this feature to integrate more seamlessly while still providing transparency to the end-user.

## Other notes

<del>This is a work in progress. This PR currently only contains the changes made to the scheduler. I need pytest support (#666) merged, along with some other changes, before I can get the integration tests running correctly in Travis. However, I see no reason to delay feedback on the actual implementation in the scheduler just because the feature is blocked on the integration infrastructure.</del>

The pytest and multi-user-test support is all merged, so this should be good to go now!