### PR TITLE
Cook Scheduler version 1.10.0 release

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.10.0] - 2018-01-22
+### Added
+- Added user-impersonation functionality to support services running on top of Cook Scheduler, from @DaoWen
+### Changed
+- Jobs that exceed a user's total resource quota are rejected rather than waiting indefinitely, from @DaoWen
+
 ## [1.9.0] - 2018-01-10
 ### Added
 - Added unauthenticated /info endpoint for retrieving basic setup information, from @DaoWen

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.10.0"
+(defproject cook "1.10.1-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.9.1-SNAPSHOT"
+(defproject cook "1.10.0"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]


### PR DESCRIPTION
## Changes proposed in this PR

- Bump version to 1.10.1-SNAPSHOT
- Update change log and project version for v1.10.0 release

## Why are we making these changes?

Cook Scheduler release, including the user-impersonation feature.