### PR TITLE
New query functions (take 2)

### DIFF
--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -348,9 +348,8 @@
 (defn job-submit-time-between
   "Returns true if the job-ent's :job/submit-time is between start-ms (inclusive) and
   end-ms (exclusive)"
-  [job-ent ^long start-ms ^long end-ms]
-  (let [^Date submit-time (:job/submit-time job-ent)
-        submit-ms (.getTime submit-time)]
+  [{^Date submit-time :job/submit-time} ^long start-ms ^long end-ms]
+  (let [submit-ms (.getTime submit-time)]
                     (and (<= start-ms submit-ms)
                          (< submit-ms end-ms))))
 

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -348,7 +348,7 @@
 (defn job-submit-time-between
   "Returns true if the job-ent's :job/submit-time is between start-ms (inclusive) and
   end-ms (exclusive)"
-  [{^Date submit-time :job/submit-time} ^long start-ms ^long end-ms]
+  [{:keys [^Date job/submit-time]} ^long start-ms ^long end-ms]
   (let [submit-ms (.getTime submit-time)]
                     (and (<= start-ms submit-ms)
                          (< submit-ms end-ms))))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -405,6 +405,7 @@
 ;; expanded start
 ;; This differs from get-active-jobs-by-user-and-state as it
 ;; is also looking up based on task state.
+;; This is about O(# jobs user submitted in the given time range)
 (defn get-completed-jobs-by-user
   "Returns all completed job entities for a particular user
    in the specified timeframe. Supports looking up based

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -344,7 +344,7 @@
 (def ^:const job-states #{"running" "waiting" "completed"})
 (def ^:const instance-states #{"success" "failed"})
 
-;; get-jobs-by-user-and-state-and-submit-by-state is a bit opaque
+;; get-jobs-by-user-and-state-and-submit is a bit opaque
 ;; because it is reaching into datomic internals. Here is a quick explanation.
 ;; seek-datoms provides a pointer into the raw datomic indices
 ;; that we can then seek through. We set the pointer to look

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -363,7 +363,7 @@
 ;; created at expanded start. This works because the submission
 ;; time (which we sort on) is correlated with the entitiy id.
 ;; We then seek through the list of all jobs in that state,
-;; then filtering to the target user.
+;; then filtering to the target user (which is cached).
 ;;
 ;; This function is O(# jobs in that state in the time range)
 (defn get-jobs-by-user-and-state-and-submit

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -71,7 +71,8 @@
   (.invalidateAll util/job-ent->resources-cache)
   (.invalidateAll util/categorize-job-cache)
   (.invalidateAll util/task-ent->user-cache)
-  (.invalidateAll util/task->feature-vector-cache))
+  (.invalidateAll util/task->feature-vector-cache)
+  (.invalidateAll util/job-ent->user-cache))
 
 (defn restore-fresh-database!
   "Completely delete all data, start a fresh database and apply transactions if


### PR DESCRIPTION
Vastly improved query functions. I tested the new git-active-jobs-by-use-and-state on a few thousand production queries and it was identical each time. 

## Changes proposed in this PR
- get-active-jobs-by-user-and-state is rewritten on top of seek-datums and is vastly faster, I see up p50's 5x-100x faster. p95's are 2x-5x faster.
- get-completed-jobs-by-user has had small tweaks made to improve it; removing reflection and minimizing datomic queries.
- Collect a histogram of metrics of time-to-search, as a function of the time range being searched.

## Why are we making these changes?
- Much greater performance.
