### PR TITLE
Reject submitted jobs that exceed user's quota

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -88,7 +88,7 @@ class MultiUserCookTest(unittest.TestCase):
                 with self.user_factory.admin():
                     util.kill_jobs(self.cook_url, all_job_uuids)
 
-    def test_job_too_much_cpu(self):
+    def test_job_cpu_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
         try:
@@ -123,7 +123,7 @@ class MultiUserCookTest(unittest.TestCase):
             with admin:
                 util.reset_limit(self.cook_url, 'quota', user.name)
 
-    def test_job_too_much_mem(self):
+    def test_job_mem_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
         try:
@@ -158,7 +158,7 @@ class MultiUserCookTest(unittest.TestCase):
             with admin:
                 util.reset_limit(self.cook_url, 'quota', user.name)
 
-    def test_job_no_quota(self):
+    def test_job_count_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
         try:

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -115,6 +115,10 @@ class MultiUserCookTest(unittest.TestCase):
             with user:
                 _, resp = util.submit_job(self.cook_url)
                 self.assertEqual(resp.status_code, 201, msg=resp.text)
+            # Can't set negative quota
+            with admin:
+                resp = util.set_limit(self.cook_url, 'quota', user.name, cpus=-4)
+                self.assertEqual(resp.status_code, 400, resp.text)
         finally:
             with admin:
                 util.reset_limit(self.cook_url, 'quota', user.name)
@@ -146,6 +150,10 @@ class MultiUserCookTest(unittest.TestCase):
             with user:
                 _, resp = util.submit_job(self.cook_url)
                 self.assertEqual(resp.status_code, 201, msg=resp.text)
+            # Can't set negative quota
+            with admin:
+                resp = util.set_limit(self.cook_url, 'quota', user.name, mem=-128)
+                self.assertEqual(resp.status_code, 400, resp.text)
         finally:
             with admin:
                 util.reset_limit(self.cook_url, 'quota', user.name)
@@ -168,6 +176,10 @@ class MultiUserCookTest(unittest.TestCase):
             with user:
                 _, resp = util.submit_job(self.cook_url)
                 self.assertEqual(resp.status_code, 201, msg=resp.text)
+            # Can't set negative quota
+            with admin:
+                resp = util.set_limit(self.cook_url, 'quota', user.name, count=-1)
+                self.assertEqual(resp.status_code, 400, resp.text)
         finally:
             with admin:
                 util.reset_limit(self.cook_url, 'quota', user.name)

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -32,7 +32,8 @@ class MultiUserCookTest(unittest.TestCase):
             job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
             self.assertEqual('failed', job['state'])
         finally:
-            util.kill_jobs(self.cook_url, [job_uuid])
+            with user1:
+                util.kill_jobs(self.cook_url, [job_uuid])
 
     def test_group_delete_permission(self):
         user1, user2 = self.user_factory.new_users(2)
@@ -49,7 +50,8 @@ class MultiUserCookTest(unittest.TestCase):
             job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
             self.assertEqual('failed', job['state'])
         finally:
-            util.kill_jobs(self.cook_url, [job_uuid])
+            with user1:
+                util.kill_jobs(self.cook_url, [job_uuid])
 
     def test_multi_user_usage(self):
         users = self.user_factory.new_users(6)
@@ -83,9 +85,10 @@ class MultiUserCookTest(unittest.TestCase):
         finally:
             # Terminate all of the jobs
             if all_job_uuids:
-                util.kill_jobs(self.cook_url, all_job_uuids)
+                with self.user_factory.admin():
+                    util.kill_jobs(self.cook_url, all_job_uuids)
 
