### PR TITLE
Lift start-up-time out of the /info handler function

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1141,6 +1141,7 @@
       (-> instance
           (assoc :job (select-keys job [:uuid :name :status :state :user]))))))
 
+;; We store the start-up time (ISO-8601) for reporting on the /info endpoint
 (def start-up-time (tf/unparse iso-8601-format (t/now)))
 
 (defn cook-info-handler
@@ -1148,7 +1149,6 @@
   [settings]
   (let [auth-middleware (:authorization-middleware settings)
         auth-scheme (str (or (-> auth-middleware meta :json-value) auth-middleware))]
-        ;; We store the start-up time (ISO-8601) for reporting on the /info endpoint
     (base-cook-handler
       {:allowed-methods [:get]
        :handle-ok (fn get-info-handler [_]

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1141,13 +1141,14 @@
       (-> instance
           (assoc :job (select-keys job [:uuid :name :status :state :user]))))))
 
+(def start-up-time (tf/unparse iso-8601-format (t/now)))
+
 (defn cook-info-handler
   "Handler for the /info endpoint"
   [settings]
   (let [auth-middleware (:authorization-middleware settings)
-        auth-scheme (str (or (-> auth-middleware meta :json-value) auth-middleware))
+        auth-scheme (str (or (-> auth-middleware meta :json-value) auth-middleware))]
         ;; We store the start-up time (ISO-8601) for reporting on the /info endpoint
-        start-up-time (tf/unparse iso-8601-format (t/now))]
     (base-cook-handler
       {:allowed-methods [:get]
        :handle-ok (fn get-info-handler [_]


### PR DESCRIPTION
## Changes proposed in this PR

Lift the "start-time" timestamp out of the handler-construction function.

## Why are we making these changes?

The timestamp was being re-evaluated to `now` on each request.

Fixes #711.