### PR TITLE
Adds endpoint for instance stats by status

### DIFF
--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.14.0
 pip==9.0.1; python_version >= '3.6'
 pytest==3.3.1
 pytest-timeout==1.2.1

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1750,8 +1750,7 @@ class CookTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
         try:
-            util.wait_for_jobs(self.cook_url, job_uuids, 'running')
-            instances = [util.wait_for_instance(self.cook_url, j) for j in job_uuids]
+            instances = [util.wait_for_running_instance(self.cook_url, j) for j in job_uuids]
             start_time = min(i['start_time'] for i in instances)
             end_time = max(i['start_time'] for i in instances)
             stats = util.get_instance_stats(self.cook_url,

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import operator
 import subprocess
 import time
@@ -8,7 +9,6 @@ import uuid
 from collections import Counter
 
 import dateutil.parser
-import math
 import pytest
 from retrying import retry
 
@@ -1739,3 +1739,137 @@ class CookTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         job = util.load_job(self.cook_url, job_uuid)
         self.assertIn(job['status'], ['running', 'waiting', 'completed'])
+
+    def test_instance_stats_running(self):
+        name = str(uuid.uuid4())
+        job_uuid_1, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
+        try:
+            util.wait_for_jobs(self.cook_url, job_uuids, 'running')
+            instances = [util.wait_for_instance(self.cook_url, j) for j in job_uuids]
+            start_time = min(i['start_time'] for i in instances)
+            end_time = max(i['start_time'] for i in instances)
+            stats = util.get_instance_stats(self.cook_url,
+                                            status='running',
+                                            start=util.to_iso(start_time),
+                                            end=util.to_iso(end_time + 1),
+                                            name=name)
+            user = util.get_user(self.cook_url, job_uuid_1)
+            self.assertEqual(3, stats['overall']['count'])
+            self.assertEqual(3, stats['by-reason']['']['count'])
+            self.assertEqual(3, stats['by-user-and-reason'][user]['']['count'])
+        finally:
+            util.kill_jobs(self.cook_url, job_uuids)
+
+    def test_instance_stats_failed(self):
+        name = str(uuid.uuid4())
+        job_uuid_1, resp = util.submit_job(self.cook_url, command='exit 1', name=name, cpus=0.1, mem=32)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 1 && exit 1', name=name, cpus=0.2, mem=64)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 2 && exit 1', name=name, cpus=0.4, mem=128)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
+        try:
+            util.wait_for_jobs(self.cook_url, job_uuids, 'completed')
+            instances = [util.wait_for_instance(self.cook_url, j) for j in job_uuids]
+            start_time = min(i['start_time'] for i in instances)
+            end_time = max(i['start_time'] for i in instances)
+            stats = util.get_instance_stats(self.cook_url,
+                                            status='failed',
+                                            start=util.to_iso(start_time),
+                                            end=util.to_iso(end_time + 1),
+                                            name=name)
+            user = util.get_user(self.cook_url, job_uuid_1)
+            stats_overall = stats['overall']
+            self.assertEqual(3, stats_overall['count'])
+            self.assertEqual(3, stats['by-reason']['Command exited non-zero']['count'])
+            self.assertEqual(3, stats['by-user-and-reason'][user]['Command exited non-zero']['count'])
+            run_times = [(i['end_time']-i['start_time'])/1000 for i in instances]
+            run_time_seconds = stats_overall['run-time-seconds']
+            percentiles = run_time_seconds['percentiles']
+            self.assertEqual(util.percentile(run_times, 50), percentiles['50'])
+            self.assertEqual(util.percentile(run_times, 75), percentiles['75'])
+            self.assertEqual(util.percentile(run_times, 95), percentiles['95'])
+            self.assertEqual(util.percentile(run_times, 99), percentiles['99'])
+            self.assertEqual(util.percentile(run_times, 100), percentiles['100'])
+            self.assertAlmostEqual(sum(run_times), run_time_seconds['total'])
+            cpu_times = [((i['end_time']-i['start_time'])/1000)*i['parent']['cpus'] for i in instances]
+            cpu_seconds = stats_overall['cpu-seconds']
+            percentiles = cpu_seconds['percentiles']
+            self.assertEqual(util.percentile(cpu_times, 50), percentiles['50'])
+            self.assertEqual(util.percentile(cpu_times, 75), percentiles['75'])
+            self.assertEqual(util.percentile(cpu_times, 95), percentiles['95'])
+            self.assertEqual(util.percentile(cpu_times, 99), percentiles['99'])
+            self.assertEqual(util.percentile(cpu_times, 100), percentiles['100'])
+            self.assertAlmostEqual(sum(cpu_times), cpu_seconds['total'])
+            mem_times = [((i['end_time']-i['start_time'])/1000)*i['parent']['mem'] for i in instances]
+            mem_seconds = stats_overall['mem-seconds']
+            percentiles = mem_seconds['percentiles']
+            self.assertEqual(util.percentile(mem_times, 50), percentiles['50'])
+            self.assertEqual(util.percentile(mem_times, 75), percentiles['75'])
+            self.assertEqual(util.percentile(mem_times, 95), percentiles['95'])
+            self.assertEqual(util.percentile(mem_times, 99), percentiles['99'])
+            self.assertEqual(util.percentile(mem_times, 100), percentiles['100'])
+            self.assertAlmostEqual(sum(mem_times), mem_seconds['total'])
+        finally:
+            util.kill_jobs(self.cook_url, job_uuids)
+
+    def test_instance_stats_success(self):
+        name = str(uuid.uuid4())
+        job_uuid_1, resp = util.submit_job(self.cook_url, command='exit 0', name=name, cpus=0.1, mem=32)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 1', name=name, cpus=0.2, mem=64)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 2', name=name, cpus=0.4, mem=128)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
+        try:
+            util.wait_for_jobs(self.cook_url, job_uuids, 'completed')
+            instances = [util.wait_for_instance(self.cook_url, j) for j in job_uuids]
+            start_time = min(i['start_time'] for i in instances)
+            end_time = max(i['start_time'] for i in instances)
+            stats = util.get_instance_stats(self.cook_url,
+                                            status='success',
+                                            start=util.to_iso(start_time),
+                                            end=util.to_iso(end_time + 1),
+                                            name=name)
+            user = util.get_user(self.cook_url, job_uuid_1)
+            stats_overall = stats['overall']
+            self.assertEqual(3, stats_overall['count'])
+            self.assertEqual(3, stats['by-reason']['']['count'])
+            self.assertEqual(3, stats['by-user-and-reason'][user]['']['count'])
+            run_times = [(i['end_time']-i['start_time'])/1000 for i in instances]
+            run_time_seconds = stats_overall['run-time-seconds']
+            percentiles = run_time_seconds['percentiles']
+            self.assertEqual(util.percentile(run_times, 50), percentiles['50'])
+            self.assertEqual(util.percentile(run_times, 75), percentiles['75'])
+            self.assertEqual(util.percentile(run_times, 95), percentiles['95'])
+            self.assertEqual(util.percentile(run_times, 99), percentiles['99'])
+            self.assertEqual(util.percentile(run_times, 100), percentiles['100'])
+            self.assertAlmostEqual(sum(run_times), run_time_seconds['total'])
+            cpu_times = [((i['end_time']-i['start_time'])/1000)*i['parent']['cpus'] for i in instances]
+            cpu_seconds = stats_overall['cpu-seconds']
+            percentiles = cpu_seconds['percentiles']
+            self.assertEqual(util.percentile(cpu_times, 50), percentiles['50'])
+            self.assertEqual(util.percentile(cpu_times, 75), percentiles['75'])
+            self.assertEqual(util.percentile(cpu_times, 95), percentiles['95'])
+            self.assertEqual(util.percentile(cpu_times, 99), percentiles['99'])
+            self.assertEqual(util.percentile(cpu_times, 100), percentiles['100'])
+            self.assertAlmostEqual(sum(cpu_times), cpu_seconds['total'])
+            mem_times = [((i['end_time']-i['start_time'])/1000)*i['parent']['mem'] for i in instances]
+            mem_seconds = stats_overall['mem-seconds']
+            percentiles = mem_seconds['percentiles']
+            self.assertEqual(util.percentile(mem_times, 50), percentiles['50'])
+            self.assertEqual(util.percentile(mem_times, 75), percentiles['75'])
+            self.assertEqual(util.percentile(mem_times, 95), percentiles['95'])
+            self.assertEqual(util.percentile(mem_times, 99), percentiles['99'])
+            self.assertEqual(util.percentile(mem_times, 100), percentiles['100'])
+            self.assertAlmostEqual(sum(mem_times), mem_seconds['total'])
+        finally:
+            util.kill_jobs(self.cook_url, job_uuids)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1753,11 +1753,11 @@ class CookTest(unittest.TestCase):
             instances = [util.wait_for_running_instance(self.cook_url, j) for j in job_uuids]
             start_time = min(i['start_time'] for i in instances)
             end_time = max(i['start_time'] for i in instances)
