### PR TITLE
Fix string encoding on rawscheduler post

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -46,6 +46,7 @@ class CookTest(unittest.TestCase):
         job_executor_type = util.get_job_executor_type(self.cook_url)
         job_uuid, resp = util.submit_job(self.cook_url, executor=job_executor_type)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
+        self.assertEqual(resp.content, str.encode(f"submitted jobs {job_uuid}"))
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
         self.assertEqual('success', job['instances'][0]['status'])
         self.assertEqual(False, job['disable_mea_culpa_retries'])

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -2168,7 +2168,8 @@
   [handler]
   (fn streaming-json-handler [req]
     (let [{:keys [headers body] :as resp} (handler req)
-          json-response (or (= "application/json" (get headers "Content-Type"))
+          json-response (or (and (= "application/json" (get headers "Content-Type"))
+                                 (not (string? body)))
                             (coll? body))]
       (cond-> resp
         json-response (res/content-type "application/json")

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -186,7 +186,7 @@
                    (assoc "state" "failed" "status" "completed"))
                (first followup-read-body)))
         (is (<= 200 (:status delete-response) 299))
-        (is (= "No content." (response->body-data delete-response)))))))
+        (is (= "No content." (:body delete-response)))))))
 
 (deftest descriptive-state
   (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -494,7 +494,7 @@
         (is (not initial-instance-cancelled?))
         (is (<= 200 (:status cancel-resp) 299))
         (is (= "application/json" (get-in cancel-resp [:headers "Content-Type"])))
-        (is (= "No content." (response->body-data cancel-resp)))
+        (is (= "No content." (:body cancel-resp)))
         (is followup-instance-cancelled?)))
 
     (testing "set cancelled on completed instance"
@@ -518,7 +518,7 @@
         (is (not initial-instance-cancelled?))
         (is (<= 200 (:status cancel-resp) 299))
         (is (= "application/json" (get-in cancel-resp [:headers "Content-Type"])))
-        (is (= "No content." (response->body-data cancel-resp)))
+        (is (= "No content." (:body cancel-resp)))
         (is followup-instance-cancelled?)))))
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- Do not encode output from /rawscheduler POST as JSON

## Why are we making these changes?

Fix a backwards compatibility change from #316 
