### PR TITLE
Fixes support for cs cat on a binary file

### DIFF
--- a/cli/cook/mesos.py
+++ b/cli/cook/mesos.py
@@ -81,3 +81,19 @@ def read_file(instance, sandbox_dir, path, offset=None, length=None):
         raise Exception('Could not read the file.')
 
     return resp.json()
+
+
+def download_file(instance, sandbox_dir, path):
+    """Calls the Mesos agent files/download API for the given path"""
+    logging.info(f'downloading file from sandbox {sandbox_dir} with path {path}')
+    agent_url = instance_to_agent_url(instance)
+    params = {'path': os.path.join(sandbox_dir, path)}
+    resp = http.__get(f'{agent_url}/files/download', params=params, stream=True)
+    if resp.status_code == 404:
+        raise Exception(f"Cannot download '{path}' (file was not found).")
+
+    if resp.status_code != 200:
+        logging.error(f'mesos agent returned status code {resp.status_code} and body {resp.text}')
+        raise Exception('Could not download the file.')
+
+    return resp

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -1,23 +1,20 @@
 import argparse
 import logging
+import sys
 from functools import partial
 
-from cook.mesos import read_file
+from cook.mesos import download_file
 from cook.querying import parse_entity_refs, query_unique_and_run, parse_entity_ref
 from cook.util import guard_no_cluster
 
 
 def cat_for_instance(instance, sandbox_dir, path):
     """Outputs the contents of the Mesos sandbox path for the given instance."""
-    read = partial(read_file, instance=instance, sandbox_dir=sandbox_dir, path=path)
-    offset = 0
-    chunk_size = 4096
-    data = read(offset=offset, length=chunk_size)['data']
+    resp = download_file(instance, sandbox_dir, path)
     try:
-        while len(data) > 0:
-            print(data, end='')
-            offset = offset + len(data)
-            data = read(offset=offset, length=chunk_size)['data']
+        for data in resp.iter_content(chunk_size=4096):
+            if data:
+                sys.stdout.buffer.write(data)
     except BrokenPipeError as bpe:
         logging.exception(bpe)
 

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -16,6 +16,7 @@ def cat_for_instance(instance, sandbox_dir, path):
             if data:
                 sys.stdout.buffer.write(data)
     except BrokenPipeError as bpe:
+        sys.stderr.close()
         logging.exception(bpe)
 
 

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.4.1'
+VERSION = '1.5.0'

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1610,6 +1610,18 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual('hello\nworld\n' * 5, cli.decode(cp.stdout))
         self.assertEqual('', cli.decode(cp.stderr))
 
+    def test_cat_binary_file(self):
+        cp, uuids = cli.submit('bash -c \''
+                               'for i in {0..255}; do num=$(printf "%x" $i); echo -n -e "\\x$num"; done > file.bin'
+                               '\'',
+                               self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp = cli.wait(uuids, self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp = cli.cat(uuids[0], 'file.bin', self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertEqual(bytes(i for i in range(0, 256)), cp.stdout)
+
     def test_usage(self):
         command = 'sleep 300'
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding `mesos.download_file` for calling the Mesos `files/download` endpoint
- changing `cat` to use `mesos.download_file`
- adding an integration test for `cat`ing a binary file

## Why are we making these changes?

Sometimes you just need to `cat` a binary file. 

The Mesos `files/read` endpoint [assumes UTF-8 encoding of file contents](https://issues.apache.org/jira/browse/MESOS-8103).