### PR TITLE
Adds histograms by failure reason for run/cpu/mem time

### DIFF
--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -171,6 +171,24 @@
                       (catch Exception e
                         (log/debug e "Error reading a string from mesos status data. Is it in the format we expect?")))))})
 
+(defn update-reason-histos!
+  "Updates histograms for run time, cpu time, and memory time,
+  where the histograms have the failure reason in the title"
+  [db mesos-reason instance-runtime {:keys [cpus mem]}]
+  (let [reason (->> mesos-reason
+                    (reason/mesos-reason->cook-reason-entity-id db)
+                    (d/entity db)
+                    :reason/name
+                    name)
+        update-histo! (fn update-histo! [s v]
+                        (histograms/update!
+                          (histograms/histogram
+                            ["cook-mesos" "scheduler" (str "hist-task-fail-" s "-reason-" reason)])
+                          v))]
+    (update-histo! "times" instance-runtime)
+    (update-histo! "cpu-times" (* instance-runtime cpus))
+    (update-histo! "mem-times" (* instance-runtime mem))))
+
 (defn handle-status-update
   "Takes a status update from mesos."
   [conn driver ^TaskScheduler fenzo sync-agent-sandboxes-fn status]
@@ -233,7 +251,9 @@
                                         instance-runtime)
              (handle-throughput-metrics complete-throughput-metrics
                                         job-resources
-                                        instance-runtime))
+                                        instance-runtime)
+             (when-not previous-reason
+               (update-reason-histos! db reason instance-runtime job-resources)))
            ;; This code kills any task that "shouldn't" be running
            (when (and
                    (or (nil? instance) ; We could know nothing about the task, meaning a DB error happened and it's a waste to finish

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -183,7 +183,7 @@
         update-histo! (fn update-histo! [s v]
                         (histograms/update!
                           (histograms/histogram
-                            ["cook-mesos" "scheduler" (str "hist-task-fail-" s "-reason-" reason)])
+                            ["cook-mesos" "scheduler" "hist-task-fail" reason s])
                           v))]
     (update-histo! "times" instance-runtime)
     (update-histo! "cpu-times" (* instance-runtime cpus))


### PR DESCRIPTION
## Changes proposed in this PR

- introducing new histograms by failure reason for run time, cpu time, and mem time
- updating the histograms when a task fails

## Why are we making these changes?

We want to enable better visibility into the amount of time and resources spent on various failures, e.g. "preempted by rebalancer".