### PR TITLE
Refactor .travis.yml to use faster infrastructure options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,62 @@
-language: java
-jdk:
-- oraclejdk8
-services:
-  - docker
-before_install:
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
-  - echo "deb https://repos.mesosphere.io/ubuntu/ trusty main" | sudo tee /etc/apt/sources.list.d/mesosphere.list
-  - sudo apt-get update -qq
-  - sudo apt-get install mesos -y </dev/null
-  - eval "$(pyenv init -)"  # ensure pyenv sees our customized $PYENV_ROOT value
-  - pyenv install --skip-existing 3.6.3  # we can skip this installation step if the target version is cached
-  - pyenv global 3.6.3  # the cli and integration tests use features from python 3.6
-branches:
-  only:
-    - master
-sudo: required
 dist: trusty
+language: java
+jdk: oraclejdk8
+
+branches:
+  only: master
+
 cache:
-    directories:
-        - $HOME/.m2
-        - $HOME/.pyenv
+  directories:
+    - $HOME/.apt-cache
+    - $HOME/.local
+    - $HOME/.m2
+
 env:
   global:
     - MESOS_NATIVE_JAVA_LIBRARY=/usr/lib/libmesos.so
     - CLJ_HTTP_ASYNC_POOL_TEST_DURATION_MULTIPLIER=5
-    - PYENV_ROOT=$HOME/.pyenv  # ensure that pyenv is using our local cache for its install root
-  matrix:
-    - TEST_DIR=executor DEPS_CMD='travis/setup.sh' TEST_CMD='travis/run_tests.sh'
-    - TEST_DIR=scheduler DEPS_CMD='travis/setup.sh' TEST_CMD='lein test :all-but-benchmark'
-    - TEST_DIR=scheduler DEPS_CMD='lein with-profiles +test deps' TEST_CMD='lein test :benchmark'
-    - TEST_DIR=jobclient DEPS_CMD='mvn dependency:resolve' TEST_CMD='mvn test'
-    - TEST_DIR=simulator DEPS_CMD='travis/prepare_simulation.sh' TEST_CMD='travis/run_simulation.sh'
-    - TEST_DIR=integration DEPS_CMD='travis/prepare_integration.sh' TEST_CMD='travis/run_integration.sh --executor=cook'
-    - TEST_DIR=integration DEPS_CMD='travis/prepare_integration.sh' TEST_CMD='travis/run_integration.sh --auth=http-basic'
+
+before_install:
+  - pyenv global 3.6
+  - echo "Sudo-enabled build? ${TRAVIS_SUDO}"
+
 matrix:
-    fast_finish: true
-    allow_failures:
-      - env: TEST_DIR=scheduler DEPS_CMD='lein with-profiles +test deps' TEST_CMD='lein test :benchmark'
-before_script: (cd $TEST_DIR && $DEPS_CMD)
-script: cd $TEST_DIR && $TEST_CMD
+  allow_failures:
+    - env: NAME='Cook Scheduler benchmark tests'
+
+  fast_finish: true
+
+  include:
+    - env: NAME='Cook Scheduler unit tests'
+      before_script: cd scheduler && ./travis/setup.sh
+      script: lein test :all-but-benchmark
+
+    - env: NAME='Cook Scheduler integration tests with HTTP Basic Auth'
+      services: docker
+      install: sudo ./travis/install_mesos.sh
+      before_script: cd integration && ./travis/prepare_integration.sh
+      script: ./travis/run_integration.sh --auth=http-basic
+
+    - env: NAME='Cook Scheduler integration tests with Cook Executor'
+      services: docker
+      install: sudo ./travis/install_mesos.sh
+      before_script: cd integration && ./travis/prepare_integration.sh
+      script: ./travis/run_integration.sh --executor=cook
+
+    - env: NAME='Cook Scheduler Simulator tests'
+      services: docker
+      install: sudo ./travis/install_mesos.sh
+      before_script: cd simulator && ./travis/prepare_simulation.sh
+      script: ./travis/run_simulation.sh
+
+    - env: NAME='Cook Scheduler benchmark tests'
+      before_script: cd scheduler && lein with-profiles +test deps
+      script: lein test :benchmark
+
+    - env: NAME='Cook Executor tests'
+      before_script: cd executor && ./travis/setup.sh
+      script: ./travis/run_tests.sh
+
+    - env: NAME='Cook JobClient unit tests'
+      before_script: cd jobclient && mvn dependency:resolve
+      script: mvn test

