### PR TITLE
Enable parallel multi-user integration tests with Kerberos

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -92,7 +92,7 @@ which will be replaced with the Cook Scheduler URL being used by the current tes
 The command must print (to `stdout`) the `Authorization` header value for the target user.
 
 * `COOK_MAX_TEST_USERS`:
-Setting this environment variable limits the number of test user allocated to each test runner process.
+Setting this environment variable limits the number of test users allocated to each test runner process.
 This is most likely necessary in any scenario where users are actually authenticated by the underlying OS.
 
 ## Credits

--- a/integration/README.md
+++ b/integration/README.md
@@ -91,9 +91,9 @@ and `{{COOK_SCHEDULER_URL}}`,
 which will be replaced with the Cook Scheduler URL being used by the current tests.
 The command must print (to `stdout`) the `Authorization` header value for the target user.
 
-When using Kerberos, multi-user integration tests must *not* be run in parallel.
-This restriction is due to only having 10 unique test user names,
-which are reused across each of the multi-user tests.
+* `COOK_MAX_TEST_USERS`:
+Setting this environment variable limits the number of test user allocated to each test runner process.
+This is most likely necessary in any scenario where users are actually authenticated by the underlying OS.
 
 ## Credits
 

--- a/integration/tests/cook/conftest.py
+++ b/integration/tests/cook/conftest.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+import threading
+import time
+
+from tests.cook import util
+
+def sudo_check(username):
+    sudo_ok = (0 == subprocess.call(f'sudo -nu {username} echo CACHED SUDO', shell=True))
+    assert sudo_ok, "You need to pre-cache your sudo credentials. (Run a simple sudo command as a test user.)"
+
+def _sudo_checker_task(username):
+    while True:
+        sudo_check(username)
+        time.sleep(60)
+
+if util.kerberos_enabled() and os.getenv('COOK_MAX_TEST_USERS'):
+    username = next(util._test_user_names())
+    sudo_check(username)
+    threading.Thread(target=_sudo_checker_task, args=[username], daemon=True).start()

--- a/integration/tests/cook/conftest.py
+++ b/integration/tests/cook/conftest.py
@@ -1,3 +1,8 @@
+# This file is automatically loaded and run by pytest during its setup process,
+# meaning it happens before any of the tests in this directory are run.
+# See the pytest documentation on conftest files for more information:
+# https://docs.pytest.org/en/2.7.3/plugins.html#conftest-py-plugins
+
 import os
 import subprocess
 import threading
@@ -5,16 +10,21 @@ import time
 
 from tests.cook import util
 
-def sudo_check(username):
+def _sudo_check(username):
+    """
+    Check if the current user can sudo as a test user.
+    This is necessary to obtain Kerberos auth headers for multi-user tests.
+    """
     sudo_ok = (0 == subprocess.call(f'sudo -nu {username} echo CACHED SUDO', shell=True))
     assert sudo_ok, "You need to pre-cache your sudo credentials. (Run a simple sudo command as a test user.)"
 
 def _sudo_checker_task(username):
+    """Periodically check sudo ability to ensure the credentials stay cached."""
     while True:
-        sudo_check(username)
+        _sudo_check(username)
         time.sleep(60)
 
 if util.kerberos_enabled() and os.getenv('COOK_MAX_TEST_USERS'):
     username = next(util._test_user_names())
-    sudo_check(username)
+    _sudo_check(username)
     threading.Thread(target=_sudo_checker_task, args=[username], daemon=True).start()


### PR DESCRIPTION
## Changes proposed in this PR

Reworks how tests users are generated across xdist workers so that there aren't user collisions when restricted to a limited number of test users with Kerberos.

## Why are we making these changes?

This lets us run all of the tests together even when using Kerberos, rather than having to run the multi-user tests separately so that they could be run sequentially.