### PR TITLE
Mark impersonation tests with multi-user and default timeout

### DIFF
--- a/integration/tests/cook/test_impersonation.py
+++ b/integration/tests/cook/test_impersonation.py
@@ -5,8 +5,9 @@ import unittest
 
 from tests.cook import util
 
-@pytest.mark.impersonation
+@pytest.mark.multi_user
 @unittest.skipUnless(util.multi_user_tests_enabled(), 'Requires using multi-user coniguration (e.g., BasicAuth) for Cook Scheduler')
+@pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class ImpersonationCookTest(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
## Changes proposed in this PR

- Add default timeout to impersonation tests (same as all the other test classes)
- Add the multi-user mark to the class since it does user switching

## Why are we making these changes?

We should have a common mark on all tests that do user switching so that it's easier to selectively run these (switching them on or off).