### PR TITLE
Support reserving hosts from the rebalancer

### DIFF
--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -219,25 +219,25 @@
                                         (sched/create-datomic-scheduler
                                          {:conn mesos-datomic-conn
                                           :driver-atom current-driver
-                                          :pending-jobs-atom mesos-pending-jobs-atom
-                                          :offer-cache offer-cache
-                                          :heartbeat-ch mesos-heartbeat-chan
-                                          :offer-incubate-time-ms offer-incubate-time-ms
-                                          :mea-culpa-failure-limit mea-culpa-failure-limit
+                                          :executor-config executor-config
+                                          :fenzo-fitness-calculator fenzo-fitness-calculator
+                                          :fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-reset
+                                          :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn
                                           :fenzo-max-jobs-considered fenzo-max-jobs-considered
                                           :fenzo-scaleback fenzo-scaleback
-                                          :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn
-                                          :fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-reset
-                                          :fenzo-fitness-calculator fenzo-fitness-calculator
-                                          :task-constraints task-constraints
-                                          :gpu-enabled? gpu-enabled?
-                                          :good-enough-fitness good-enough-fitness
                                           :framework-id framework-id
-                                          :sandbox-syncer-state sandbox-syncer-state
-                                          :executor-config executor-config
+                                          :good-enough-fitness good-enough-fitness
+                                          :gpu-enabled? gpu-enabled?
+                                          :heartbeat-ch mesos-heartbeat-chan
+                                          :mea-culpa-failure-limit mea-culpa-failure-limit
+                                          :offer-cache offer-cache
+                                          :offer-incubate-time-ms offer-incubate-time-ms
+                                          :pending-jobs-atom mesos-pending-jobs-atom
                                           :progress-config progress-config
-                                          :trigger-chans trigger-chans
-                                          :rebalancer-reservation-atom rebalancer-reservation-atom})
+                                          :rebalancer-reservation-atom rebalancer-reservation-atom
+                                          :sandbox-syncer-state sandbox-syncer-state
+                                          :task-constraints task-constraints
+                                          :trigger-chans trigger-chans})
                                         driver (make-mesos-driver-fn scheduler framework-id)]
                                     (mesomatic.scheduler/start! driver)
                                     (reset! current-driver driver)

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -187,13 +187,10 @@
 
 (defn build-rebalancer-reservation-constraint
   "Constructs a rebalancer-reservation-constraint"
-  [job job-uuid->reserved-hostname]
-  (let [reserved-hosts (-> (hash-set)
-                           (into (vals job-uuid->reserved-hostname))
-                           (disj (job-uuid->reserved-hostname (:job/uuid job))))]
-    (-> reserved-hosts
-        ->rebalancer-reservation-constraint
-        fenzoize-job-constraint)))
+  [reserved-hosts]
+  (-> reserved-hosts
+      ->rebalancer-reservation-constraint
+      fenzoize-job-constraint))
 
 (defn make-rebalancer-job-constraints
   "Returns a sequence of all job constraints for 'job', in rebalancer-compatible (rebalancer.clj)

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -121,7 +121,7 @@
     [this _ vm-attributes]
     (let [target-hostname (get vm-attributes "HOSTNAME")]
       [(not (contains? reserved-hosts target-hostname))
-       "Host was reserved for rebalancing"]))
+       "Host is reserved for rebalancing"]))
   (job-constraint-evaluate
     [this _ vm-attributes _]
     (job-constraint-evaluate this _ vm-attributes)))

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -121,7 +121,7 @@
     [this _ vm-attributes]
     (let [target-hostname (get vm-attributes "HOSTNAME")]
       [(not (contains? reserved-hosts target-hostname))
-       "Host is reserved for rebalancing"]))
+       "Host is temporarily reserved"]))
   (job-constraint-evaluate
     [this _ vm-attributes _]
     (job-constraint-evaluate this _ vm-attributes)))

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -114,6 +114,18 @@
   (let [needs-gpus? (job-needs-gpus? job)]
     (->gpu-host-constraint job needs-gpus?)))
 
