### PR TITLE
Removes overall cluster utilization from cs usage

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1650,7 +1650,6 @@ class CookCliTest(unittest.TestCase):
             cluster_usage = usage['clusters'][self.cook_url]
             total_usage = cluster_usage['usage']
             share = cluster_usage['share']
-            utilization = cluster_usage['cluster_utilization']
             applications = cluster_usage['applications']
             cs_usage = applications['cook-scheduler-cli']['usage']
             ungrouped_usage = applications['cook-scheduler-cli']['groups']['null']['usage']
@@ -1671,9 +1670,6 @@ class CookCliTest(unittest.TestCase):
             self.assertLessEqual(0, share['cpus'])
             self.assertLessEqual(0, share['mem'])
             self.assertLessEqual(0, share['gpus'])
-            self.assertLessEqual(0, utilization['cpus'])
-            self.assertLessEqual(0, utilization['mem'])
-            self.assertLessEqual(0, utilization['gpus'])
             self.assertLessEqual(round(0.1 * 6, 1), round(cs_usage['cpus'], 1))
             self.assertLessEqual(round(16 * 6, 1), round(cs_usage['mem'], 1))
             self.assertLessEqual(0, cs_usage['gpus'])


### PR DESCRIPTION
## Changes proposed in this PR

- removing the overall cluster utilization from `cs usage`

## Why are we making these changes?

Fetching the metrics from Mesos can be very slow:

https://issues.apache.org/jira/browse/MESOS-4740

## Example Output

```bash
$ cs usage --user root
dev0
Share: No CPU Limit, No Memory Limit, No GPU Limit
Usage: 0.9 CPU, 144 MB Memory
Applications:
- cook-scheduler-cli
  Usage: 0.6 CPU, 96 MB Memory
  Job Groups:
        - [ungrouped]
          Usage: 0.3 CPU, 48 MB Memory
          Jobs: 3

        - foo (b910938b-732c-4636-b852-1e49499f99bd)
          Usage: 0.3 CPU, 48 MB Memory
          Jobs: 3

- 29881152-a851-4412-a655-9951343f9872
  Usage: 0.3 CPU, 48 MB Memory
  Job Groups:
        - qux (28a7898e-92ef-4464-be79-57a52b93f696)
          Usage: 0.3 CPU, 48 MB Memory
          Jobs: 3
```
