### PR TITLE
ce: ensures the pymesos module is loaded in the setup process

### DIFF
--- a/executor/tests/conftest.py
+++ b/executor/tests/conftest.py
@@ -1,0 +1,10 @@
+# This file is automatically loaded and run by pytest during its setup process,
+# meaning it happens before any of the tests in this directory are run.
+# See the pytest documentation on conftest files for more information:
+# https://docs.pytest.org/en/2.7.3/plugins.html#conftest-py-plugins
+
+# Please see: https://github.com/twosigma/Cook/issues/749
+
+import pymesos as pm
+
+pm.encode_data((str({'foo': 'bar'}).encode('utf8')))


### PR DESCRIPTION
- please see https://github.com/twosigma/Cook/issues/749

## Changes proposed in this PR

- Loads pymesos module in conftest.py to avoid main thread errors

## Why are we making these changes?
To get more consistent builds

