### PR TITLE
Disable bash verbose mode in run-docker.sh

### DIFF
--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -5,7 +5,7 @@
 #   --auth={http-basic,one-user}    Use the specified authentication scheme. Default is one-user.
 #   --executor={cook,mesos}         Use the specified job executor. Default is cook.
 
-set -ev
+set -e
 
 # Defaults (overridable via environment)
 : ${COOK_PORT:=12321}


### PR DESCRIPTION
## Changes proposed in this PR

- Remove the `-v` (verbose) setting from `run-docker.sh`

## Why are we making these changes?

I accidentally copied this flag over from the Travis run-scheduler script. While it doesn't break anything, it's kind of annoying to have the whole script contents dumped to the terminal every time I run the script.
