### PR TITLE
Initial interface for optimizer component

### DIFF
--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -271,7 +271,7 @@ Optionally, you can include a "rebalancer" stanza.  If you do, on startup, Cook 
 
 The link:optimizer.md[optimizer] is a component that can make more global decisions about the cluster, job placement and autoscaling.
 By default, Cook will use a no-op optimizer. To plug in an implementation, add the optional "optimizer" stanza. The two pluggable pieces,
-host-feed, and optimizer, each have the same structure to configure. A :create-fn:: key which is a namespaced symbol
+host-feed and optimizer, each have the same structure to configure. A :create-fn:: key which is a namespaced symbol
 on the class path and a :config:: key which is an arbitrary map. See the example below.
 
  :host-feed::
@@ -292,7 +292,7 @@ on the class path and a :config:: key which is an arbitrary map. See the example
  :optimizer::
     The implementation for the optimizer to use. The optimizer accepts the output of the host feed, the queue, the running tasks and the available offers and outputs a schedule of suggestions.
 
-A schedule is a map from T milliseconds in the future to a map of optimizer recommendations. Each recommendation map can contain multiple keys, currently, only one, :suggested-matches. The value of :suggested-matches is a map from a host type map described above to a list of job uuids that the optimizers recommends matching onto that host type at this point in the future.
+A schedule is a map from T milliseconds in the future to a map of optimizer recommendations. Each recommendation map can contain multiple keys, currently, only one, :suggested-matches. The value of :suggested-matches is a map from a host type map described above to a list of job uuids that the optimizer recommends matching onto that host type at this point in the future.
 
  :optimizer-interval-seconds::
     The interval to run the optimizer, in seconds. The default is 30.

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -271,7 +271,7 @@ Optionally, you can include a "rebalancer" stanza.  If you do, on startup, Cook 
 
 The link:optimizer.md[optimizer] is a component that can make more global decisions about the cluster, job placement and autoscaling.
 By default, Cook will use a no-op optimizer. To plug in an implementation, add the optional "optimizer" stanza. The three pluggable pieces,
-host-feed, optimizer and schedule-consumer, each have the same structure to configure. A :create-fn:: key which is a namespaced symbol
+host-feed, and optimizer, each have the same structure to configure. A :create-fn:: key which is a namespaced symbol
 on the class path and a :config:: key which is an arbitrary map. See the example below.
 
  :host-feed::
@@ -279,9 +279,6 @@ on the class path and a :config:: key which is an arbitrary map. See the example
 
  :optimizer::
     The implementation for the optimizer to use. The optimizer accepts the output of the host feed, the queue, the running tasks and the available offers and outputs a schedule of suggestions.
-
- :schedule-consumer::
-    The implementation for the schedule-consumer. The schedule consumer accepts the schedule from the optimizer and acts on it.
 
  :optimizer-interval-seconds::
     The interval to run the optimizer, in seconds. The default is 30.
@@ -296,8 +293,6 @@ Example optimizer config:
                          :config {}}
              :optimizer {:create-fn cook.mesos.optimizer/create-dummy-optimizer
                          :config {}}
-             :schedule-consumer {:create-fn cook.mesos.optimizer/create-dummy-consumer
-                                 :config {}}
              :optimizer-interval-seconds 30}
  ; ... snip ...
 }

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -229,7 +229,7 @@ Example: +
   If Cook has been allowing Fenzo to see only 1 job for this number of iterations, it measn that the cluster is essentially down.  In this case, Cook will log an error message and then reset the number of jobs Fenzo can see to the value of "fenzo-max-jobs-considered" (see above).
 
 :fenzo-fitness-calculator::
-  By default, Cook will have Fenzo attempt to bin-pack using a combination of memory and CPU when choosing which hosts will field which tasks.  By choosing a different option in fenzo-fitness-calculator, you can specify that Fenzo should use a different implemention of https://github.com/Netflix/Fenzo/blob/master/fenzo-core/src/main/java/com/netflix/fenzo/VMTaskFitnessCalculator.java[VMTaskFitnessCalculator].  This value can either refer to a static member of a Java class on the classpath (e.g. "com.netflix.fenzo.plugins.BinPackingFitnessCalculators/cpuMemBinPacker", the default), or a namespaced clojure symbol (e.g. "cook.mesos.scheduler/dummy-fitness-calculator") 
+  By default, Cook will have Fenzo attempt to bin-pack using a combination of memory and CPU when choosing which hosts will field which tasks.  By choosing a different option in fenzo-fitness-calculator, you can specify that Fenzo should use a different implemention of https://github.com/Netflix/Fenzo/blob/master/fenzo-core/src/main/java/com/netflix/fenzo/VMTaskFitnessCalculator.java[VMTaskFitnessCalculator].  This value can either refer to a static member of a Java class on the classpath (e.g. "com.netflix.fenzo.plugins.BinPackingFitnessCalculators/cpuMemBinPacker", the default), or a namespaced clojure symbol (e.g. "cook.mesos.scheduler/dummy-fitness-calculator")
 
 `:task-constraints`::
   This option is a map that allows you to configure limits for tasks, to ensure that impossible-to-schedule tasks and tasks that run forever won't bog down your cluster.
@@ -267,18 +267,32 @@ Optionally, you can include a "rebalancer" stanza.  If you do, on startup, Cook 
   settings (recommended), or increase the dru-scale setting to e.g. 10^300.
 
 [[optimizer]]
-====Optimizer configuration
+==== Optimizer configuration
 
 The link:optimizer.md[optimizer] is a component that can make more global decisions about the cluster, job placement and autoscaling.
-By default, Cook will use a no-op optimizer. To plug in an implementation, add the optional "optimizer" stanza. The three pluggable pieces,
+By default, Cook will use a no-op optimizer. To plug in an implementation, add the optional "optimizer" stanza. The two pluggable pieces,
 host-feed, and optimizer, each have the same structure to configure. A :create-fn:: key which is a namespaced symbol
 on the class path and a :config:: key which is an arbitrary map. See the example below.
 
  :host-feed::
