### PR TITLE
cs: provides env variables that contains the resources requested by the job

### DIFF
--- a/scheduler/docs/faq.md
+++ b/scheduler/docs/faq.md
@@ -30,12 +30,12 @@ the job is only launched once, set `max-retries: 1` and `disable-mea-culpa-retri
 ## Does Cook set any environment variables before running a task?
 
 The following environment variables are set by Cook before running a task:
-- COOK_JOB_UUID: represents the UUID of the Job the task belongs to.
-- COOK_JOB_GROUP_UUID: represents the UUID of the Group the task belongs to.
-- COOK_JOB_CPUS: represents the amount of `cpus` configured in the Job. It can be a fractional number.
-- COOK_JOB_GPUS: represents the amount of `gpus` configured in the Job. It can be a fractional number.
-- COOK_JOB_MEM_MB: represents the amount of `mem` (in megabytes) configured in the Job. It can be a fractional number.
+- `COOK_JOB_UUID`: represents the UUID of the job the task belongs to.
+- `COOK_JOB_GROUP_UUID`: represents the UUID of the job group the task belongs to.
+- `COOK_JOB_CPUS`: represents the amount of `cpus` configured in the job. It can be a fractional number.
+- `COOK_JOB_GPUS`: represents the amount of `gpus` configured in the job. It can be a fractional number.
+- `COOK_JOB_MEM_MB`: represents the amount of `mem` (in megabytes) configured in the job. It can be a fractional number.
 
 Any environment variables configured in the Job are also included.
-In addition, when running an Instance using the Cook Executor, the executor configurations are passed as environment variables.
+In addition, when running an instance using the Cook Executor, the [executor configurations](configuration.adoc#cook_executor) are passed as environment variables.
 

--- a/scheduler/docs/faq.md
+++ b/scheduler/docs/faq.md
@@ -26,3 +26,16 @@ can simply query cook with the intended job uuid to see if it exists
 Cook has the concept of "mea-culpa" retries, for instance when a job is killed due to pre-emption. Some users may prefer for jobs to
 just fail in this case instead of attempting to restart it (e.g. when a job is not idempotent.) To prevent this behavior and ensure
 the job is only launched once, set `max-retries: 1` and `disable-mea-culpa-retries: true`.
+
+## Does Cook set any environment variables before running a task?
+
+The following environment variables are set by Cook before running a task:
+- COOK_JOB_UUID: represents the UUID of the Job the task belongs to.
+- COOK_JOB_GROUP_UUID: represents the UUID of the Group the task belongs to.
+- COOK_JOB_CPUS: represents the amount of `cpus` configured in the Job. It can be a fractional number.
+- COOK_JOB_GPUS: represents the amount of `gpus` configured in the Job. It can be a fractional number.
+- COOK_JOB_MEM_MB: represents the amount of `mem` (in megabytes) configured in the Job. It can be a fractional number.
+
+Any environment variables configured in the Job are also included.
+In addition, when running an Instance using the Cook Executor, the executor configurations are passed as environment variables.
+

--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -85,6 +85,9 @@
         environment (cond-> (assoc (util/job-ent->env job-ent)
                               "COOK_JOB_UUID" (-> job-ent :job/uuid str))
                             group-uuid (assoc "COOK_JOB_GROUP_UUID" (str group-uuid))
+                            (:cpus resources) (assoc "COOK_JOB_CPUS" (-> resources :cpus int str))
+                            (:gpus resources) (assoc "COOK_JOB_GPUS" (-> resources :gpus int str))
+                            (:mem resources) (assoc "COOK_JOB_MEM_MB" (-> resources :mem int str))
                             cook-executor? (merge (build-executor-environment executor-config job-ent)))
         labels (util/job-ent->label job-ent)
         command {:environment environment

--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -85,9 +85,9 @@
         environment (cond-> (assoc (util/job-ent->env job-ent)
                               "COOK_JOB_UUID" (-> job-ent :job/uuid str))
                             group-uuid (assoc "COOK_JOB_GROUP_UUID" (str group-uuid))
-                            (:cpus resources) (assoc "COOK_JOB_CPUS" (-> resources :cpus int str))
-                            (:gpus resources) (assoc "COOK_JOB_GPUS" (-> resources :gpus int str))
-                            (:mem resources) (assoc "COOK_JOB_MEM_MB" (-> resources :mem int str))
+                            (:cpus resources) (assoc "COOK_JOB_CPUS" (-> resources :cpus str))
+                            (:gpus resources) (assoc "COOK_JOB_GPUS" (-> resources :gpus str))
+                            (:mem resources) (assoc "COOK_JOB_MEM_MB" (-> resources :mem str))
                             cook-executor? (merge (build-executor-environment executor-config job-ent)))
         labels (util/job-ent->label job-ent)
         command {:environment environment

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -330,8 +330,8 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_CPUS" "1"
-                         "COOK_JOB_MEM_MB" "10"
+            environment {"COOK_JOB_CPUS" "1.0"
+                         "COOK_JOB_MEM_MB" "10.0"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id executor job-ent task-id)]
         (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
@@ -357,9 +357,9 @@
             job-ent (d/entity db job)
             group-ent (d/entity db group-ent-id)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_CPUS" "1"
+            environment {"COOK_JOB_CPUS" "1.0"
                          "COOK_JOB_GROUP_UUID" (-> group-ent :group/uuid str)
-                         "COOK_JOB_MEM_MB" "10"
+                         "COOK_JOB_MEM_MB" "10.0"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id executor job-ent task-id)]
         (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
@@ -383,8 +383,8 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_CPUS" "1"
-                         "COOK_JOB_MEM_MB" "10"
+            environment {"COOK_JOB_CPUS" "1.0"
+                         "COOK_JOB_MEM_MB" "10.0"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id executor job-ent task-id)]
         (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
@@ -408,8 +408,8 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_CPUS" "1"
-                         "COOK_JOB_MEM_MB" "10"
+            environment {"COOK_JOB_CPUS" "1.0"
+                         "COOK_JOB_MEM_MB" "10.0"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)
                          "EXECUTOR_LOG_LEVEL" (:log-level executor)
                          "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
@@ -443,10 +443,10 @@
             group-ent (d/entity db group-ent-id)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_CPUS" "1"
+            environment {"COOK_JOB_CPUS" "1.0"
                          "COOK_JOB_GROUP_UUID" (-> group-ent :group/uuid str)
-                         "COOK_JOB_GPUS" "1000"
-                         "COOK_JOB_MEM_MB" "10"
+                         "COOK_JOB_GPUS" "1000.0"
+                         "COOK_JOB_MEM_MB" "10.0"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)
                          "EXECUTOR_LOG_LEVEL" (:log-level executor)
                          "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
@@ -478,8 +478,8 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_CPUS" "1"
-                         "COOK_JOB_MEM_MB" "10"
+            environment {"COOK_JOB_CPUS" "1.0"
+                         "COOK_JOB_MEM_MB" "10.0"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id {} job-ent task-id)]
         (is (= {:command {:environment environment
@@ -514,8 +514,8 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_CPUS" "1"
-                         "COOK_JOB_MEM_MB" "10"
+            environment {"COOK_JOB_CPUS" "1.0"
+                         "COOK_JOB_MEM_MB" "10.0"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id {} job-ent task-id)]
         (is (= {:command {:environment environment
@@ -553,8 +553,8 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_CPUS" "1"
-                         "COOK_JOB_MEM_MB" "200"
+            environment {"COOK_JOB_CPUS" "1.0"
+                         "COOK_JOB_MEM_MB" "200.0"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id {} job-ent task-id)]
         (is (= {:command {:environment environment

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -330,7 +330,9 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_UUID" (-> job-ent :job/uuid str)}
+            environment {"COOK_JOB_CPUS" "1"
+                         "COOK_JOB_MEM_MB" "10"
+                         "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id executor job-ent task-id)]
         (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                 :container nil
@@ -355,7 +357,9 @@
             job-ent (d/entity db job)
             group-ent (d/entity db group-ent-id)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_GROUP_UUID" (-> group-ent :group/uuid str)
+            environment {"COOK_JOB_CPUS" "1"
+                         "COOK_JOB_GROUP_UUID" (-> group-ent :group/uuid str)
+                         "COOK_JOB_MEM_MB" "10"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id executor job-ent task-id)]
         (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
@@ -379,7 +383,9 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_UUID" (-> job-ent :job/uuid str)}
+            environment {"COOK_JOB_CPUS" "1"
+                         "COOK_JOB_MEM_MB" "10"
+                         "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id executor job-ent task-id)]
         (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                 :container nil
@@ -402,7 +408,9 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_UUID" (-> job-ent :job/uuid str)
+            environment {"COOK_JOB_CPUS" "1"
+                         "COOK_JOB_MEM_MB" "10"
+                         "COOK_JOB_UUID" (-> job-ent :job/uuid str)
                          "EXECUTOR_LOG_LEVEL" (:log-level executor)
                          "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                          "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
@@ -430,12 +438,15 @@
       (let [task-id (str (UUID/randomUUID))
             group-ent-id (tu/create-dummy-group conn)
             job (tu/create-dummy-job conn :command "run-my-command" :custom-executor? false :executor :executor/cook
-                                     :group group-ent-id :job-state :job.state/running :user "test-user" )
+                                     :group group-ent-id :gpus 1000 :job-state :job.state/running :user "test-user")
             db (d/db conn)
             group-ent (d/entity db group-ent-id)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_GROUP_UUID" (-> group-ent :group/uuid str)
+            environment {"COOK_JOB_CPUS" "1"
+                         "COOK_JOB_GROUP_UUID" (-> group-ent :group/uuid str)
+                         "COOK_JOB_GPUS" "1000"
+                         "COOK_JOB_MEM_MB" "10"
                          "COOK_JOB_UUID" (-> job-ent :job/uuid str)
                          "EXECUTOR_LOG_LEVEL" (:log-level executor)
                          "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
@@ -467,7 +478,9 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_UUID" (-> job-ent :job/uuid str)}
+            environment {"COOK_JOB_CPUS" "1"
+                         "COOK_JOB_MEM_MB" "10"
+                         "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id {} job-ent task-id)]
         (is (= {:command {:environment environment
                           :uris []
@@ -501,7 +514,9 @@
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_UUID" (-> job-ent :job/uuid str)}
+            environment {"COOK_JOB_CPUS" "1"
+                         "COOK_JOB_MEM_MB" "10"
+                         "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id {} job-ent task-id)]
         (is (= {:command {:environment environment
                           :uris []
@@ -533,11 +548,14 @@
                                                  :container/volumes []}
                                      :custom-executor? false
                                      :job-state :job.state/running
+                                     :memory 200
                                      :user "test-user")
             db (d/db conn)
             job-ent (d/entity db job)
             framework-id {:value "framework-id"}
-            environment {"COOK_JOB_UUID" (-> job-ent :job/uuid str)}
+            environment {"COOK_JOB_CPUS" "1"
+                         "COOK_JOB_MEM_MB" "200"
+                         "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
             task-metadata (task/job->task-metadata db framework-id {} job-ent task-id)]
         (is (= {:command {:environment environment
                           :uris []
@@ -553,7 +571,7 @@
                 :labels {}
                 :name (format "dummy_job_%s_%s" (:job/user job-ent) task-id)
                 :num-ports 0
-                :resources {:cpus 1.0, :mem 10.0}
+                :resources {:cpus 1.0, :mem 200.0}
                 :task-id task-id}
                (dissoc task-metadata :data)))
         (is (= (pr-str {:instance "0"}) (-> task-metadata :data (String. "UTF-8"))))))))


### PR DESCRIPTION


## Changes proposed in this PR

- Makes the job resources (cpus, gpus and mem) available as environment variables to the Mesos task

## Why are we making these changes?

- Given these environment variables, jobs can decide how much memory and threads they can allocate at runtime.