-    def test_job_too_big(self):
+    def test_job_too_much_cpu(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
         try:
@@ -98,19 +101,65 @@ class MultiUserCookTest(unittest.TestCase):
                 self.assertEqual(resp.status_code, 422, msg=resp.text)
             # User with tiny quota can't submit bigger jobs, but can submit tiny jobs
             with admin:
-                resp = util.set_limit(self.cook_url, 'quota', user.name, cpus=4)
+                resp = util.set_limit(self.cook_url, 'quota', user.name, cpus=0.25)
                 self.assertEqual(resp.status_code, 201, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url, cpus=5)
+                _, resp = util.submit_job(self.cook_url, cpus=0.5)
                 self.assertEqual(resp.status_code, 422, msg=resp.text)
-                _, resp = util.submit_job(self.cook_url, cpus=4)
+                _, resp = util.submit_job(self.cook_url, cpus=0.25)
                 self.assertEqual(resp.status_code, 201, msg=resp.text)
-            # User with zero-jobs quota can't submit any jobs
+            # Reset user's quota back to default, then user can submit jobs again
+            with admin:
+                resp = util.reset_limit(self.cook_url, 'quota', user.name)
+                self.assertEqual(resp.status_code, 204, resp.text)
+            with user:
+                _, resp = util.submit_job(self.cook_url)
+                self.assertEqual(resp.status_code, 201, msg=resp.text)
+        finally:
+            with admin:
+                util.reset_limit(self.cook_url, 'quota', user.name)
+
+    def test_job_too_much_mem(self):
+        admin = self.user_factory.admin()
+        user = self.user_factory.new_user()
+        try:
+            # User with no quota can't submit jobs
+            with admin:
+                resp = util.set_limit(self.cook_url, 'quota', user.name, mem=0)
+                self.assertEqual(resp.status_code, 201, resp.text)
+            with user:
+                _, resp = util.submit_job(self.cook_url)
+                self.assertEqual(resp.status_code, 422, msg=resp.text)
+            # User with tiny quota can't submit bigger jobs, but can submit tiny jobs
+            with admin:
+                resp = util.set_limit(self.cook_url, 'quota', user.name, mem=10)
+                self.assertEqual(resp.status_code, 201, resp.text)
+            with user:
+                _, resp = util.submit_job(self.cook_url, mem=11)
+                self.assertEqual(resp.status_code, 422, msg=resp.text)
+                _, resp = util.submit_job(self.cook_url, mem=10)
+                self.assertEqual(resp.status_code, 201, msg=resp.text)
+            # Reset user's quota back to default, then user can submit jobs again
+            with admin:
+                resp = util.reset_limit(self.cook_url, 'quota', user.name)
+                self.assertEqual(resp.status_code, 204, resp.text)
+            with user:
+                _, resp = util.submit_job(self.cook_url)
+                self.assertEqual(resp.status_code, 201, msg=resp.text)
+        finally:
+            with admin:
+                util.reset_limit(self.cook_url, 'quota', user.name)
+
+    def test_job_no_quota(self):
+        admin = self.user_factory.admin()
+        user = self.user_factory.new_user()
+        try:
+            # User with no quota can't submit jobs
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, count=0)
                 self.assertEqual(resp.status_code, 201, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url, cpus=0.1)
+                _, resp = util.submit_job(self.cook_url)
                 self.assertEqual(resp.status_code, 422, msg=resp.text)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
@@ -122,3 +171,4 @@ class MultiUserCookTest(unittest.TestCase):
         finally:
             with admin:
                 util.reset_limit(self.cook_url, 'quota', user.name)
+

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -869,14 +869,15 @@ def query_queue(cook_url):
     return session.get(f'{cook_url}/queue')
 
 
-def set_limit(cook_url, limit_type, user, mem=None, cpus=None, gpus=None, jobs=None, reason='testing'):
+def set_limit(cook_url, limit_type, user, mem=None, cpus=None, gpus=None, count=None, reason='testing'):
     limits = {}
     body = {'user': user, limit_type: limits}
     if reason is not None: body['reason'] = reason
     if mem is not None: limits['mem'] = mem
     if cpus is not None: limits['cpus'] = cpus
     if gpus is not None: limits['gpus'] = gpus
