### PR TITLE
Guava 16.0 is incompatable with datomic cassandra bridge.

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -30,7 +30,7 @@
                  [com.rpl/specter "1.0.1"]
 
                  ;;Utility
-                 [com.google.guava/guava "16.0"]
+                 [com.google.guava/guava "17.0"]
                  [amalloy/ring-buffer "1.1"]
                  [listora/ring-congestion "0.1.2"]
                  [lonocloud/synthread "1.0.4"]


### PR DESCRIPTION
Upgrade to 17.0. This shows up in a lein repl. Outside of a lein repl,
you may or may not get a newer version based on how you handle
classpath construction.

## Changes proposed in this PR

- 
- 
- 

## Why are we making these changes?


