### PR TITLE
Use thread-based timeouts by default in pytest cfg

### DIFF
--- a/integration/setup.cfg
+++ b/integration/setup.cfg
@@ -1,3 +1,3 @@
 [tool:pytest]
-addopts = -n10 -v
+addopts = -n10 -v --timeout-method=thread
 timeout = 1200


### PR DESCRIPTION
## Changes proposed in this PR

Use thread-based timeouts by default in pytest by setting that option in `integration/setup.cfg`

## Why are we making these changes?

It seems that most Linux systems don't allow us to run pytest with parallel testing enabled if using the default (signal) timeout method.