### PR TITLE
Handles NoSuchProcess thrown by psutil.Process

### DIFF
--- a/executor/cook/_version.py
+++ b/executor/cook/_version.py
@@ -1,4 +1,4 @@
 # This file is read by setup.py to obtain the version.
 # Be aware that changing the format may break the parsing logic.
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/executor/cook/subprocess.py
+++ b/executor/cook/subprocess.py
@@ -139,7 +139,7 @@ def _send_signal_to_process_tree(root_process_id, signal_to_send):
                 num_processes_killed += 1
             else:
                 signal_sent_to_all_processes_successfully = False
-        except ProcessLookupError:
+        except psutil.NoSuchProcess:
             logging.info('Unable to send {} as could not find process (id: {})'.format(signal_name, loop_process_id))
         except Exception:
             logging.exception('Error in sending {} to process (id: {})'.format(signal_name, loop_process_id))


### PR DESCRIPTION

## Changes proposed in this PR

-  handles NoSuchProcess thrown by `psutil`.Process (instead of `ProcessLookupError`)

## Why are we making these changes?

- It correctly catches the exception thrown by the `psutil` library and avoids an unexpected error while trying to terminate a task.