-            stats = util.get_instance_stats(self.cook_url,
-                                            status='running',
-                                            start=util.to_iso(start_time),
-                                            end=util.to_iso(end_time + 1),
-                                            name=name)
+            stats, _ = util.get_instance_stats(self.cook_url,
+                                               status='running',
+                                               start=util.to_iso(start_time),
+                                               end=util.to_iso(end_time + 1),
+                                               name=name)
             user = util.get_user(self.cook_url, job_uuid_1)
             self.assertEqual(3, stats['overall']['count'])
             self.assertEqual(3, stats['by-reason']['']['count'])
@@ -1779,17 +1779,17 @@ class CookTest(unittest.TestCase):
             instances = [util.wait_for_instance(self.cook_url, j) for j in job_uuids]
             start_time = min(i['start_time'] for i in instances)
             end_time = max(i['start_time'] for i in instances)
-            stats = util.get_instance_stats(self.cook_url,
-                                            status='failed',
-                                            start=util.to_iso(start_time),
-                                            end=util.to_iso(end_time + 1),
-                                            name=name)
+            stats, _ = util.get_instance_stats(self.cook_url,
+                                               status='failed',
+                                               start=util.to_iso(start_time),
+                                               end=util.to_iso(end_time + 1),
+                                               name=name)
             user = util.get_user(self.cook_url, job_uuid_1)
             stats_overall = stats['overall']
             self.assertEqual(3, stats_overall['count'])
             self.assertEqual(3, stats['by-reason']['Command exited non-zero']['count'])
             self.assertEqual(3, stats['by-user-and-reason'][user]['Command exited non-zero']['count'])
-            run_times = [(i['end_time']-i['start_time'])/1000 for i in instances]
+            run_times = [(i['end_time'] - i['start_time']) / 1000 for i in instances]
             run_time_seconds = stats_overall['run-time-seconds']
             percentiles = run_time_seconds['percentiles']
             self.assertEqual(util.percentile(run_times, 50), percentiles['50'])
