### PR TITLE
New query functions

### DIFF
--- a/executor/tests/test_subprocess.py
+++ b/executor/tests/test_subprocess.py
@@ -45,7 +45,7 @@ class SubprocessTest(unittest.TestCase):
         tu.redirect_stderr_to_file(stderr_name)
 
         try:
-            command = "bash -c 'function handle_term { echo GOT TERM; }; trap handle_term SIGTERM TERM; sleep 100'"
+            command = "bash -c 'function handle_term { echo GOT TERM; }; trap handle_term SIGTERM TERM; sleep 200'"
             process = cs.launch_process(command, {})
             shutdown_grace_period_ms = 1000
 
@@ -82,7 +82,7 @@ class SubprocessTest(unittest.TestCase):
         tu.redirect_stderr_to_file(stderr_name)
 
         try:
-            command = "trap '' TERM SIGTERM; sleep 100"
+            command = "trap '' TERM SIGTERM; sleep 200"
             process = cs.launch_process(command, {})
             shutdown_grace_period_ms = 1000
 

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -62,7 +62,7 @@ class MultiUserCookTest(unittest.TestCase):
             for i, user in enumerate(users):
                 with user:
                     for j in range(i):
-                        job_uuid, resp = util.submit_job(self.cook_url, command='sleep 240', **job_resources)
+                        job_uuid, resp = util.submit_job(self.cook_url, command='sleep 480', **job_resources)
                         self.assertEqual(resp.status_code, 201, resp.content)
                         all_job_uuids.append(job_uuid)
             # Don't query until the jobs are all running

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -323,7 +323,7 @@
          (filter #(= state-keyword (:job/state %)))
          (filter #(not (:job/custom-executor %))))))
 
-;; This differs from the get-active-jobs-by-user-and-state is also looking up based on task state.
+;; This differs from get-active-jobs-by-user-and-state as it is also looking up based on task state.
 (defn get-completed-jobs-by-user
   "Returns all completed job entities for a particular user
    in the specified timeframe, without a custom executor. Supports looking up based
@@ -337,12 +337,12 @@
                name-filter-fn (filter #(name-filter-fn (:job/name %))))
       (take limit))))
 
-;; This query looks for all jobs by job state only (i.e., no 'success' or 'failed')
 (defn get-active-jobs-by-user-and-state
   "Returns all jobs for a particular user in the specified state
    and timeframe, without a custom executor.
    Note that this query is not performant for completed jobs, use
-   get-completed-jobs-by-user instead."
+   get-completed-jobs-by-user instead. This query looks for all
+   jobs by job state only (i.e., no 'success' or 'failed')"
   [db user start end state name-filter-fn]
   (let [state-keyword (case state
                         "running" :job.state/running

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -339,9 +339,7 @@
 
 (defn get-active-jobs-by-user-and-state
   "Returns all jobs for a particular user in the specified state
-   and timeframe, without a custom executor.
-   Note that this query is not performant for completed jobs, use
-   get-completed-jobs-by-user instead. This query looks for all
+   and timeframe, without a custom executor. This query looks for all
    jobs by job state only (i.e., no 'success' or 'failed')"
   [db user start end state name-filter-fn]
   (let [state-keyword (case state


### PR DESCRIPTION
## Changes proposed in this PR

- New query functions
- 
- 

## Why are we making these changes?
Makes API query performance for waiting/running jobs for a user in a time window go from O(#waiting/running jobs in entire system) to O(# jobs that user submitted during the time window)
Makes simple 'cs jobs' go 3x-10x faster (in staging environment)
