### PR TITLE
Adds support for including custom executor jobs in /jobs

### DIFF
--- a/executor/tests/test_subprocess.py
+++ b/executor/tests/test_subprocess.py
@@ -35,6 +35,10 @@ def find_process_ids_in_group(group_id):
 
 
 class SubprocessTest(unittest.TestCase):
+    # FIXME - remove the xfail mark once the issue with this test failing is resolved:
+    # https://github.com/twosigma/Cook/issues/737
+    @pytest.mark.xfail
+    @unittest.skip('This test fails occasionally')
     def test_kill_task_terminate_with_sigterm(self):
         task_id = tu.get_random_task_id()
 

--- a/executor/tests/test_subprocess.py
+++ b/executor/tests/test_subprocess.py
@@ -5,6 +5,7 @@ import time
 import unittest
 
 import collections
+import pytest
 
 import cook.subprocess as cs
 import tests.utils as tu

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -2041,7 +2041,7 @@
                                 ::limit (parse-int-default limit Integer/MAX_VALUE)
                                 ::end-ms (parse-long-default end-ms (System/currentTimeMillis))
                                 ::name-filter-fn (name-filter-str->name-filter-fn name)
-                                ::include-custom-executor? (Boolean/parseBoolean include-custom-executor)}]
+                                ::include-custom-executor? (Boolean/valueOf ^String include-custom-executor)}]
                         (catch NumberFormatException e
                           [true {::error (.toString e)}])))))
     :allowed? (fn [ctx]

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -171,8 +171,8 @@
                       (catch Exception e
                         (log/debug e "Error reading a string from mesos status data. Is it in the format we expect?")))))})
 
-(defn update-reason-histos!
-  "Updates histograms for run time, cpu time, and memory time,
+(defn update-reason-metrics!
+  "Updates histograms and counters for run time, cpu time, and memory time,
   where the histograms have the failure reason in the title"
   [db mesos-reason instance-runtime {:keys [cpus mem]}]
   (let [reason (->> mesos-reason
@@ -180,14 +180,20 @@
                     (d/entity db)
                     :reason/name
                     name)
-        update-histo! (fn update-histo! [s v]
-                        (histograms/update!
-                          (histograms/histogram
-                            ["cook-mesos" "scheduler" "hist-task-fail" reason s])
-                          v))]
-    (update-histo! "times" instance-runtime)
-    (update-histo! "cpu-times" (* instance-runtime cpus))
-    (update-histo! "mem-times" (* instance-runtime mem))))
+        update-metrics! (fn update-metrics! [s v]
+                          (histograms/update!
+                            (histograms/histogram
+                              ["cook-mesos" "scheduler" "hist-task-fail" reason s])
+                            v)
+                          (counters/inc!
+                            (counters/counter
+                              ["cook-mesos" "scheduler" "hist-task-fail" reason s "total"])
+                            v))
+        instance-runtime-seconds (/ instance-runtime 1000)
+        mem-gb (/ mem 1024)]
+    (update-metrics! "times" instance-runtime-seconds)
+    (update-metrics! "cpu-times" (* instance-runtime-seconds cpus))
+    (update-metrics! "mem-times" (* instance-runtime-seconds mem-gb))))
 
 (defn handle-status-update
   "Takes a status update from mesos."
@@ -253,7 +259,7 @@
                                         job-resources
                                         instance-runtime)
              (when-not previous-reason
-               (update-reason-histos! db reason instance-runtime job-resources)))
+               (update-reason-metrics! db reason instance-runtime job-resources)))
            ;; This code kills any task that "shouldn't" be running
            (when (and
                    (or (nil? instance) ; We could know nothing about the task, meaning a DB error happened and it's a waste to finish

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -375,7 +375,7 @@
                (filter #(= :job.state/completed (:job/state %))))]
       (->>
         (cond->> jobs
-                 (not include-custom-executor?) (remove :job/custom-executor)
+                 (not include-custom-executor?) (filter #(false? (:job/custom-executor %)))
                  (instance-states state) (filter #(= state (job-ent->state %)))
                  name-filter-fn (filter #(name-filter-fn (:job/name %))))
         (take limit)))))
@@ -412,7 +412,7 @@
                   db user state-keyword start end)
                (map (partial d/entity db))))]
     (cond->> jobs
-             (not include-custom-executor?) (remove :job/custom-executor)
+             (not include-custom-executor?) (filter #(false? (:job/custom-executor %)))
              name-filter-fn (filter #(name-filter-fn (:job/name %)))
              (and include-custom-executor? (= :job.state/waiting state-keyword)) (remove uncommitted?))))
 

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1519,7 +1519,7 @@
     (is (= 201 (:status (submit-job handler "alice" "carol"))))
     (is (= 403 (:status (submit-job handler "bob" "carol"))))))
 
