### PR TITLE
CS: runs the sandbox syncer without the need for datomic reads for task filtering

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -293,13 +293,12 @@
                                     (cache/lru-cache-factory :threshold max-size)
                                     (cache/ttl-cache-factory :ttl ttl-ms)
                                     atom))
-     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer filter-batch-size filter-interval-ms max-consecutive-sync-failure
+     :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure
                                              publish-batch-size publish-interval-ms sync-interval-ms]]
                                  framework-id mesos-agent-query-cache mesos-datomic]
                              ((lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)
-                               framework-id mesos-datomic filter-batch-size filter-interval-ms
-                               publish-batch-size publish-interval-ms sync-interval-ms max-consecutive-sync-failure
-                               mesos-agent-query-cache))
+                               framework-id mesos-datomic publish-batch-size publish-interval-ms sync-interval-ms
+                               max-consecutive-sync-failure mesos-agent-query-cache))
      :mesos-leadership-atom (fnk [] (atom false))
      :mesos-pending-jobs-atom (fnk [] (atom {}))
      :mesos-offer-cache (fnk [[:settings [:offer-cache max-size ttl-ms]]]
@@ -359,10 +358,7 @@
                             agent-query-cache))
      :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
                        (merge
-                         {:filter-batch-size 2000
-                          ;; The default should ideally be lower than the sync-interval-ms
-                          :filter-interval-ms 5000
-                          :max-consecutive-sync-failure 15
+                         {:max-consecutive-sync-failure 15
                           :publish-batch-size 100
                           :publish-interval-ms 2500
                           ;; The default should ideally be lower than the agent-query-cache ttl-ms

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -252,7 +252,7 @@
              (when (and (#{:task-starting :task-running} task-state)
                         (not= :executor/cook (:instance/executor instance-ent)))
                ;; cook executor tasks should automatically get sandbox directory updates
-               (sync-agent-sandboxes-fn (:instance/hostname instance-ent)))
+               (sync-agent-sandboxes-fn (:instance/hostname instance-ent) task-id))
              ;; (println "update:" task-id task-state job instance instance-status prior-job-state)
              (log/debug "Transacting updated state for instance" instance "to status" instance-status)
              ;; The database can become inconsistent if we make multiple calls to :instance/update-state in a single
@@ -1495,7 +1495,7 @@
   "Creates the mesos scheduler which processes status updates asynchronously but in order of receipt."
   [configured-framework-id gpu-enabled? conn heartbeat-ch fenzo offers-chan match-trigger-chan handle-progress-message
    sandbox-syncer-state]
-  (let [sync-agent-sandboxes-fn #(sandbox/sync-agent-sandboxes sandbox-syncer-state configured-framework-id %)]
+  (let [sync-agent-sandboxes-fn #(sandbox/sync-agent-sandboxes sandbox-syncer-state configured-framework-id %1 %2)]
     (mesos/scheduler
       (registered
         [this driver framework-id master-info]


### PR DESCRIPTION

## Changes proposed in this PR

- Avoid using datomic queries to filter entries received from the host
- Instead 'remember' the tasks which requested sandbox directory lookup and use them in the filter

## Why are we making these changes?

We want to avoid making datomic queries where we can to avoid introducing performance issues.

