### PR TITLE
cs: adds support for Mesos run-as-user

### DIFF
--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -136,6 +136,11 @@ We'll look at the configurable options in turn:
   This sets the role that Cook will connect to Mesos with. Default: `*`
   You can omit this property unless you've enabled security features in Mesos. The value should be in authorized list for the current `:principal` in `register_frameworks` Action in Mesos Authorization file. See http://mesos.apache.org/documentation/latest/authorization/ for details.
 
+`:run-as-user`::
+  When configured, this sets the user that Cook will override and set as the user to run tasks on Mesos with.
+  You can omit this property, in which case the user configured in the job will be used as user to run specific jobs on Mesos.
+  Cook's scheduling algorithm continues to use the user specified in the job to compute job schedules.
+
 `:framework-name`::
   This sets part of the name of the framework that Cook will register to Mesos. Default: Cook
   When connecting to Mesos, Cook will use a framework name like "YourFrameworkName-e254483".  It will append the current git hash to the value you specify here.

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -138,7 +138,7 @@ We'll look at the configurable options in turn:
 
 `:run-as-user`::
   When configured, this sets the user that Cook will override and set as the user to run tasks on Mesos with.
-  You can omit this property, in which case the user configured in the job will be used as user to run specific jobs on Mesos.
+  You can omit this property, in which case the user configured in the job will be used as the user to run the job (the default behavior).
   Cook's scheduling algorithm continues to use the user specified in the job to compute job schedules.
 
 `:framework-name`::

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -76,8 +76,8 @@
                            fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback
                            good-enough-fitness hostname mea-culpa-failure-limit mesos-failover-timeout mesos-framework-name
                            mesos-gpu-enabled mesos-leader-path mesos-master mesos-master-hosts mesos-principal
-                           mesos-role offer-incubate-time-ms optimizer progress rebalancer server-port task-constraints
-                           user-metrics-interval-seconds]
+                           mesos-role mesos-run-as-user offer-incubate-time-ms optimizer progress rebalancer server-port
+                           task-constraints user-metrics-interval-seconds]
                           curator-framework framework-id mesos-datomic mesos-datomic-mult mesos-leadership-atom
                           mesos-offer-cache mesos-pending-jobs-atom sandbox-syncer-state]
                       (log/info "Initializing mesos scheduler")
@@ -110,6 +110,7 @@
                              :mesos-datomic-mult mesos-datomic-mult
                              :mesos-leadership-atom mesos-leadership-atom
                              :mesos-pending-jobs-atom mesos-pending-jobs-atom
+                             :mesos-run-as-user mesos-run-as-user
                              :offer-cache mesos-offer-cache
                              :offer-incubate-time-ms offer-incubate-time-ms
                              :optimizer-config optimizer

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -259,6 +259,10 @@
                         principal)
      :mesos-role (fnk [[:config [:mesos {role "*"}]]]
                    role)
+     :mesos-run-as-user (fnk [[:config [:mesos {run-as-user nil}]]]
+                          (when run-as-user
+                            (log/info "Tasks launched in Mesos will ignore user specified in the job and run as" run-as-user))
+                          run-as-user)
      :mesos-framework-name (fnk [[:config [:mesos {framework-name "Cook"}]]]
                              framework-name)
      :mesos-framework-id (fnk [[:config [:mesos {framework-id nil}]]]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -261,7 +261,7 @@
                    role)
      :mesos-run-as-user (fnk [[:config [:mesos {run-as-user nil}]]]
                           (when run-as-user
-                            (log/info "Tasks launched in Mesos will ignore user specified in the job and run as" run-as-user))
+                            (log/warn "Tasks launched in Mesos will ignore user specified in the job and run as" run-as-user))
                           run-as-user)
      :mesos-framework-name (fnk [[:config [:mesos {framework-name "Cook"}]]]
                              framework-name)

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -195,7 +195,7 @@
    user-metrics-interval-seconds -- long, time in seconds between collecting and counting per-user job metrics"
   [{:keys [curator-framework executor-config fenzo-config framework-id get-mesos-utilization gpu-enabled? make-mesos-driver-fn
            mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom mesos-pending-jobs-atom
-           offer-cache offer-incubate-time-ms optimizer-config progress-config rebalancer-config
+           mesos-run-as-user offer-cache offer-incubate-time-ms optimizer-config progress-config rebalancer-config
            sandbox-syncer-state server-config task-constraints trigger-chans user-metrics-interval-seconds zk-prefix]}]
   (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
                 fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness]} fenzo-config
@@ -233,6 +233,7 @@
                                           :gpu-enabled? gpu-enabled?
                                           :heartbeat-ch mesos-heartbeat-chan
                                           :mea-culpa-failure-limit mea-culpa-failure-limit
+                                          :mesos-run-as-user mesos-run-as-user
                                           :offer-cache offer-cache
                                           :offer-incubate-time-ms offer-incubate-time-ms
                                           :pending-jobs-atom mesos-pending-jobs-atom

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1529,8 +1529,10 @@
                                             category->pending-jobs-atom (atom category->pending-jobs)
                                             user->usage (or user->usage {test-user {:count 1, :cpus 2, :mem 1024, :gpus 0}})
                                             user->quota (or user-quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}})
-                                            result (sched/handle-resource-offers! conn driver fenzo framework-id executor category->pending-jobs-atom (init-offer-cache)
-                                                                                  user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom)]
+                                            mesos-run-as-user nil
+                                            result (sched/handle-resource-offers!
+                                                     conn driver fenzo framework-id executor category->pending-jobs-atom mesos-run-as-user
+                                                     user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom)]
                                         (async/>!! offers-chan :end-marker)
                                         result))]
 

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -138,6 +138,7 @@
           :mesos-datomic-mult mesos-mult#
           :mesos-leadership-atom mesos-leadership-atom#
           :mesos-pending-jobs-atom pending-jobs-atom#
+          :mesos-run-as-user nil
           :offer-cache offer-cache#
           :offer-incubate-time-ms offer-incubate-time-ms#
           :optimizer-config optimizer-config#


### PR DESCRIPTION

## Changes proposed in this PR

- this sets the user that Cook will override and set as the user to run tasks on Mesos with

## Why are we making these changes?

Allows us to mimic submitting jobs from many users.