-    if jobs is not None: limits['jobs'] = jobs
+    if count is not None: limits['count'] = count
+    logger.debug(f'Setting {user} {limit_type} to {limits}: {body}')
     return session.post(f'{cook_url}/{limit_type}', json=body)
 
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -870,6 +870,11 @@ def query_queue(cook_url):
 
 
 def set_limit(cook_url, limit_type, user, mem=None, cpus=None, gpus=None, count=None, reason='testing'):
+    """
+    Set resource limits for the given user.
+    The limit_type parameter should be either 'share' or 'quota', specifying which type of limit is being set.
+    Any subset of the mem, cpus, gpus and count (job-count) limits can be specified.
+    """
     limits = {}
     body = {'user': user, limit_type: limits}
     if reason is not None: body['reason'] = reason
@@ -882,6 +887,10 @@ def set_limit(cook_url, limit_type, user, mem=None, cpus=None, gpus=None, count=
 
 
 def reset_limit(cook_url, limit_type, user, reason='testing'):
+    """
+    Resets resource limits for the given user to the default for the cluster.
+    The limit_type parameter should be either 'share' or 'quota', specifying which type of limit is being reset.
+    """
     params = {'user': user}
     if reason is not None: params['reason'] = reason
     return session.delete(f'{cook_url}/{limit_type}', params=params)

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1313,8 +1313,8 @@
         user-quota (quota/get-quota db user)
         errors (for [job (::jobs ctx)
                      resource resource-keys
-                     :let [job-usage (get job resource 0)
-                           quota-val (get user-quota resource)]
+                     :let [job-usage (-> job (get resource 0) double)
+                           quota-val (-> user-quota (get resource) double)]
                      :when (> job-usage quota-val)]
                  (format "Job %s exceeds quota for %s: %f > %f"
                          (:uuid job) (name resource) job-usage quota-val))]

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -108,8 +108,13 @@
 (def ZeroInt
   (s/both s/Int (s/pred zero? 'zero?)))
 
-(def PosNum
+(s/defschema PosNum
+  "Positive number (float or int)"
   (s/both s/Num (s/pred pos? 'pos?)))
+
+(s/defschema NonNegNum
+  "Non-negative number (float or int)"
+  (s/both s/Num (s/pred (comp not neg?) 'non-negative?)))
 
 (def PosInt
   (s/both s/Int (s/pred pos? 'pos?)))
@@ -1291,6 +1296,33 @@
       true
       [false {::error "You are not authorized to create jobs"}])))
 
+(defn no-job-exceeds-quota?
+  "Check if any of the submitted jobs exceed the user's total quota,
+   in which case the job would never be schedulable (unless the quota is increased).
+
+   If none of the jobs individually seem to exceed the user's quota, returns true;
+   otherwise, the following error structure is returned:
+
+     [false {::error \"...\"}]
+
+  where \"...\" is a detailed error string describing the quota bounds exceeded."
+  [conn ctx]
+  (let [db (db conn)
+        resource-keys [:cpus :mem :gpus]
+        user (get-in ctx [:request :authorization/user])
+        user-quota (quota/get-quota db user)
+        errors (for [job (::jobs ctx)
+                     resource resource-keys
+                     :let [job-usage (get job resource 0)
+                           quota-val (get user-quota resource)]
+                     :when (> job-usage quota-val)]
+                 (format "Job %s exceeds quota for %s: %f > %f"
+                         (:uuid job) (name resource) job-usage quota-val))]
+    (cond
+      (zero? (:count user-quota)) [false {::error "User quota is set to zero jobs."}]
+      (seq errors) [false {::error (str/join "\n" errors)}]
+      :else true)))
+
 ;;; On POST; JSON blob that looks like:
 ;;; {"jobs": [{"command": "echo hello world",
 ;;;            "uuid": "123898485298459823985",
@@ -1333,7 +1365,9 @@
                 (let [db (d/db conn)
                       existing (filter (partial job-exists? db) (map :uuid (::jobs ctx)))]
                   [(seq existing) {::existing existing}]))
-
+     ;; We want to return a 422 (unprocessable entity) if the requested resources
+     ;; for a single job exceed the user's total resource quota.
+     :processable? (partial no-job-exceeds-quota? conn)
      ;; To ensure compatibility with existing clients,
      ;; we need to return 409 (conflict) when a client POSTs a Job UUID that already exists.
      ;; Liberator normally only supports 409 responses to PUT requests, so we need to override
@@ -1758,7 +1792,7 @@
 
 (defn set-limit-params
   [limit-type]
-  {:body-params (merge UserLimitChangeParams {limit-type {s/Keyword s/Num}})})
+  {:body-params (merge UserLimitChangeParams {limit-type {s/Keyword NonNegNum}})})
 
 (defn retrieve-user-limit
   [get-limit-fn conn ctx]

--- a/scheduler/src/cook/mesos/quota.clj
+++ b/scheduler/src/cook/mesos/quota.clj
@@ -99,7 +99,8 @@
   [conn user reason & kvs]
   (loop [[type amount & kvs] kvs
          txns []]
-    (if (and amount (pos? amount))
+    (if (nil? amount)
+      @(d/transact conn txns)
       (if (= type :count)
         (recur kvs (into [{:db/id (d/tempid :db.part/user)
                                   :quota/user user
@@ -120,8 +121,7 @@
                       :quota/user user
                       :quota/resource [{:resource/type type
                                         :resource/amount amount}]}])]
-          (recur kvs (into txn txns))))
-      @(d/transact conn txns)))
+          (recur kvs (into txn txns))))))
   @(d/transact conn [[:db/add [:quota/user user] :quota/reason reason]]))
 
 (defn create-user->quota-fn

--- a/scheduler/test/cook/test/mesos/quota.clj
+++ b/scheduler/test/cook/test/mesos/quota.clj
@@ -33,6 +33,12 @@
     (quota/set-quota! conn "u4" "no jobs allowed" :count 0)
     (quota/set-quota! conn "default" "lock most users down" :cpus 1.0 :mem 2.0 :gpus 1.0)
     (let [db (db conn)]
+      (testing "set and query zero job count"
+        (is (= {:count 0
+                :cpus 1.0 :mem 2.0 :gpus 1.0} (quota/get-quota db "u4"))))
+      (testing "set and query zero gpus"
+        (is (= {:count Double/MAX_VALUE
+                :cpus 1.0 :mem 2.0 :gpus 0.0} (quota/get-quota db "u3"))))
       (testing "set and query."
         (is (= {:count Double/MAX_VALUE
                 :cpus 5.0 :mem 10.0 :gpus 1.0} (quota/get-quota db "u2"))))

--- a/scheduler/test/cook/test/mesos/quota.clj
+++ b/scheduler/test/cook/test/mesos/quota.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(ns cook.test.mesos.share
+(ns cook.test.mesos.quota
   (:use clojure.test)
   (:require [cook.mesos.scheduler :as sched]
             [cook.mesos.quota :as quota]
@@ -29,6 +29,8 @@
     (quota/set-quota! conn "u1" "too many CPUs" :cpus 5.0)
     (quota/set-quota! conn "u1" "higher count" :count 6)
     (quota/set-quota! conn "u2" "custom limits" :cpus 5.0  :mem 10.0)
+    (quota/set-quota! conn "u3" "needs no GPUs" :gpus 0.0)
+    (quota/set-quota! conn "u4" "no jobs allowed" :count 0)
     (quota/set-quota! conn "default" "lock most users down" :cpus 1.0 :mem 2.0 :gpus 1.0)
     (let [db (db conn)]
       (testing "set and query."


### PR DESCRIPTION
## Changes proposed in this PR

If a single job requires more resources than the user's entire quota, then reject the job.

## Why are we making these changes?

It seems better to reject an unschedulable job at submission time, rather than letting the user submit a job that can never be scheduled (assuming the user's quota doesn't change).

This is particularly useful in scenarios where an organization has multiple Cook clusters, but the user only has quota on some of those clusters. Currently, a user could submit a bunch of jobs to a cluster where they have no quota, and the jobs just sit there forever. After this change, all jobs would be rejected on any clusters where the user has no quota.