### PR TITLE
Allows status field on job submit for backwards compatibility

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1728,3 +1728,11 @@ class CookTest(unittest.TestCase):
         scheduler_default_job_name = 'cookjob'
         job = util.load_job(self.cook_url, job_uuid)
         self.assertEqual(scheduler_default_job_name, job['name'])
+
+    def test_submit_with_status(self):
+        # The Java job client used to send the status field on job submission.
+        # At some point, that changed, but we still allow it for backwards compat.
+        job_uuid, resp = util.submit_job(self.cook_url, status='not a real status')
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job = util.load_job(self.cook_url, job_uuid)
+        self.assertIn(job['status'], ['running', 'waiting', 'completed'])

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -286,6 +286,11 @@
              (s/optional-key :max-runtime) PosInt
              (s/optional-key :name) JobName
              (s/optional-key :priority) JobPriority
+             ;; The Java job client used to send the
+             ;; status field on job submission. At some
+             ;; point, that changed, but we will keep
+             ;; allowing it here for backwards compat.
+             (s/optional-key :status) s/Str
              (s/optional-key :uris) [UriRequest])))
 
 (def JobRequest
@@ -298,6 +303,7 @@
   For example, it can include descriptions of instances for the job."
   (-> JobRequestMap
       (dissoc (s/optional-key :group))
+      (dissoc (s/optional-key :status))
       (merge {:framework-id (s/maybe s/Str)
               :retries-remaining NonNegInt
               :status s/Str


### PR DESCRIPTION
## Changes proposed in this PR

- adding `status` as an optional field on job submission
- adding an integration test to confirm that it works

## Why are we making these changes?

The Java job client used to send status on job submission. We want to allow this for backwards compatibility.