-    The implementation for the host feed to use. The host feed returns a list of maps where each map describes a host type that can be purchased.
+    The implementation for the host feed to use. The host feed returns a list of maps where each map describes a host type that can be purchased. Each map should include the following keys:
+
+ * :count::
+    The number of hosts available of that type. Should be a non-negative integer
+ * :instance-type::
+    The name of the host type. Should be a string
+ * :cpus::
+    The number of cpus available for the particular host type. Should be a postive number
+ * :mem::
+    The amount of memory available for the host type, in MB. Should be a positive number
+ * :gpu::
+    (Optional) The number of GPUs available for the host type. Should be a positive number
+
 
  :optimizer::
     The implementation for the optimizer to use. The optimizer accepts the output of the host feed, the queue, the running tasks and the available offers and outputs a schedule of suggestions.
+
+A schedule is a map from T milliseconds in the future to a map of optimizer recommendations. Each recommendation map can contain multiple keys, currently, only one, :suggested-matches. The value of :suggested-matches is a map from a host type map described above to a list of job uuids that the optimizers recommends matching onto that host type at this point in the future.
 
  :optimizer-interval-seconds::
     The interval to run the optimizer, in seconds. The default is 30.

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -78,7 +78,7 @@ If need it to bind to another port, you can specify that with the `:local-port` 
   The value of this key is a set of usernames who should be considered administrators when using the `configfile-admins-auth` authorization-fn.
 
 `:rate-limit`::
-  Configure rate limits for the scheduler. `rate-limit` is a map with two possible keys, `user-limit-per-m`. `user-limit-per-m` is the max requests a single user can send in a minute. The default is 600 requests. 
+  Configure rate limits for the scheduler. `rate-limit` is a map with two possible keys, `user-limit-per-m`. `user-limit-per-m` is the max requests a single user can send in a minute. The default is 600 requests.
 
 `:agent-query-cache`::
   Configure the cache used to store sandbox locations of tasks on different mesos agents.
@@ -179,14 +179,14 @@ We'll look at the three authentication mechanisms supported:
 
 `:http-basic`::
   Most organizations will want to use HTTP Basic authentication.
-  Cook allows you to configure how the user name and password are configured. 
+  Cook allows you to configure how the user name and password are configured.
   Currently, Cook supports specifying the logins in the config file or using no validation
   This also makes it super easy to get started:
   to use HTTP Basic, simply use `{:http-basic true}` as your `:authorization`.
-  This will use no validation. 
+  This will use no validation.
   To use config-file validation, set `:authorization` to:
   `{:http-basic {:validation :config-file :valid-logins #{["user" "password"] ["user2" "password2"]}}}`
-  
+
 
 `:kerberos`::
   If you have Kerberos at your organization, then you can use it to authenticate users with Cook.
@@ -266,6 +266,42 @@ Optionally, you can include a "rebalancer" stanza.  If you do, on startup, Cook 
   To obtain useful DRU metrics in this situation, you can either adjust your share
   settings (recommended), or increase the dru-scale setting to e.g. 10^300.
 
+[[optimizer]]
+====Optimizer configuration
+
+The link:optimizer.md[optimizer] is a component that can make more global decisions about the cluster, job placement and autoscaling.
+By default, Cook will use a no-op optimizer. To plug in an implementation, add the optional "optimizer" stanza. The three pluggable pieces,
+host-feed, optimizer and schedule-consumer, each have the same structure to configure. A :create-fn:: key which is a namespaced symbol
+on the class path and a :config:: key which is an arbitrary map. See the example below.
+
+ :host-feed::
+    The implementation for the host feed to use. The host feed returns a list of maps where each map describes a host type that can be purchased.
+
+ :optimizer::
+    The implementation for the optimizer to use. The optimizer accepts the output of the host feed, the queue, the running tasks and the available offers and outputs a schedule of suggestions.
+
+ :schedule-consumer::
+    The implementation for the schedule-consumer. The schedule consumer accepts the schedule from the optimizer and acts on it.
+
+ :optimizer-interval-seconds::
+    The interval to run the optimizer, in seconds. The default is 30.
+
+Example optimizer config:
++
+[source,edn]
+----
+{
+ ; ... snip ...
+ :optimizer {:host-feed {:create-fn cook.mesos.optimizer/create-dummy-host-feed
+                         :config {}}
+             :optimizer {:create-fn cook.mesos.optimizer/create-dummy-optimizer
+                         :config {}}
+             :schedule-consumer {:create-fn cook.mesos.optimizer/create-dummy-consumer
+                                 :config {}}
+             :optimizer-interval-seconds 30}
+ ; ... snip ...
+}
+----
 
 [[task_constraints]]
 ==== Task Constraints
@@ -286,7 +322,7 @@ Optionally, you can include a "rebalancer" stanza.  If you do, on startup, Cook 
 `:cpus`::
   This is just like `:memory-gb`, but for CPUs.
   You should make sure this is small enough that users can't accidentally submit tasks that are too big for your slaves.
-  
+
 `:retry-limit`::
   This limits the number of retries a job is allowed to request. Something in the low tens is often more than sufficient.
 

--- a/scheduler/docs/optimizer.md
+++ b/scheduler/docs/optimizer.md
@@ -1,13 +1,13 @@
 Optimizer
 =========
 
-The optimizer is intended to provide a longer term, holistic plan for the cluster that other components in cook can consume to inform their operation.
+The optimizer is intended to provide a longer term, holistic plan for the cluster that other components in Cook can consume to inform their operation.
 Cook will provide a no-op implementation of an optimizer and allow for plugging in different implementations.
 
 The optimizer is provided with the current queue, the jobs that are running, the offers that are available and a pluggable feed of hosts that can be purchased.
 There are plans to support more plug-ins such as expected demand in the future.
 With these  inputs, the optimizer produces a 'schedule' of suggestions of what hosts to purchase and matches of jobs and hosts at different time horizons.
 
-There are plans to have the schedule be feed to the matcher so that it may treat the suggestions of the optimizer as soft constraints.
+There are plans to have the schedule be fed to the matcher so that it may treat the suggestions of the optimizer as soft constraints.
 
 The specification of pluggable pieces can be found in [optimizer.clj](scheduler/src/cook/mesos/optimizer.clj).

--- a/scheduler/docs/optimizer.md
+++ b/scheduler/docs/optimizer.md
@@ -8,11 +8,6 @@ The optimizer is provided with the current queue, the jobs that are running, the
 There are plans to support more plug-ins such as expected demand in the future.
 With these  inputs, the optimizer produces a 'schedule' of suggestions of what hosts to purchase and matches of jobs and hosts at different time horizons.
 
