### PR TITLE
Fix group retry allow logic

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1675,7 +1675,7 @@
     (or (first (for [guuid (::groups ctx)
                      :let [group (d/entity (db conn) [:group/uuid guuid])
                            job (-> group :group/job first)]
-                     :when (some-> job unauthorized-job?)]
+                     :when (some-> job :job/uuid unauthorized-job?)]
                  [false {::error (str "You are not authorized to retry jobs from group " guuid ".")}]))
         (when-let [unauthorized-jobs (->> ctx ::non-group-jobs (filter unauthorized-job?) seq)]
           [false {::error (->> unauthorized-jobs


### PR DESCRIPTION
## Changes proposed in this PR

- Fixes a type error in the group-retry-allowed logic.
- Adds unit tests for the `/retry` endpoint using groups.

## Why are we making these changes?

Group retries currently only work for admins. That's obviously not the intended behavior.