### PR TITLE
Add JSONException to JobClient Constraint interface

### DIFF
--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/constraint/Constraint.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/constraint/Constraint.java
@@ -17,6 +17,7 @@
 package com.twosigma.cook.jobclient.constraint;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 
 /**
  * The interface to specify a constraint in Cook
@@ -38,7 +39,7 @@ public interface Constraint {
     /**
      * @return this constraint as a JSONArray.
      */
-    JSONArray toJson();
+    JSONArray toJson() throws JSONException;
 
     /**
      * @return the attribute of this constraint.


### PR DESCRIPTION
## Changes proposed in this PR

Add JSONException to JobClient Constraint interface.

## Why are we making these changes?

@WenboZhao asked for the exception annotations on this method in the concrete class, and it looks like we need it in the interface as well.