-(defn list-jobs
+(defn list-jobs-with-list
   "Simulates a call to the /list endpoint with the given query params"
   [handler user state start-ms end-ms include-custom-executor?]
   (response->body-data (handler {:request-method :get
@@ -1532,6 +1532,20 @@
                                                 "end-ms" (str end-ms)
                                                 "include-custom-executor" (str include-custom-executor?)}})))
 
+(defn list-jobs-with-jobs
+  "Simulates a call to the /jobs endpoint with the given query params"
+  [handler user states start-ms end-ms]
+  (let [response (handler {:request-method :get
+                           :scheme :http
+                           :uri "/jobs"
+                           :authorization/user "user"
+                           :query-params {"user" user
+                                          "state" states
+                                          "start" (str start-ms)
+                                          "end" (str end-ms)}})]
+    (is (= 200 (:status response)))
+    (response->body-data response)))
+
 (deftest test-list-jobs-by-time
   (let [conn (restore-fresh-database! "datomic:mem://test-list-jobs")
         handler (basic-handler conn)
@@ -1541,7 +1555,7 @@
                                                                        :authorization/user "user"
                                                                        :query-params {"job" %}})))
                                  "submit_time")
-        list-jobs-fn #(list-jobs handler "user" "running+waiting+completed" %1 %2 nil)
+        list-jobs-fn #(list-jobs-with-list handler "user" "running+waiting+completed" %1 %2 nil)
         response-1 (submit-job handler "user")
         _ (is (= 201 (:status response-1)))
         _ (Thread/sleep 10)
@@ -1560,19 +1574,17 @@
   (let [conn (restore-fresh-database! "datomic:mem://test-list-jobs-include-custom-executor")
         handler (basic-handler conn)
         before (t/now)
-        list-jobs-fn #(list-jobs handler "user" "running+waiting+completed" (.getMillis before) (.getMillis (t/now)) %)
+        list-jobs-fn #(list-jobs-with-jobs handler "user" ["running" "waiting" "completed"]
+                                           (.getMillis before) (.getMillis (t/now)))
         response-1 (submit-job handler "user")
-        response-2 (submit-job handler "user")]
-    @(d/transact conn [[:db/add [:job/uuid (UUID/fromString (:uuid response-1))] :job/custom-executor true]])
+        response-2 (submit-job handler "user")
+        _ @(d/transact conn [[:db/add [:job/uuid (UUID/fromString (:uuid response-1))] :job/custom-executor true]])
+        jobs (list-jobs-fn)]
     (is (= 201 (:status response-2)))
     (is (= 201 (:status response-1)))