+(defrecord rebalancer-reservation-constraint [reserved-hosts]
+  JobConstraint
+  (job-constraint-name [this] (get-class-name this))
+  (job-constraint-evaluate
+    [this _ vm-attributes]
+    (let [target-hostname (get vm-attributes "HOSTNAME")]
+      [(not (contains? reserved-hosts target-hostname))
+       "Host was reserved for rebalancing"]))
+  (job-constraint-evaluate
+    [this _ vm-attributes _]
+    (job-constraint-evaluate this _ vm-attributes)))
+
 (defrecord user-defined-constraint [constraints]
   JobConstraint
   (job-constraint-name [this] (get-class-name this))
@@ -172,6 +184,16 @@
   (for [constraint-constructor job-constraint-constructors
         :let [constraint (constraint-constructor job)]]
     (fenzoize-job-constraint constraint)))
+
+(defn build-rebalancer-reservation-constraint
+  "Constructs a rebalancer-reservation-constraint"
+  [job job-uuid->reserved-hostname]
+  (let [reserved-hosts (-> (hash-set)
+                           (into (vals job-uuid->reserved-hostname))
+                           (disj (job-uuid->reserved-hostname (:job/uuid job))))]
+    (-> reserved-hosts
+        ->rebalancer-reservation-constraint
+        fenzoize-job-constraint)))
 
 (defn make-rebalancer-job-constraints
   "Returns a sequence of all job constraints for 'job', in rebalancer-compatible (rebalancer.clj)

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -391,9 +391,9 @@
                                         (:hostname d)]))
                           (into {}))]
     (swap! rebalancer-reservation-atom (fn [{:keys [launched-job-uuids]}]
-                                        ; In case one of the jobs the rebalancer has launched already while computing
-                                        ; the pre-emption decisions, remove it's reservation from the map. Then
-                                        ; we can clear the launched-job-uuids set.
+                                        ; In case one of the jobs the rebalancer has decided to reserve a host for
+                                        ; launched while computing the pre-emption decisions, remove it's
+                                        ; reservation from the map. Then we can clear the launched-job-uuids set.
                                          {:job-uuid->reserved-host (apply dissoc reservations launched-job-uuids)
                                           :launched-job-uuids #{}}))))
 

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -629,7 +629,6 @@
                          (make-task-request db job
                                             :guuid->considerable-cotask-ids guuid->considerable-cotask-ids
                                             :reserved-hosts (disj reserved-hosts (job-uuid->reserved-host (:job/uuid job)))
-                                            :job-uuid->reserved-host job-uuid->reserved-host
                                             :running-cotask-cache running-cotask-cache
                                             :task-id (considerable->task-id job)))
                        considerable)
@@ -840,7 +839,11 @@
                 (getTaskAssigner)
                 (call task-request hostname))))))))
 
