### PR TITLE
Refactors config code into config namespace

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -13,19 +13,15 @@
 ;; limitations under the License.
 ;;
 (ns cook.components
-  (:require [clj-logging-config.log4j :as log4j-conf]
-            [clj-time.core :as t]
-            [clojure.core.cache :as cache]
-            [clojure.edn :as edn]
+  (:require [clojure.core.cache :as cache]
             [clojure.pprint :refer (pprint)]
-            [clojure.stacktrace :as stacktrace]
-            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [compojure.core :refer (GET POST routes context)]
             [compojure.route :as route]
             [congestion.limits :refer (RateLimit)]
             [congestion.middleware :refer (wrap-rate-limit ip-rate-limit)]
             [congestion.storage :as storage]
+            [cook.config :as config]
             [cook.curator :as curator]
             [cook.impersonation :refer (impersonation-authorized-wrapper)]
             [cook.util :as util]
@@ -58,22 +54,9 @@
                 [:headers "Cache-control"]
                 "max-age=0"))))
 
-(defn lazy-load-var
-  "Takes a symbol name of a var, requires the ns if not yet required, and
-   returns the var."
-  [var-sym]
-  (let [ns (namespace var-sym)]
-    (when-not ns
-      (throw (ex-info "Can only load vars that are ns-qualified!" {})))
-    (require (symbol ns))
-    (let [resolved (resolve var-sym)]
-      (if resolved
-        resolved
-        (throw (ex-info "Unable to resolve var, is it valid?" {:var-sym var-sym}))))))
-
 (def raw-scheduler-routes
   {:scheduler (fnk [mesos mesos-datomic mesos-leadership-atom mesos-pending-jobs-atom framework-id settings]
-                ((lazy-load-var 'cook.mesos.api/main-handler)
+                ((util/lazy-load-var 'cook.mesos.api/main-handler)
                   mesos-datomic
                   framework-id
                   (fn [] @mesos-pending-jobs-atom)
@@ -94,23 +77,23 @@
                            fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback
                            good-enough-fitness hostname mea-culpa-failure-limit mesos-failover-timeout mesos-framework-name
                            mesos-gpu-enabled mesos-leader-path mesos-master mesos-master-hosts mesos-principal
-                           mesos-role offer-incubate-time-ms optimizer progress rebalancer riemann server-port task-constraints
+                           mesos-role offer-incubate-time-ms optimizer progress rebalancer server-port task-constraints
                            user-metrics-interval-seconds]
                           curator-framework framework-id mesos-datomic mesos-datomic-mult mesos-leadership-atom
                           mesos-offer-cache mesos-pending-jobs-atom sandbox-syncer-state]
                       (log/info "Initializing mesos scheduler")
-                      (let [make-mesos-driver-fn (partial (lazy-load-var 'cook.mesos/make-mesos-driver)
+                      (let [make-mesos-driver-fn (partial (util/lazy-load-var 'cook.mesos/make-mesos-driver)
                                                           {:mesos-master mesos-master
                                                            :mesos-failover-timeout mesos-failover-timeout
                                                            :mesos-principal mesos-principal
                                                            :mesos-role mesos-role
                                                            :mesos-framework-name mesos-framework-name
                                                            :gpus-enabled? mesos-gpu-enabled})
-                            get-mesos-utilization-fn (partial (lazy-load-var 'cook.mesos/get-mesos-utilization) mesos-master-hosts)
-                            trigger-chans ((lazy-load-var 'cook.mesos/make-trigger-chans) rebalancer progress optimizer task-constraints)]
+                            get-mesos-utilization-fn (partial (util/lazy-load-var 'cook.mesos/get-mesos-utilization) mesos-master-hosts)
+                            trigger-chans ((util/lazy-load-var 'cook.mesos/make-trigger-chans) rebalancer progress optimizer task-constraints)]
                         (try
                           (Class/forName "org.apache.mesos.Scheduler")
-                          ((lazy-load-var 'cook.mesos/start-mesos-scheduler)
+                          ((util/lazy-load-var 'cook.mesos/start-mesos-scheduler)
                             {:curator-framework curator-framework
                              :executor-config executor
                              :fenzo-config {:fenzo-max-jobs-considered fenzo-max-jobs-considered
@@ -130,7 +113,7 @@
                              :mesos-pending-jobs-atom mesos-pending-jobs-atom
                              :offer-cache mesos-offer-cache
                              :offer-incubate-time-ms offer-incubate-time-ms
-                             :optimizer-config optimizer   
+                             :optimizer-config optimizer
                              :progress-config progress
                              :rebalancer-config rebalancer
                              :sandbox-syncer-state sandbox-syncer-state
@@ -159,12 +142,12 @@
 
 (def mesos-datomic
   (fnk [[:settings mesos-datomic-uri]]
-    ((lazy-load-var 'datomic.api/create-database) mesos-datomic-uri)
-    (let [conn ((lazy-load-var 'datomic.api/connect) mesos-datomic-uri)]
-      (doseq [txn (deref (lazy-load-var 'cook.mesos.schema/work-item-schema))]
-        (deref ((lazy-load-var 'datomic.api/transact) conn txn))
-        ((lazy-load-var 'metatransaction.core/install-metatransaction-support) conn)
-        ((lazy-load-var 'metatransaction.utils/install-utils-support) conn))
+    ((util/lazy-load-var 'datomic.api/create-database) mesos-datomic-uri)
+    (let [conn ((util/lazy-load-var 'datomic.api/connect) mesos-datomic-uri)]
+      (doseq [txn (deref (util/lazy-load-var 'cook.mesos.schema/work-item-schema))]
+        (deref ((util/lazy-load-var 'datomic.api/transact) conn txn))
+        ((util/lazy-load-var 'metatransaction.core/install-metatransaction-support) conn)
+        ((util/lazy-load-var 'metatransaction.utils/install-utils-support) conn))
       conn)))
 
 (def curator-framework
@@ -177,7 +160,7 @@
       (.. curator-framework
           getConnectionStateListenable
           (addListener (reify ConnectionStateListener
-                         (stateChanged [_ client newState]
+                         (stateChanged [_ _ newState]
                            (log/info "Curator state changed:"
                                      (str newState))))))
       (.start curator-framework)
@@ -196,9 +179,9 @@
                               (reify Principal ; Shim principal to pass username along
                                 (equals [this another]
                                   (= this another))
-                                (getName [this]
+                                (getName [_]
                                   (:authorization/user req))
-                                (toString [this]
+                                (toString [_]
                                   (str "Shim principal for user: " (:authorization/user req))))
                               (into-array String []))))
       (h req))))
@@ -217,15 +200,6 @@
                                                     (.setExtended true)
                                                     (.setPreferProxiedForAddress true)))
                                   (.setServer server)))))))
-
-(defrecord UserRateLimit [id quota ttl]
-  RateLimit
-  (get-key [self req]
-    (str (.getName (type self)) id "-" (:authorization/user req)))
-  (get-quota [self req]
-    quota)
-  (get-ttl [self req]
-    ttl))
 
 (defn framework-id-from-zk
   "Returns the framework id from ZooKeeper, or nil if not present"
@@ -252,7 +226,7 @@
                          leader-reports-unhealthy [:rate-limit user-limit]] [:route view] mesos-leadership-atom]
                     (log/info "Launching http server")
                     (let [rate-limit-storage (storage/local-storage)
-                          jetty ((lazy-load-var 'qbits.jet.server/run-jetty)
+                          jetty ((util/lazy-load-var 'qbits.jet.server/run-jetty)
                                   {:port server-port
                                    :ring-handler (routes
                                                    (route/resources "/resource")
@@ -286,7 +260,7 @@
                        (log/info "Using framework id:" framework-id)
                        framework-id))
      :mesos-datomic-mult (fnk [mesos-datomic]
-                           (first ((lazy-load-var 'cook.datomic/create-tx-report-mult) mesos-datomic)))
+                           (first ((util/lazy-load-var 'cook.datomic/create-tx-report-mult) mesos-datomic)))
      :local-zookeeper (fnk [[:settings zookeeper-server]]
                         (when zookeeper-server
                           (log/info "Starting local ZK server")
@@ -300,7 +274,7 @@
      :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure
                                              publish-batch-size publish-interval-ms sync-interval-ms]]
                                  framework-id mesos-agent-query-cache mesos-datomic]
-                             ((lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)
+                             ((util/lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)
                                framework-id mesos-datomic publish-batch-size publish-interval-ms sync-interval-ms
                                max-consecutive-sync-failure mesos-agent-query-cache))
      :mesos-leadership-atom (fnk [] (atom false))
@@ -312,387 +286,16 @@
                               atom))
      :curator-framework curator-framework}))
 
-#_(def dev-mem-settings
-    {:server-port (fnk [] 12321)
-     :authorization-middleware (fnk [] (fn [h] (fn [req] (h (assoc req :authorization/user (System/getProperty "user.name"))))))
-     :sim-agent-path (fnk [] "/usr/bin/sim-agent") ;;TODO parameterize
-     :mesos-datomic-uri (fnk [] "datomic:mem://mesos-jobs")
-     :zookeeper (fnk []
-                  "localhost:3291")
-     :zookeeper-server (fnk []
-                         (org.apache.curator.test.TestingServer. 3291 true) ;; Start a local ZK for simplicity
-                         )
-     :hostname (fnk [] (.getCanonicalHostName (java.net.InetAddress/getLocalHost)))
-     :offer-incubate-time-ms (fnk [] (* 15 1000))
-     :task-constraints (fnk []
-                         {:timeout-hours 1
-                          :timeout-interval-minutes 1
-                          :memory-gb 48
-                          :cpus 6
-                          :retry-limit 5})
-     ;:task-constraints (fnk []
-     ;                       {:timeout-hours (* 5 24)
-     ;                        :timeout-interval-minutes 10
-     ;                        :memory-gb 128
-     ;                        :cpus 24})
-     :mesos-master (fnk [] "zk://localhost:2181/mesos")
-     :mesos-failover-timeout (fnk [] nil) ; don't fail over
-     ;:mesos-failover-timeout (fnk [] (* 1.0
-     ;                                   3600  ; seconds/hour
-     ;                                   24    ; hours/day
-     ;                                   7     ; days/week
-     ;                                   2     ; weeks
-     ;                                   ))
-     :mesos-leader-path (fnk [] (str "/cook-scheduler"))
-     :mesos-principal (fnk [] nil) ;; You can change this to customize for your environment
-     :exception-handler (fnk [] ((lazy-load-var 'cook.util/install-email-on-exception-handler))) ;;TODO parameterize
-     })
-
-(def default-authorization {:authorization-fn 'cook.authorization/open-auth})
-(def default-fitness-calculator "com.netflix.fenzo.plugins.BinPackingFitnessCalculators/cpuMemBinPacker")
-
-
-(def config-settings
-  "Parses the settings out of a config file"
-  (graph/eager-compile
-    {:agent-query-cache (fnk [[:config {agent-query-cache nil}]]
-                          (merge
-                            {:max-size 5000
-                             :ttl-ms (* 60 1000)}
-                            agent-query-cache))
-     :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
-                       (merge
-                         {:max-consecutive-sync-failure 15
-                          :publish-batch-size 100
-                          :publish-interval-ms 2500
-                          ;; The default should ideally be lower than the agent-query-cache ttl-ms
-                          :sync-interval-ms 15000}
-                         sandbox-syncer))
-     :server-port (fnk [[:config port]]
-                    port)
-     :is-authorized-fn (fnk [[:config {authorization-config default-authorization}]]
-                            (let [auth-fn @(lazy-load-var 'cook.authorization/is-authorized?)]
-                              ; we only wrap the authorization function if we have impersonators configured
-                              (if (-> authorization-config :impersonators seq)
-                                (impersonation-authorized-wrapper auth-fn authorization-config)
-                                (partial auth-fn authorization-config))))
-     :authorization-middleware (fnk [[:config [:authorization {one-user false} {kerberos false} {http-basic false}]]]
-                                 (cond
-                                   http-basic
-                                   (let [validation (get http-basic :validation :none)
-                                         user-password-valid?
-                                         ((lazy-load-var 'cook.basic-auth/make-user-password-valid?) validation http-basic)]
-                                     (log/info "Using http basic authorization with validation" validation)
-                                     (with-meta
-                                       ((lazy-load-var 'cook.basic-auth/create-http-basic-middleware) user-password-valid?)
-                                       {:json-value "http-basic"}))
-
-                                   one-user
-                                   (do
-                                     (log/info "Using single user authorization")
-                                     (with-meta
-                                       (fn one-user-middleware [h]
-                                         (fn one-user-auth-wrapper [req]
-                                           (h (assoc req :authorization/user one-user))))
-                                       {:json-value "one-user"}))
-
-                                   kerberos
-                                   (do
-                                     (log/info "Using kerberos middleware")
-                                     (with-meta
-                                       @(lazy-load-var 'cook.spnego/require-gss)
-                                       {:json-value "kerberos"}))
-                                   :else (throw (ex-info "Missing authorization configuration" {}))))
-     :impersonation-middleware (fnk [[:config {authorization-config nil}]]
-                                    (let [{impersonators :impersonators} authorization-config]
-                                      (with-meta
-                                        ((lazy-load-var 'cook.impersonation/create-impersonation-middleware) impersonators)
-                                        {:json-value "config-impersonation"})))
-     :rate-limit (fnk [[:config {rate-limit nil}]]
-                   (let [{:keys [user-limit-per-m]
-                          :or {user-limit-per-m 600}} rate-limit]
-                     {:user-limit (->UserRateLimit :user-limit user-limit-per-m (t/minutes 1))}))
-     :sim-agent-path (fnk [] "/usr/bin/sim-agent")
-     :executor (fnk [[:config {executor {}}]]
-                 (if (str/blank? (:command executor))
-                   (do
-                     (log/info "Executor config is missing command, will use the command executor by default"
-                               {:executor-config executor})
-                     {})
-                   (do
-                     (when-let [environment (:environment executor)]
-                       (when-not (and (map? environment)
-                                      (every? string? (keys environment))
-                                      (every? string? (vals environment)))
-                         (throw (ex-info "Executor environment must be a map from string to string!" {:executor executor}))))
-                     (when (and (:portion executor) (not (<= 0 (:portion executor) 1)))
-                       (throw (ex-info "Executor portion must be in the range [0, 1]!" {:executor executor})))
-                     (let [default-executor-config {:default-progress-regex-string "progress:\\s+([0-9]*\\.?[0-9]+)($|\\s+.*)"
-                                                    :environment {}
-                                                    :log-level "INFO"
-                                                    :max-message-length 512
-                                                    :portion 0.0
-                                                    :progress-sample-interval-ms (* 1000 60 5)
-                                                    :retry-limit 5}
-                           default-uri-config {:cache true
-                                               :executable true
-                                               :extract false}
-                           executor-uri-configured (and (:uri executor)
-                                                        (-> executor (get-in [:uri :value]) str/blank? not))]
-                       (when-not executor-uri-configured
-                         (log/info "Executor uri value is missing, the uri config will be disabled" {:executor executor}))
-                       (let [base-executor-config (merge default-executor-config executor)]
-                         (if executor-uri-configured
-                           (update base-executor-config :uri #(merge default-uri-config %1))
-                           (dissoc base-executor-config :uri)))))))
-     :mesos-datomic-uri (fnk [[:config [:database datomic-uri]]]
-                          (when-not datomic-uri
-                            (throw (ex-info "Must set a the :database's :datomic-uri!" {})))
-                          datomic-uri)
-     :hostname (fnk [[:config {hostname (.getCanonicalHostName (java.net.InetAddress/getLocalHost))}]]
-                 hostname)
-     :leader-reports-unhealthy (fnk [[:config [:mesos {leader-reports-unhealthy false}]]]
-                                 leader-reports-unhealthy)
-     :local-zk-port (fnk [[:config [:zookeeper {local-port 3291}]]]
-                      local-port)
-     :zookeeper-server (fnk [[:config [:zookeeper {local? false}]] local-zk-port]
-                         (when local?
-                           (log/info "Created local ZooKeeper; not yet started")
-                           (org.apache.curator.test.TestingServer. local-zk-port false)))
-     :zookeeper (fnk [[:config [:zookeeper {local? false} {connection nil}]] local-zk-port]
-                  (cond
-                    local? (str "localhost:" local-zk-port)
-                    connection connection
-                    :else (throw (ex-info "Must specify a zookeeper connection" {}))))
-     :task-constraints (fnk [[:config [:scheduler {task-constraints nil}]]]
-                         ;; Trying to pick conservative defaults
-                         (merge
-                           {:timeout-hours 1
-                            :timeout-interval-minutes 1
-                            :retry-limit 20
-                            :memory-gb 12
-                            :cpus 4}
-                           task-constraints))
-     :offer-incubate-time-ms (fnk [[:config [:scheduler {offer-incubate-ms 15000}]]]
-                               offer-incubate-ms)
-     :offer-cache (fnk [[:config [:scheduler {offer-cache nil}]]]
-                    (merge
-                      {:max-size 2000
-                       :ttl-ms 15000}
-                      offer-cache))
-     :mea-culpa-failure-limit (fnk [[:config [:scheduler {mea-culpa-failure-limit nil}]]]
-                                mea-culpa-failure-limit)
-     :fenzo-max-jobs-considered (fnk [[:config [:scheduler {fenzo-max-jobs-considered 1000}]]]
-                                  fenzo-max-jobs-considered)
-     :fenzo-scaleback (fnk [[:config [:scheduler {fenzo-scaleback 0.95}]]]
-                        fenzo-scaleback)
-     :fenzo-floor-iterations-before-warn (fnk [[:config [:scheduler {fenzo-floor-iterations-before-warn 10}]]]
-                                           fenzo-floor-iterations-before-warn)
-     :fenzo-floor-iterations-before-reset (fnk [[:config [:scheduler {fenzo-floor-iterations-before-reset 1000}]]]
-                                            fenzo-floor-iterations-before-reset)
-     :fenzo-fitness-calculator (fnk [[:config [:scheduler {fenzo-fitness-calculator default-fitness-calculator}]]]
-                                 fenzo-fitness-calculator)
-     :mesos-gpu-enabled (fnk [[:config [:mesos {enable-gpu-support false}]]]
-                          (boolean enable-gpu-support))
-     :good-enough-fitness (fnk [[:config [:scheduler {good-enough-fitness 0.8}]]]
-                            good-enough-fitness)
-     :mesos-master (fnk [[:config [:mesos master]]]
-                     master)
-     :mesos-master-hosts (fnk [[:config [:mesos master {master-hosts nil}]]]
-                           (if master-hosts
-                             (if (and (sequential? master-hosts) (every? string? master-hosts))
-                               master-hosts
-                               (throw (ex-info ":mesos-master should be a list of hostnames (e.g. [\"host1.example.com\", ...])" {})))
-                             (->> master
-                                  (re-seq #"[/|,]?([^/,:]+):\d+")
-                                  (mapv second))))
-     :mesos-failover-timeout (fnk [[:config [:mesos {failover-timeout-ms nil}]]]
-                               failover-timeout-ms)
-     :mesos-leader-path (fnk [[:config [:mesos leader-path]]]
-                          leader-path)
-     :mesos-principal (fnk [[:config [:mesos {principal nil}]]]
-                        principal)
-     :mesos-role (fnk [[:config [:mesos {role "*"}]]]
-                   role)
-     :mesos-framework-name (fnk [[:config [:mesos {framework-name "Cook"}]]]
-                             framework-name)
-     :mesos-framework-id (fnk [[:config [:mesos {framework-id nil}]]]
-                           framework-id)
-     ;:riemann-metrics (fnk [[:config [:metrics {riemann nil}]]]
-     ;                  (when riemann
-     ;                    (when-not (= 4 (count (select-keys riemann [:host :port])))
-     ;                      (throw (ex-info "You must specify the riemann :host and :port!" riemann)))
-     ;                    ((lazy-load-var 'cook.reporter/riemann-reporter) riemann)))
-     :jmx-metrics (fnk [[:config [:metrics {jmx false}]]]
-                    (when jmx
-                      ((lazy-load-var 'cook.reporter/jmx-reporter))))
-     :graphite-metrics (fnk [[:config [:metrics {graphite nil}]]]
-                         (when graphite
-                           (when-not (:host graphite)
-                             (throw (ex-info "You must specify the graphite host!" {:graphite graphite})))
-                           (let [config (merge {:port 2003 :pickled? true} graphite)]
-                             ((lazy-load-var 'cook.reporter/graphite-reporter) config))))
-     :progress (fnk [[:config {progress nil}]]
-                 (merge {:batch-size 100
-                         :pending-threshold 4000
-                         :publish-interval-ms 2500
-                         :sequence-cache-threshold 1000}
-                        progress))
-     :riemann (fnk [[:config [:metrics {riemann nil}]]]
-                riemann)
-     :riemann-metrics (fnk [[:config [:metrics {riemann nil}]]]
-                        (when riemann
-                          (when-not (:host riemann)
-                            (throw (ex-info "You must specific the :host to send the riemann metrics to!" {:riemann riemann})))
-                          (when-not (every? string? (:tags riemann))
-                            (throw (ex-info "Riemann tags must be a [\"list\", \"of\", \"strings\"]" riemann)))
-                          (let [config (merge {:port 5555
-                                               :local-host (.getHostName
-                                                             (java.net.InetAddress/getLocalHost))}
-                                              riemann)]
-                            ((lazy-load-var 'cook.reporter/riemann-reporter) config))))
-     :console-metrics (fnk [[:config [:metrics {console false}]]]
-                        (when console
-                          ((lazy-load-var 'cook.reporter/console-reporter))))
-
-     :user-metrics-interval-seconds (fnk [[:config [:metrics {user-metrics-interval-seconds 20}]]]
-                                      user-metrics-interval-seconds)
-
-     :rebalancer (fnk [[:config {rebalancer nil}]]
-                   (merge {:interval-seconds 300
-                           :dru-scale 1.0}
-                          rebalancer))
-                       
-     :optimizer (fnk [[:config {optimizer nil}]]
-                     (let [optimizer-config
-                           (merge {:host-feed {:create-fn 'cook.mesos.optimizer/create-dummy-host-feed
-                                               :config {}}
-                                   :optimizer {:create-fn 'cook.mesos.optimizer/create-dummy-optimizer
-                                               :config {}}
-                                   :optimizer-interval-seconds 30}
-                                  optimizer)]
-                       optimizer-config))
-
-     :nrepl-server (fnk [[:config [:nrepl {enabled? false} {port 0}]]]
-                     (when enabled?
-                       (when (zero? port)
-                         (throw (ex-info "You enabled nrepl but didn't configure a port. Please configure a port in your config file." {})))
-                       ((lazy-load-var 'clojure.tools.nrepl.server/start-server) :port port)))}))
-
-(defn init-logger
-  ([] (init-logger {:levels {"datomic.db" :warn
-                             "datomic.peer" :warn
-                             "datomic.kv-cluster" :warn
-                             "com.netflix.fenzo.AssignableVMs" :warn
-                             "com.netflix.fenzo.TaskScheduler" :warn
-                             "com.netflix.fenzo.AssignableVirtualMachine" :warn}}))
-  ([{:keys [file] :or {file "log/cook.log"} {:keys [default] :or {default :info} :as overrides} :levels}]
-   (try
-     (.. (org.apache.log4j.Logger/getRootLogger)
-         (getLoggerRepository)
-         (resetConfiguration))
-     ;; This lets you inspect which loggers have which appenders turned on
-     ;;(clojure.pprint/pprint (map #(select-keys % [:allAppenders :name]) (log4j-conf/get-loggers)))
-     (let [overrides (->> overrides
-                          (filter (comp string? key))
-                          (mapcat (fn [[logger level]]
-                                    [[logger] {:level level}])))]
-       (apply log4j-conf/set-loggers!
-              (org.apache.log4j.Logger/getRootLogger)
-              {:out (org.apache.log4j.DailyRollingFileAppender.
-                      (org.apache.log4j.PatternLayout.
-                        "%d{ISO8601} %-5p %c [%t] - %m%n")
-                      file
-                      "'.'yyyy-MM-dd")
-               :level default}
-              overrides))
-     (catch Throwable t
-       (.println System/err "Failed to initialize logging!")
-       (stacktrace/print-cause-trace t)
-       (println "Exiting.")
-       (System/exit 1)))))
-
-(def pre-configuration
-  "This configures logging and exception handling, to make the configuration phase simpler to understand"
-  (graph/eager-compile
-    {:exception-handler (fnk [[:config [:unhandled-exceptions {log-level :error} {email nil}]] logging]
-                          ((lazy-load-var 'cook.util/install-email-on-exception-handler) log-level email))
-     :logging (fnk [[:config log]]
-                (init-logger log))}))
-
-(defn- env [name]
-  (System/getenv name))
-
-(defn read-edn-config [config]
-  (edn/read-string
-    {:readers
-     {'config/env #(env %)
-      'config/env-int-default (fn [[variable default]]
-                                (if-let [value (env variable)]
-                                  (Integer/parseInt value)
-                                  default))
-      'config/env-int #(Integer/parseInt (env %))
-      'config/env-bool #(Boolean/valueOf (env %))}}
-    config))
-
 (defn -main
-  [config & args]
-  (println "Cook" @util/version "( commit" @util/commit ")")
-  (when-not (.exists (java.io.File. config))
-    (.println System/err (str "The config file doesn't appear to exist: " config)))
-  (.println System/err (str "Reading config from file:" config))
+  "Entry point for Cook. Initializes configuration settings,
+  instruments the JVM, and starts up the scheduler and API."
+  [config]
   (try
-    (let [config-format (try
-                          (com.google.common.io.Files/getFileExtension config)
-                          (catch Throwable t
-                            (.println System/err "Failed to start Cook")
-                            (stacktrace/print-cause-trace t)
-                            (println "Exiting.")
-                            (System/exit 1)))
-          literal-config (try
-                           {:config
-                            (case config-format
-                              "edn" (read-edn-config (slurp config))
-                              (do
-                                (.println System/err (str "Invalid config file format " config-format))
-                                (System/exit 1)))}
-                           (catch Throwable t
-                             (.println System/err "Failed to start Cook")
-                             (stacktrace/print-cause-trace t)
-                             (println "Exiting.")
-                             (System/exit 1)))]
-      (pre-configuration literal-config)
-      (.println System/err "Configured logging")
-      (log/info "Configured logging")
-      (log/info "Cook" @util/version "( commit" @util/commit ")")
-      (metrics-jvm/instrument-jvm)
-      (let [settings {:settings (config-settings literal-config)}
-            _ (log/info "Interpreted settings")
-            server (scheduler-server settings)]
-        (intern 'user 'main-graph server)
-        (log/info "Started cook, stored variable in user/main-graph")))
+    (let [settings (config/init-settings config)
+          _ (metrics-jvm/instrument-jvm)
+          server (scheduler-server settings)]
+      (intern 'user 'main-graph server)
+      (log/info "Started Cook, stored variable in user/main-graph"))
     (catch Throwable t
       (log/error t "Failed to start Cook")
       (System/exit 1))))
-
-(comment
-  ;; Here are some helpful fragments for changing debug levels, especially with datomic
-  (require 'datomic.api)
-  (log4j-conf/set-logger! :level :debug)
-
-  (do
-    (log4j-conf/set-loggers! (org.apache.log4j.Logger/getRootLogger)
-                             {:level :info :out (org.apache.log4j.FileAppender.
-                                                  (org.apache.log4j.PatternLayout.
-                                                    "%d{ISO8601} %-5p %c [%t] - %m%n")
-                                                  "debug.log")}
-                             ["datomic.peer"]
-                             {:level :warn})
-    (log/info "confirm we're online"))
-
-  (log4j-conf/set-loggers! (org.apache.log4j.Logger/getRootLogger)
-                           {:level :info :out (org.apache.log4j.ConsoleAppender.
-                                                (org.apache.log4j.PatternLayout.
-                                                  "%d{ISO8601} %-5p %c [%t] - %m%n"))}
-                           ["datomic.peer"]
-                           {:level :warn}))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -288,7 +288,7 @@
 (defn -main
   "Entry point for Cook. Initializes configuration settings,
   instruments the JVM, and starts up the scheduler and API."
-  [config]
+  [config & _]
   (try
     (let [settings (config/init-settings config)
           _ (metrics-jvm/instrument-jvm)

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -18,7 +18,6 @@
             [clojure.tools.logging :as log]
             [compojure.core :refer (GET POST routes context)]
             [compojure.route :as route]
-            [congestion.limits :refer (RateLimit)]
             [congestion.middleware :refer (wrap-rate-limit ip-rate-limit)]
             [congestion.storage :as storage]
             [cook.config :as config]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -20,12 +20,12 @@
             [clojure.stacktrace :as stacktrace]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [congestion.limits :refer (RateLimit)]
             [cook.impersonation :refer (impersonation-authorized-wrapper)]
             [cook.util :as util]
             [plumbing.core :refer (fnk)]
             [plumbing.graph :as graph])
   (:import (com.google.common.io Files)
-           (congestion.limits RateLimit)
            (java.net InetAddress)
            (org.apache.log4j DailyRollingFileAppender Logger PatternLayout)))
 

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -1,0 +1,353 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.config
+  (:require [clj-logging-config.log4j :as log4j-conf]
+            [clj-time.core :as t]
+            [clojure.edn :as edn]
+            [clojure.stacktrace :as stacktrace]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [cook.impersonation :refer (impersonation-authorized-wrapper)]
+            [cook.util :as util]
+            [plumbing.core :refer (fnk)]
+            [plumbing.graph :as graph])
+  (:import (com.google.common.io Files)
+           (congestion.limits RateLimit)
+           (java.net InetAddress)
+           (org.apache.log4j DailyRollingFileAppender Logger PatternLayout)))
+
+(defn- env [name]
+  (System/getenv name))
+
+(defn read-edn-config [config]
+  (edn/read-string
+    {:readers
+     {'config/env #(env %)
+      'config/env-int-default (fn [[variable default]]
+                                (if-let [value (env variable)]
+                                  (Integer/parseInt value)
+                                  default))
+      'config/env-int #(Integer/parseInt (env %))
+      'config/env-bool #(Boolean/valueOf (env %))}}
+    config))
+
+(defn init-logger
+  ([] (init-logger {:levels {"datomic.db" :warn
+                             "datomic.peer" :warn
+                             "datomic.kv-cluster" :warn
+                             "com.netflix.fenzo.AssignableVMs" :warn
+                             "com.netflix.fenzo.TaskScheduler" :warn
+                             "com.netflix.fenzo.AssignableVirtualMachine" :warn}}))
+  ([{:keys [file] :or {file "log/cook.log"} {:keys [default] :or {default :info} :as overrides} :levels}]
+   (try
+     (.. (Logger/getRootLogger)
+         (getLoggerRepository)
+         (resetConfiguration))
+     (let [overrides (->> overrides
+                          (filter (comp string? key))
+                          (mapcat (fn [[logger level]]
+                                    [[logger] {:level level}])))]
+       (apply log4j-conf/set-loggers!
+              (Logger/getRootLogger)
+              {:out (DailyRollingFileAppender.
+                      (PatternLayout.
+                        "%d{ISO8601} %-5p %c [%t] - %m%n")
+                      file
+                      "'.'yyyy-MM-dd")
+               :level default}
+              overrides))
+     (catch Throwable t
+       (.println System/err "Failed to initialize logging!")
+       (stacktrace/print-cause-trace t)
+       (throw t)))))
+
+(def pre-configuration
+  "This configures logging and exception handling, to make the configuration phase simpler to understand"
+  (graph/eager-compile
+    {:exception-handler (fnk [[:config [:unhandled-exceptions {log-level :error} {email nil}]] logging]
+                             ((util/lazy-load-var 'cook.util/install-email-on-exception-handler) log-level email))
+     :logging (fnk [[:config log]]
+                   (init-logger log))}))
+
+(def default-authorization {:authorization-fn 'cook.authorization/open-auth})
+(def default-fitness-calculator "com.netflix.fenzo.plugins.BinPackingFitnessCalculators/cpuMemBinPacker")
+
+(defrecord UserRateLimit [id quota ttl]
+  RateLimit
+  (get-key [self req]
+    (str (.getName (type self)) id "-" (:authorization/user req)))
+  (get-quota [self req]
+    quota)
+  (get-ttl [self req]
+    ttl))
+
+(def config-settings
+  "Parses the settings out of a config file"
+  (graph/eager-compile
+    {:agent-query-cache (fnk [[:config {agent-query-cache nil}]]
+                          (merge
+                            {:max-size 5000
+                             :ttl-ms (* 60 1000)}
+                            agent-query-cache))
+     :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
+                       (merge
+                         {:max-consecutive-sync-failure 15
+                          :publish-batch-size 100
+                          :publish-interval-ms 2500
+                          ;; The default should ideally be lower than the agent-query-cache ttl-ms
+                          :sync-interval-ms 15000}
+                         sandbox-syncer))
+     :server-port (fnk [[:config port]]
+                    port)
+     :is-authorized-fn (fnk [[:config {authorization-config default-authorization}]]
+                         (let [auth-fn @(util/lazy-load-var 'cook.authorization/is-authorized?)]
+                           ; we only wrap the authorization function if we have impersonators configured
+                           (if (-> authorization-config :impersonators seq)
+                             (impersonation-authorized-wrapper auth-fn authorization-config)
+                             (partial auth-fn authorization-config))))
+     :authorization-middleware (fnk [[:config [:authorization {one-user false} {kerberos false} {http-basic false}]]]
+                                 (cond
+                                   http-basic
+                                   (let [validation (get http-basic :validation :none)
+                                         user-password-valid?
+                                         ((util/lazy-load-var 'cook.basic-auth/make-user-password-valid?) validation http-basic)]
+                                     (log/info "Using http basic authorization with validation" validation)
+                                     (with-meta
+                                       ((util/lazy-load-var 'cook.basic-auth/create-http-basic-middleware) user-password-valid?)
+                                       {:json-value "http-basic"}))
+
+                                   one-user
+                                   (do
+                                     (log/info "Using single user authorization")
+                                     (with-meta
+                                       (fn one-user-middleware [h]
+                                         (fn one-user-auth-wrapper [req]
+                                           (h (assoc req :authorization/user one-user))))
+                                       {:json-value "one-user"}))
+
+                                   kerberos
+                                   (do
+                                     (log/info "Using kerberos middleware")
+                                     (with-meta
+                                       @(util/lazy-load-var 'cook.spnego/require-gss)
+                                       {:json-value "kerberos"}))
+                                   :else (throw (ex-info "Missing authorization configuration" {}))))
+     :impersonation-middleware (fnk [[:config {authorization-config nil}]]
+                                 (let [{impersonators :impersonators} authorization-config]
+                                   (with-meta
+                                     ((util/lazy-load-var 'cook.impersonation/create-impersonation-middleware) impersonators)
+                                     {:json-value "config-impersonation"})))
+     :rate-limit (fnk [[:config {rate-limit nil}]]
+                   (let [{:keys [user-limit-per-m]
+                          :or {user-limit-per-m 600}} rate-limit]
+                     {:user-limit (->UserRateLimit :user-limit user-limit-per-m (t/minutes 1))}))
+     :sim-agent-path (fnk [] "/usr/bin/sim-agent")
+     :executor (fnk [[:config {executor {}}]]
+                 (if (str/blank? (:command executor))
+                   (do
+                     (log/info "Executor config is missing command, will use the command executor by default"
+                               {:executor-config executor})
+                     {})
+                   (do
+                     (when-let [environment (:environment executor)]
+                       (when-not (and (map? environment)
+                                      (every? string? (keys environment))
+                                      (every? string? (vals environment)))
+                         (throw (ex-info "Executor environment must be a map from string to string!" {:executor executor}))))
+                     (when (and (:portion executor) (not (<= 0 (:portion executor) 1)))
+                       (throw (ex-info "Executor portion must be in the range [0, 1]!" {:executor executor})))
+                     (let [default-executor-config {:default-progress-regex-string "progress:\\s+([0-9]*\\.?[0-9]+)($|\\s+.*)"
+                                                    :environment {}
+                                                    :log-level "INFO"
+                                                    :max-message-length 512
+                                                    :portion 0.0
+                                                    :progress-sample-interval-ms (* 1000 60 5)
+                                                    :retry-limit 5}
+                           default-uri-config {:cache true
+                                               :executable true
+                                               :extract false}
+                           executor-uri-configured (and (:uri executor)
+                                                        (-> executor (get-in [:uri :value]) str/blank? not))]
+                       (when-not executor-uri-configured
+                         (log/info "Executor uri value is missing, the uri config will be disabled" {:executor executor}))
+                       (let [base-executor-config (merge default-executor-config executor)]
+                         (if executor-uri-configured
+                           (update base-executor-config :uri #(merge default-uri-config %1))
+                           (dissoc base-executor-config :uri)))))))
+     :mesos-datomic-uri (fnk [[:config [:database datomic-uri]]]
+                          (when-not datomic-uri
+                            (throw (ex-info "Must set a the :database's :datomic-uri!" {})))
+                          datomic-uri)
+     :hostname (fnk [[:config {hostname (.getCanonicalHostName (InetAddress/getLocalHost))}]]
+                 hostname)
+     :leader-reports-unhealthy (fnk [[:config [:mesos {leader-reports-unhealthy false}]]]
+                                 leader-reports-unhealthy)
+     :local-zk-port (fnk [[:config [:zookeeper {local-port 3291}]]]
+                      local-port)
+     :zookeeper-server (fnk [[:config [:zookeeper {local? false}]] local-zk-port]
+                         (when local?
+                           (log/info "Created local ZooKeeper; not yet started")
+                           (org.apache.curator.test.TestingServer. local-zk-port false)))
+     :zookeeper (fnk [[:config [:zookeeper {local? false} {connection nil}]] local-zk-port]
+                  (cond
+                    local? (str "localhost:" local-zk-port)
+                    connection connection
+                    :else (throw (ex-info "Must specify a zookeeper connection" {}))))
+     :task-constraints (fnk [[:config [:scheduler {task-constraints nil}]]]
+                         ;; Trying to pick conservative defaults
+                         (merge
+                           {:timeout-hours 1
+                            :timeout-interval-minutes 1
+                            :retry-limit 20
+                            :memory-gb 12
+                            :cpus 4}
+                           task-constraints))
+     :offer-incubate-time-ms (fnk [[:config [:scheduler {offer-incubate-ms 15000}]]]
+                               offer-incubate-ms)
+     :offer-cache (fnk [[:config [:scheduler {offer-cache nil}]]]
+                    (merge
+                      {:max-size 2000
+                       :ttl-ms 15000}
+                      offer-cache))
+     :mea-culpa-failure-limit (fnk [[:config [:scheduler {mea-culpa-failure-limit nil}]]]
+                                mea-culpa-failure-limit)
+     :fenzo-max-jobs-considered (fnk [[:config [:scheduler {fenzo-max-jobs-considered 1000}]]]
+                                  fenzo-max-jobs-considered)
+     :fenzo-scaleback (fnk [[:config [:scheduler {fenzo-scaleback 0.95}]]]
+                        fenzo-scaleback)
+     :fenzo-floor-iterations-before-warn (fnk [[:config [:scheduler {fenzo-floor-iterations-before-warn 10}]]]
+                                           fenzo-floor-iterations-before-warn)
+     :fenzo-floor-iterations-before-reset (fnk [[:config [:scheduler {fenzo-floor-iterations-before-reset 1000}]]]
+                                            fenzo-floor-iterations-before-reset)
+     :fenzo-fitness-calculator (fnk [[:config [:scheduler {fenzo-fitness-calculator default-fitness-calculator}]]]
+                                 fenzo-fitness-calculator)
+     :mesos-gpu-enabled (fnk [[:config [:mesos {enable-gpu-support false}]]]
+                          (boolean enable-gpu-support))
+     :good-enough-fitness (fnk [[:config [:scheduler {good-enough-fitness 0.8}]]]
+                            good-enough-fitness)
+     :mesos-master (fnk [[:config [:mesos master]]]
+                     master)
+     :mesos-master-hosts (fnk [[:config [:mesos master {master-hosts nil}]]]
+                           (if master-hosts
+                             (if (and (sequential? master-hosts) (every? string? master-hosts))
+                               master-hosts
+                               (throw (ex-info ":mesos-master should be a list of hostnames (e.g. [\"host1.example.com\", ...])" {})))
+                             (->> master
+                                  (re-seq #"[/|,]?([^/,:]+):\d+")
+                                  (mapv second))))
+     :mesos-failover-timeout (fnk [[:config [:mesos {failover-timeout-ms nil}]]]
+                               failover-timeout-ms)
+     :mesos-leader-path (fnk [[:config [:mesos leader-path]]]
+                          leader-path)
+     :mesos-principal (fnk [[:config [:mesos {principal nil}]]]
+                        principal)
+     :mesos-role (fnk [[:config [:mesos {role "*"}]]]
+                   role)
+     :mesos-framework-name (fnk [[:config [:mesos {framework-name "Cook"}]]]
+                             framework-name)
+     :mesos-framework-id (fnk [[:config [:mesos {framework-id nil}]]]
+                           framework-id)
+     :jmx-metrics (fnk [[:config [:metrics {jmx false}]]]
+                    (when jmx
+                      ((util/lazy-load-var 'cook.reporter/jmx-reporter))))
+     :graphite-metrics (fnk [[:config [:metrics {graphite nil}]]]
+                         (when graphite
+                           (when-not (:host graphite)
+                             (throw (ex-info "You must specify the graphite host!" {:graphite graphite})))
+                           (let [config (merge {:port 2003 :pickled? true} graphite)]
+                             ((util/lazy-load-var 'cook.reporter/graphite-reporter) config))))
+     :progress (fnk [[:config {progress nil}]]
+                 (merge {:batch-size 100
+                         :pending-threshold 4000
+                         :publish-interval-ms 2500
+                         :sequence-cache-threshold 1000}
+                        progress))
+     :riemann (fnk [[:config [:metrics {riemann nil}]]]
+                riemann)
+     :riemann-metrics (fnk [[:config [:metrics {riemann nil}]]]
+                        (when riemann
+                          (when-not (:host riemann)
+                            (throw (ex-info "You must specific the :host to send the riemann metrics to!" {:riemann riemann})))
+                          (when-not (every? string? (:tags riemann))
+                            (throw (ex-info "Riemann tags must be a [\"list\", \"of\", \"strings\"]" riemann)))
+                          (let [config (merge {:port 5555
+                                               :local-host (.getHostName
+                                                             (InetAddress/getLocalHost))}
+                                              riemann)]
+                            ((util/lazy-load-var 'cook.reporter/riemann-reporter) config))))
+     :console-metrics (fnk [[:config [:metrics {console false}]]]
+                        (when console
+                          ((util/lazy-load-var 'cook.reporter/console-reporter))))
+
+     :user-metrics-interval-seconds (fnk [[:config [:metrics {user-metrics-interval-seconds 20}]]]
+                                      user-metrics-interval-seconds)
+
+     :rebalancer (fnk [[:config {rebalancer nil}]]
+                   (merge {:interval-seconds 300
+                           :dru-scale 1.0}
+                          rebalancer))
+
+     :optimizer (fnk [[:config {optimizer nil}]]
+                  (let [optimizer-config
+                        (merge {:host-feed {:create-fn 'cook.mesos.optimizer/create-dummy-host-feed
+                                            :config {}}
+                                :optimizer {:create-fn 'cook.mesos.optimizer/create-dummy-optimizer
+                                            :config {}}
+                                :optimizer-interval-seconds 30}
+                               optimizer)]
+                    optimizer-config))
+
+     :nrepl-server (fnk [[:config [:nrepl {enabled? false} {port 0}]]]
+                     (when enabled?
+                       (when (zero? port)
+                         (throw (ex-info "You enabled nrepl but didn't configure a port. Please configure a port in your config file." {})))
+                       ((util/lazy-load-var 'clojure.tools.nrepl.server/start-server) :port port)))}))
+
+(defn init-settings
+  "Given a config file path, parses the file and initializes and returns the settings map"
+  [config]
+  (println "Cook" @util/version "( commit" @util/commit ")")
+  (when-not (.exists (java.io.File. config))
+    (.println System/err (str "The config file doesn't appear to exist: " config)))
+  (.println System/err (str "Reading config from file: " config))
+  (try
+    (let [config-format (try
+                          (Files/getFileExtension config)
+                          (catch Throwable t
+                            (.println System/err "Failed to get config file extension")
+                            (stacktrace/print-cause-trace t)
+                            (throw t)))
+          literal-config (try
+                           {:config
+                            (case config-format
+                              "edn" (read-edn-config (slurp config))
+                              (do
+                                (.println System/err (str "Invalid config file format " config-format))
+                                (throw (ex-info "Invalid config file format" {:config-format config-format}))))}
+                           (catch Throwable t
+                             (.println System/err "Failed to read edn config")
+                             (stacktrace/print-cause-trace t)
+                             (throw t)))]
+      (pre-configuration literal-config)
+      (.println System/err "Configured logging")
+      (log/info "Configured logging")
+      (log/info "Cook" @util/version "( commit" @util/commit ")")
+      (let [settings {:settings (config-settings literal-config)}]
+        (log/info "Interpreted settings")
+        settings))
+    (catch Throwable t
+      (log/error t "Failed to initialize settings")
+      (throw t))))

--- a/scheduler/src/cook/impersonation.clj
+++ b/scheduler/src/cook/impersonation.clj
@@ -50,7 +50,7 @@
     [^String user
      ^Keyword verb
      ^String impersonator
-     {:keys [owner item] :as object}]
+     {:keys [item] :as object}]
     (log/debug "[is-impersonatable?] Checking whether user" impersonator
                "may impersonate user" user
                "performing" verb "on" (str object) "...")

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -24,7 +24,7 @@
             [clojure.edn :as edn]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [cook.components :refer (default-fitness-calculator)]
+            [cook.config :refer (default-fitness-calculator)]
             [cook.datomic :refer (transact-with-retries)]
             [cook.mesos.constraints :as constraints]
             [cook.mesos.dru :as dru]

--- a/scheduler/src/cook/scratch.clj
+++ b/scheduler/src/cook/scratch.clj
@@ -165,3 +165,25 @@
             reason (:reason/name (rand-nth (cook.mesos.reason/all-known-reasons (db conn))))]
         (create-job conn host instance-status start-time end-time reason :user user :job-state :job.state/completed)))
     (range 100)))
+
+(comment
+  ;; Here are some helpful fragments for changing debug levels, especially with datomic
+  (require 'datomic.api)
+  (log4j-conf/set-logger! :level :debug)
+
+  (do
+    (log4j-conf/set-loggers! (org.apache.log4j.Logger/getRootLogger)
+                             {:level :info :out (org.apache.log4j.FileAppender.
+                                                  (org.apache.log4j.PatternLayout.
+                                                    "%d{ISO8601} %-5p %c [%t] - %m%n")
+                                                  "debug.log")}
+                             ["datomic.peer"]
+                             {:level :warn})
+    (log/info "confirm we're online"))
+
+  (log4j-conf/set-loggers! (org.apache.log4j.Logger/getRootLogger)
+                           {:level :info :out (org.apache.log4j.ConsoleAppender.
+                                                (org.apache.log4j.PatternLayout.
+                                                  "%d{ISO8601} %-5p %c [%t] - %m%n"))}
+                           ["datomic.peer"]
+                           {:level :warn}))

--- a/scheduler/test/cook/test/components.clj
+++ b/scheduler/test/cook/test/components.clj
@@ -1,3 +1,18 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns cook.test.components
   (:require [clojure.test :refer :all]
             [cook.components :as components]))
@@ -34,11 +49,3 @@
         (swap! leadership-atom (constantly true))
         (is (= "Called handler!" (middleware {:uri "/real-request"})))))))
 
-(deftest test-read-edn-config
-  (is (= {} (components/read-edn-config "{}")))
-  (is (= {:foo 1} (components/read-edn-config "{:foo 1}")))
-  (with-redefs [components/env (constantly "something")]
-    (is (= {:master "something"} (components/read-edn-config "{:master #config/env \"MESOS_MASTER\"}"))))
-  (with-redefs [components/env (constantly "12345")]
-    (is (= {:port "12345"} (components/read-edn-config "{:port #config/env \"COOK_PORT\"}")))
-    (is (= {:port 12345} (components/read-edn-config "{:port #config/env-int \"COOK_PORT\"}")))))

--- a/scheduler/test/cook/test/config.clj
+++ b/scheduler/test/cook/test/config.clj
@@ -1,0 +1,27 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.test.config
+  (:require [clojure.test :refer :all]
+            [cook.config :as config]))
+
+(deftest test-read-edn-config
+  (is (= {} (config/read-edn-config "{}")))
+  (is (= {:foo 1} (config/read-edn-config "{:foo 1}")))
+  (with-redefs [config/env (constantly "something")]
+    (is (= {:master "something"} (config/read-edn-config "{:master #config/env \"MESOS_MASTER\"}"))))
+  (with-redefs [config/env (constantly "12345")]
+    (is (= {:port "12345"} (config/read-edn-config "{:port #config/env \"COOK_PORT\"}")))
+    (is (= {:port 12345} (config/read-edn-config "{:port #config/env-int \"COOK_PORT\"}")))))

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -22,7 +22,7 @@
             [clojure.string :as str]
             [clojure.walk :refer [keywordize-keys]]
             [cook.authorization :as auth]
-            [cook.components :as components]
+            [cook.config :as config]
             [cook.impersonation :as imp]
             [cook.mesos.api :as api]
             [cook.mesos.reason :as reason]
@@ -1321,7 +1321,7 @@
   (let [socket (ServerSocket.)]
     (is (= {:foo (str socket)} (api/stringify {:foo socket})))
     (.close socket))
-  (let [settings (components/config-settings (minimal-config))]
+  (let [settings (config/config-settings (minimal-config))]
     (is (thrown? JsonGenerationException (cheshire/generate-string settings)))
     (is (cheshire/generate-string (api/stringify settings)))))
 

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1702,7 +1702,7 @@
   (testing "java class on classpath"
     (is (instance? VMTaskFitnessCalculator
                    (sched/config-string->fitness-calculator
-                     cook.components/default-fitness-calculator))))
+                     cook.config/default-fitness-calculator))))
 
   (testing "bad input"
     (is (thrown? IllegalArgumentException (sched/config-string->fitness-calculator "not-a-valid-anything"))))

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -14,7 +14,7 @@
             [clojure.tools.logging :as log]
             [clojure.walk :refer (keywordize-keys)]
             [com.rpl.specter :refer (transform ALL MAP-VALS MAP-KEYS select FIRST)]
-            [cook.components :refer (init-logger)]
+            [cook.config :refer (init-logger)]
             [cook.mesos :as c]
             [cook.mesos.mesos-mock :as mm]
             [cook.mesos.share :as share]


### PR DESCRIPTION
## Changes proposed in this PR

- `lazy-load-var` was defined twice (once in `cook.components`, again in `cook.util`), consolidating
- moving all config-related code from `cook.components` to the new `cook.config`
- deleting some dead code

## Why are we making these changes?

For readability / organization. Having all of the config code in one place makes it easier to read the code.