-    (is (= 1 (count (list-jobs-fn nil))))
-    (is (= 1 (count (list-jobs-fn false))))
-    (is (= 2 (count (list-jobs-fn true))))
-    (is (= (:uuid response-2) (-> (list-jobs-fn nil) first (get "uuid"))))
-    (is (= (:uuid response-2) (-> (list-jobs-fn false) first (get "uuid"))))
-    (is (= (:uuid response-2) (-> (list-jobs-fn true) first (get "uuid"))))
-    (is (= (:uuid response-1) (-> (list-jobs-fn true) second (get "uuid"))))))
+    (is (= 2 (count jobs)))
+    (is (= (:uuid response-2) (-> jobs first (get "uuid"))))
+    (is (= (:uuid response-1) (-> jobs second (get "uuid"))))))
 
 (deftest test-name-filter-str->name-filter-pattern
   (is (= (str #".*") (str (api/name-filter-str->name-filter-pattern "***"))))

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1584,7 +1584,14 @@
     (is (= 201 (:status response-1)))
     (is (= 2 (count jobs)))
     (is (= (:uuid response-2) (-> jobs first (get "uuid"))))
-    (is (= (:uuid response-1) (-> jobs second (get "uuid"))))))
+    (is (= (:uuid response-1) (-> jobs second (get "uuid"))))
+    (is (-> (d/entity (d/db conn) [:job/uuid (UUID/fromString (:uuid response-1))])
+            d/touch
+            :job/custom-executor))
+    (is (-> (d/entity (d/db conn) [:job/uuid (UUID/fromString (:uuid response-2))])
+            d/touch
+            :job/custom-executor
+            not))))
 
 (deftest test-name-filter-str->name-filter-pattern
   (is (= (str #".*") (str (api/name-filter-str->name-filter-pattern "***"))))

--- a/scheduler/test/cook/test/mesos/util.clj
+++ b/scheduler/test/cook/test/mesos/util.clj
@@ -379,35 +379,35 @@
                                    :custom-executor? false)
             _ (Thread/sleep 5)
             half-way-time (Date.)
-            job3 (create-dummy-job conn
-                                   :user "u2"
-                                   :job-state state
-                                   :submit-time (Date.)
-                                   :custom-executor? false)
+            _ (create-dummy-job conn
+                                :user "u2"
+                                :job-state state
+                                :submit-time (Date.)
+                                :custom-executor? false)
             _ (Thread/sleep 5)
-            job4 (create-dummy-job conn
-                                   :user "u1"
-                                   :job-state state
-                                   :submit-time (Date.)
-                                   :custom-executor? false)
+            _ (create-dummy-job conn
+                                :user "u1"
+                                :job-state state
+                                :submit-time (Date.)
+                                :custom-executor? false)
             _ (Thread/sleep 5)
             end-time (Date.)
             states [(name state)]
             name (constantly true)]
         (testing (str "get " state " jobs")
-          (is (= 2 (count (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time half-way-time 10 name))))
-          (is (= 1 (count (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time half-way-time 1 name))))
-          (is (= (map :db/id (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time half-way-time 1 name))
+          (is (= 2 (count (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time half-way-time 10 name nil))))
+          (is (= 1 (count (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time half-way-time 1 name nil))))
+          (is (= (map :db/id (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time half-way-time 1 name nil))
                  [job1]))
-          (is (= 3 (count (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time end-time 10 name))))
-          (is (= 2 (count (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time end-time 2 name))))
-          (is (= (map :db/id (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time end-time 2 name))
+          (is (= 3 (count (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time end-time 10 name nil))))
+          (is (= 2 (count (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time end-time 2 name nil))))
+          (is (= (map :db/id (util/get-jobs-by-user-and-states (d/db conn) "u1" states start-time end-time 2 name nil))
                  [job1 job2]))
 
-          (is (= 1 (count (util/get-jobs-by-user-and-states (d/db conn) "u2" states start-time end-time 10 name))))
-          (is (= 0 (count (util/get-jobs-by-user-and-states (d/db conn) "u3" states start-time end-time 10 name))))
+          (is (= 1 (count (util/get-jobs-by-user-and-states (d/db conn) "u2" states start-time end-time 10 name nil))))
+          (is (= 0 (count (util/get-jobs-by-user-and-states (d/db conn) "u3" states start-time end-time 10 name nil))))
           (is (= 0 (count (util/get-jobs-by-user-and-states (d/db conn) "u1" states
-                                                            #inst "2017-06-01" #inst "2017-06-02" 10 name)))))))))
+                                                            #inst "2017-06-01" #inst "2017-06-02" 10 name nil)))))))))
 
 (deftest test-reducing-pipe
   (testing "basic piping"


### PR DESCRIPTION
## Changes proposed in this PR

- adding the ability to list jobs on `/jobs`
- `/jobs` will not filter out custom executor jobs

## Why are we making these changes?

We want to give users and tools the option of including custom executor jobs when listing (while maintaining backwards compatibility).