-(defn update-host-reservations! [rebalancer-reservation-atom matches]
+(defn update-host-reservations!
+  "Updates the rebalancer-reservation-atom with the result of the match cycle.
+   - Releases reservations for jobs that were matched
+   - Adds matched job uuids to the launched-job-uuids list"
+  [rebalancer-reservation-atom matches]
   (let [matched-job-uuids (->> matches
                                (mapcat #(-> % :tasks))
                                (map #(-> % .getRequest :job))

--- a/scheduler/test/cook/test/mesos/constraints.clj
+++ b/scheduler/test/cook/test/mesos/constraints.clj
@@ -140,8 +140,7 @@
         job-id (create-dummy-job conn :user "pschorf" :ncpus 5.0 :memory 5.0)
         db (d/db conn)
         job (d/entity db job-id)
-        reserved-hosts {(:job/uuid job) "hostA"
-                        "jobB" "hostB"}
+        reserved-hosts #{"hostB"}
         hostA-offer #mesomatic.types.Offer{:id #mesomatic.types.OfferID {:value "my-offer-id"}
                                            :framework-id framework-id
                                            :slave-id #mesomatic.types.SlaveID{:value "my-slave-id"},
@@ -162,8 +161,7 @@
                                                        #mesomatic.types.Resource{:name "ports", :type :value-ranges, :scalar 0.0, :ranges [#mesomatic.types.ValueRange{:begin 31000, :end 32000}], :set #{}, :role "*"}],
                                            :attributes [],
                                            :executor-ids []}
-        constraint (constraints/build-rebalancer-reservation-constraint job reserved-hosts)
-        ]
+        constraint (constraints/build-rebalancer-reservation-constraint reserved-hosts)]
     (is (not (.isSuccessful
               (.evaluate constraint
                          (sched/make-task-request db job-id)

--- a/scheduler/test/cook/test/mesos/constraints.clj
+++ b/scheduler/test/cook/test/mesos/constraints.clj
@@ -131,3 +131,54 @@
                          (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter non-gpu-offer 0)))
                        nil))
         "non GPU task on non GPU host should succeed"))))
+
+
+(deftest test-rebalancer-reservation-constraint
+  (let [framework-id #mesomatic.types.FrameworkID{:value "my-framework-id"}
+        uri "datomic:mem://test-rebalancer-reservation-constraint"
+        conn (restore-fresh-database! uri)
+        job-id (create-dummy-job conn :user "pschorf" :ncpus 5.0 :memory 5.0)
+        db (d/db conn)
+        job (d/entity db job-id)
+        reserved-hosts {(:job/uuid job) "hostA"
+                        "jobB" "hostB"}
+        hostA-offer #mesomatic.types.Offer{:id #mesomatic.types.OfferID {:value "my-offer-id"}
+                                           :framework-id framework-id
+                                           :slave-id #mesomatic.types.SlaveID{:value "my-slave-id"},
+                                           :hostname "hostA",
+                                           :resources [#mesomatic.types.Resource{:name "cpus", :type :value-scalar, :scalar 40.0, :ranges [], :set #{}, :role "*"}
+                                                       #mesomatic.types.Resource{:name "mem", :type :value-scalar, :scalar 5000.0, :ranges [], :set #{}, :role "*"}
+                                                       #mesomatic.types.Resource{:name "disk", :type :value-scalar, :scalar 6000.0, :ranges [], :set #{}, :role "*"}
+                                                       #mesomatic.types.Resource{:name "ports", :type :value-ranges, :scalar 0.0, :ranges [#mesomatic.types.ValueRange{:begin 31000, :end 32000}], :set #{}, :role "*"}],
+                                           :attributes [],
+                                           :executor-ids []}
+        hostB-offer #mesomatic.types.Offer{:id #mesomatic.types.OfferID {:value "my-offer-id"}
+                                           :framework-id framework-id
+                                           :slave-id #mesomatic.types.SlaveID{:value "my-slave-id"},
+                                           :hostname "hostB",
+                                           :resources [#mesomatic.types.Resource{:name "cpus", :type :value-scalar, :scalar 40.0, :ranges [], :set #{}, :role "*"}
+                                                       #mesomatic.types.Resource{:name "mem", :type :value-scalar, :scalar 5000.0, :ranges [], :set #{}, :role "*"}
+                                                       #mesomatic.types.Resource{:name "disk", :type :value-scalar, :scalar 6000.0, :ranges [], :set #{}, :role "*"}
+                                                       #mesomatic.types.Resource{:name "ports", :type :value-ranges, :scalar 0.0, :ranges [#mesomatic.types.ValueRange{:begin 31000, :end 32000}], :set #{}, :role "*"}],
+                                           :attributes [],
+                                           :executor-ids []}
+        constraint (constraints/build-rebalancer-reservation-constraint job reserved-hosts)
+        ]
+    (is (not (.isSuccessful
+              (.evaluate constraint
+                         (sched/make-task-request db job-id)
+                         (reify com.netflix.fenzo.VirtualMachineCurrentState
+                           (getHostname [_] "hostB")
+                           (getRunningTasks [_] [])
+                           (getTasksCurrentlyAssigned [_] [])
+                           (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter hostB-offer 0)))
+                         nil))))
+    (is (.isSuccessful
+         (.evaluate constraint
+                    (sched/make-task-request db job-id)
+                    (reify com.netflix.fenzo.VirtualMachineCurrentState
+                      (getHostname [_] "hostA")
+                      (getRunningTasks [_] [])
+                      (getTasksCurrentlyAssigned [_] [])
+                      (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter hostA-offer 0)))
+                    nil)))))

