### PR TITLE
Stops dumping sandbox logs when there are test failures

### DIFF
--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -93,7 +93,7 @@ pytest -n4 -v --color=no --timeout-method=thread --boxed -m "${PYTEST_MARKS}" ||
 
 # If there were failures, dump the executor logs
 if [ "$test_failures" = true ]; then
-  echo "Displaying executor logs"
-  ${PROJECT_DIR}/../travis/show_executor_logs.sh
+  echo "Displaying scheduler logs"
+  ${TRAVIS_BUILD_DIR}/travis/show_scheduler_logs.sh
   exit 1
 fi

--- a/travis/show_executor_logs.sh
+++ b/travis/show_executor_logs.sh
@@ -1,18 +1,11 @@
 #!/bin/bash
 set -v
 
-echo "what logs are there"
-find $PROJECT_DIR/../scheduler/log -name 'cook*.log'
 echo "Printing out all executor logs..."
 while read path; do
     echo "Contents of ${path}";
     cat "${path}";
     echo "------------------------------------"
-done <<< "$(find $PROJECT_DIR/../travis/.minimesos -name 'stdout' -o -name 'stderr' -o -name 'executor.log')"
+done <<< "$(find ${TRAVIS_BUILD_DIR}/travis/.minimesos -name 'stdout' -o -name 'stderr' -o -name 'executor.log')"
 
-for log in $PROJECT_DIR/../scheduler/log/cook*.log;
-do
-    echo "Contents of ${log}"
-    cat "${log}";
-    echo "------------------------------------"
-done
+${TRAVIS_BUILD_DIR}/travis/show_scheduler_logs.sh

--- a/travis/show_scheduler_logs.sh
+++ b/travis/show_scheduler_logs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+for log in ${TRAVIS_BUILD_DIR}/scheduler/log/cook*.log;
+do
+    echo "Contents of ${log}"
+    cat "${log}";
+    echo "------------------------------------"
+done


### PR DESCRIPTION
## Changes proposed in this PR

- extracting the code for dumping the cook scheduler logs into a new `show_scheduler_logs.sh` script
- changing `integration/travis/run_integration.sh` to only dump scheduler logs, instead of all sandbox logs

## Why are we making these changes?

When we have test failures, dumping all of the logs currently takes a really long time (> 30 minutes), and the actual cook scheduler log files get truncated due to the 4MB output limit on Travis.