### PR TITLE
Change JVM options. remove MaxPermSize and add +UseStringDeduplication

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -207,7 +207,9 @@
 
   :main cook.components
   :jvm-opts ["-Dpython.cachedir.skip=true"
-             "-XX:MaxPermSize=500M"
+             "-XX:+UseG1GC"
+             "-XX:+UseStringDeduplication"
+             "-XX:+PrintStringDeduplicationStatistics"
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"


### PR DESCRIPTION
## Changes proposed in this PR
Switch to G1GC and turn on string deduplication. 
Remove deprecated JDK option

## Why are we making these changes?
- In a test with a 500k jobs in queue, there were 92M strings in memory, with the char arrays accounting for a third of the heap.
- We have been using G1GC internally for a while, so expect that change to be safe.

