### PR TITLE
Allow setting COOK_MESOS_LEADER_URL env var for integration tests

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -68,15 +68,17 @@ def retrieve_cook_url(varname='COOK_SCHEDULER_URL', value='http://localhost:1232
 
 
 def retrieve_mesos_url(varname='MESOS_PORT', value='5050'):
-    mesos_port = os.getenv(varname, value)
-    cook_url = retrieve_cook_url()
-    wait_for_cook(cook_url)
-    mesos_master_hosts = settings(cook_url).get('mesos-master-hosts', ['localhost'])
-    resp = session.get('http://%s:%s/redirect' % (mesos_master_hosts[0], mesos_port), allow_redirects=False)
-    if resp.status_code != 307:
-        raise RuntimeError('Unable to find mesos leader, redirect endpoint returned %d' % resp.status_code)
-    mesos_url = 'http:%s' % resp.headers['Location']
-    logger.info('Using mesos url %s' % mesos_url)
+    mesos_url = os.getenv('COOK_MESOS_LEADER_URL')
+    if mesos_url is None:
+        mesos_port = os.getenv(varname, value)
+        cook_url = retrieve_cook_url()
+        wait_for_cook(cook_url)
+        mesos_master_hosts = settings(cook_url).get('mesos-master-hosts', ['localhost'])
+        resp = session.get('http://%s:%s/redirect' % (mesos_master_hosts[0], mesos_port), allow_redirects=False)
+        if resp.status_code != 307:
+            raise RuntimeError('Unable to find mesos leader, redirect endpoint returned %d' % resp.status_code)
+        mesos_url = 'http:%s' % resp.headers['Location']
+    logger.info(f'Using mesos url {mesos_url}')
     return mesos_url
 
 


### PR DESCRIPTION
## Changes proposed in this PR

Allow manually setting the Mesos URL used in our integration tests via the `COOK_MESOS_LEADER_URL` environment variable.

## Why are we making these changes?

I'm setting this manually on my laptop as a workaround for running some test locally that need to talk directly to Mesos, but can't access Mesos via the default docker IP address.