--- a/scheduler/test/cook/test/mesos/rebalancer.clj
+++ b/scheduler/test/cook/test/mesos/rebalancer.clj
@@ -1196,6 +1196,7 @@
         (is (= {(:job/uuid (d/entity db job4)) "hostA"}
                (:job-uuid->reserved-host @reservations)))
         (is (= #{} (:launched-job-uuids @reservations))))))
+
   (testing "does not reserve host for single preempted task"
     (let [datomic-uri "datomic:mem://test-rebalance-host-reservation-single"
           conn (restore-fresh-database! datomic-uri)
@@ -1227,6 +1228,7 @@
         (is (= [task1] (map :db/id task)))
         (is (= {} (:job-uuid->reserved-host @reservations)))
         (is (= #{} (:launched-job-uuids @reservations))))))
+
   (testing "does not reserve host for job already launched"
     (let [datomic-uri "datomic:mem://test-rebalance-host-reservation"
           conn (restore-fresh-database! datomic-uri)
@@ -1314,5 +1316,3 @@
       (is (= #{}) (:launched-job-uuids @rebalancer-reservation-atom)))))
 
 (comment (run-tests))
-
-

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1484,18 +1484,44 @@
                                             ^TaskScheduler fenzo (sched/make-fenzo-scheduler driver-atom 1500 nil 0.8)
                                             group-ent-id (create-dummy-group conn)
                                             get-uuid (fn [name] (get job-name->uuid name (d/squuid)))
-                                            job-1 (d/entity test-db (create-dummy-job conn :uuid (get-uuid "job-1")
-                                                                                      :group group-ent-id :name "job-1" :ncpus 3 :memory 2048))
-                                            job-2 (d/entity test-db (create-dummy-job conn :uuid (get-uuid "job-2")
-                                                                                      :group group-ent-id :name "job-2" :ncpus 13 :memory 1024))
-                                            job-3 (d/entity test-db (create-dummy-job conn :uuid (get-uuid "job-3")
-                                                                                      :group group-ent-id :name "job-3" :ncpus 7 :memory 4096))
-                                            job-4 (d/entity test-db (create-dummy-job conn :uuid (get-uuid "job-4")
-                                                                                      :group group-ent-id :name "job-4" :ncpus 11 :memory 1024))
-                                            job-5 (d/entity test-db (create-dummy-job conn :uuid (get-uuid "job-5")
-                                                                                      :group group-ent-id :name "job-5" :ncpus 5 :memory 2048 :gpus 2))
-                                            job-6 (d/entity test-db (create-dummy-job conn :uuid (get-uuid "job-6")
-                                                                                      :group group-ent-id :name "job-6" :ncpus 19 :memory 1024 :gpus 4))
+                                            job-1 (d/entity test-db (create-dummy-job conn
+                                                                                      :uuid (get-uuid "job-1")
+                                                                                      :group group-ent-id
+                                                                                      :name "job-1"
+                                                                                      :ncpus 3
+                                                                                      :memory 2048))
+                                            job-2 (d/entity test-db (create-dummy-job conn
+                                                                                      :uuid (get-uuid "job-2")
+                                                                                      :group group-ent-id
+                                                                                      :name "job-2"
+                                                                                      :ncpus 13
+                                                                                      :memory 1024))
+                                            job-3 (d/entity test-db (create-dummy-job conn
+                                                                                      :uuid (get-uuid "job-3")
+                                                                                      :group group-ent-id
+                                                                                      :name "job-3"
+                                                                                      :ncpus 7
+                                                                                      :memory 4096))
+                                            job-4 (d/entity test-db (create-dummy-job conn
+                                                                                      :uuid (get-uuid "job-4")
+                                                                                      :group group-ent-id
+                                                                                      :name "job-4"
+                                                                                      :ncpus 11
+                                                                                      :memory 1024))
+                                            job-5 (d/entity test-db (create-dummy-job conn
+                                                                                      :uuid (get-uuid "job-5")
+                                                                                      :group group-ent-id
+                                                                                      :name "job-5"
+                                                                                      :ncpus 5
+                                                                                      :memory 2048
+                                                                                      :gpus 2))
+                                            job-6 (d/entity test-db (create-dummy-job conn
+                                                                                      :uuid (get-uuid "job-6")
+                                                                                      :group group-ent-id
+                                                                                      :name "job-6"
+                                                                                      :ncpus 19
+                                                                                      :memory 1024
+                                                                                      :gpus 4))
                                             entity->map (fn [entity]
                                                           (util/job-ent->map entity (d/db conn)))
                                             category->pending-jobs (->> {:normal [job-1 job-2 job-3 job-4] :gpu [job-5 job-6]}

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1637,7 +1637,7 @@
     (testing "will not launch jobs on reserved host"
       (let [num-considerable 10
             offers [offer-1]
-            initial-reservation-state {:reservations {(UUID/randomUUID) (:hostname offer-1)}}
+            initial-reservation-state {:job-uuid->reserved-host {(UUID/randomUUID) (:hostname offer-1)}}
             rebalancer-reservation-atom (atom initial-reservation-state)]
         (is (run-handle-resource-offers! num-considerable offers :rebalancer-reservation-atom rebalancer-reservation-atom))
         (is (= 0 (count @launched-job-ids-atom)))
@@ -1648,16 +1648,16 @@
             offers [offer-9] ; large enough to launch jobs 1, 2, 3, and 4
             job-1-uuid (d/squuid)
             job-2-uuid (d/squuid)
-            initial-reservation-state {:reservations {job-1-uuid (:hostname offer-9)
-                                                      job-2-uuid (:hostname offer-9)}}
+            initial-reservation-state {:job-uuid->reserved-host {job-1-uuid (:hostname offer-9)
+                                                                 job-2-uuid (:hostname offer-9)}}
             rebalancer-reservation-atom (atom initial-reservation-state)]
         (is (run-handle-resource-offers! num-considerable offers :rebalancer-reservation-atom rebalancer-reservation-atom
                                          :job-name->uuid {"job-1" job-1-uuid "job-2" job-2-uuid}))
         (is (= :end-marker (async/<!! offers-chan)))
         (is (= 2 (count @launched-job-ids-atom)))
         (is (= #{"job-1" "job-2"} (set @launched-job-ids-atom)))
-        (is (= {:reservations {}
-                :launched-jobs #{job-1-uuid job-2-uuid}}
+        (is (= {:job-uuid->reserved-host {}
+                :launched-job-uuids #{job-1-uuid job-2-uuid}}
                @rebalancer-reservation-atom))))))
 
 


### PR DESCRIPTION
## Changes proposed in this PR
- Introduces `rebalancer-reservation-atom` to reserve hosts for jobs which preempted several other jobs
- Reserves hosts after each rebalance cycle
- Releases reservations when all jobs reserving the host have been scheduled

## Why are we making these changes?
It's possible when preempting multiple tasks to get a new offer which only represents part of the total resources prevented. Then, smaller, lower-priority jobs could be scheduled on this offer which delays scheduling for the actual job the rebalancer was trying to launch.