### PR TITLE
Fix an inconsistency between completed jobs and active/running jobs.

### DIFF
--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -372,7 +372,7 @@
                (filter #(<= (.getTime start) (.getTime (:job/submit-time %))))
                (filter #(< (.getTime (:job/submit-time %)) (.getTime end)))
                (filter #(= :job.state/completed (:job/state %)))
-               (filter #(not (:job/custom-executor %))))]
+               (filter #(false? (:job/custom-executor %))))]
       (->>
         (cond->> jobs
                  (instance-states state) (filter #(= state (job-ent->state %)))


### PR DESCRIPTION
The database can have records that lack :job/custom-executor key entirely, 
In that case the API function for completed jobs use a filter predicate of (not #(:job/custom-executor %))
This predicate is inconsistent with the datomic query filter we use for waiting/running jobs. [?j :job/custom-executor false]. 

## Changes proposed in this PR
- We make completed jobs API function consistent with waiting/running jobs.

## Why are we making these changes?
- Make the two API functions consistent.