@@ -1798,7 +1798,7 @@ class CookTest(unittest.TestCase):
             self.assertEqual(util.percentile(run_times, 99), percentiles['99'])
             self.assertEqual(util.percentile(run_times, 100), percentiles['100'])
             self.assertAlmostEqual(sum(run_times), run_time_seconds['total'])
-            cpu_times = [((i['end_time']-i['start_time'])/1000)*i['parent']['cpus'] for i in instances]
+            cpu_times = [((i['end_time'] - i['start_time']) / 1000) * i['parent']['cpus'] for i in instances]
             cpu_seconds = stats_overall['cpu-seconds']
             percentiles = cpu_seconds['percentiles']
             self.assertEqual(util.percentile(cpu_times, 50), percentiles['50'])
@@ -1807,7 +1807,7 @@ class CookTest(unittest.TestCase):
             self.assertEqual(util.percentile(cpu_times, 99), percentiles['99'])
             self.assertEqual(util.percentile(cpu_times, 100), percentiles['100'])
             self.assertAlmostEqual(sum(cpu_times), cpu_seconds['total'])
-            mem_times = [((i['end_time']-i['start_time'])/1000)*i['parent']['mem'] for i in instances]
+            mem_times = [((i['end_time'] - i['start_time']) / 1000) * i['parent']['mem'] for i in instances]
             mem_seconds = stats_overall['mem-seconds']
             percentiles = mem_seconds['percentiles']
             self.assertEqual(util.percentile(mem_times, 50), percentiles['50'])
@@ -1833,17 +1833,17 @@ class CookTest(unittest.TestCase):
             instances = [util.wait_for_instance(self.cook_url, j) for j in job_uuids]
             start_time = min(i['start_time'] for i in instances)
             end_time = max(i['start_time'] for i in instances)
-            stats = util.get_instance_stats(self.cook_url,
-                                            status='success',
-                                            start=util.to_iso(start_time),
-                                            end=util.to_iso(end_time + 1),
-                                            name=name)
+            stats, _ = util.get_instance_stats(self.cook_url,
+                                               status='success',
+                                               start=util.to_iso(start_time),
+                                               end=util.to_iso(end_time + 1),
+                                               name=name)
             user = util.get_user(self.cook_url, job_uuid_1)
             stats_overall = stats['overall']
             self.assertEqual(3, stats_overall['count'])
             self.assertEqual(3, stats['by-reason']['']['count'])
             self.assertEqual(3, stats['by-user-and-reason'][user]['']['count'])
-            run_times = [(i['end_time']-i['start_time'])/1000 for i in instances]
+            run_times = [(i['end_time'] - i['start_time']) / 1000 for i in instances]
             run_time_seconds = stats_overall['run-time-seconds']
             percentiles = run_time_seconds['percentiles']
             self.assertEqual(util.percentile(run_times, 50), percentiles['50'])
@@ -1852,7 +1852,7 @@ class CookTest(unittest.TestCase):
             self.assertEqual(util.percentile(run_times, 99), percentiles['99'])
             self.assertEqual(util.percentile(run_times, 100), percentiles['100'])
             self.assertAlmostEqual(sum(run_times), run_time_seconds['total'])
-            cpu_times = [((i['end_time']-i['start_time'])/1000)*i['parent']['cpus'] for i in instances]
+            cpu_times = [((i['end_time'] - i['start_time']) / 1000) * i['parent']['cpus'] for i in instances]
             cpu_seconds = stats_overall['cpu-seconds']
             percentiles = cpu_seconds['percentiles']
             self.assertEqual(util.percentile(cpu_times, 50), percentiles['50'])
@@ -1861,7 +1861,7 @@ class CookTest(unittest.TestCase):
             self.assertEqual(util.percentile(cpu_times, 99), percentiles['99'])
             self.assertEqual(util.percentile(cpu_times, 100), percentiles['100'])
             self.assertAlmostEqual(sum(cpu_times), cpu_seconds['total'])
-            mem_times = [((i['end_time']-i['start_time'])/1000)*i['parent']['mem'] for i in instances]
+            mem_times = [((i['end_time'] - i['start_time']) / 1000) * i['parent']['mem'] for i in instances]
             mem_seconds = stats_overall['mem-seconds']
             percentiles = mem_seconds['percentiles']
             self.assertEqual(util.percentile(mem_times, 50), percentiles['50'])
@@ -1872,3 +1872,51 @@ class CookTest(unittest.TestCase):
             self.assertAlmostEqual(sum(mem_times), mem_seconds['total'])
         finally:
             util.kill_jobs(self.cook_url, job_uuids)
+
+    def test_instance_stats_supports_epoch_time_params(self):
+        name = str(uuid.uuid4())
+        job_uuid_1, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
+        try:
+            instances = [util.wait_for_running_instance(self.cook_url, j) for j in job_uuids]
+            start_time = min(i['start_time'] for i in instances)
+            end_time = max(i['start_time'] for i in instances)
+            stats, _ = util.get_instance_stats(self.cook_url,
+                                               status='running',
+                                               start=start_time,
+                                               end=end_time + 1,
+                                               name=name)
+            self.logger.info(json.dumps(stats, indent=2))
+            user = util.get_user(self.cook_url, job_uuid_1)
+            self.assertEqual(3, stats['overall']['count'])
+            self.assertEqual(3, stats['by-reason']['']['count'])
+            self.assertEqual(3, stats['by-user-and-reason'][user]['']['count'])
+        finally:
+            util.kill_jobs(self.cook_url, job_uuids)
+
+    def test_instance_stats_rejects_invalid_params(self):
+        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-02-20', end='2018-02-21')
+        self.assertEqual(200, resp.status_code)
+        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-02-20')
+        self.assertEqual(400, resp.status_code)
+        _, resp = util.get_instance_stats(self.cook_url, status='running', end='2018-02-21')
+        self.assertEqual(400, resp.status_code)
+        _, resp = util.get_instance_stats(self.cook_url, start='2018-02-20', end='2018-02-21')
+        self.assertEqual(400, resp.status_code)
+        _, resp = util.get_instance_stats(self.cook_url, status='bogus', start='2018-02-20', end='2018-02-21')
+        self.assertEqual(400, resp.status_code)
+        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-02-20',
+                                          end='2018-02-21', name='foo')
+        self.assertEqual(200, resp.status_code)
+        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-02-20',
+                                          end='2018-02-21', name='?')
+        self.assertEqual(400, resp.status_code)
+        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-01-01', end='2018-02-01')
+        self.assertEqual(200, resp.status_code)
+        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-01-01', end='2018-02-02')
+        self.assertEqual(400, resp.status_code)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -7,8 +7,10 @@ import os.path
 import subprocess
 import time
 import uuid
