### PR TITLE
CS: Ensures the task filters for the sandbox syncer occur on a single thread

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -359,7 +359,7 @@
                             agent-query-cache))
      :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
                        (merge
-                         {:filter-batch-size 1000
+                         {:filter-batch-size 2000
                           ;; The default should ideally be lower than the sync-interval-ms
                           :filter-interval-ms 5000
                           :max-consecutive-sync-failure 15

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -293,12 +293,13 @@
                                     (cache/lru-cache-factory :threshold max-size)
                                     (cache/ttl-cache-factory :ttl ttl-ms)
                                     atom))
-     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure publish-batch-size
-                                             publish-interval-ms sync-interval-ms]]
+     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer filter-batch-size filter-interval-ms max-consecutive-sync-failure
+                                             publish-batch-size publish-interval-ms sync-interval-ms]]
                                  framework-id mesos-agent-query-cache mesos-datomic]
                              ((lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)
-                               framework-id mesos-datomic publish-batch-size publish-interval-ms sync-interval-ms
-                               max-consecutive-sync-failure mesos-agent-query-cache))
+                               framework-id mesos-datomic filter-batch-size filter-interval-ms
+                               publish-batch-size publish-interval-ms sync-interval-ms max-consecutive-sync-failure
+                               mesos-agent-query-cache))
      :mesos-leadership-atom (fnk [] (atom false))
      :mesos-pending-jobs-atom (fnk [] (atom {}))
      :mesos-offer-cache (fnk [[:settings [:offer-cache max-size ttl-ms]]]
@@ -358,11 +359,14 @@
                             agent-query-cache))
      :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
                        (merge
-                         {:max-consecutive-sync-failure 15
+                         {:filter-batch-size 1000
+                          ;; The default should ideally be lower than the sync-interval-ms
+                          :filter-interval-ms 5000
+                          :max-consecutive-sync-failure 15
                           :publish-batch-size 100
                           :publish-interval-ms 2500
                           ;; The default should ideally be lower than the agent-query-cache ttl-ms
-                          :sync-interval-ms (* 15 1000)}
+                          :sync-interval-ms 15000}
                          sandbox-syncer))
      :server-port (fnk [[:config port]]
                     port)

--- a/scheduler/src/cook/mesos/sandbox.clj
+++ b/scheduler/src/cook/mesos/sandbox.clj
@@ -36,6 +36,14 @@
 (def sandbox-updater-publish-rate (meters/meter ["cook-mesos" "scheduler" "sandbox-updater-publish-rate"]))
 (def sandbox-updater-tx-duration (timers/timer ["cook-mesos" "scheduler" "sandbox-updater-tx-duration"]))
 (def sandbox-updater-tx-rate (meters/meter ["cook-mesos" "scheduler" "sandbox-updater-tx-rate"]))
