### PR TITLE
Use d/squuid to derive task ID's do that they're more tightly clustered.

### DIFF
--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -609,7 +609,7 @@
    during the same Fenzo scheduling cycle as the newly created TaskRequest."
   [db job & {:keys [resources task-id assigned-resources guuid->considerable-cotask-ids reserved-hosts running-cotask-cache]
           :or {resources (util/job-ent->resources job)
-               task-id (str (java.util.UUID/randomUUID))
+               task-id (str (d/squuid))
                assigned-resources (atom nil)
                guuid->considerable-cotask-ids (constantly #{})
                running-cotask-cache (atom (cache/fifo-cache-factory {} :threshold 1))


### PR DESCRIPTION
## Changes proposed in this PR
- Change UUID generation for tasks to be more temporal.
- 
- 
- 

## Why are we making these changes?
Increases the hit rate and the locality for storage of these datomic ID's.

