### PR TITLE
cs: adds logging for the iteration where the rebalance was a no-op

### DIFF
--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -550,7 +550,7 @@
                           rebalancer-reservation-atom
                           (assoc params :category :gpu
                                         :compute-pending-job-dru compute-pending-gpu-job-dru)))
-            (log/info "Rebalance iteration is a no-op"
+            (log/info "Skipping rebalancing due to low cluster utilization"
                       {:mesos-utilization (str utilization)
                        :min-utilization-threshold (str min-utilization-threshold)}))))
       {:error-handler (fn [ex] (log/error ex "Rebalance failed"))})


### PR DESCRIPTION
## Changes proposed in this PR

- log when the rebalance was a no-op
- minor refactoring to sort keys and remove unused values

## Why are we making these changes?

Helps us quickly identify why a rebalance iteration was a no-op.

