### PR TITLE
Use pytest for executor tests

### DIFF
--- a/executor/README.md
+++ b/executor/README.md
@@ -100,17 +100,17 @@ Some of the executor configurations are sent to the Cook executor as the followi
 
 ### Tests
 
-The cook executor uses `nose`.
+The cook executor uses `pytest`.
 To install test dependencies and run the executor test suite, run:
 
 ```bash
-$ python setup.py nosetests
+$ pytest
 ```
 
 If you want to run a single test and see the log messages as they occur, you can run, for example:
 
 ```bash
-$ nosetests tests.test_executor:ExecutorTest.test_get_task_id --nologcapture
+$ pytest -svk test_get_task_id
 ```
 
 ### Troubleshooting

--- a/executor/setup.cfg
+++ b/executor/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+addopts = -n10 -v --timeout-method=thread
+timeout = 1200

--- a/executor/setup.py
+++ b/executor/setup.py
@@ -3,6 +3,13 @@
 
 from setuptools import setup
 
+test_deps=[
+    'pytest==3.3.1',
+    'pytest-timeout==1.2.1',
+    'pytest-xdist==1.20.1'
+]
+
+extras = { 'test': test_deps }
 
 setup(
     name='cook-executor',
@@ -13,10 +20,8 @@ setup(
     keywords='cook-executor',
     packages=['cook'],
     test_suite='tests',
-    tests_require=[
-        'nose>=1.0'
-    ],
-    setup_requires=['nose>=1.0'],
+    tests_require=test_deps,
+    extras_require=extras,
     install_requires=['psutil==5.4.1', 'pymesos==0.2.15'],
     entry_points={
         'console_scripts': [

--- a/executor/travis/run_tests.sh
+++ b/executor/travis/run_tests.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# Runs the nosetests for the executor
+# Runs the Cook Executor tests
 
 export PROJECT_DIR=`pwd`
 cd ${PROJECT_DIR}
 
 python --version
-python setup.py nosetests --attr '!explicit'
+pytest --version
+
+pytest -n4

--- a/executor/travis/setup.sh
+++ b/executor/travis/setup.sh
@@ -6,4 +6,4 @@ export PROJECT_DIR=`pwd`
 cd ${PROJECT_DIR}
 
 python --version
-python setup.py install
+pip install -e '.[test]'


### PR DESCRIPTION
## Changes proposed in this PR

Move the Cook Executor from nose to pytest.

## Why are we making these changes?

Mainly for consistency, but we're also hoping this will help us debug #678.

Closes #699.