### PR TITLE
Clean up jobs submitted by quota tests

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -91,6 +91,7 @@ class MultiUserCookTest(unittest.TestCase):
     def test_job_cpu_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
+        all_job_uuids = []
         try:
             # User with no quota can't submit jobs
             with admin:
@@ -106,26 +107,30 @@ class MultiUserCookTest(unittest.TestCase):
             with user:
                 _, resp = util.submit_job(self.cook_url, cpus=0.5)
                 self.assertEqual(resp.status_code, 422, msg=resp.text)
-                _, resp = util.submit_job(self.cook_url, cpus=0.25)
+                job_uuid, resp = util.submit_job(self.cook_url, cpus=0.25)
                 self.assertEqual(resp.status_code, 201, msg=resp.text)
+                all_job_uuids.append(job_uuid)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
                 resp = util.reset_limit(self.cook_url, 'quota', user.name)
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url)
+                job_uuid, resp = util.submit_job(self.cook_url)
                 self.assertEqual(resp.status_code, 201, msg=resp.text)
+                all_job_uuids.append(job_uuid)
             # Can't set negative quota
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, cpus=-4)
                 self.assertEqual(resp.status_code, 400, resp.text)
         finally:
             with admin:
+                util.kill_jobs(self.cook_url, all_job_uuids)
                 util.reset_limit(self.cook_url, 'quota', user.name)
 
     def test_job_mem_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
+        all_job_uuids = []
         try:
             # User with no quota can't submit jobs
             with admin:
@@ -141,26 +146,30 @@ class MultiUserCookTest(unittest.TestCase):
             with user:
                 _, resp = util.submit_job(self.cook_url, mem=11)
                 self.assertEqual(resp.status_code, 422, msg=resp.text)
-                _, resp = util.submit_job(self.cook_url, mem=10)
+                job_uuid, resp = util.submit_job(self.cook_url, mem=10)
                 self.assertEqual(resp.status_code, 201, msg=resp.text)
+                all_job_uuids.append(job_uuid)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
                 resp = util.reset_limit(self.cook_url, 'quota', user.name)
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url)
+                job_uuid, resp = util.submit_job(self.cook_url)
                 self.assertEqual(resp.status_code, 201, msg=resp.text)
+                all_job_uuids.append(job_uuid)
             # Can't set negative quota
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, mem=-128)
                 self.assertEqual(resp.status_code, 400, resp.text)
         finally:
             with admin:
+                util.kill_jobs(self.cook_url, all_job_uuids)
                 util.reset_limit(self.cook_url, 'quota', user.name)
 
     def test_job_count_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
+        all_job_uuids = []
         try:
             # User with no quota can't submit jobs
             with admin:
@@ -174,13 +183,15 @@ class MultiUserCookTest(unittest.TestCase):
                 resp = util.reset_limit(self.cook_url, 'quota', user.name)
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url)
+                job_uuid, resp = util.submit_job(self.cook_url)
                 self.assertEqual(resp.status_code, 201, msg=resp.text)
+                all_job_uuids.append(job_uuid)
             # Can't set negative quota
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, count=-1)
                 self.assertEqual(resp.status_code, 400, resp.text)
         finally:
             with admin:
+                util.kill_jobs(self.cook_url, all_job_uuids)
                 util.reset_limit(self.cook_url, 'quota', user.name)
 


### PR DESCRIPTION
## Changes proposed in this PR

Always delete all jobs created by a multi-user integration test, including the default (trivial) jobs.

## Why are we making these changes?

Fixes a bug in multi-user integration tests where a quota test running directly before the usage test may throw off the observed usage.