### PR TITLE
Removes superfluous /settings request from cs usage

### DIFF
--- a/cli/cook/subcommands/usage.py
+++ b/cli/cook/subcommands/usage.py
@@ -20,11 +20,6 @@ def get_usage_on_cluster(cluster, user):
         print_error(f'Unable to retrieve share information on {cluster["name"]} ({cluster["url"]}).')
         return {'count': 0}
 
-    settings_map = http.make_data_request(cluster, lambda: http.get(cluster, 'settings', params={}))
-    if not settings_map:
-        print_error(f'Unable to retrieve settings information on {cluster["name"]} ({cluster["url"]}).')
-        return {'count': 0}
-
     ungrouped_running_job_uuids = usage_map['ungrouped']['running_jobs']
     job_uuids_to_retrieve = ungrouped_running_job_uuids[:]
     grouped = usage_map['grouped']

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.4.0'
+VERSION = '1.4.1'


### PR DESCRIPTION
## Changes proposed in this PR

- removing the request to `/settings` from `cs usage`

## Why are we making these changes?

The request was there in order to get the mesos master when we were retrieving overall cluster utilization. Since we're no longer including that information, we should remove this as well.
