### PR TITLE
WIP: Incremental pending jobs while ranking

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -145,7 +145,7 @@
                    ; library instead of the datomic-free library, by
                    ; using a profiles.clj file that defines a profile
                    ; which pulls in datomic-pro
-                   [com.datomic/datomic-free "0.9.5206"
+                   [com.datomic/datomic-free "0.9.5390"
                     :exclusions [com.fasterxml.jackson.core/jackson-core
                                  joda-time
                                  org.slf4j/jcl-over-slf4j

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -1351,7 +1351,7 @@
 
 (defn filter-offensive-jobs
   "Base on the constraints on memory and cpus, given a list of job entities it
-   puts the offensive jobs into offensive-job-ch asynchronically and returns
+   puts the offensive jobs into offensive-job-ch asynchronously and returns
    the inoffensive jobs.
 
    A job is offensive if and only if its required memory or cpus exceeds the
@@ -1365,10 +1365,10 @@
           is-offensive? (partial is-offensive? max-memory-mb max-cpus)
           inoffensive (remove is-offensive? jobs)
           offensive (filter is-offensive? jobs)]
-      ;; Put offensive jobs asynchronically such that it could return the
-      ;; inoffensive jobs immediately.
-      (async/go
-        (when (seq offensive)
+      (when (seq offensive)
+        ;; Put offensive jobs asynchronously such that it could return the
+        ;; inoffensive jobs immediately.
+        (async/go
           (log/info "Found" (count offensive) "offensive jobs")
           (async/>! offensive-jobs-ch offensive)))
       inoffensive)))
@@ -1377,7 +1377,7 @@
   "It returns an async channel which will be used to receive offensive jobs expected
    to be killed / aborted.
 
-   It asynchronically pulls offensive jobs from the channel and abort these
+   It asynchronously pulls offensive jobs from the channel and abort these
    offensive jobs by marking job state as completed."
   [conn]
   (let [offensive-jobs-ch (async/chan (async/sliding-buffer 256))]

--- a/scheduler/test/cook/test/benchmark.clj
+++ b/scheduler/test/cook/test/benchmark.clj
@@ -41,17 +41,19 @@
     (dotimes [_ 10000]
       (create-running-job conn "abc" :user (pick-user) :job-state :job.state/running))
     (testing "rank-jobs"
-      (let [db (d/db conn)
+      (let [conn-db (d/db conn)
+            conn-log (d/log conn)
             task-constraints {:memory-gb 100 :cpus 30}
             offensive-jobs-ch (sched/make-offensive-job-stifler conn)
             offensive-job-filter (partial sched/filter-offensive-jobs task-constraints offensive-jobs-ch)]
         (println "============ rank-jobs timing ============")
-        (cc/quick-bench (sched/rank-jobs db offensive-job-filter))))
+        (cc/quick-bench (sched/rank-jobs conn-log conn-db offensive-job-filter))))
     (testing "rank-jobs minus offensive-job-filter"
-      (let [db (d/db conn)
+      (let [conn-db (d/db conn)
+            conn-log (d/log conn)
             offensive-job-filter identity]
         (println "============ rank-jobs minus offensive-job-filter timing ============")
-        (cc/quick-bench (sched/rank-jobs db offensive-job-filter))))
+        (cc/quick-bench (sched/rank-jobs conn-log conn-db offensive-job-filter))))
     (testing "sort-jobs-by-dru-helper"
       (let [db (d/db conn)
             pending-task-ents (util/get-pending-job-ents db)

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -606,7 +606,7 @@
         offensive-job-filter (partial sched/filter-offensive-jobs constraints offensive-jobs-ch)]
     (is (= {:normal (list (util/job-ent->map job-entity-2))
             :gpu ()}
-           (sched/rank-jobs test-db offensive-job-filter)))))
+           (:category->jobs (sched/rank-jobs test-db offensive-job-filter))))))
 
 (deftest test-virtual-machine-lease-adapter
   ;; ensure that the VirtualMachineLeaseAdapter can successfully handle an offer from Mesomatic.

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -599,6 +599,7 @@
                                    :memory (* 1024 (- (:memory-gb constraints) 2.0))
                                    :ncpus (- (:cpus constraints) 1.0))
         test-db (d/db conn)
+        test-log (d/log conn)
         job-entity-1 (d/entity test-db job-id-1)
         job-entity-2 (d/entity test-db job-id-2)
         jobs [job-entity-1 job-entity-2]
@@ -606,7 +607,7 @@
         offensive-job-filter (partial sched/filter-offensive-jobs constraints offensive-jobs-ch)]
     (is (= {:normal (list (util/job-ent->map job-entity-2))
             :gpu ()}
-           (:category->jobs (sched/rank-jobs test-db offensive-job-filter))))))
+           (:category->jobs (sched/rank-jobs test-log test-db offensive-job-filter))))))
 
 (deftest test-virtual-machine-lease-adapter
   ;; ensure that the VirtualMachineLeaseAdapter can successfully handle an offer from Mesomatic.


### PR DESCRIPTION
## Changes proposed in this PR

- incremental loading of pending jobs by the ranker
- changes to `chime-at-ch` that support state in the `go-loop`

## Why are we making these changes?

To optimize the ranking time by minimizing the get pending jobs time. Uses the Datomic Log API (support added in the in-memory database) to query transactions and find new jobs.

## TODO: Performance comparison