--- a/integration/travis/prepare_integration.sh
+++ b/integration/travis/prepare_integration.sh
@@ -2,6 +2,6 @@
 
 set -ev
 
-export PROJECT_DIR=`pwd`
-../travis/prepare.sh
-pip install -r requirements.txt
+PROJECT_DIR=`pwd` ../travis/prepare.sh
+python --version
+pip install --user -r requirements.txt

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -113,13 +113,8 @@ if [ "$curl_error" = true ]; then
     exit 1
 fi
 
-# Install the CLI
-cd ${TRAVIS_BUILD_DIR}/cli
-python --version
-pip install -e .
-CLI=$(pyenv which cs)
-export PATH=${PATH}:$(dirname ${CLI})
-cs --help
+# Ensure the Cook Scheduler CLI is available
+command -v cs
 
 # Run the integration tests
 cd ${PROJECT_DIR}

--- a/travis/build_cook_executor.sh
+++ b/travis/build_cook_executor.sh
@@ -3,6 +3,6 @@
 set -ev
 
 cd ${TRAVIS_BUILD_DIR}/executor
-pip install -r requirements.txt
+pip install --user -r requirements.txt
 ./bin/prepare-executor.sh local ${TRAVIS_BUILD_DIR}/scheduler/resources/public
 tar -C ${TRAVIS_BUILD_DIR}/travis -xzf ./dist/cook-executor-local.tar.gz

--- a/travis/install_mesos.sh
+++ b/travis/install_mesos.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+PACKAGE_CACHE_DIR=$HOME/.apt-cache
+
+if [ -d "$PACKAGE_CACHE_DIR" ] && [ -n "$(find $PACKAGE_CACHE_DIR -name 'mesos_*.deb')" ]; then
+    echo 'Using cached Mesos library...'
+    cp -f $PACKAGE_CACHE_DIR/*.deb /var/cache/apt/archives/
+else
+    echo 'Downloading Mesos library...'
+    apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+    echo "deb https://repos.mesosphere.io/ubuntu/ trusty main" | sudo tee /etc/apt/sources.list.d/mesosphere.list
+    apt-get update -qq
+    apt-get install mesos -y --download-only
+    mkdir -p $PACKAGE_CACHE_DIR/
+    cp -f /var/cache/apt/archives/*.deb $PACKAGE_CACHE_DIR/
+fi
+
+dpkg --force-all --install /var/cache/apt/archives/mesos_*.deb && apt-get install -fy
+APT_EXIT_CODE=$?
+
+if [ $APT_EXIT_CODE -ne 0 ]; then
+    echo 'Mesos installation error! Wiping package cache...'
+    rm -rf $PACKAGE_CACHE_DIR
+    exit $APT_EXIT_CODE
+fi


### PR DESCRIPTION
## Changes proposed in this PR

- Expand the run matrix to make what each job does explicit rather than having a level of indirection through the environment settings.
- Use faster `sudo: false` job instances where possible. (Requires the expanded run matrix.)
- Cache Mesos packages to avoid registering the mesosphere repository on most runs.
- Use the pre-installed Python v3.6.3 runtime (from the updated Travis images) rather than downloading and installing our own copy of the same runtime.

## Why are we making these changes?

1. Since `sudo: false` is significantly faster (container vs vm), we should use it where possible.
2. We avoid installing Mesos on the jobs that don't use it.
3. Caching the Mesos `.deb` files on the jobs where we *do* use the library still speeds things up a bit, and avoids some failures we've seen semi-regularly with `apt-get`.
4. Using the pre-installed Python distribution is obviously preferable to re-downloading the same thing.