### PR TITLE
Fixes bug with single-state /jobs requests

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -772,6 +772,13 @@ def list_jobs(cook_url, **kwargs):
     return resp
 
 
+def jobs(cook_url, **kwargs):
+    """Makes a request to the /jobs endpoint using the provided kwargs as the query params"""
+    query_params = urlencode(kwargs, doseq=True)
+    resp = session.get('%s/jobs?%s' % (cook_url, query_params))
+    return resp
+
+
 def contains_job_uuid(jobs, job_uuid):
     """Returns true if jobs contains a job with the given uuid"""
     return any(job for job in jobs if job['uuid'] == job_uuid)

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1188,13 +1188,14 @@
   "Returns a [true {::error ...}] pair if the request is malformed, and
   otherwise [false m], where m represents data that gets merged into the ctx"
   [ctx]
-  (let [{:strs [state user start end limit name]} (get-in ctx [:request :query-params])]
+  (let [{:strs [state user start end limit name]} (get-in ctx [:request :query-params])
+        states (wrap-seq state)]
     (cond
-      (not (and state user start end))
+      (not (and states user start end))
       [true {::error "must supply the state, user name, start time, and end time"}]
 
-      (not (set/superset? allowed-list-states state))
-      [true {::error (str "unsupported state in " state ", must be one of: " allowed-list-states)}]
+      (not (set/superset? allowed-list-states states))
+      [true {::error (str "unsupported state in " states ", must be one of: " allowed-list-states)}]
 
       (not (valid-name-filter? name))
       [true {::error
@@ -1203,7 +1204,7 @@
 
       :else
       (try
-        [false {::states (normalize-list-states state)
+        [false {::states (normalize-list-states states)
                 ::user user
                 ::start-ms (-> start ^DateTime util/parse-time .getMillis)
                 ::end-ms (-> end ^DateTime util/parse-time .getMillis)


### PR DESCRIPTION
## Changes proposed in this PR

- adding call to `wrap-seq` to properly handle `/jobs` queries with a single state
- adding an integration test to verify

## Why are we making these changes?

Currently if you pass a single state query param to `/jobs`, you get an error.
