### PR TITLE
Cleanly handles invalid time range on /stats/instances

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1931,3 +1931,5 @@ class CookTest(unittest.TestCase):
         self.assertEqual(200, resp.status_code)
         _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-01-01', end='2018-02-02')
         self.assertEqual(400, resp.status_code)
+        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-01-01', end='2017-12-31')
+        self.assertEqual(400, resp.status_code)

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -2189,8 +2189,7 @@
                           (or (tf/parse s)
                               (tc/from-long (Long/parseLong s))))
              start-time (parse-time start)
-             end-time (parse-time end)
-             interval (t/interval start-time end-time)]
+             end-time (parse-time end)]
          (cond
            (not (allowed-instance-statuses status))
            [true {::error (str "unsupported status " status ", must be one of: " allowed-instance-statuses)}]
@@ -2200,8 +2199,11 @@
                   (str "unsupported name filter " name
                        ", can only contain alphanumeric characters, '.', '-', '_', and '*' as a wildcard")}]
 
-           (< 31 (t/in-days interval))
-           [true {::error (str "time interval " interval ", must be less than or equal to 31 days")}]
+           (not (t/after? end-time start-time))
+           [true {::error "end time must be after start time"}]
+
+           (< 31 (t/in-days (t/interval start-time end-time)))
+           [true {::error (str "time interval must be less than or equal to 31 days")}]
 
            :else
            (try


### PR DESCRIPTION
## Changes proposed in this PR

- checking for `(not (t/after? end-time start-time))` on `/stats/instances`
- adding an integration test case for it

## Why are we making these changes?

Currently you get a 500 and an unhelpful error message.