### PR TITLE
Improves configuration for running against a real Mesos

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -30,4 +30,4 @@ COPY . /opt/cook/
 # Run cook
 EXPOSE 12321
 ENTRYPOINT ["lein", "with-profiles", "+docker", "run"]
-CMD ["container-config.edn"]
+CMD ["config.edn"]

--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -125,6 +125,7 @@ docker create \
     -e "COOK_DATOMIC_URI=${COOK_DATOMIC_URI}" \
     -e "COOK_LOG_FILE=log/cook-${COOK_PORT}.log" \
     -e "COOK_HTTP_BASIC_AUTH=${COOK_HTTP_BASIC_AUTH:-false}" \
+    -e "COOK_ONE_USER_AUTH=root" \
     -e "COOK_EXECUTOR_PORTION=${COOK_EXECUTOR_PORTION:-0}" \
     -v ${DIR}/../log:/opt/cook/log \
     cook-scheduler:latest ${COOK_CONFIG:-}

--- a/scheduler/bin/run-local.sh
+++ b/scheduler/bin/run-local.sh
@@ -3,6 +3,8 @@
 # Usage: ./bin/run-local.sh
 # Runs the cook scheduler locally.
 
+set -e
+
 # Defaults (overridable via environment)
 : ${COOK_DATOMIC_URI="datomic:mem://cook-jobs"}
 : ${COOK_FRAMEWORK_ID:=cook-framework-$(date +%s)}
@@ -10,6 +12,7 @@
 : ${COOK_PORT:=${1:-12321}}
 : ${MASTER_IP:="127.0.0.2"}
 : ${ZOOKEEPER_IP:="127.0.0.1"}
+: ${MESOS_NATIVE_JAVA_LIBRARY:="/usr/local/lib/libmesos.dylib"}
 
 if [ -z "$( curl -Is --connect-timeout 2 --max-time 4 http://${MASTER_IP}:5050/state.json | head -1 )" ]; then
   echo "Mesos master (${MASTER_IP}) is unavailable"
@@ -45,6 +48,8 @@ export COOK_DATOMIC_URI="${COOK_DATOMIC_URI}"
 export COOK_FRAMEWORK_ID="${COOK_FRAMEWORK_ID}"
 export COOK_EXECUTOR=""
 export COOK_EXECUTOR_COMMAND="${COOK_EXECUTOR_COMMAND}"
+export COOK_EXECUTOR_PORTION=1
+export COOK_ONE_USER_AUTH=$(whoami)
 export COOK_HOSTNAME="cook-scheduler-${COOK_PORT}"
 export COOK_LOG_FILE="log/cook-${COOK_PORT}.log"
 export COOK_NREPL_PORT="${COOK_NREPL_PORT}"
@@ -54,7 +59,7 @@ export COOK_ZOOKEEPER_LOCAL="${COOK_ZOOKEEPER_LOCAL}"
 export LIBPROCESS_IP="${MASTER_IP}"
 export MESOS_MASTER="${MASTER_IP}:5050"
 export MESOS_MASTER_HOST="${MASTER_IP}"
-export MESOS_NATIVE_JAVA_LIBRARY="/usr/local/lib/libmesos.dylib"
+export MESOS_NATIVE_JAVA_LIBRARY="${MESOS_NATIVE_JAVA_LIBRARY}"
 
 echo "Starting cook..."
-lein run container-config.edn
+lein run config.edn

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -3,7 +3,7 @@
  :authorization {;; Note that internally, Cook will select :http-basic if it's set to true,
                  ;; and fall back to :one-user only if :http-basic is false.
                  :http-basic #config/env-bool "COOK_HTTP_BASIC_AUTH"
-                 :one-user "root"}
+                 :one-user #config/env "COOK_ONE_USER_AUTH"}
  :authorization-config {;; What function should be used to perform user authorization?
                         ;; See the docstring in cook.authorization for details.
                         :authorization-fn cook.authorization/configfile-admins-auth-open-gets


### PR DESCRIPTION
## Changes proposed in this PR

- renaming `container-config.edn` to `config.edn`; we don't only use it when running in a container
- introducing `COOK_ONE_USER_AUTH` so that the user name can be specified at runtime
- allowing `MESOS_NATIVE_JAVA_LIBRARY` to be overriden at runtime
- setting `COOK_EXECUTOR_PORTION=1` in `run-local.sh`

## Why are we making these changes?

These changes were mostly needed in order to run Cook Scheduler against a real Mesos (as opposed to minimesos) on Ubuntu.