+(def sandbox-updater-unfiltered-count (counters/counter ["cook-mesos" "scheduler" "sandbox-updater-unfiltered-count"]))
+
+(defn- threadsafe-counter-reset
+  "Resets the value of the counter to the provided value."
+  [the-counter new-value]
+  (counters/clear! the-counter)
+  (when-not (zero? new-value)
+    (counters/inc! the-counter new-value)))
 
 (defn agent->task-id->sandbox
   "Returns the sandbox in the current agent state."
@@ -47,8 +55,7 @@
    Since we expect instances to have the same sandbox, we do not check for value equality."
   [task-id->sandbox published-task-id->sandbox]
   (let [task-id->sandbox' (apply dissoc task-id->sandbox (keys published-task-id->sandbox))]
-    (counters/clear! sandbox-aggregator-pending-count)
-    (counters/inc! sandbox-aggregator-pending-count (count task-id->sandbox'))
+    (threadsafe-counter-reset sandbox-aggregator-pending-count (count task-id->sandbox'))
     task-id->sandbox'))
 
 (defn aggregate-sandbox
@@ -149,28 +156,23 @@
             (contains? #{:success :threshold} reason)
             (update :host->consecutive-failures dissoc hostname))))
 
-(defn- remove-task-ids-with-sandbox
-  "Filters the task-ids which have a sandbox directory from task-id->sandbox."
-  [datomic-conn task-id->sandbox]
-  (letfn [(retrieve-task-ids-with-sandbox [datomic-db task-ids]
-            (d/q '[:find [?t ...]
-                   :in $ [?t ...]
-                   :where
-                   [?e :instance/task-id ?t]
-                   [?e :instance/sandbox-directory ?s]]
-                 datomic-db task-ids))
-          (remove-task-id-with-sandbox [task-id->sandbox task-id]
-            (dissoc! task-id->sandbox task-id))
-          (update-filter-entries-histogram! [task-id->sandbox]
-            (histograms/update! sandbox-updater-filter-entries (count task-id->sandbox))
-            task-id->sandbox)]
-    (timers/time!
-      sandbox-updater-filter-duration
-      (->> (keys task-id->sandbox)
-           (retrieve-task-ids-with-sandbox (d/db datomic-conn))
-           (reduce remove-task-id-with-sandbox (transient task-id->sandbox))
-           persistent!
-           update-filter-entries-histogram!))))
+(defn- aggregate-unprocessed-task-ids!
+  "Aggregates the unprocessed task-id->sandbox-directory into the unprocessed-task-id->sandbox-atom."
+  [unprocessed-task-id->sandbox-atom task-id->sandbox-directory]
+  (swap! unprocessed-task-id->sandbox-atom
+         (fn [unprocessed-task-id->sandbox-in-atom]
+           (let [result-map (merge unprocessed-task-id->sandbox-in-atom task-id->sandbox-directory)]
+             (threadsafe-counter-reset sandbox-updater-unfiltered-count (count result-map))
+             result-map))))
+
+(defn- remove-processed-task-ids!
+  "Removes the processed-task-ids from the unprocessed-task-id->sandbox-atom."
+  [unprocessed-task-id->sandbox-atom processed-task-ids]
+  (swap! unprocessed-task-id->sandbox-atom
+         (fn [unprocessed-task-id->sandbox-in-atom]
+           (let [result-map (apply dissoc unprocessed-task-id->sandbox-in-atom processed-task-ids)]
+             (threadsafe-counter-reset sandbox-updater-unfiltered-count (count result-map))
+             result-map))))
 
 (defn refresh-agent-cache-entry
   "If the entry for the specified agent is not cached:
@@ -178,15 +180,13 @@
    - After the indexed version is built, the tasks which have sandbox directories are removed;
    - The filtered version of tasks without sandbox directories is then synced into the task-id->sandbox-agent.
    The function call is a no-op if the specified agent already exists in the cache."
-  [{:keys [datomic-conn mesos-agent-query-cache pending-sync-agent task-id->sandbox-agent]} framework-id agent-hostname]
+  [{:keys [mesos-agent-query-cache pending-sync-agent unprocessed-task-id->sandbox-atom]} framework-id agent-hostname]
   (try
     (let [run (delay
                 (try
-                  (let [task-id->sandbox-directory (retrieve-sandbox-directories-on-agent framework-id agent-hostname)
-                        filtered-task-id->sandbox-directory (remove-task-ids-with-sandbox datomic-conn task-id->sandbox-directory)]
-                    (log/info "Found" (count filtered-task-id->sandbox-directory) "tasks without sandbox directories on"
-                              agent-hostname "after retrieving" (count task-id->sandbox-directory) "tasks")
-                    (send task-id->sandbox-agent aggregate-sandbox filtered-task-id->sandbox-directory)
+                  (let [task-id->sandbox-directory (retrieve-sandbox-directories-on-agent framework-id agent-hostname)]
+                    (log/info "Found" (count task-id->sandbox-directory) "tasks on" agent-hostname)
+                    (aggregate-unprocessed-task-ids! unprocessed-task-id->sandbox-atom task-id->sandbox-directory)
                     (send pending-sync-agent clear-pending-sync-hostname agent-hostname :success)
                     :success)
                   (catch Exception e
@@ -265,8 +265,60 @@
 
               :else
               (recur remaining-hostnames pending-sync-agent-send-performed))))))
-    {:error-handler (fn sandbox-publisher-error-handler [ex]
+    {:error-handler (fn start-host-sandbox-syncer-error-handler [ex]
                       (log/error ex "Sync of sandbox directories on pending hosts failed"))}))
+
+(defn- remove-task-ids-with-sandbox
+  "Filters the task-ids which have a sandbox directory from task-id->sandbox."
+  [datomic-conn task-id->sandbox]
+  (letfn [(retrieve-task-ids-with-sandbox [datomic-db task-ids]
+            (d/q '[:find [?t ...]
+                   :in $ [?t ...]
+                   :where
+                   [?e :instance/task-id ?t]
+                   [?e :instance/sandbox-directory ?s]]
+                 datomic-db task-ids))
+          (remove-task-id-with-sandbox [task-id->sandbox task-id]
+            (dissoc! task-id->sandbox task-id))
+          (update-filter-entries-histogram! [task-id->sandbox]
+            (histograms/update! sandbox-updater-filter-entries (count task-id->sandbox))
+            task-id->sandbox)]
+    (timers/time!
+      sandbox-updater-filter-duration
+      (->> (keys task-id->sandbox)
+           (retrieve-task-ids-with-sandbox (d/db datomic-conn))
+           (reduce remove-task-id-with-sandbox (transient task-id->sandbox))
+           persistent!
+           update-filter-entries-histogram!))))
+
+(defn process-unprocessed-task-ids
+  "Processes the entries in unprocessed-task-id->sandbox-atom, removes the tasks that have sandbox entries in datomic,
+   and publishes them to task-id->sandbox-agent. The entries are processed in batches of size filter-batch-size to
+   reduce the overhead in making datomic queries."
+  [{:keys [datomic-conn task-id->sandbox-agent unprocessed-task-id->sandbox-atom]} filter-batch-size]
+  (let [unprocessed-task-id->sandbox @unprocessed-task-id->sandbox-atom]
+    (log/info "Found" (count unprocessed-task-id->sandbox) "tasks to process for presence of sandbox directories")
+    (when (seq unprocessed-task-id->sandbox)
+      (let [unprocessed-task-id->sandbox-partitions (partition-all filter-batch-size unprocessed-task-id->sandbox)]
+        (doseq [unprocessed-task-id->sandbox-partition unprocessed-task-id->sandbox-partitions]
+          (let [unprocessed-task-ids (keys unprocessed-task-id->sandbox-partition)]
+            (remove-processed-task-ids! unprocessed-task-id->sandbox-atom unprocessed-task-ids))
+          (let [filtered-task-id->sandbox-directory (remove-task-ids-with-sandbox datomic-conn unprocessed-task-id->sandbox)]
+            (log/info "Filtered" (count filtered-task-id->sandbox-directory) "tasks without sandbox directories from"
+                      (count unprocessed-task-id->sandbox) "tasks")
+            (when (seq filtered-task-id->sandbox-directory)
+              (send task-id->sandbox-agent aggregate-sandbox filtered-task-id->sandbox-directory))))))))
+
+(defn start-unprocessed-entries-processor
+  "Launches a timer task that triggers syncing of sandbox directories of any pending hosts."
+  [publisher-state filter-batch-size filter-interval-ms]
+  (log/info "Starting unprocessed entries processor at intervals of" filter-interval-ms "ms")
+  (chime/chime-at
+    (periodic/periodic-seq (time/now) (time/millis filter-interval-ms))
+    (fn start-unprocessed-entries-processor-task [_]
+      (process-unprocessed-task-ids publisher-state filter-batch-size))
+    {:error-handler (fn start-unprocessed-entries-processor-error-handler [ex]
+                      (log/error ex "Filtering tasks with sandbox directories failed"))}))
 
 (defn prepare-sandbox-publisher
   "This function initializes the sandbox publisher as well as helper functions to send individual
@@ -275,19 +327,25 @@
    :mesos-agent-query-cache - the cache that throttles the state sync calls to the mesos agents.
    :publisher-cancel-fn - fn that take no arguments and that terminates the publisher.
    :task-id->sandbox-agent - The agent that manages the task-id->sandbox aggregation and publishing."
-  [framework-id datomic-conn publish-batch-size publish-interval-ms sync-interval-ms max-consecutive-sync-failure
-   mesos-agent-query-cache]
+  [framework-id datomic-conn filter-batch-size filter-interval-ms publish-batch-size publish-interval-ms
+   sync-interval-ms max-consecutive-sync-failure mesos-agent-query-cache]
   (let [pending-sync-agent (agent {:framework-id framework-id
                                    :host->consecutive-failures {}
                                    :pending-sync-hosts #{}}) ;; stores the names of hosts pending sync
         task-id->sandbox-agent (agent {}) ;; stores all the pending task-id->sandbox state
+        unprocessed-task-id->sandbox-atom (atom {}) ;; stores all pending task-id->sandbox entries that have not yet been filtered
         publisher-state {:datomic-conn datomic-conn
                          :mesos-agent-query-cache mesos-agent-query-cache
                          :pending-sync-agent pending-sync-agent
-                         :task-id->sandbox-agent task-id->sandbox-agent}
+                         :task-id->sandbox-agent task-id->sandbox-agent
+                         :unprocessed-task-id->sandbox-atom unprocessed-task-id->sandbox-atom}
+        processor-cancel-fn (start-unprocessed-entries-processor
+                              publisher-state filter-batch-size filter-interval-ms)
         publisher-cancel-fn (start-sandbox-publisher
                               task-id->sandbox-agent datomic-conn publish-batch-size publish-interval-ms)
-        syncer-cancel-fn (start-host-sandbox-syncer publisher-state sync-interval-ms max-consecutive-sync-failure)]
+        syncer-cancel-fn (start-host-sandbox-syncer
+                           publisher-state sync-interval-ms max-consecutive-sync-failure)]
     (assoc publisher-state
+      :processor-cancel-fn processor-cancel-fn
       :publisher-cancel-fn publisher-cancel-fn
       :syncer-cancel-fn syncer-cancel-fn)))


### PR DESCRIPTION
## Changes proposed in this PR

- Move the logic to query datomic for presence of sandbox directories into a single thread

## Why are we making these changes?

On large clusters, the sandbox syncer can spin up many threads (in the order of hundreds) that trigger datomic queries. Datomic has a read concurrency setting which causes these queries to start becoming a performance concern if many threads make read queries that end up hitting backing storage. As a result, the sandbox syncer starts performing poorly as well as affecting the performance of other read queries in the cook scheduler. With the single reader thread version for the syncer, we can minimize the effect we have on datomic read performance.

## Relevant Links

[Datomic Peer properties](https://docs.datomic.com/on-prem/system-properties.html#peer-properties)