-The schedule is passed to a pluggable schedule consumer which may make take actions using the schedule.
 There are plans to have the schedule be feed to the matcher so that it may treat the suggestions of the optimizer as soft constraints.
-
-The architecture looks like:
-
-![Optimizer architecture](scheduler/docs/images/optimizer_architecture.png)
 
 The specification of pluggable pieces can be found in [optimizer.clj](scheduler/src/cook/mesos/optimizer.clj).

--- a/scheduler/docs/optimizer.md
+++ b/scheduler/docs/optimizer.md
@@ -1,0 +1,18 @@
+Optimizer
+=========
+
+The optimizer is intended to provide a longer term, holistic plan for the cluster that other components in cook can consume to inform their operation.
+Cook will provide a no-op implementation of an optimizer and allow for plugging in different implementations.
+
+The optimizer is provided with the current queue, the jobs that are running, the offers that are available and a pluggable feed of hosts that can be purchased.
+There are plans to support more plug-ins such as expected demand in the future.
+With these  inputs, the optimizer produces a 'schedule' of suggestions of what hosts to purchase and matches of jobs and hosts at different time horizons.
+
+The schedule is passed to a pluggable schedule consumer which may make take actions using the schedule.
+There are plans to have the schedule be feed to the matcher so that it may treat the suggestions of the optimizer as soft constraints.
+
+The architecture looks like:
+
+![Optimizer architecture](scheduler/docs/images/optimizer_architecture.png)
+
+The specification of pluggable pieces can be found in [optimizer.clj](scheduler/src/cook/mesos/optimizer.clj).

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -66,7 +66,10 @@
     (when-not ns
       (throw (ex-info "Can only load vars that are ns-qualified!" {})))
     (require (symbol ns))
-    (resolve var-sym)))
+    (let [resolved (resolve var-sym)]
+      (if resolved
+        resolved
+        (throw (ex-info "Unable to resolve var, is it valid?" {:var-sym var-sym}))))))
 
 (def raw-scheduler-routes
   {:scheduler (fnk [mesos mesos-datomic mesos-leadership-atom mesos-pending-jobs-atom framework-id settings]
@@ -91,7 +94,7 @@
                            fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback
                            good-enough-fitness hostname mea-culpa-failure-limit mesos-failover-timeout mesos-framework-name
                            mesos-gpu-enabled mesos-leader-path mesos-master mesos-master-hosts mesos-principal
-                           mesos-role offer-incubate-time-ms progress rebalancer riemann server-port task-constraints
+                           mesos-role offer-incubate-time-ms optimizer progress rebalancer riemann server-port task-constraints
                            user-metrics-interval-seconds]
                           curator-framework framework-id mesos-datomic mesos-datomic-mult mesos-leadership-atom
                           mesos-offer-cache mesos-pending-jobs-atom sandbox-syncer-state]
@@ -127,6 +130,7 @@
                              :mesos-pending-jobs-atom mesos-pending-jobs-atom
                              :offer-cache mesos-offer-cache
                              :offer-incubate-time-ms offer-incubate-time-ms
+                             :optimizer-config optimizer   
                              :progress-config progress
                              :rebalancer-config rebalancer
                              :sandbox-syncer-state sandbox-syncer-state
@@ -557,6 +561,19 @@
                    (merge {:interval-seconds 300
                            :dru-scale 1.0}
                           rebalancer))
