### PR TITLE
Add required "reason" param to swagger for user limit delete ops

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1497,3 +1497,30 @@ class CookTest(unittest.TestCase):
             self.assertGreaterEqual(usage_data['total_usage']['jobs'], job_count, usage_data)
         finally:
             util.kill_jobs(self.cook_url, job_uuids)
+
+    def test_user_limits_change(self):
+        user = 'limit_change_test_user'
+        # set user quota
+        resp = util.set_limit(self.cook_url, 'quota', user, cpus=20)
+        self.assertEqual(resp.status_code, 201, resp.text)
+        # set user quota fails (malformed) if no reason is given
+        resp = util.set_limit(self.cook_url, 'quota', user, cpus=10, reason=None)
+        self.assertEqual(resp.status_code, 400, resp.text)
+        # reset user quota back to default
+        resp = util.reset_limit(self.cook_url, 'quota', user)
+        self.assertEqual(resp.status_code, 204, resp.text)
+        # reset user quota fails (malformed) if no reason is given
+        resp = util.reset_limit(self.cook_url, 'quota', user, reason=None)
+        self.assertEqual(resp.status_code, 400, resp.text)
+        # set user share
+        resp = util.set_limit(self.cook_url, 'share', user, cpus=10)
+        self.assertEqual(resp.status_code, 201, resp.text)
+        # set user share fails (malformed) if no reason is given
+        resp = util.set_limit(self.cook_url, 'share', user, cpus=10, reason=None)
+        self.assertEqual(resp.status_code, 400, resp.text)
+        # reset user share back to default
+        resp = util.reset_limit(self.cook_url, 'share', user)
+        self.assertEqual(resp.status_code, 204, resp.text)
+        # reset user share fails (malformed) if no reason is given
+        resp = util.reset_limit(self.cook_url, 'share', user, reason=None)
+        self.assertEqual(resp.status_code, 400, resp.text)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -664,6 +664,23 @@ def user_current_usage(cook_url, **kwargs):
     return session.get('%s/usage' % cook_url, params=kwargs)
 
 
+def set_limit(cook_url, limit_type, user, mem=None, cpus=None, gpus=None, jobs=None, reason='testing'):
+    limits = {}
+    body = {'user': user, limit_type: limits}
+    if reason is not None: body['reason'] = reason
+    if mem is not None: limits['mem'] = mem
+    if cpus is not None: limits['cpus'] = cpus
+    if gpus is not None: limits['gpus'] = gpus
+    if jobs is not None: limits['jobs'] = jobs
+    return session.post(f'{cook_url}/{limit_type}', json=body)
+
+
+def reset_limit(cook_url, limit_type, user, reason='testing'):
+    params = {'user': user}
+    if reason is not None: params['reason'] = reason
+    return session.delete(f'{cook_url}/{limit_type}', params=params)
+
+
 def retrieve_progress_file_env(cook_url):
     """Retrieves the environment variable used by the cook executor to lookup the progress file."""
     cook_settings = settings(cook_url)

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1737,14 +1737,15 @@
 
 ;; /share and /quota
 (def UserParam {:user s/Str})
+(def ReasonParam {:reason s/Str})
+(def UserLimitChangeParams (merge UserParam ReasonParam))
 
 (def UserLimitsResponse
   {String s/Num})
 
 (defn set-limit-params
   [limit-type]
-  {:body-params (merge UserParam {limit-type {s/Keyword s/Num}
-                                  :reason s/Str})})
+  {:body-params (merge UserLimitChangeParams {limit-type {s/Keyword s/Num}})})
 
 (defn retrieve-user-limit
   [get-limit-fn conn ctx]
@@ -2281,7 +2282,7 @@
                                                    share/get-share share/set-share!
                                                    conn is-authorized-fn)}
              :delete {:summary "Reset a user's share to the default"
-                      :parameters {:query-params UserParam}
+                      :parameters {:query-params UserLimitChangeParams}
                       :handler (destroy-limit-handler :share share/retract-share! conn is-authorized-fn)}}))
 
         (c-api/context
@@ -2301,7 +2302,7 @@
                                                    quota/get-quota quota/set-quota!
                                                    conn is-authorized-fn)}
              :delete {:summary "Reset a user's quota to the default"
-                      :parameters {:query-params UserParam}
+                      :parameters {:query-params UserLimitChangeParams}
                       :handler (destroy-limit-handler :delete quota/retract-quota! conn is-authorized-fn)}}))
 
         (c-api/context


### PR DESCRIPTION
## Changes proposed in this PR

Add the required `reason` query-string parameter to the Swagger annotations on the quota and share `DELETE` endpoints.

## Why are we making these changes?

The required parameter should be documented, and we'd prefer a 400 (malformed) error over a 500 (internal server exception) error.