### PR TITLE
Converts pending jobs query from using metatransaction to commit latch

### DIFF
--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -418,6 +418,20 @@
             db user)
          (map (partial d/entity db)))))
 
+(timers/deftimer [cook-mesos scheduler get-running-jobs-duration])
+
+(defn get-running-job-ents
+  "Returns all running job entities."
+  [db]
+  (timers/time!
+    get-running-jobs-duration
+    (->> (q '[:find [?j ...]
+              :in $
+              :where
+              [?j :job/state :job.state/running]]
+            db)
+         (map (partial d/entity db)))))
+
 (defn job-allowed-to-start?
   "Converts the DB function :job/allowed-to-start? into a predicate"
   [db job]


### PR DESCRIPTION
## Changes proposed in this PR

- using `util/get-pending-job-ents` instead of using the metatransaction-filtered `db`
- adding `util/get-running-job-ents` and using it for running jobs

## Why are we making these changes?

Running queries using the metatransaction-filtered `db` is very slow.