+                       
+     :optimizer (fnk [[:config {optimizer nil}]]
+                     ;; TODO include a datomic connection to config so we can write purchase decisions
+                     (let [optimizer-config
+                           (merge {:host-feed {:create-fn 'cook.mesos.optimizer/create-dummy-host-feed
+                                               :config {}}
+                                   :optimizer {:create-fn 'cook.mesos.optimizer/create-dummy-optimizer
+                                               :config {}}
+                                   :schedule-consumer {:create-fn 'cook.mesos.optimizer/create-dummy-consumer
+                                                       :config {}}
+                                   :optimizer-interval-seconds 30}
+                                  optimizer)]
+                       optimizer-config))
 
      :nrepl-server (fnk [[:config [:nrepl {enabled? false} {port 0}]]]
                      (when enabled?

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -569,8 +569,6 @@
                                                :config {}}
                                    :optimizer {:create-fn 'cook.mesos.optimizer/create-dummy-optimizer
                                                :config {}}
-                                   :schedule-consumer {:create-fn 'cook.mesos.optimizer/create-dummy-consumer
-                                                       :config {}}
                                    :optimizer-interval-seconds 30}
                                   optimizer)]
                        optimizer-config))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -107,7 +107,7 @@
                                                            :mesos-framework-name mesos-framework-name
                                                            :gpus-enabled? mesos-gpu-enabled})
                             get-mesos-utilization-fn (partial (lazy-load-var 'cook.mesos/get-mesos-utilization) mesos-master-hosts)
-                            trigger-chans ((lazy-load-var 'cook.mesos/make-trigger-chans) rebalancer progress task-constraints)]
+                            trigger-chans ((lazy-load-var 'cook.mesos/make-trigger-chans) rebalancer progress optimizer task-constraints)]
                         (try
                           (Class/forName "org.apache.mesos.Scheduler")
                           ((lazy-load-var 'cook.mesos/start-mesos-scheduler)

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -563,7 +563,6 @@
                           rebalancer))
                        
      :optimizer (fnk [[:config {optimizer nil}]]
-                     ;; TODO include a datomic connection to config so we can write purchase decisions
                      (let [optimizer-config
                            (merge {:host-feed {:create-fn 'cook.mesos.optimizer/create-dummy-host-feed
                                                :config {}}

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -260,7 +260,9 @@
                                                                               :view-incubating-offers view-incubating-offers})
                                     (when (seq optimizer-config)
                                       (cook.mesos.optimizer/start-optimizer-cycles! (fn get-queue []
-                                                                                      ;; TODO Use filters scheduler uses
+                                                                                      ;; TODO Use filter of queue that scheduler uses to filter to considerable.
+                                                                                      ;;      Specifically, think about filtering to jobs that are waiting and 
+                                                                                      ;;      think about how to handle quota 
                                                                                       @mesos-pending-jobs-atom)
                                                                                     (fn get-running []
                                                                                       (cook.mesos.util/get-running-task-ents (d/db mesos-datomic-conn)))

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -25,8 +25,10 @@
             [cook.datomic :refer (transact-with-retries)]
             [cook.mesos.heartbeat]
             [cook.mesos.monitor]
+            [cook.mesos.optimizer]
             [cook.mesos.rebalancer]
             [cook.mesos.scheduler :as sched]
+            [cook.mesos.util]
             [cook.util]
             [datomic.api :as d :refer (q)]
             [mesomatic.scheduler]
@@ -157,6 +159,7 @@
     {:cancelled-task-trigger-chan (prepare-trigger-chan (time/seconds 3))
      :lingering-task-trigger-chan (prepare-trigger-chan (time/minutes timeout-interval-minutes))
      :match-trigger-chan (prepare-trigger-chan (time/seconds 1))
+     :optimizer-trigger-chan (prepare-trigger-chan (time/seconds 10))
      :progress-updater-trigger-chan (prepare-trigger-chan (time/millis (:publish-interval-ms progress-config)))
      :rank-trigger-chan (prepare-trigger-chan (time/seconds 5))
      :rebalancer-trigger-chan (prepare-trigger-chan (time/seconds (:interval-seconds rebalancer-config)))
@@ -192,12 +195,12 @@
    user-metrics-interval-seconds -- long, time in seconds between collecting and counting per-user job metrics"
   [{:keys [curator-framework executor-config fenzo-config framework-id get-mesos-utilization gpu-enabled? make-mesos-driver-fn
            mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom mesos-pending-jobs-atom
-           offer-cache offer-incubate-time-ms progress-config rebalancer-config
+           offer-cache offer-incubate-time-ms optimizer-config progress-config rebalancer-config
            sandbox-syncer-state server-config task-constraints trigger-chans user-metrics-interval-seconds zk-prefix]}]
   (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
                 fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness]} fenzo-config
-        {:keys [cancelled-task-trigger-chan lingering-task-trigger-chan rebalancer-trigger-chan
-                straggler-trigger-chan]} trigger-chans
+        {:keys [cancelled-task-trigger-chan lingering-task-trigger-chan optimizer-trigger-chan
+                rebalancer-trigger-chan straggler-trigger-chan]} trigger-chans
         {:keys [hostname server-port]} server-config
         datomic-report-chan (async/chan (async/sliding-buffer 4096))
         mesos-heartbeat-chan (async/chan (async/buffer 4096))
@@ -255,6 +258,15 @@
                                                                               :pending-jobs-atom mesos-pending-jobs-atom
                                                                               :trigger-chan rebalancer-trigger-chan
                                                                               :view-incubating-offers view-incubating-offers})
+                                    (when (seq optimizer-config)
+                                      (cook.mesos.optimizer/start-optimizer-cycles! (fn get-queue []
+                                                                                      ;; TODO Use filters scheduler uses
+                                                                                      @mesos-pending-jobs-atom)
+                                                                                    (fn get-running []
+                                                                                      (cook.mesos.util/get-running-task-ents (d/db mesos-datomic-conn)))
+                                                                                    view-incubating-offers
+                                                                                    optimizer-config
+                                                                                    optimizer-trigger-chan))
                                     (counters/inc! mesos-leader)
                                     (async/tap mesos-datomic-mult datomic-report-chan)
                                     (cook.mesos.scheduler/monitor-tx-report-queue datomic-report-chan mesos-datomic-conn current-driver)

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -147,7 +147,7 @@
   "Creates a map of of the trigger channels expected by `start-mesos-scheduler`
    Each channel receives chime triggers at particular intervals and it is
    possible to send additional events as desired"
-  [rebalancer-config progress-config
+  [rebalancer-config progress-config optimizer-config
    {:keys [timeout-interval-minutes]
     :or {timeout-interval-minutes 1}
     :as task-constraints}]
@@ -159,7 +159,7 @@
     {:cancelled-task-trigger-chan (prepare-trigger-chan (time/seconds 3))
      :lingering-task-trigger-chan (prepare-trigger-chan (time/minutes timeout-interval-minutes))
      :match-trigger-chan (prepare-trigger-chan (time/seconds 1))
-     :optimizer-trigger-chan (prepare-trigger-chan (time/seconds 10))
+     :optimizer-trigger-chan (prepare-trigger-chan (time/seconds (:optimizer-interval-seconds optimizer-config 10)))
      :progress-updater-trigger-chan (prepare-trigger-chan (time/millis (:publish-interval-ms progress-config)))
      :rank-trigger-chan (prepare-trigger-chan (time/seconds 5))
      :rebalancer-trigger-chan (prepare-trigger-chan (time/seconds (:interval-seconds rebalancer-config)))

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -32,7 +32,7 @@
             [cook.mesos.unscheduled :as unscheduled]
             [cook.mesos.util :as util]
             [cook.mesos]
-            [cook.util]
+            [cook.util :refer [ZeroInt PosNum NonNegNum PosInt NonNegInt PosDouble UserName NonEmptyString]]
             [datomic.api :as d :refer [q]]
             [liberator.core :as liberator]
             [liberator.util :refer [combine]]
@@ -104,32 +104,6 @@
                 (update k :k ->snake_case)
                 (->snake_case k)))
             schema))
-
-(def ZeroInt
-  (s/both s/Int (s/pred zero? 'zero?)))
-
-(s/defschema PosNum
-  "Positive number (float or int)"
-  (s/both s/Num (s/pred pos? 'pos?)))
-
-(s/defschema NonNegNum
-  "Non-negative number (float or int)"
-  (s/both s/Num (s/pred (comp not neg?) 'non-negative?)))
-
-(def PosInt
-  (s/both s/Int (s/pred pos? 'pos?)))
-
-(def NonNegInt
-  (s/both s/Int (s/pred (comp not neg?) 'non-negative?)))
-
-(def PosDouble
-  (s/both double (s/pred pos? 'pos?)))
-
-(def UserName
-  (s/both s/Str (s/pred #(re-matches #"\A[a-z][a-z0-9_-]{0,62}[a-z0-9]\z" %) 'lowercase-alphanum?)))
-
-(def NonEmptyString
-  (s/both s/Str (s/pred #(not (zero? (count %))) 'not-empty-string)))
 
 (def iso-8601-format (:date-time tf/formatters))
 

--- a/scheduler/src/cook/mesos/optimizer.clj
+++ b/scheduler/src/cook/mesos/optimizer.clj
@@ -24,9 +24,9 @@
             [clojure.tools.logging :as log]
             [cook.util :refer [lazy-load-var]]
             [cook.mesos.util :as util]
-            [com.rpl.specter :as sp]
             [datomic.api :as d :refer (q)]
             [schema.core :as s]))
+
 (def PosNum
   (s/both s/Num (s/pred pos? 'pos?)))
 
@@ -109,7 +109,8 @@
         host-infos (get-available-host-info host-feed)
         _ (s/validate [HostInfo] host-infos)
         schedule (produce-schedule optimizer @queue @running @offers host-infos)]
-    (s/validate Schedule schedule)))
+    (s/validate Schedule schedule)
+    schedule))
 
 (defn start-optimizer-cycles!
   "Every interval, call `optimizer-cycle!`.

--- a/scheduler/src/cook/mesos/optimizer.clj
+++ b/scheduler/src/cook/mesos/optimizer.clj
@@ -106,8 +106,8 @@
   (let [queue (future (get-queue))
         running (future (get-running))
         offers (future (get-offers))
-        host-infos (future (get-available-host-info host-feed))
-        _ (s/validate [HostInfo] @host-infos)
+        host-infos (get-available-host-info host-feed)
+        _ (s/validate [HostInfo] host-infos)
         schedule (produce-schedule optimizer @queue @running @offers @host-infos)]
     (s/validate Schedule schedule)))
 

--- a/scheduler/src/cook/mesos/optimizer.clj
+++ b/scheduler/src/cook/mesos/optimizer.clj
@@ -108,7 +108,7 @@
         offers (future (get-offers))
         host-infos (get-available-host-info host-feed)
         _ (s/validate [HostInfo] host-infos)
-        schedule (produce-schedule optimizer @queue @running @offers @host-infos)]
+        schedule (produce-schedule optimizer @queue @running @offers host-infos)]
     (s/validate Schedule schedule)))
 
 (defn start-optimizer-cycles!

--- a/scheduler/src/cook/mesos/optimizer.clj
+++ b/scheduler/src/cook/mesos/optimizer.clj
@@ -1,0 +1,158 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.mesos.optimizer
+  (:require [cheshire.core :as cheshire]
+            [chime :refer [chime-at chime-ch]]
+            [clj-http.client :as http]
+            [clj-time.core :as t]
+            [clj-time.coerce :as tc]
+            [clj-time.periodic :as periodic]
+            [clojure.core.async :as async]
+            [clojure.tools.logging :as log]
+            [cook.util :refer [lazy-load-var]]
+            [cook.mesos.util :as util]
+            [com.rpl.specter :as sp]
+            [datomic.api :as d :refer (q)]
+            [schema.core :as s]))
+(def PosNum
+  (s/both s/Num (s/pred pos? 'pos?)))
+
+(def PosInt
+  (s/both s/Int (s/pred pos? 'pos?)))
+
+(def NonNegInt
+  (s/both s/Int (s/pred #(<= 0 %) 'pos?)))
+
+(def TimePeriodMs NonNegInt)
+
+;; Elements missing:
+;;   1. Attributes (chip set, az, ..) -- have a combinitorial problem here
+;;   2. Price
+;;   3. Prob preemption in 10 minutes increments (or something like that
+(def HostInfo
+  {:count NonNegInt
+   :instance-type s/Str
+   :cpus PosNum
+   :mem PosNum
+   (s/optional-key :gpus) PosNum
+   :time-to-start TimePeriodMs})
+
+(defprotocol HostFeed
+  "Protocol defining a service to get information on hosts that can be purchased."
+  (get-available-host-info [this] "Returns a list of host info maps conforming
+                                   to HostInfo schema above"))
+
+(def Schedule
+  {TimePeriodMs {:suggested-matches {HostInfo [s/Uuid]}
+                 :suggested-purchases {HostInfo NonNegInt}}})
+
+(defprotocol Optimizer
+  "Protocol defining a tool to produce a schedule to execute"
+  (produce-schedule [this queue running available host-infos]
+                    "Returns a schedule of what jobs to place on what machines
+                     and what hosts to purchase at different time steps.
+                     Conforms to the Schedule schema above
+
+                     Parameters:
+                     queue -- Ordered list of jobs to run (see cook.mesos.schema job)
+                     running -- Set of tasks running (see cook.mesos.schema instance)
+                     available -- Set of offers outstanding
+                     host-infos -- Host infos from HostFeed"))
+
+(defprotocol ScheduleConsumer
+  "Protocol defining a consumer of the optimizer's schedule.
+   An examples is a component to take the schedules suggested
+   purchases and execute on them"
+  ;;Question to self: Should this be run its own thread or let it kick off a thread
+  (consume-schedule [this schedule]
+                    "Act on the schedule passed in.
+                     It is expected this function has side effects
+                     and it will be run in a separate thread"))
+
+(defn create-dummy-host-feed
+  "Returns an instance of HostFeed which returns an empty list of hosts"
+  [_]
+  (reify HostFeed
+    (get-available-host-info [this]
+      [])))
+
+(defn create-dummy-optimizer
+  "Returns an instance of Optimizer which returns an empty schedule"
+  [_]
+  (reify Optimizer
+    (produce-schedule [this queue running available host-infos]
+      {0 {:suggested-purchases {} :suggested-matches {}}})))
+
+(defn create-dummy-consumer
+  "Returns an instance of ScheduleConsumer which does nothing"
+  [_]
+  (reify ScheduleConsumer
+    (consume-schedule [this schedule])))
+
+(defn optimizer-cycle!
+  "Starts a cycle that:
+   1. Gets queue, running, offer and purchasable host info
+   2. Calls the `optimizer` to get a schedule
+   3. Passes the schedule to each of the consumers
+
+   Parameters:
+   get-queue -- fn, no args fn that returns ordered list of jobs to run
+   get-running -- fn, no args fn that returns a set of tasks running
+   get-offers -- fn, no args fn that returns a set of offers
+   host-feed -- instance of HostFeed
+   optimizer -- instance of Optimizer
+   schedule-consumer -- instance of ScheduleConsumer
+   interval -- joda-time period
+
+   Raises an exception if there was a problem in the execution"
+  [get-queue get-running get-offers host-feed optimizer schedule-consumer]
+  (let [queue (future (get-queue))
+        running (future (get-running))
+        offers (future (get-offers))
+        host-infos (future (get-available-host-info host-feed))
+        _ (s/validate [HostInfo] @host-infos)
+        schedule (produce-schedule optimizer @queue @running @offers @host-infos)]
+    (s/validate Schedule schedule)
+    (async/thread
+      (try
+        (consume-schedule schedule-consumer schedule)
+        (catch Exception e
+          (log/warn e "Error consuming schedule"))))
+    ;; TODO: should we block on consumers finishing?
+    ))
+
+(defn start-optimizer-cycles!
+  "Every interval, call `optimizer-cycle!`.
+   Returns a function of no arguments to stop"
+  [get-queue get-running get-offers optimizer-config trigger-chan]
+  (log/info "Starting optimization cycler")
+  (let [construct (fn construct [{:keys [create-fn config] :as c}]
+                    ((lazy-load-var create-fn) config))
+        host-feed (-> optimizer-config :host-feed construct)
+        optimizer (-> optimizer-config :optimizer construct)
+        schedule-consumer (-> optimizer-config :schedule-consumer construct)]
+    (log/info "Optimizer constructed")
+    (util/chime-at-ch trigger-chan
+                      (fn []
+                        (log/info "Starting optimization cycle")
+                        (optimizer-cycle! get-queue
+                                          get-running
+                                          get-offers
+                                          host-feed
+                                          optimizer
+                                          schedule-consumer))
+                      {:error-handler (fn [e]
+                                        (log/warn e "Error running optimizer"))})))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -91,7 +91,7 @@
 
 (defn entity->map
   "Takes a datomic entity and converts it along with any nested entities
-  into clojure maps"
+   into clojure maps"
   ([entity db]
    (entity->map (d/entity db (:db/id entity))))
   ([entity]
@@ -121,7 +121,6 @@
                         hash-set))]
        (cond-> job
          group (assoc :group/_job group))))))
-
 
 (defn remove-datomic-namespacing
   "Takes a map from datomic (pull) and removes the namespace

--- a/scheduler/src/cook/util.clj
+++ b/scheduler/src/cook/util.clj
@@ -20,7 +20,8 @@
             [clojure.java.io :as io :refer [reader file]]
             [clojure.tools.logging :as log]
             [postal.core :as postal]
-            [postal.core :as postal])
+            [postal.core :as postal]
+            [schema.core :as s])
   (:use [clojure-miniprofiler :as miniprofiler]
         [clojure.java.shell :only [sh]]
         [clojure.pprint :only [pp pprint]]
@@ -307,7 +308,7 @@
   "When an exception isn't caught anywhere, this installs a global handler.
    It will log the exception at the given log-level (:error is recommended),
    and it will send an email to the address specified by the email-config.
-   
+
    email-config comes from the postal library. Usually, you'll specify
    a map like:
    {:to [\"admin@example.com\"]
@@ -333,3 +334,30 @@
       (throw (ex-info "Can only load vars that are ns-qualified!" {})))
     (require (symbol ns))
     (resolve var-sym)))
+
+(def ZeroInt
+  (s/both s/Int (s/pred zero? 'zero?)))
+
+(s/defschema PosNum
+  "Positive number (float or int)"
+  (s/both s/Num (s/pred pos? 'pos?)))
+
+(s/defschema NonNegNum
+  "Non-negative number (float or int)"
+  (s/both s/Num (s/pred (comp not neg?) 'non-negative?)))
+
+(def PosInt
+  (s/both s/Int (s/pred pos? 'pos?)))
+
+(def NonNegInt
+  (s/both s/Int (s/pred (comp not neg?) 'non-negative?)))
+
+(def PosDouble
+  (s/both double (s/pred pos? 'pos?)))
+
+(def UserName
+  (s/both s/Str (s/pred #(re-matches #"\A[a-z][a-z0-9_-]{0,62}[a-z0-9]\z" %) 'lowercase-alphanum?)))
+
+(def NonEmptyString
+  (s/both s/Str (s/pred #(not (zero? (count %))) 'not-empty-string)))
+

--- a/scheduler/test/cook/test/mesos/optimizer.clj
+++ b/scheduler/test/cook/test/mesos/optimizer.clj
@@ -1,0 +1,32 @@
+(ns cook.test.mesos.optimizer
+  (:use clojure.test)
+  (:require [clj-time.core :as t]
+            [clojure.core.async :as async]
+            [cook.mesos.optimizer :as optimizer]))
+
+;; Tests to make sure data flows and validates properly
+(deftest test-optimizer-cycle
+  (let [host {:count 1
+              :instance-type "small"
+              :cpus 1
+              :mem 1000
+              :time-to-start  (-> 30 t/seconds t/in-millis)}
+        host-feed (reify optimizer/HostFeed
+                         (get-available-host-info [this]
+                           [host]))
+        optimizer (reify optimizer/Optimizer
+                          (produce-schedule [this queue running available [host-info & host-infos]]
+                            {0 {:suggested-purchases {host-info 2}
+                                :suggested-matches {host-info (map :job/uuid queue)}}}))
+        consumer (reify optimizer/ScheduleConsumer
+                   (consume-schedule [this schedule]
+                     (is (= (count schedule) 1))
+                     (is (= (first (keys (get-in schedule [0 :suggested-matches])))
+                            host))))
+        queue [{:job/uuid (java.util.UUID/randomUUID)} {:job/uuid (java.util.UUID/randomUUID)}]]
+    (async/<!! (optimizer/optimizer-cycle! (fn get-queue [] queue)
+                                (fn get-running [] [])
+                                (fn get-offers [] [])
+                                host-feed
+                                optimizer
+                                consumer))))

--- a/scheduler/test/cook/test/mesos/optimizer.clj
+++ b/scheduler/test/cook/test/mesos/optimizer.clj
@@ -16,9 +16,12 @@
         optimizer (reify optimizer/Optimizer
                           (produce-schedule [this queue running available [host-info & host-infos]]
                             {0 {:suggested-matches {host-info (map :job/uuid queue)}}})) 
-        queue [{:job/uuid (java.util.UUID/randomUUID)} {:job/uuid (java.util.UUID/randomUUID)}]]
-    (optimizer/optimizer-cycle! (fn get-queue [] queue)
-                                (fn get-running [] [])
-                                (fn get-offers [] [])
-                                host-feed
-                                optimizer)))
+        queue [{:job/uuid (java.util.UUID/randomUUID)} {:job/uuid (java.util.UUID/randomUUID)}]
+        schedule (optimizer/optimizer-cycle! (fn get-queue [] queue)
+                                             (fn get-running [] [])
+                                             (fn get-offers [] [])
+                                             host-feed
+                                             optimizer)]
+    (is (= (count schedule) 1))
+    (is (= (first (keys (get-in schedule [0 :suggested-matches])))
+           host))))

--- a/scheduler/test/cook/test/mesos/optimizer.clj
+++ b/scheduler/test/cook/test/mesos/optimizer.clj
@@ -9,24 +9,16 @@
   (let [host {:count 1
               :instance-type "small"
               :cpus 1
-              :mem 1000
-              :time-to-start  (-> 30 t/seconds t/in-millis)}
+              :mem 1000}
         host-feed (reify optimizer/HostFeed
                          (get-available-host-info [this]
                            [host]))
         optimizer (reify optimizer/Optimizer
                           (produce-schedule [this queue running available [host-info & host-infos]]
-                            {0 {:suggested-purchases {host-info 2}
-                                :suggested-matches {host-info (map :job/uuid queue)}}}))
-        consumer (reify optimizer/ScheduleConsumer
-                   (consume-schedule [this schedule]
-                     (is (= (count schedule) 1))
-                     (is (= (first (keys (get-in schedule [0 :suggested-matches])))
-                            host))))
+                            {0 {:suggested-matches {host-info (map :job/uuid queue)}}})) 
         queue [{:job/uuid (java.util.UUID/randomUUID)} {:job/uuid (java.util.UUID/randomUUID)}]]
-    (async/<!! (optimizer/optimizer-cycle! (fn get-queue [] queue)
+    (optimizer/optimizer-cycle! (fn get-queue [] queue)
                                 (fn get-running [] [])
                                 (fn get-offers [] [])
                                 host-feed
-                                optimizer
-                                consumer))))
+                                optimizer)))

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -303,9 +303,7 @@
         opt-config {:host-feed {:create-fn 'cook.mesos.optimizer/create-dummy-host-feed
                                 :config {}}
                     :optimizer {:create-fn 'cook.mesos.optimizer/create-dummy-optimizer
-                                :config {}}
-                    :schedule-consumer {:create-fn 'cook.mesos.optimizer/create-dummy-consumer
-                                        :config {}}}
+                                :config {}}}
         scheduler-config (merge (:scheduler-config config)
                                 {:optimizer-config opt-config}
                                 {:trigger-chans {:rank-trigger-chan ranker-trigger-chan
@@ -593,7 +591,7 @@
   (not (seq (trace-diffs trace-a trace-b))))
 
 (deftest test-simulator
-  (time (let [users ["a" "b" "c" "d"]
+  (let [users ["a" "b" "c" "d"]
         jobs (-> (for [minute (range 5)
                        sim-i (range (+ (rand-int 50) 30))]
                    (create-trace-job (+ (rand-int 1200000) 600000) ; 1 to 20 minutes
@@ -618,12 +616,12 @@
                 (trace-host i host-mem host-cpus))
         cycle-step-ms 30000
         config {:shares [{:user "default" :mem (/ host-mem 10) :cpus (/ host-cpus 10) :gpus 1.0}]
-               :scheduler-config {:rebalancer-config {:max-preemption 1.0}
-                                  :fenzo-config {:fenzo-max-jobs-considered 200}}}
+                :scheduler-config {:rebalancer-config {:max-preemption 1.0}
+                                   :fenzo-config {:fenzo-max-jobs-considered 200}}}
         out-trace-a (simulate hosts jobs cycle-step-ms config)
         out-trace-b (simulate hosts jobs cycle-step-ms config)]
     (is (> (count out-trace-a) 0))
     (is (> (count out-trace-b) 0))
     (is (traces-equivalent? out-trace-a out-trace-b)
         {:diffs (sort-by (comp :submit-time first second)
-                         (trace-diffs out-trace-a out-trace-b))}))))
+                         (trace-diffs out-trace-a out-trace-b))})))

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -95,7 +95,7 @@
          zk-prefix# (or (:zk-prefix ~scheduler-config)
                         "/cook")
          offer-incubate-time-ms# (or (:offer-incubate-time-ms ~scheduler-config)
-                                    1000)
+                                     1000)
          mea-culpa-failure-limit# (or (:mea-culpa-failure-limit ~scheduler-config)
                                       5)
          task-constraints# (merge default-task-constraints (:task-constraints ~scheduler-config))
@@ -121,7 +121,9 @@
          mesos-leadership-atom# (atom false)
          fenzo-config# (merge default-fenzo-config (:fenzo-config ~scheduler-config))
          trigger-chans# (or (:trigger-chans ~scheduler-config)
-                            (c/make-trigger-chans rebalancer-config# progress-config# task-constraints#))]
+                            (c/make-trigger-chans rebalancer-config# progress-config# task-constraints#))
+         optimizer-config# (or (:optimizer-config ~scheduler-config)
+                               {})]
      (try
        (c/start-mesos-scheduler
          {:curator-framework curator-framework#
@@ -138,6 +140,7 @@
           :mesos-pending-jobs-atom pending-jobs-atom#
           :offer-cache offer-cache#
           :offer-incubate-time-ms offer-incubate-time-ms#
+          :optimizer-config optimizer-config#
           :progress-config progress-config#
           :rebalancer-config rebalancer-config#
           :sandbox-syncer-state sandbox-syncer-state#
@@ -201,9 +204,9 @@
   "Returns a seq of task entities from the db"
   [mesos-db]
   (->> (d/q '[:find [?i ...]
-         :where
-         [?i :instance/task-id _]]
-       mesos-db)
+              :where
+              [?i :instance/task-id _]]
+            mesos-db)
        (map (partial d/entity mesos-db))))
 
 (defn submit-job
@@ -268,6 +271,8 @@
   [coll]
   (= coll (sort coll)))
 
+()
+
 ;; TODO need way of setting share
 (defn simulate
   "Starts cook scheduler connected to a mock of mesos and submits jobs in the
@@ -281,9 +286,10 @@
         mesos-datomic-conn (restore-fresh-database! (str "datomic:mem://mock-mesos"))
         offer-trigger-chan (async/chan)
         complete-trigger-chan (async/chan)
-		ranker-trigger-chan (async/chan)
+        ranker-trigger-chan (async/chan)
         matcher-trigger-chan (async/chan)
         rebalancer-trigger-chan (async/chan)
+        optimizer-trigger-chan (async/chan)
         state-atom (atom {})
         make-mesos-driver-fn (fn [scheduler _]
                                (mm/mesos-mock mesos-hosts offer-trigger-chan scheduler
@@ -294,10 +300,18 @@
         initial-time (System/currentTimeMillis)
         config (merge {:shares [{:user "default" :mem 4000.0 :cpus 4.0 :gpus 1.0}]}
                       config)
+        opt-config {:host-feed {:create-fn 'cook.mesos.optimizer/create-dummy-host-feed
+                                :config {}}
+                    :optimizer {:create-fn 'cook.mesos.optimizer/create-dummy-optimizer
+                                :config {}}
+                    :schedule-consumer {:create-fn 'cook.mesos.optimizer/create-dummy-consumer
+                                        :config {}}}
         scheduler-config (merge (:scheduler-config config)
+                                {:optimizer-config opt-config}
                                 {:trigger-chans {:rank-trigger-chan ranker-trigger-chan
                                                  :match-trigger-chan matcher-trigger-chan
                                                  :rebalancer-trigger-chan rebalancer-trigger-chan
+                                                 :optimizer-trigger-chan optimizer-trigger-chan
                                                  ;; Don't care about these yet
                                                  :straggler-trigger-chan (async/chan)
                                                  :lingering-task-trigger-chan (async/chan)
@@ -324,6 +338,7 @@
                 flush-complete-chan (async/chan)
                 match-complete-chan (async/chan)
                 rank-complete-chan (async/chan)
+                optimizer-complete-chan (async/chan)
                 rebalancer-complete-chan (async/chan)]
             (when-not (sorted-order? (map :submit-time-ms submission-batch))
               (throw (ex-info "Trace jobs are expected to be sorted by submit-time-ms"
@@ -390,6 +405,9 @@
             (async/<!! rank-complete-chan)
             (log/info "Rank complete")
 
+            (async/>!! optimizer-trigger-chan optimizer-complete-chan)
+            (async/<!! optimizer-complete-chan)
+
             ;; Match
             (log/info "Starting match")
             (org.joda.time.DateTimeUtils/setCurrentMillisFixed (inc (.getTime (tc/to-date (t/now)))))
@@ -403,6 +421,7 @@
                         50
                         60000)
             (log/info "Match complete")
+
 
             (when (seq trace)
               (recur (drop (count submission-batch) trace)
@@ -574,7 +593,7 @@
   (not (seq (trace-diffs trace-a trace-b))))
 
 (deftest test-simulator
-  (let [users ["a" "b" "c" "d"]
+  (time (let [users ["a" "b" "c" "d"]
         jobs (-> (for [minute (range 5)
                        sim-i (range (+ (rand-int 50) 30))]
                    (create-trace-job (+ (rand-int 1200000) 600000) ; 1 to 20 minutes
@@ -592,10 +611,13 @@
                                          :memory 10000
                                          :ncpus 3)))
         jobs (sort-by :submit-time-ms jobs)
-        hosts (for [i (range 120)]
-                (trace-host i 20000.0 20.0))
+        num-hosts 120
+        host-mem 20000.0
+        host-cpus 20.0
+        hosts (for [i (range num-hosts)]
+                (trace-host i host-mem host-cpus))
         cycle-step-ms 30000
-        config {:shares [{:user "default" :mem 2000.0 :cpus 2.0 :gpus 1.0}]
+        config {:shares [{:user "default" :mem (/ host-mem 10) :cpus (/ host-cpus 10) :gpus 1.0}]
                :scheduler-config {:rebalancer-config {:max-preemption 1.0}
                                   :fenzo-config {:fenzo-max-jobs-considered 200}}}
         out-trace-a (simulate hosts jobs cycle-step-ms config)
@@ -604,4 +626,4 @@
     (is (> (count out-trace-b) 0))
     (is (traces-equivalent? out-trace-a out-trace-b)
         {:diffs (sort-by (comp :submit-time first second)
-                         (trace-diffs out-trace-a out-trace-b))})))
+                         (trace-diffs out-trace-a out-trace-b))}))))

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -120,10 +120,10 @@
          host-settings# {:server-port 12321 :hostname "localhost"}
          mesos-leadership-atom# (atom false)
          fenzo-config# (merge default-fenzo-config (:fenzo-config ~scheduler-config))
-         trigger-chans# (or (:trigger-chans ~scheduler-config)
-                            (c/make-trigger-chans rebalancer-config# progress-config# task-constraints#))
          optimizer-config# (or (:optimizer-config ~scheduler-config)
-                               {})]
+                               {})
+         trigger-chans# (or (:trigger-chans ~scheduler-config)
+                            (c/make-trigger-chans rebalancer-config# progress-config# optimizer-config# task-constraints#))]
      (try
        (c/start-mesos-scheduler
          {:curator-framework curator-framework#
@@ -615,7 +615,7 @@
         hosts (for [i (range num-hosts)]
                 (trace-host i host-mem host-cpus))
         cycle-step-ms 30000
-        config {:shares [{:user "default" :mem (/ host-mem 10) :cpus (/ host-cpus 10) :gpus 1.0}]
+        config {:shares [{:cpus (/ host-cpus 10) :gpus 1.0 :mem (/ host-mem 10) :user "default"}]
                 :scheduler-config {:rebalancer-config {:max-preemption 1.0}
                                    :fenzo-config {:fenzo-max-jobs-considered 200}}}
         out-trace-a (simulate hosts jobs cycle-step-ms config)


### PR DESCRIPTION
## Changes proposed in this PR

The PR introduces a new component into Cook, the optimizer, that is intended to take longer, more global views of scheduling.

## Why are we making these changes?

This introduces the interface that we can then build off of.

