### PR TITLE
Use local pip install for executor deps in Travis

### DIFF
--- a/executor/travis/setup.sh
+++ b/executor/travis/setup.sh
@@ -6,4 +6,4 @@ export PROJECT_DIR=`pwd`
 cd ${PROJECT_DIR}
 
 python --version
-pip install -e '.[test]'
+pip install --user -e '.[test]'


### PR DESCRIPTION
## Changes proposed in this PR

Install dependencies for Cook Executor tests into user's home directory.

## Why are we making these changes?

The deps aren't being cached by Travis right now because they're being installed globally rather than locally.