+from datetime import datetime
 from urllib.parse import urlencode
 
+import numpy
 import requests
 from retrying import retry
 
@@ -60,7 +62,7 @@ def _test_user_ids():
     pytest_worker = os.getenv('PYTEST_XDIST_WORKER')
     max_test_users = int(os.getenv('COOK_MAX_TEST_USERS', 0))
     if pytest_worker and max_test_users:
-        pytest_worker_id = int(pytest_worker[2:]) # e.g., "gw4" -> 4
+        pytest_worker_id = int(pytest_worker[2:])  # e.g., "gw4" -> 4
         test_user_min_id = max_test_users * pytest_worker_id
         test_user_max_id = test_user_min_id + max_test_users
         return range(test_user_min_id, test_user_max_id)
@@ -79,7 +81,7 @@ def _test_user_names(test_name_prefix=None):
 
 
 # Shell command used to obtain Kerberos credentials for a given test user
-_kerberos_missing_cmd =  'echo "MISSING COOK_KERBEROS_TEST_AUTH_CMD" && exit 1'
+_kerberos_missing_cmd = 'echo "MISSING COOK_KERBEROS_TEST_AUTH_CMD" && exit 1'
 _kerberos_auth_cmd = os.getenv('COOK_KERBEROS_TEST_AUTH_CMD', _kerberos_missing_cmd)
 
 
@@ -140,7 +142,6 @@ class _BasicAuthUser(_AuthenticatedUser):
         self.previous_auth = None
 
 
-
 class _KerberosUser(_AuthenticatedUser):
     """
     Object representing a Cook user with Kerberos credentials.
@@ -148,9 +149,7 @@ class _KerberosUser(_AuthenticatedUser):
 
     def __init__(self, name, impersonatee=None):
         super().__init__(name, impersonatee)
-        subcommand = (_kerberos_auth_cmd
-                      .replace('{{COOK_USER}}', name)
-                      .replace('{{COOK_SCHEDULER_URL}}', retrieve_cook_url()))
+        self.auth = None
         self.auth_token = self._generate_kerberos_ticket_for_user(name)
         self.previous_token = None
 
@@ -199,7 +198,7 @@ class UserFactory(object):
         # Set up generator for new user objects
         if test_handle:
             test_id = test_handle.id()
-            test_base_name = test_id[test_id.rindex('.test_')+6:].lower()
+            test_base_name = test_id[test_id.rindex('.test_') + 6:].lower()
             self.__user_generator = _test_user_names(test_base_name)
 
     def new_user(self):
@@ -522,10 +521,6 @@ def load_instance(cook_url, instance_uuid, assert_response=True):
     return load_resource(cook_url, 'instances', instance_uuid, assert_response)
 
 
-def multi_cluster_tests_enabled():
-    return os.getenv('COOK_MULTI_CLUSTER') is not None
-
-
 def wait_until(query, predicate, max_wait_ms=DEFAULT_TIMEOUT_MS, wait_interval_ms=1000):
     """
     Block until the predicate is true for the result of the provided query.
@@ -788,6 +783,7 @@ def wait_for_instance(cook_url, job_uuid):
     """Waits for the job with the given job_uuid to have a single instance, and returns the instance uuid"""
     job = wait_until(lambda: load_job(cook_url, job_uuid), lambda j: len(j['instances']) == 1)
     instance = job['instances'][0]
+    instance['parent'] = job
     return instance
 
 
