### PR TITLE
Refactors :dependencies for easier replacement via profiles

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -35,7 +35,7 @@
   :java-source-paths ["java"]
 
   :profiles
-  {:defaults
+  {:default
    [:base :system :user :provided :dev :foo :bar]
 
    :uberjar

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -55,6 +55,7 @@
                  [org.clojure/tools.logging "0.2.6"]
                  [clj-logging-config "1.9.10"
                   :exclusions [log4j]]
+                 [org.slf4j/slf4j-log4j12 "1.7.12"]
                  [com.draines/postal "1.11.0"
                   :exclusions [commons-codec]]
                  [prismatic/plumbing "0.5.3"]
@@ -129,15 +130,19 @@
 
   :profiles
   {
+   ; By default, activate the :oss profile (explained below)
    :default [:base :system :user :provided :dev :oss]
 
-   ; The :oss profile exists so that Cook can be built using a more
-   ; appropriate set of dependencies for a specific environment than the
-   ; ones defined here. For example, one could drop in the datomic-pro
-   ; library instead of the datomic-free library, by using a
-   ; profiles.clj file that defines a profile which pulls in datomic-pro.
+   ; The :oss profile exists so that Cook can be built with a more
+   ; appropriate set of dependencies for a specific environment than
+   ; the ones defined here (by using `lein with-profile -oss` ...)
    :oss
-   {:dependencies [[com.datomic/datomic-free "0.9.5206"
+   {:dependencies [
+                   ; For example, one could drop in the datomic-pro
+                   ; library instead of the datomic-free library, by
+                   ; using a profiles.clj file that defines a profile
+                   ; which pulls in datomic-pro
+                   [com.datomic/datomic-free "0.9.5206"
                     :exclusions [org.slf4j/slf4j-api
                                  com.fasterxml.jackson.core/jackson-core
                                  org.slf4j/jcl-over-slf4j
@@ -145,7 +150,8 @@
                                  org.slf4j/log4j-over-slf4j
                                  org.slf4j/slf4j-nop
                                  joda-time]]
-                   [org.slf4j/slf4j-log4j12 "1.7.12"]
+                   ; Similarly, one could use an older version of the
+                   ; mesomatic library in environments that require it
                    [wyegelwe/mesomatic "1.0.1-r0-SNAPSHOT"]]}
 
    :uberjar

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -35,40 +35,7 @@
   :java-source-paths ["java"]
 
   :profiles
-  {:default
-   [:base :system :user :provided :dev :foo :bar]
-
-   :uberjar
-   {:aot [cook.components]}
-
-   :dev
-   {:dependencies [[clj-http-fake "1.0.1"]
-                   [criterium "0.4.4"]
-                   [org.mockito/mockito-core "1.10.19"]
-                   [twosigma/cook-jobclient "0.1.2-SNAPSHOT"]
-                   [org.clojure/test.check "0.6.1"]
-                   [log4j/log4j "1.2.17" :exclusions [javax.mail/mail
-                                                      javax.jms/jms
-                                                      com.sun.jdmk/jmxtools
-                                                      com.sun.jmx/jmxri]]
-                   [ring/ring-jetty-adapter "1.5.0"]]
-    :jvm-opts ["-Xms2G"
-               "-XX:-OmitStackTraceInFastThrow"
-               "-Xmx2G"
-               "-Dcom.sun.management.jmxremote.authenticate=false"
-               "-Dcom.sun.management.jmxremote.ssl=false"]
-    :resource-paths ["test-resources"]
-    :source-paths []}
-
-   :test-console
-   {:jvm-opts ["-Dcook.test.logging.console"]}
-
-   :docker
-   ; avoid calling javac in docker
-   ; (.java sources are only used for unit test support)
-   {:java-source-paths ^:replace []}
-
-   :foo
+  {:foo
    {:dependencies [[org.clojure/clojure "1.8.0"]
 
                    ;;Data marshalling
@@ -173,7 +140,43 @@
                                  org.slf4j/slf4j-api
                                  org.slf4j/slf4j-simple]]
                    [org.slf4j/slf4j-log4j12 "1.7.12"]
-                   [wyegelwe/mesomatic "1.0.1-r0-SNAPSHOT"]]}}
+                   [wyegelwe/mesomatic "1.0.1-r0-SNAPSHOT"]]}
+
+   :uberjar
+   {:aot [cook.components]}
+
+   :dev
+   {:dependencies [[clj-http-fake "1.0.1"]
+                   [criterium "0.4.4"]
+                   [org.mockito/mockito-core "1.10.19"]
+                   [twosigma/cook-jobclient "0.1.2-SNAPSHOT"]
+                   [org.clojure/test.check "0.6.1"]
+                   [log4j/log4j "1.2.17" :exclusions [javax.mail/mail
+                                                      javax.jms/jms
+                                                      com.sun.jdmk/jmxtools
+                                                      com.sun.jmx/jmxri]]
+                   [ring/ring-jetty-adapter "1.5.0"]]
+    :jvm-opts ["-Xms2G"
+               "-XX:-OmitStackTraceInFastThrow"
+               "-Xmx2G"
+               "-Dcom.sun.management.jmxremote.authenticate=false"
+               "-Dcom.sun.management.jmxremote.ssl=false"]
+    :resource-paths ["test-resources"]
+    :source-paths []}
+
+   :test-console
+   {:jvm-opts ["-Dcook.test.logging.console"]}
+
+   :docker
+   ; avoid calling javac in docker
+   ; (.java sources are only used for unit test support)
+   {:java-source-paths ^:replace []}}
+
+  :aliases {"deps" ["with-profile" "+foo,+bar" "deps"]
+            "jar" ["with-profile" "+foo,+bar" "jar"]
+            "run" ["with-profile" "+foo,+bar" "run"]
+            "test" ["with-profile" "+foo,+bar" "test"]
+            "uberjar" ["with-profile" "+foo,+bar" "uberjar"]}
 
   :plugins [[lein-print "0.1.0"]]
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -16,6 +16,93 @@
 (defproject cook "1.9.1-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
+  :dependencies [[org.clojure/clojure "1.8.0"]
+
+                 ;;Data marshalling
+                 [org.clojure/data.codec "0.1.0"]
+                 [byte-streams "0.1.4"]
+                 [org.clojure/data.json "0.2.2"]
+                 [com.taoensso/nippy "2.8.0"
+                  :exclusions [org.clojure/tools.reader]]
+                 [circleci/clj-yaml "0.5.5"]
+                 [camel-snake-kebab "0.4.0"]
+                 [com.rpl/specter "1.0.1"]
+
+                 ;;Utility
+                 [amalloy/ring-buffer "1.1"]
+                 [listora/ring-congestion "0.1.2"]
+                 [lonocloud/synthread "1.0.4"]
+                 [org.clojure/tools.namespace "0.2.4"]
+                 [org.clojure/core.cache "0.6.4"]
+                 [org.clojure/core.memoize "0.5.8"]
+                 [clj-time "0.9.0"]
+                 [org.clojure/core.async "0.3.442" :exclusions [org.clojure/tools.reader]]
+                 [org.clojure/tools.cli "0.3.5"]
+                 [prismatic/schema "1.1.3"]
+                 [clojure-miniprofiler "0.4.0"]
+                 [jarohen/chime "0.1.6"]
+                 [org.clojure/data.priority-map "0.0.5"]
+                 [swiss-arrows "1.0.0"]
+                 [riddley "0.1.10"]
+
+                 ;;Logging
+                 [org.clojure/tools.logging "0.2.6"]
+                 [clj-logging-config "1.9.10"
+                  :exclusions [log4j]]
+                 [com.draines/postal "1.11.0"
+                  :exclusions [commons-codec]]
+                 [prismatic/plumbing "0.5.3"]
+                 [log4j "1.2.17"]
+                 [instaparse "1.4.0"]
+                 [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
+                 [clj-pid "0.1.1"]
+                 [jarohen/chime "0.1.6"]
+
+                 ;;Networking
+                 [clj-http "2.0.0"]
+                 [io.netty/netty "3.10.1.Final"]
+                 [cc.qbits/jet "0.6.4" :exclusions [org.eclipse.jetty/jetty-io
+                                                    org.eclipse.jetty/jetty-security
+                                                    org.eclipse.jetty/jetty-server
+                                                    org.eclipse.jetty/jetty-http
+                                                    cheshire]]
+                 [org.eclipse.jetty/jetty-server "9.2.6.v20141205"]
+                 [org.eclipse.jetty/jetty-security "9.2.6.v20141205"]
+
+
+                 ;;Metrics
+                 [metrics-clojure "2.6.1"
+                  :exclusions [io.netty/netty org.clojure/clojure]]
+                 [metrics-clojure-ring "2.3.0" :exclusions [com.codahale.metrics/metrics-core
+                                                            org.clojure/clojure io.netty/netty]]
+                 [metrics-clojure-jvm "2.6.1"]
+                 [io.dropwizard.metrics/metrics-graphite "3.1.2"]
+                 [com.aphyr/metrics3-riemann-reporter "0.4.0"]
+                 [riemann-clojure-client "0.4.1"]
+
+                 ;;External system integrations
+                 [me.raynes/conch "0.5.2"]
+                 [org.clojure/tools.nrepl "0.2.3"]
+
+                 ;;Ring
+                 [ring/ring-core "1.4.0"]
+                 [ring/ring-devel "1.4.0" :exclusions [org.clojure/tools.namespace]]
+                 [compojure "1.4.0"]
+                 [metosin/compojure-api "1.1.8"]
+                 [hiccup "1.0.5"]
+                 [ring/ring-json "0.2.0"]
+                 [ring-edn "0.1.0"]
+                 [com.duelinmarkers/ring-request-logging "0.2.0"]
+                 [liberator "0.15.0"]
+
+                 ;;Databases
+                 [org.apache.curator/curator-framework "2.7.1"
+                  :exclusions [io.netty/netty]]
+                 [org.apache.curator/curator-recipes "2.7.1"
+                  :exclusions [org.slf4j/slf4j-log4j12
+                               org.slf4j/log4j
+                               log4j]]
+                 [org.apache.curator/curator-test "2.7.1"]]
 
   :repositories {"maven2" {:url "https://files.couchbase.com/maven2/"}
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
@@ -35,96 +122,7 @@
   :java-source-paths ["java"]
 
   :profiles
-  {:foo
-   {:dependencies [[org.clojure/clojure "1.8.0"]
-
-                   ;;Data marshalling
-                   [org.clojure/data.codec "0.1.0"]
-                   [byte-streams "0.1.4"]
-                   [org.clojure/data.json "0.2.2"]
-                   [com.taoensso/nippy "2.8.0"
-                    :exclusions [org.clojure/tools.reader]]
-                   [circleci/clj-yaml "0.5.5"]
-                   [camel-snake-kebab "0.4.0"]
-                   [com.rpl/specter "1.0.1"]
-
-                   ;;Utility
-                   [amalloy/ring-buffer "1.1"]
-                   [listora/ring-congestion "0.1.2"]
-                   [lonocloud/synthread "1.0.4"]
-                   [org.clojure/tools.namespace "0.2.4"]
-                   [org.clojure/core.cache "0.6.4"]
-                   [org.clojure/core.memoize "0.5.8"]
-                   [clj-time "0.9.0"]
-                   [org.clojure/core.async "0.3.442" :exclusions [org.clojure/tools.reader]]
-                   [org.clojure/tools.cli "0.3.5"]
-                   [prismatic/schema "1.1.3"]
-                   [clojure-miniprofiler "0.4.0"]
-                   [jarohen/chime "0.1.6"]
-                   [org.clojure/data.priority-map "0.0.5"]
-                   [swiss-arrows "1.0.0"]
-                   [riddley "0.1.10"]
-
-                   ;;Logging
-                   [org.clojure/tools.logging "0.2.6"]
-                   [clj-logging-config "1.9.10"
-                    :exclusions [log4j]]
-                   [com.draines/postal "1.11.0"
-                    :exclusions [commons-codec]]
-                   [prismatic/plumbing "0.5.3"]
-                   [log4j "1.2.17"]
-                   [instaparse "1.4.0"]
-                   [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
-                   [clj-pid "0.1.1"]
-                   [jarohen/chime "0.1.6"]
-
-                   ;;Networking
-                   [clj-http "2.0.0"]
-                   [io.netty/netty "3.10.1.Final"]
-                   [cc.qbits/jet "0.6.4" :exclusions [org.eclipse.jetty/jetty-io
-                                                      org.eclipse.jetty/jetty-security
-                                                      org.eclipse.jetty/jetty-server
-                                                      org.eclipse.jetty/jetty-http
-                                                      cheshire]]
-                   [org.eclipse.jetty/jetty-server "9.2.6.v20141205"]
-                   [org.eclipse.jetty/jetty-security "9.2.6.v20141205"]
-
-
-                   ;;Metrics
-                   [metrics-clojure "2.6.1"
-                    :exclusions [io.netty/netty org.clojure/clojure]]
-                   [metrics-clojure-ring "2.3.0" :exclusions [com.codahale.metrics/metrics-core
-                                                              org.clojure/clojure io.netty/netty]]
-                   [metrics-clojure-jvm "2.6.1"]
-                   [io.dropwizard.metrics/metrics-graphite "3.1.2"]
-                   [com.aphyr/metrics3-riemann-reporter "0.4.0"]
-                   [riemann-clojure-client "0.4.1"]
-
-                   ;;External system integrations
-                   [me.raynes/conch "0.5.2"]
-                   [org.clojure/tools.nrepl "0.2.3"]
-
-                   ;;Ring
-                   [ring/ring-core "1.4.0"]
-                   [ring/ring-devel "1.4.0" :exclusions [org.clojure/tools.namespace]]
-                   [compojure "1.4.0"]
-                   [metosin/compojure-api "1.1.8"]
-                   [hiccup "1.0.5"]
-                   [ring/ring-json "0.2.0"]
-                   [ring-edn "0.1.0"]
-                   [com.duelinmarkers/ring-request-logging "0.2.0"]
-                   [liberator "0.15.0"]
-
-                   ;;Databases
-                   [org.apache.curator/curator-framework "2.7.1"
-                    :exclusions [io.netty/netty]]
-                   [org.apache.curator/curator-recipes "2.7.1"
-                    :exclusions [org.slf4j/slf4j-log4j12
-                                 org.slf4j/log4j
-                                 log4j]]
-                   [org.apache.curator/curator-test "2.7.1"]]}
-
-   :bar
+  {:bar
    {:dependencies [[cheshire "5.3.1"]
                    [com.datomic/datomic-free "0.9.5206"
                     :exclusions [org.slf4j/slf4j-api
@@ -172,11 +170,11 @@
    ; (.java sources are only used for unit test support)
    {:java-source-paths ^:replace []}}
 
-  :aliases {"deps" ["with-profile" "+foo,+bar" "deps"]
-            "jar" ["with-profile" "+foo,+bar" "jar"]
-            "run" ["with-profile" "+foo,+bar" "run"]
-            "test" ["with-profile" "+foo,+bar" "test"]
-            "uberjar" ["with-profile" "+foo,+bar" "uberjar"]}
+  :aliases {"deps" ["with-profile" "+bar" "deps"]
+            "jar" ["with-profile" "+bar" "jar"]
+            "run" ["with-profile" "+bar" "run"]
+            "test" ["with-profile" "+bar" "test"]
+            "uberjar" ["with-profile" "+bar" "uberjar"]}
 
   :plugins [[lein-print "0.1.0"]]
 
@@ -199,5 +197,4 @@
              "-XX:NumberOfGCLogFiles=20"
              "-XX:GCLogFileSize=128M"
              "-XX:+PrintGCDateStamps"
-             "-XX:+HeapDumpOnOutOfMemoryError"
-             ])
+             "-XX:+HeapDumpOnOutOfMemoryError"])

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -122,7 +122,13 @@
   :java-source-paths ["java"]
 
   :profiles
-  {:bar
+  {
+   ; The :oss profile exists so that Cook can be built using a more
+   ; appropriate set of dependencies for a specific environment than the
+   ; ones defined here. For example, one could drop in the datomic-pro
+   ; library instead of the datomic-free library, by using a
+   ; profiles.clj file that defines a profile which pulls in datomic-pro.
+   :oss
    {:dependencies [[cheshire "5.3.1"]
                    [com.datomic/datomic-free "0.9.5206"
                     :exclusions [org.slf4j/slf4j-api
@@ -170,11 +176,15 @@
    ; (.java sources are only used for unit test support)
    {:java-source-paths ^:replace []}}
 
-  :aliases {"deps" ["with-profile" "+bar" "deps"]
-            "jar" ["with-profile" "+bar" "jar"]
-            "run" ["with-profile" "+bar" "run"]
-            "test" ["with-profile" "+bar" "test"]
-            "uberjar" ["with-profile" "+bar" "uberjar"]}
+  ; We define :aliases to pull in the :oss profile on the commonly
+  ; used commands so that developers don't have to remember to use
+  ; with-profile. The :displace metadata keyword allows these
+  ; aliases to be "overriden" by other profiles if needed.
+  :aliases ^:displace {"deps" ["with-profile" "+oss" "deps"]
+                       "jar" ["with-profile" "+oss" "jar"]
+                       "run" ["with-profile" "+oss" "run"]
+                       "test" ["with-profile" "+oss" "test"]
+                       "uberjar" ["with-profile" "+oss" "uberjar"]}
 
   :plugins [[lein-print "0.1.0"]]
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -20,6 +20,7 @@
 
                  ;;Data marshalling
                  [org.clojure/data.codec "0.1.0"]
+                 ^:displace [cheshire "5.3.1"]
                  [byte-streams "0.1.4"]
                  [org.clojure/data.json "0.2.2"]
                  [com.taoensso/nippy "2.8.0"
@@ -44,6 +45,11 @@
                  [org.clojure/data.priority-map "0.0.5"]
                  [swiss-arrows "1.0.0"]
                  [riddley "0.1.10"]
+                 ^:displace [com.netflix.fenzo/fenzo-core "0.10.0"
+                             :exclusions [org.apache.mesos/mesos
+                                          com.fasterxml.jackson.core/jackson-core
+                                          org.slf4j/slf4j-api
+                                          org.slf4j/slf4j-simple]]
 
                  ;;Logging
                  [org.clojure/tools.logging "0.2.6"]
@@ -123,14 +129,15 @@
 
   :profiles
   {
+   :default [:base :system :user :provided :dev :oss]
+
    ; The :oss profile exists so that Cook can be built using a more
    ; appropriate set of dependencies for a specific environment than the
    ; ones defined here. For example, one could drop in the datomic-pro
    ; library instead of the datomic-free library, by using a
    ; profiles.clj file that defines a profile which pulls in datomic-pro.
    :oss
-   {:dependencies [[cheshire "5.3.1"]
-                   [com.datomic/datomic-free "0.9.5206"
+   {:dependencies [[com.datomic/datomic-free "0.9.5206"
                     :exclusions [org.slf4j/slf4j-api
                                  com.fasterxml.jackson.core/jackson-core
                                  org.slf4j/jcl-over-slf4j
@@ -138,11 +145,6 @@
                                  org.slf4j/log4j-over-slf4j
                                  org.slf4j/slf4j-nop
                                  joda-time]]
-                   [com.netflix.fenzo/fenzo-core "0.10.0"
-                    :exclusions [org.apache.mesos/mesos
-                                 com.fasterxml.jackson.core/jackson-core
-                                 org.slf4j/slf4j-api
-                                 org.slf4j/slf4j-simple]]
                    [org.slf4j/slf4j-log4j12 "1.7.12"]
                    [wyegelwe/mesomatic "1.0.1-r0-SNAPSHOT"]]}
 
@@ -175,16 +177,6 @@
    ; avoid calling javac in docker
    ; (.java sources are only used for unit test support)
    {:java-source-paths ^:replace []}}
-
-  ; We define :aliases to pull in the :oss profile on the commonly
-  ; used commands so that developers don't have to remember to use
-  ; with-profile. The :displace metadata keyword allows these
-  ; aliases to be "overriden" by other profiles if needed.
-  :aliases ^:displace {"deps" ["with-profile" "+oss" "deps"]
-                       "jar" ["with-profile" "+oss" "jar"]
-                       "run" ["with-profile" "+oss" "run"]
-                       "test" ["with-profile" "+oss" "test"]
-                       "uberjar" ["with-profile" "+oss" "uberjar"]}
 
   :plugins [[lein-print "0.1.0"]]
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -16,110 +16,6 @@
 (defproject cook "1.9.1-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-
-                 ;;Data marshalling
-                 [org.clojure/data.codec "0.1.0"]
-                 [cheshire "5.3.1"]
-                 [byte-streams "0.1.4"]
-                 [org.clojure/data.json "0.2.2"]
-                 [com.taoensso/nippy "2.8.0"
-                  :exclusions [org.clojure/tools.reader]]
-                 [circleci/clj-yaml "0.5.5"]
-                 [camel-snake-kebab "0.4.0"]
-                 [com.rpl/specter "1.0.1"]
-
-                 ;;Utility
-                 [amalloy/ring-buffer "1.1"]
-                 [listora/ring-congestion "0.1.2"]
-                 [lonocloud/synthread "1.0.4"]
-                 [org.clojure/tools.namespace "0.2.4"]
-                 [org.clojure/core.cache "0.6.4"]
-                 [org.clojure/core.memoize "0.5.8"]
-                 [clj-time "0.9.0"]
-                 [org.clojure/core.async "0.3.442" :exclusions [org.clojure/tools.reader]]
-                 [org.clojure/tools.cli "0.3.5"]
-                 [prismatic/schema "1.1.3"]
-                 [clojure-miniprofiler "0.4.0"]
-                 [jarohen/chime "0.1.6"]
-                 [org.clojure/data.priority-map "0.0.5"]
-                 [swiss-arrows "1.0.0"]
-                 [riddley "0.1.10"]
-                 [com.netflix.fenzo/fenzo-core "0.10.0"
-                  :exclusions [org.apache.mesos/mesos
-                               com.fasterxml.jackson.core/jackson-core
-                               org.slf4j/slf4j-api
-                               org.slf4j/slf4j-simple]]
-
-                 ;;Logging
-                 [org.clojure/tools.logging "0.2.6"]
-                 [clj-logging-config "1.9.10"
-                  :exclusions [log4j]]
-                 [org.slf4j/slf4j-log4j12 "1.7.12"]
-                 [com.draines/postal "1.11.0"
-                  :exclusions [commons-codec]]
-                 [prismatic/plumbing "0.5.3"]
-                 [log4j "1.2.17"]
-                 [instaparse "1.4.0"]
-                 [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
-                 [clj-pid "0.1.1"]
-                 [jarohen/chime "0.1.6"]
-
-                 ;;Networking
-                 [clj-http "2.0.0"]
-                 [io.netty/netty "3.10.1.Final"]
-                 [cc.qbits/jet "0.6.4" :exclusions [org.eclipse.jetty/jetty-io
-                                                    org.eclipse.jetty/jetty-security
-                                                    org.eclipse.jetty/jetty-server
-                                                    org.eclipse.jetty/jetty-http
-                                                    cheshire]]
-                 [org.eclipse.jetty/jetty-server "9.2.6.v20141205"]
-                 [org.eclipse.jetty/jetty-security "9.2.6.v20141205"]
-
-
-                 ;;Metrics
-                 [metrics-clojure "2.6.1"
-                  :exclusions [io.netty/netty org.clojure/clojure]]
-                 [metrics-clojure-ring "2.3.0" :exclusions [com.codahale.metrics/metrics-core
-                                                            org.clojure/clojure io.netty/netty]]
-                 [metrics-clojure-jvm "2.6.1"]
-                 [io.dropwizard.metrics/metrics-graphite "3.1.2"]
-                 [com.aphyr/metrics3-riemann-reporter "0.4.0"]
-                 [riemann-clojure-client "0.4.1"]
-
-                 ;;External system integrations
-                 [me.raynes/conch "0.5.2"]
-                 [wyegelwe/mesomatic "1.0.1-r0-SNAPSHOT"]
-                 [org.clojure/tools.nrepl "0.2.3"]
-
-                 ;;Ring
-                 [ring/ring-core "1.4.0"]
-                 [ring/ring-devel "1.4.0" :exclusions [org.clojure/tools.namespace]]
-                 [compojure "1.4.0"]
-                 [metosin/compojure-api "1.1.8"]
-                 [hiccup "1.0.5"]
-                 [ring/ring-json "0.2.0"]
-                 [ring-edn "0.1.0"]
-                 [com.duelinmarkers/ring-request-logging "0.2.0"]
-                 [liberator "0.15.0"]
-
-                 ;;Databases
-                 [com.datomic/datomic-free "0.9.5206"
-                  :exclusions [org.slf4j/slf4j-api
-                               com.fasterxml.jackson.core/jackson-core
-                               org.slf4j/jcl-over-slf4j
-                               org.slf4j/jul-to-slf4j
-                               org.slf4j/log4j-over-slf4j
-                               org.slf4j/slf4j-nop
-                               joda-time]]
-                 [org.apache.curator/curator-framework "2.7.1"
-                  :exclusions [io.netty/netty]]
-                 [org.apache.curator/curator-recipes "2.7.1"
-                  :exclusions [org.slf4j/slf4j-log4j12
-                               org.slf4j/log4j
-                               log4j
-                               ]]
-                 [org.apache.curator/curator-test "2.7.1"]]
 
   :repositories {"maven2" {:url "https://files.couchbase.com/maven2/"}
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
@@ -139,7 +35,10 @@
   :java-source-paths ["java"]
 
   :profiles
-  {:uberjar
+  {:defaults
+   [:base :system :user :provided :dev :foo :bar]
+
+   :uberjar
    {:aot [cook.components]}
 
    :dev
@@ -167,7 +66,114 @@
    :docker
    ; avoid calling javac in docker
    ; (.java sources are only used for unit test support)
-   {:java-source-paths ^:replace []}}
+   {:java-source-paths ^:replace []}
+
+   :foo
+   {:dependencies [[org.clojure/clojure "1.8.0"]
+
+                   ;;Data marshalling
+                   [org.clojure/data.codec "0.1.0"]
+                   [byte-streams "0.1.4"]
+                   [org.clojure/data.json "0.2.2"]
+                   [com.taoensso/nippy "2.8.0"
+                    :exclusions [org.clojure/tools.reader]]
+                   [circleci/clj-yaml "0.5.5"]
+                   [camel-snake-kebab "0.4.0"]
+                   [com.rpl/specter "1.0.1"]
+
+                   ;;Utility
+                   [amalloy/ring-buffer "1.1"]
+                   [listora/ring-congestion "0.1.2"]
+                   [lonocloud/synthread "1.0.4"]
+                   [org.clojure/tools.namespace "0.2.4"]
+                   [org.clojure/core.cache "0.6.4"]
+                   [org.clojure/core.memoize "0.5.8"]
+                   [clj-time "0.9.0"]
+                   [org.clojure/core.async "0.3.442" :exclusions [org.clojure/tools.reader]]
+                   [org.clojure/tools.cli "0.3.5"]
+                   [prismatic/schema "1.1.3"]
+                   [clojure-miniprofiler "0.4.0"]
+                   [jarohen/chime "0.1.6"]
+                   [org.clojure/data.priority-map "0.0.5"]
+                   [swiss-arrows "1.0.0"]
+                   [riddley "0.1.10"]
+
+                   ;;Logging
+                   [org.clojure/tools.logging "0.2.6"]
+                   [clj-logging-config "1.9.10"
+                    :exclusions [log4j]]
+                   [com.draines/postal "1.11.0"
+                    :exclusions [commons-codec]]
+                   [prismatic/plumbing "0.5.3"]
+                   [log4j "1.2.17"]
+                   [instaparse "1.4.0"]
+                   [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
+                   [clj-pid "0.1.1"]
+                   [jarohen/chime "0.1.6"]
+
+                   ;;Networking
+                   [clj-http "2.0.0"]
+                   [io.netty/netty "3.10.1.Final"]
+                   [cc.qbits/jet "0.6.4" :exclusions [org.eclipse.jetty/jetty-io
+                                                      org.eclipse.jetty/jetty-security
+                                                      org.eclipse.jetty/jetty-server
+                                                      org.eclipse.jetty/jetty-http
+                                                      cheshire]]
+                   [org.eclipse.jetty/jetty-server "9.2.6.v20141205"]
+                   [org.eclipse.jetty/jetty-security "9.2.6.v20141205"]
+
+
+                   ;;Metrics
+                   [metrics-clojure "2.6.1"
+                    :exclusions [io.netty/netty org.clojure/clojure]]
+                   [metrics-clojure-ring "2.3.0" :exclusions [com.codahale.metrics/metrics-core
+                                                              org.clojure/clojure io.netty/netty]]
+                   [metrics-clojure-jvm "2.6.1"]
+                   [io.dropwizard.metrics/metrics-graphite "3.1.2"]
+                   [com.aphyr/metrics3-riemann-reporter "0.4.0"]
+                   [riemann-clojure-client "0.4.1"]
+
+                   ;;External system integrations
+                   [me.raynes/conch "0.5.2"]
+                   [org.clojure/tools.nrepl "0.2.3"]
+
+                   ;;Ring
+                   [ring/ring-core "1.4.0"]
+                   [ring/ring-devel "1.4.0" :exclusions [org.clojure/tools.namespace]]
+                   [compojure "1.4.0"]
+                   [metosin/compojure-api "1.1.8"]
+                   [hiccup "1.0.5"]
+                   [ring/ring-json "0.2.0"]
+                   [ring-edn "0.1.0"]
+                   [com.duelinmarkers/ring-request-logging "0.2.0"]
+                   [liberator "0.15.0"]
+
+                   ;;Databases
+                   [org.apache.curator/curator-framework "2.7.1"
+                    :exclusions [io.netty/netty]]
+                   [org.apache.curator/curator-recipes "2.7.1"
+                    :exclusions [org.slf4j/slf4j-log4j12
+                                 org.slf4j/log4j
+                                 log4j]]
+                   [org.apache.curator/curator-test "2.7.1"]]}
+
+   :bar
+   {:dependencies [[cheshire "5.3.1"]
+                   [com.datomic/datomic-free "0.9.5206"
+                    :exclusions [org.slf4j/slf4j-api
+                                 com.fasterxml.jackson.core/jackson-core
+                                 org.slf4j/jcl-over-slf4j
+                                 org.slf4j/jul-to-slf4j
+                                 org.slf4j/log4j-over-slf4j
+                                 org.slf4j/slf4j-nop
+                                 joda-time]]
+                   [com.netflix.fenzo/fenzo-core "0.10.0"
+                    :exclusions [org.apache.mesos/mesos
+                                 com.fasterxml.jackson.core/jackson-core
+                                 org.slf4j/slf4j-api
+                                 org.slf4j/slf4j-simple]]
+                   [org.slf4j/slf4j-log4j12 "1.7.12"]
+                   [wyegelwe/mesomatic "1.0.1-r0-SNAPSHOT"]]}}
 
   :plugins [[lein-print "0.1.0"]]
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding `^:displace` to the cheshire and fenzo `:dependencies`
- adding a new profile, `:oss` (activated in `:default`)
- moving the datomic-free and mesomatic `:dependencies` to `:oss`

## Why are we making these changes?

The `:oss` profile allows Cook to be built with a more appropriate set of dependencies for a specific environment than the ones it defines (by using `lein with-profile -oss ...`). For example, one could drop in the datomic-pro library instead of the datomic-free library by creating a `profiles.clj` file that defines a profile which pulls in datomic-pro. Similarly, one could use an older version of the mesomatic library in environments that require it.