@@ -922,11 +918,16 @@ def set_limit(cook_url, limit_type, user, mem=None, cpus=None, gpus=None, count=
     """
     limits = {}
     body = {'user': user, limit_type: limits}
-    if reason is not None: body['reason'] = reason
-    if mem is not None: limits['mem'] = mem
-    if cpus is not None: limits['cpus'] = cpus
-    if gpus is not None: limits['gpus'] = gpus
-    if count is not None: limits['count'] = count
+    if reason is not None:
+        body['reason'] = reason
+    if mem is not None:
+        limits['mem'] = mem
+    if cpus is not None:
+        limits['cpus'] = cpus
+    if gpus is not None:
+        limits['gpus'] = gpus
+    if count is not None:
+        limits['count'] = count
     logger.debug(f'Setting {user} {limit_type} to {limits}: {body}')
     return session.post(f'{cook_url}/{limit_type}', json=body)
 
@@ -937,7 +938,8 @@ def reset_limit(cook_url, limit_type, user, reason='testing'):
     The limit_type parameter should be either 'share' or 'quota', specifying which type of limit is being reset.
     """
     params = {'user': user}
-    if reason is not None: params['reason'] = reason
+    if reason is not None:
+        params['reason'] = reason
     return session.delete(f'{cook_url}/{limit_type}', params=params)
 
 
@@ -946,3 +948,19 @@ def retrieve_progress_file_env(cook_url):
     cook_settings = settings(cook_url)
     default_value = 'EXECUTOR_PROGRESS_OUTPUT_FILE'
     return get_in(cook_settings, 'executor', 'environment', 'EXECUTOR_PROGRESS_OUTPUT_FILE_ENV') or default_value
+
+
+def get_instance_stats(cook_url, **kwargs):
+    """Gets instance stats using the provided kwargs as query params"""
+    resp = session.get(f'{cook_url}/stats/instances', params=kwargs)
+    return resp.json()
+
+
+def to_iso(time_millis):
+    """Converts the given time since epoch in millis to an ISO 8601 string"""
+    return datetime.utcfromtimestamp(time_millis / 1000).isoformat()
+
+
+def percentile(a, q):
+    """Returns the qth percentile of a"""
+    return numpy.percentile(a, q, interpolation='higher')

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -974,7 +974,7 @@ def retrieve_progress_file_env(cook_url):
 def get_instance_stats(cook_url, **kwargs):
     """Gets instance stats using the provided kwargs as query params"""
     resp = session.get(f'{cook_url}/stats/instances', params=kwargs)
-    return resp.json()
+    return resp.json(), resp
 
 
 def to_iso(time_millis):

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -2160,34 +2160,34 @@
 ;;
 
 (def HistogramStats
-  {:percentiles {(s/required-key 50) NonNegNum
-                 (s/required-key 75) NonNegNum
-                 (s/required-key 95) NonNegNum
-                 (s/required-key 99) NonNegNum
-                 (s/required-key 100) NonNegNum}
+  {:percentiles {(s/required-key 50) s/Num
+                 (s/required-key 75) s/Num
+                 (s/required-key 95) s/Num
+                 (s/required-key 99) s/Num
+                 (s/required-key 100) s/Num}
    :total NonNegNum})
 
 (def TaskStats
   {(s/optional-key :count) NonNegInt
-   (s/optional-key :run-time-seconds) HistogramStats
    (s/optional-key :cpu-seconds) HistogramStats
-   (s/optional-key :mem-seconds) HistogramStats})
+   (s/optional-key :mem-seconds) HistogramStats}
+   (s/optional-key :run-time-seconds) HistogramStats)
 
 (def UserLeaders
   {s/Str NonNegNum})
 
 (def TaskStatsResponse
-  {:overall TaskStats
-   :by-reason {s/Any TaskStats}
+  {:by-reason {s/Any TaskStats}
    :by-user-and-reason {s/Str {s/Any TaskStats}}
    :leaders {:cpu-seconds UserLeaders
-             :mem-seconds UserLeaders}})
+             :mem-seconds UserLeaders}}
+   :overall TaskStats)
 
 (def TaskStatsParams
-  {:status s/Str
+  {:status (s/enum "unknown" "running" "success" "failed")
    :start s/Str
    :end s/Str
-   :name s/Str})
+   :name (s/constrained s/Str valid-name-filter?)})
 
 (defn task-stats-handler
   [conn is-authorized-fn]

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -2186,7 +2186,8 @@
 (def TaskStatsParams
   {:status s/Str
    :start s/Str
-   :end s/Str})
+   :end s/Str
+   :name s/Str})
 
 (defn task-stats-handler
   [conn is-authorized-fn]
@@ -2203,14 +2204,10 @@
      (fn [ctx]
        (let [params (-> ctx :request :params)]
          (task-stats/get-stats conn
-                               (case (:status params)
-                                 "failed" :instance.status/failed
-                                 "success" :instance.status/success
-                                 "running" :instance.status/running
-                                 "unknown" :instance.status/unknown
-                                 (throw (ex-info "Encountered unexpected status" params)))
+                               (keyword "instance.status" (:status params))
                                (tf/parse (:start params))
-                               (tf/parse (:end params)))))}))
+                               (tf/parse (:end params))
+                               (name-filter-str->name-filter-fn (:name params)))))}))
 
 (defn- streaming-json-encoder
   "Takes as input the response body which can be converted into JSON,

--- a/scheduler/src/cook/mesos/task_stats.clj
+++ b/scheduler/src/cook/mesos/task_stats.clj
@@ -1,0 +1,119 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.mesos.task-stats
+  (:require [clj-time.core :as t]
+            [cook.mesos.util :as util]
+            [datomic.api :as d]
+            [plumbing.core :as pc]))
+
+(defn- task->task-entry
+  "Updates the provided stats map with the data from the provided task entity"
+  [task-ent]
+  (let [job-ent (:job/_instance task-ent)
+        user (:job/user job-ent)
+        resources (util/job-ent->resources job-ent)
+        run-time (-> task-ent util/task-run-time)
+        seconds (-> run-time .toDuration .getMillis (/ 1000.0))]
+    (assoc resources
+      :user user
+      :run-time-seconds seconds
+      :cpu-seconds (* seconds (:cpus resources))
+      :mem-seconds (* seconds (:mem resources))
+      :reason (get-in task-ent [:instance/reason :reason/string]))))
+
+(defn- get-tasks
+  "Gets all tasks that started in the specified time range and with the specified status."
+  [db instance-status start end]
+  (let [start-entity-id (d/entid-at db :db.part/user (.toDate (t/minus start (t/hours 1))))
+        end-entity-id (d/entid-at db :db.part/user (.toDate (t/plus end (t/hours 1))))
+        instance-status-entid (d/entid db instance-status)
+        instance-status-attribute-entid (d/entid db :instance/status)
+        start-millis (.getTime (.toDate start))
+        end-millis (.getTime (.toDate end))]
+    (->> (d/seek-datoms db :avet :instance/status instance-status-entid start-entity-id)
+         (take-while #(and
+                        (< (.e %) end-entity-id)
+                        (= (.a %) instance-status-attribute-entid)
+                        (= (.v %) instance-status-entid)))
+         (map #(.e %))
+         (map (partial d/entity db))
+         (filter #(<= start-millis (.getTime (:instance/start-time %))))
+         (filter #(< (.getTime (:instance/start-time %)) end-millis)))))
+
+(defn- percentile
+  "Calculates the p-th percentile of the values in coll
+  (where 0 < p <= 100), using the Nearest Rank method:
+  https://en.wikipedia.org/wiki/Percentile#The_Nearest_Rank_method
+  Assumes that coll is sorted (see percentiles below for context)"
+  [coll p]
+  (if (or (empty? coll) (not (number? p)) (<= p 0) (> p 100))
+    nil
+    (nth coll
+         (-> p
+             (/ 100)
+             (* (count coll))
+             (Math/ceil)
+             (dec)))))
+
+(defn- percentiles
+  "Calculates the p-th percentiles of the values in coll for
+  each p in p-list (where 0 < p <= 100), and returns a map of
+  p -> value"
+  [coll & p-list]
+  (let [sorted (sort coll)]
+    (into {} (map (fn [p] [p (percentile sorted p)]) p-list))))
+
+(defn- generate-stats
+  "Generates statistics based on the provided task entries"
+  [task-entries]
+  (if (pos? (count task-entries))
+    (let [stats (fn [xs] {:percentiles (percentiles xs 50 75 95 99 100)
+                          :total (reduce + xs)})]
+      {:count (count task-entries)
+       :run-time-seconds (stats (map :run-time-seconds task-entries))
+       :cpu-seconds (stats (map :cpu-seconds task-entries))
+       :mem-seconds (stats (map :mem-seconds task-entries))})
+    {}))
+
+(defn- generate-all-stats
+  "Generates both aggregate and per-user statistics for the provided tasks"
+  [tasks]
+  (let [stats-by (fn [k ts] (->> ts (group-by k) (pc/map-vals generate-stats)))
+        task-entries (map task->task-entry tasks)
+        overall-stats (generate-stats task-entries)
+        reason-stats (stats-by :reason task-entries)
+        user->tasks (group-by :user task-entries)
+        user-reason-stats (->> user->tasks (pc/map-vals #(stats-by :reason %)))
+        leaders (fn [k]
+                  (->> task-entries
+                       (stats-by :user)
+                       (map (fn [[u m]] [(get-in m [k :total]) u]))
+                       (sort-by #(* -1 (first %)))
+                       (take 10)
+                       (map (fn [[n u]] [u n]))
+                       (into {})))]
+    {:overall overall-stats
+     :by-reason reason-stats
+     :by-user-and-reason user-reason-stats
+     :leaders {:cpu-seconds (leaders :cpu-seconds)
+               :mem-seconds (leaders :mem-seconds)}}))
+
+(defn get-stats
+  "Returns a map containing task stats for tasks
+  with the given status from the provided time range"
+  [conn instance-status start end]
+  (let [tasks (get-tasks (d/db conn) instance-status start end)]
+    (generate-all-stats tasks)))

--- a/scheduler/src/cook/scratch.clj
+++ b/scheduler/src/cook/scratch.clj
@@ -171,11 +171,12 @@
   (let [job-ent (:job/_instance task-ent)
         user (:job/user job-ent)
         resources (util/job-ent->resources job-ent)
-        hours (-> task-ent util/task-run-time .toDurationMillis (/ 1000) (/ 60) (/ 60))]
+        millis (-> task-ent util/task-run-time .toDurationMillis)
+        hours (-> millis (/ 1000) (/ 60) (/ 60))]
     (-> stats
         (update-in [user :cpu-hours] #(+ (or % 0) (* hours (:cpus resources))))
         (update-in [user :mem-hours] #(+ (or % 0) (* hours (:mem resources))))
-        (update-in [user :hours] #(+ (or % 0) hours)))))
+        (update-in [user :millis] #(+ (or % 0) millis)))))
 
 (defn get-completed-tasks
   "Gets all tasks that completed in the specified time range and with the specified

--- a/scheduler/src/cook/scratch.clj
+++ b/scheduler/src/cook/scratch.clj
@@ -174,7 +174,8 @@
         hours (-> task-ent util/task-run-time .toDurationMillis (/ 1000) (/ 60) (/ 60))]
     (-> stats
         (update-in [user :cpu-hours] #(+ (or % 0) (* hours (:cpus resources))))
-        (update-in [user :mem-hours] #(+ (or % 0) (* hours (:mem resources)))))))
+        (update-in [user :mem-hours] #(+ (or % 0) (* hours (:mem resources))))
+        (update-in [user :hours] #(+ (or % 0) hours)))))
 
 (defn get-completed-tasks
   "Gets all tasks that completed in the specified time range and with the specified

--- a/scheduler/src/cook/scratch.clj
+++ b/scheduler/src/cook/scratch.clj
@@ -14,9 +14,11 @@
 ;; limitations under the License.
 ;;
 (ns cook.scratch
-  (:require [cook.datomic :refer (transact-with-retries)]
-            [cook.mesos.monitor :refer (riemann-reporter)]
+  (:require [clj-time.core :as t]
+            [cook.datomic :refer (transact-with-retries)]
             [cook.mesos.scheduler :as sched]
+            [cook.mesos.util :as util]
+            [cook.test.testutil :as testutil]
             [datomic.api :as d :refer (q)]
             [metatransaction.core :refer (db)]))
 
@@ -114,17 +116,17 @@
         db (d/db conn)
         one-week-ago (- (.getTime (java.util.Date.)) (* 7 24 60 60 1000))
         job-eids (->>
-                      (q '[:find ?j ?start-time
-                           :where
-                           [?j :job/instance ?i]
-                           [?j :job/state :job.state/running]
-                           [?i :instance/start-time ?start-time]
-                           [?i :instance/status :instance.status/running]]
-                         db)
-                      (filter (fn [[j start-time]]
-                                (<=(.getTime start-time) one-week-ago)))
-                      (sort-by second)
-                      (map first))
+                   (q '[:find ?j ?start-time
+                        :where
+                        [?j :job/instance ?i]
+                        [?j :job/state :job.state/running]
+                        [?i :instance/start-time ?start-time]
+                        [?i :instance/status :instance.status/running]]
+                      db)
+                   (filter (fn [[j start-time]]
+                             (<= (.getTime start-time) one-week-ago)))
+                   (sort-by second)
+                   (map first))
         txns (map (fn [job-eid]
                     [:db/add job-eid :job/state :job.state/completed])
                   job-eids)]
@@ -133,3 +135,59 @@
   ;; Retract quota.
   (let [conn (d/connect "datomic:riak://db.example.com:8098/datomic/mesos-jobs?interface=http")]
     (sched/retract-quota! conn "testuser")))
+
+(defn create-job
+  "Creates a new job with one instance"
+  [conn host instance-status start-time end-time & args]
+  (let [job (apply testutil/create-dummy-job (cons conn args))
+        inst (testutil/create-dummy-instance conn job
+                                             :instance-status instance-status
+                                             :hostname host
+                                             :start-time start-time
+                                             :end-time end-time)]
+    [job inst]))
+
+(defn rand-str
+  "Returns a random string of length len"
+  [len]
+  (apply str (take len (repeatedly #(char (+ (rand 26) 65))))))
+
+(defn populate-dummy-data
+  "Populates 100 jobs, each with one completed instance, with some random fields"
+  [conn]
+  (run!
+    (fn [_]
+      (let [host (rand-str 16)
+            instance-status (rand-nth [:instance.status/failed :instance.status/success])
+            user (rand-nth ["alice" "bob" "claire" "doug" "emily" "frank" "gloria" "henry"])
+            start-time (.toDate (t/ago (t/minutes (inc (rand-int 120)))))
+            end-time (.toDate (t/now))]
+        (create-job conn host instance-status start-time end-time :user user :job-state :job.state/completed)))
+    (range 100)))
+
+(defn update-stats
+  "Updates the provided stats map with the data from the provided task entity"
+  [stats task-ent]
+  (let [job-ent (:job/_instance task-ent)
+        state (:instance/status task-ent)
+        user (:job/user job-ent)
+        resources (util/job-ent->resources job-ent)
+        hours (-> task-ent util/task-run-time .toDurationMillis (/ 1000) (/ 60) (/ 60))]
+    (-> stats
+        (update-in [state user :cpu-hours] #(+ (or % 0) (* hours (:cpus resources))))
+        (update-in [state user :mem-hours] #(+ (or % 0) (* hours (:mem resources)))))))
+
+(defn get-completed-task-data
+  "Returns a map from status -> user -> stats"
+  [db start end]
+  (let [task-ents
+        (->> (q '[:find [?i ...]
+                  :in $ [?status ...] ?start ?end
+                  :where
+                  [?i :instance/status ?status]
+                  [?i :instance/end-time ?t]
+                  [(<= ?start ?t)]
+                  [(< ?t ?end)]]
+                db [:instance.status/failed :instance.status/success] (.toDate start) (.toDate end))
+             (map (partial d/entity db)))]
+    (reduce update-stats {} task-ents)))

--- a/scheduler/src/cook/scratch.clj
+++ b/scheduler/src/cook/scratch.clj
@@ -237,8 +237,15 @@
   (let [task-entries (map task->task-entry tasks)
         stats (generate-stats task-entries)
         user->tasks (group-by :user task-entries)
-        user-stats (into {} (map (fn [[k v]] [k (generate-stats v)]) user->tasks))]
-    (assoc stats :users user-stats)))
+        user-stats (into {} (map (fn [[u ts]] [u (generate-stats ts)]) user->tasks))
+        leaders (fn [k]
+                  (->> user-stats
+                       (map (fn [[u m]] [(get-in m [k :total]) u]))
+                       (sort-by #(* -1 (first %)))
+                       (take 5)))]
+    (assoc stats :users user-stats
+                 :cpu-seconds-leaders (leaders :cpu-seconds)
+                 :mem-seconds-leaders (leaders :mem-seconds))))
 
 (defn get-completed-task-stats
   "Returns a map from status -> user -> stats"

--- a/scheduler/src/cook/scratch.clj
+++ b/scheduler/src/cook/scratch.clj
@@ -177,10 +177,10 @@
         (update-in [user :mem-hours] #(+ (or % 0) (* hours (:mem resources)))))))
 
 (defn get-completed-tasks
-  "Gets all tasks that completed in the specified time range and with the
-  specified status. Assumes that tasks complete within 14 days of starting."
-  [db end-time-start end-time-end instance-status]
-  (let [start-entity-id (d/entid-at db :db.part/user (.toDate (t/minus end-time-start (t/days 14))))
+  "Gets all tasks that completed in the specified time range and with the specified
+  status. Assumes that tasks complete within max-run-time of starting."
+  [db end-time-start end-time-end instance-status max-run-time]
+  (let [start-entity-id (d/entid-at db :db.part/user (.toDate (t/minus end-time-start max-run-time)))
         end-entity-id (d/entid-at db :db.part/user (.toDate (t/plus end-time-end (t/hours 1))))
         instance-status-entid (d/entid db instance-status)
         instance-status-attribute-entid (d/entid db :instance/status)
@@ -198,8 +198,8 @@
 
 (defn get-completed-task-stats
   "Returns a map from status -> user -> stats"
-  [db end-time-start end-time-end]
-  (let [failed-tasks (get-completed-tasks db end-time-start end-time-end :instance.status/failed)
-        success-tasks (get-completed-tasks db end-time-start end-time-end :instance.status/success)]
+  [db end-time-start end-time-end max-run-time]
+  (let [failed-tasks (get-completed-tasks db end-time-start end-time-end :instance.status/failed max-run-time)
+        success-tasks (get-completed-tasks db end-time-start end-time-end :instance.status/success max-run-time)]
     {:failed  (reduce update-stats {} failed-tasks)
      :success (reduce update-stats {} success-tasks)}))

--- a/scheduler/src/cook/scratch.clj
+++ b/scheduler/src/cook/scratch.clj
@@ -232,16 +232,17 @@
     {:count            (count task-entries)
      :run-time-seconds (stats (map :run-time-seconds task-entries))
      :cpu-seconds      (stats (map :cpu-seconds task-entries))
-     :mem-seconds      (stats (map :mem-seconds task-entries))
-     :reasons          (frequencies (map :reason task-entries))}))
+     :mem-seconds      (stats (map :mem-seconds task-entries))}))
 
 (defn generate-all-stats
   "Generates both aggregate and per-user statistics for the provided tasks"
   [tasks]
   (let [task-entries (map task->task-entry tasks)
         stats (generate-stats task-entries)
-        user->tasks (group-by :user task-entries)
-        user-stats (into {} (map (fn [[u ts]] [u (generate-stats ts)]) user->tasks))
+        user->tasks (->> task-entries (group-by (fn [t] [(:user t) (:reason t)])))
+        user-stats (->> user->tasks
+                        (map (fn [[ur ts]] [ur (generate-stats ts)]))
+                        (into {}))
         leaders (fn [k]
                   (->> user-stats
                        (map (fn [[u m]] [(get-in m [k :total]) u]))


### PR DESCRIPTION
## Changes proposed in this PR

- adding new namespace, `task-stats`, for querying tasks by status and time range, and then generating statistics (run time, cpu time, and mem time overall, by reason, and by user and reason)
- adding new admin-only endpoint, `/stats/instances`, that exposes the above stats
- adding a new scractch function, `populate-dummy-data`, that can be used to generate dummy instances for use in testing

## Why are we making these changes?

We want to be able to analyze the cpu time and memory time we are spending on, for example, successful vs. failed instances.

## Example

```bash
$ curl -s 'localhost:12321/stats/instances?status=failed&start=2018-02-01&end=2018-02-28' | jq                                                                                                                                       
{
  "by-reason": {
    "Command exited non-zero": {
      "count": 3,
      "cpu-seconds": {
        "percentiles": {
          "50": 0.7905,
          "75": 1.291,
          "95": 1.291,
          "99": 1.291,
          "100": 1.291
        },
        "total": 2.3965
      },
      "mem-seconds": {
        "percentiles": {
          "50": 50.592,
          "75": 82.624,
          "95": 82.624,
          "99": 82.624,
          "100": 82.624
        },
        "total": 153.376
      },
      "run-time-seconds": {
        "percentiles": {
          "50": 1.581,
          "75": 2.582,
          "95": 2.582,
          "99": 2.582,
          "100": 2.582
        },
        "total": 4.793
      }
    }
  },
  "by-user-and-reason": {
    "root": {
      "Command exited non-zero": {
        "count": 3,
        "cpu-seconds": {
          "percentiles": {
            "50": 0.7905,
            "75": 1.291,
            "95": 1.291,
            "99": 1.291,
            "100": 1.291
          },
          "total": 2.3965
        },
        "mem-seconds": {
          "percentiles": {
            "50": 50.592,
            "75": 82.624,
            "95": 82.624,
            "99": 82.624,
            "100": 82.624
          },
          "total": 153.376
        },
        "run-time-seconds": {
          "percentiles": {
            "50": 1.581,
            "75": 2.582,
            "95": 2.582,
            "99": 2.582,
            "100": 2.582
          },
          "total": 4.793
        }
      }
    }
  },
  "leaders": {
    "cpu-seconds": {
      "root": 2.3965
    },
    "mem-seconds": {
      "root": 153.376
    }
  },
  "overall": {
    "count": 3,
    "cpu-seconds": {
      "percentiles": {
        "50": 0.7905,
        "75": 1.291,
        "95": 1.291,
        "99": 1.291,
        "100": 1.291
      },
      "total": 2.3965
    },
    "mem-seconds": {
      "percentiles": {
        "50": 50.592,
        "75": 82.624,
        "95": 82.624,
        "99": 82.624,
        "100": 82.624
      },
      "total": 153.376
    },
    "run-time-seconds": {
      "percentiles": {
        "50": 1.581,
        "75": 2.582,
        "95": 2.582,
        "99": 2.582,
        "100": 2.582
      },
      "total": 4.793
    }
  }
}
```