### PR TITLE
jc: adds support for handling transaction timeouts during job submit

### DIFF
--- a/jobclient/src/test/java/com/twosigma/cook/jobclient/JobClientTest.java
+++ b/jobclient/src/test/java/com/twosigma/cook/jobclient/JobClientTest.java
@@ -19,24 +19,27 @@ package com.twosigma.cook.jobclient;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 
-import org.apache.http.client.HttpClient;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,51 +55,23 @@ import com.google.common.collect.Lists;
  */
 @RunWith(JMockit.class)
 public class JobClientTest {
-    private Job _initializedJob;
-    private Job _initializedImpersonatedJob;
 
-    private JobClient _client;
-
-    private JobListener _listener;
-
-    private static class MockHttpClient extends MockUp<JobClient> {
-        private String buildResponseMessage(HttpRequestBase request) {
-            final Header impersonationHeader = request.getFirstHeader(JobClient.COOK_IMPERSONATE_HEADER);
-            if (null != impersonationHeader) {
-                return String.format("test impersonated %s", impersonationHeader.getValue());
-            } else {
-                return "test reason";
-            }
-        }
-
-        @Mock
-        public HttpResponse executeWithRetries(HttpRequestBase request, int ignore1, long ignore2) throws IOException {
-            final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
-            final BasicHttpEntity httpEntity = new BasicHttpEntity();
-            httpEntity.setContent(IOUtils.toInputStream("hello", "UTF-8"));
-            final String msg = buildResponseMessage(request);
-            // Test http post for submitting jobs.
-            if (request instanceof HttpPost) {
-                final BasicStatusLine statusLine =
-                        new BasicStatusLine(protocolVersion, 201, msg);
-                final BasicHttpResponse response = new BasicHttpResponse(statusLine);
-                response.setEntity(httpEntity);
-                return response;
-            } else if (request instanceof HttpDelete) {
-                final BasicStatusLine statusLine =
-                        new BasicStatusLine(protocolVersion, 204, msg);
-                final BasicHttpResponse response = new BasicHttpResponse(statusLine);
-                response.setEntity(httpEntity);
-                return response;
-            } else {
-                return null;
-            }
+    private static String buildResponseMessage(HttpRequestBase request) {
+        final Header impersonationHeader = request.getFirstHeader(JobClient.COOK_IMPERSONATE_HEADER);
+        if (null != impersonationHeader) {
+            return String.format("test impersonated %s", impersonationHeader.getValue());
+        } else {
+            return "test reason";
         }
     }
 
+    private Job _initializedJob;
+    private Job _initializedImpersonatedJob;
+    private JobClient _client;
+    private JobListener _listener;
+
     @Before
     public void setup() throws URISyntaxException {
-        new MockHttpClient();
         final Job.Builder jobBuilder = new Job.Builder();
         jobBuilder.setUUID(UUID.randomUUID());
         jobBuilder.setCommand("sleep 10s");
@@ -121,18 +96,192 @@ public class JobClientTest {
                 }
             }
         };
-        _client = builder.setHost("127.0.0.1").setPort(80).setEndpoint("cook").build();
-
+        _client = builder.setHost("127.0.0.1").setPort(80).setEndpoint("cook").setSubmitRetryInterval(1).build();
     }
 
     @Test
-    public void test() throws JobClientException {
+    public void testJobSubmit() throws JobClientException {
+        // arrange
+        final AtomicInteger postCounter = new AtomicInteger(0);
+        new MockUp<JobClient>() {
+            @Mock
+            public HttpResponse executeWithRetries(HttpRequestBase request, int ignore1, long ignore2) throws IOException {
+                final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
+                final BasicHttpEntity httpEntity = new BasicHttpEntity();
+                httpEntity.setContent(IOUtils.toInputStream("hello", "UTF-8"));
+                final String msg = buildResponseMessage(request);
+                // Test http post for submitting jobs.
+                if (request instanceof HttpPost) {
+                    postCounter.incrementAndGet();
+                    final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 201, msg);
+                    final BasicHttpResponse response = new BasicHttpResponse(statusLine);
+                    response.setEntity(httpEntity);
+                    return response;
+                } else {
+                    return null;
+                }
+            }
+        };
+        // act
         _client.submit(Lists.newArrayList(_initializedJob), _listener);
+        // assert
+        Assert.assertEquals(1, postCounter.get());
+    }
+
+    @Test(expected = JobClientException.class)
+    public void testJobSubmitWithTransactionTimeoutAndFailingEmptyQuery() throws JobClientException {
+        // arrange
+        final AtomicInteger postCounter = new AtomicInteger(0);
+        final AtomicInteger queryCounter = new AtomicInteger(0);
+        new MockUp<JobClient>() {
+            @Mock
+            public HttpResponse executeWithRetries(HttpRequestBase request, int ignore1, long ignore2) throws IOException {
+                final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
+                final BasicHttpEntity httpEntity = new BasicHttpEntity();
+                final String msg = buildResponseMessage(request);
+                // Test http post for submitting jobs.
+                if (request instanceof HttpPost) {
+                    postCounter.incrementAndGet();
+                    final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 500, msg);
+                    final BasicHttpResponse response = new BasicHttpResponse(statusLine);
+                    httpEntity.setContent(IOUtils.toInputStream("Transaction timed out. {:db.error :db.error/transaction-timeout}", "UTF-8"));
+                    response.setEntity(httpEntity);
+                    return response;
+                } else {
+                    return null;
+                }
+            }
+
+            @Mock
+            public Map<UUID, Job> queryJobs(Collection<UUID> uuids) {
+                queryCounter.incrementAndGet();
+                Assert.assertEquals(1, uuids.size());
+                return new HashMap<>();
+            }
+        };
+        // act
+        _client.submit(Lists.newArrayList(_initializedJob), _listener);
+        // assert
+        Assert.assertEquals(1, postCounter.get());
+        Assert.assertEquals(1, queryCounter.get());
+    }
+
+    @Test(expected = JobClientException.class)
+    public void testJobSubmitWithTransactionTimeoutAndFailingInQuery() throws JobClientException {
+        // arrange
+        final AtomicInteger postCounter = new AtomicInteger(0);
+        final AtomicInteger queryCounter = new AtomicInteger(0);
+        new MockUp<JobClient>() {
+            @Mock
+            public HttpResponse executeWithRetries(HttpRequestBase request, int ignore1, long ignore2) throws IOException {
+                final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
+                final BasicHttpEntity httpEntity = new BasicHttpEntity();
+                final String msg = buildResponseMessage(request);
+                // Test http post for submitting jobs.
+                if (request instanceof HttpPost) {
+                    postCounter.incrementAndGet();
+                    final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 500, msg);
+                    final BasicHttpResponse response = new BasicHttpResponse(statusLine);
+                    httpEntity.setContent(IOUtils.toInputStream("Transaction timed out. {:db.error :db.error/transaction-timeout}", "UTF-8"));
+                    response.setEntity(httpEntity);
+                    return response;
+                } else {
+                    return null;
+                }
+            }
+
+            @Mock
+            public Map<UUID, Job> queryJobs(Collection<UUID> uuids) throws JobClientException {
+                queryCounter.incrementAndGet();
+                Assert.assertEquals(1, uuids.size());
+                throw new JobClientException("Exception thrown from test");
+            }
+        };
+        try {
+            // act
+            _client.submit(Lists.newArrayList(_initializedJob), _listener);
+        } finally {
+            // assert
+            Assert.assertEquals(1, postCounter.get());
+            Assert.assertEquals(1, queryCounter.get());
+        }
+    }
+
+    @Test
+    public void testJobSubmitWithTransactionTimeoutAndSucceeding() throws JobClientException {
+        // arrange
+        final AtomicInteger postCounter = new AtomicInteger(0);
+        final AtomicInteger queryCounter = new AtomicInteger(0);
+        new MockUp<JobClient>() {
+            @Mock
+            public HttpResponse executeWithRetries(HttpRequestBase request, int ignore1, long ignore2) throws IOException {
+                final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
+                final BasicHttpEntity httpEntity = new BasicHttpEntity();
+                final String msg = buildResponseMessage(request);
+                // Test http post for submitting jobs.
+                if (request instanceof HttpPost) {
+                    postCounter.incrementAndGet();
+                    final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 500, msg);
+                    final BasicHttpResponse response = new BasicHttpResponse(statusLine);
+                    httpEntity.setContent(IOUtils.toInputStream("Transaction timed out. {:db.error :db.error/transaction-timeout}", "UTF-8"));
+                    response.setEntity(httpEntity);
+                    return response;
+                } else {
+                    return null;
+                }
+            }
+
+            @Mock
+            public Map<UUID, Job> queryJobs(Collection<UUID> uuids) {
+                queryCounter.incrementAndGet();
+                Assert.assertEquals(1, uuids.size());
+                Map<UUID, Job> uuidToJob = new HashMap<UUID, Job>();
+                uuidToJob.put(_initializedJob.getUUID(), _initializedJob);
+                return uuidToJob;
+            }
+        };
+        // act
+        _client.submit(Lists.newArrayList(_initializedJob), _listener);
+        // assert
+        Assert.assertEquals(1, postCounter.get());
+        Assert.assertEquals(1, queryCounter.get());
     }
 
     @Test
     public void testImpersonation() throws JobClientException {
+        // arrange
+        final AtomicInteger deleteCounter = new AtomicInteger(0);
+        final AtomicInteger postCounter = new AtomicInteger(0);
+        new MockUp<JobClient>() {
+            @Mock
+            public HttpResponse executeWithRetries(HttpRequestBase request, int ignore1, long ignore2) throws IOException {
+                final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
+                final BasicHttpEntity httpEntity = new BasicHttpEntity();
+                httpEntity.setContent(IOUtils.toInputStream("hello", "UTF-8"));
+                final String msg = buildResponseMessage(request);
+                // Test http post for submitting jobs.
+                if (request instanceof HttpPost) {
+                    postCounter.incrementAndGet();
+                    final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 201, msg);
+                    final BasicHttpResponse response = new BasicHttpResponse(statusLine);
+                    response.setEntity(httpEntity);
+                    return response;
+                } else if (request instanceof HttpDelete) {
+                    deleteCounter.incrementAndGet();
+                    final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 204, msg);
+                    final BasicHttpResponse response = new BasicHttpResponse(statusLine);
+                    response.setEntity(httpEntity);
+                    return response;
+                } else {
+                    return null;
+                }
+            }
+        };
+        // act
         _client.impersonating("foo").submit(Lists.newArrayList(_initializedImpersonatedJob), _listener);
         _client.impersonating("foo").abort(Lists.newArrayList(_initializedImpersonatedJob.getUUID()));
+        // assert
+        Assert.assertEquals(1, deleteCounter.get());
+        Assert.assertEquals(1, postCounter.get());
     }
 }

--- a/jobclient/src/test/java/com/twosigma/cook/jobclient/JobClientTest.java
+++ b/jobclient/src/test/java/com/twosigma/cook/jobclient/JobClientTest.java
@@ -128,6 +128,23 @@ public class JobClientTest {
         Assert.assertEquals(1, postCounter.get());
     }
 
+    private HttpResponse executeAndReturnTransactionTimedOutError(HttpRequestBase request, AtomicInteger postCounter) throws IOException {
+        final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
+        final BasicHttpEntity httpEntity = new BasicHttpEntity();
+        final String msg = buildResponseMessage(request);
+        // Test http post for submitting jobs.
+        if (request instanceof HttpPost) {
+            postCounter.incrementAndGet();
+            final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 500, msg);
+            final BasicHttpResponse response = new BasicHttpResponse(statusLine);
+            httpEntity.setContent(IOUtils.toInputStream("Transaction timed out.", "UTF-8"));
+            response.setEntity(httpEntity);
+            return response;
+        } else {
+            return null;
+        }
+    }
+
     @Test(expected = JobClientException.class)
     public void testJobSubmitWithTransactionTimeoutAndFailingEmptyQuery() throws JobClientException {
         // arrange
@@ -136,20 +153,7 @@ public class JobClientTest {
         new MockUp<JobClient>() {
             @Mock
             public HttpResponse executeWithRetries(HttpRequestBase request, int ignore1, long ignore2) throws IOException {
-                final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
-                final BasicHttpEntity httpEntity = new BasicHttpEntity();
-                final String msg = buildResponseMessage(request);
-                // Test http post for submitting jobs.
-                if (request instanceof HttpPost) {
-                    postCounter.incrementAndGet();
-                    final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 500, msg);
-                    final BasicHttpResponse response = new BasicHttpResponse(statusLine);
-                    httpEntity.setContent(IOUtils.toInputStream("Transaction timed out. {:db.error :db.error/transaction-timeout}", "UTF-8"));
-                    response.setEntity(httpEntity);
-                    return response;
-                } else {
-                    return null;
-                }
+                return executeAndReturnTransactionTimedOutError(request, postCounter);
             }
 
             @Mock
@@ -174,20 +178,7 @@ public class JobClientTest {
         new MockUp<JobClient>() {
             @Mock
             public HttpResponse executeWithRetries(HttpRequestBase request, int ignore1, long ignore2) throws IOException {
-                final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
-                final BasicHttpEntity httpEntity = new BasicHttpEntity();
-                final String msg = buildResponseMessage(request);
-                // Test http post for submitting jobs.
-                if (request instanceof HttpPost) {
-                    postCounter.incrementAndGet();
-                    final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 500, msg);
-                    final BasicHttpResponse response = new BasicHttpResponse(statusLine);
-                    httpEntity.setContent(IOUtils.toInputStream("Transaction timed out. {:db.error :db.error/transaction-timeout}", "UTF-8"));
-                    response.setEntity(httpEntity);
-                    return response;
-                } else {
-                    return null;
-                }
+                return executeAndReturnTransactionTimedOutError(request, postCounter);
             }
 
             @Mock
@@ -215,20 +206,7 @@ public class JobClientTest {
         new MockUp<JobClient>() {
             @Mock
             public HttpResponse executeWithRetries(HttpRequestBase request, int ignore1, long ignore2) throws IOException {
-                final ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
-                final BasicHttpEntity httpEntity = new BasicHttpEntity();
-                final String msg = buildResponseMessage(request);
-                // Test http post for submitting jobs.
-                if (request instanceof HttpPost) {
-                    postCounter.incrementAndGet();
-                    final BasicStatusLine statusLine = new BasicStatusLine(protocolVersion, 500, msg);
-                    final BasicHttpResponse response = new BasicHttpResponse(statusLine);
-                    httpEntity.setContent(IOUtils.toInputStream("Transaction timed out. {:db.error :db.error/transaction-timeout}", "UTF-8"));
-                    response.setEntity(httpEntity);
-                    return response;
-                } else {
-                    return null;
-                }
+                return executeAndReturnTransactionTimedOutError(request, postCounter);
             }
 
             @Mock

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1529,7 +1529,11 @@
 
      :post! (partial create-jobs! conn)
      :handle-exception (fn [{:keys [exception]}]
-                         {:error (str "Exception occurred while creating job - " (.getMessage exception))})
+                         (if (str/includes? (str (.getMessage exception)) "db.error/transaction-timeout")
+                           {:error (str "Transaction timed out."
+                                        " Your jobs may not have been created successfully."
+                                        " Please query your jobs and check whether they were created successfully.")}
+                           {:error (str "Exception occurred while creating job - " (.getMessage exception))}))
      :handle-created (fn [ctx] (::results ctx))}))
 
 (defn retrieve-groups

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1529,7 +1529,7 @@
 
      :post! (partial create-jobs! conn)
      :handle-exception (fn [{:keys [exception]}]
-                         (if (str/includes? (str (.getMessage exception)) "db.error/transaction-timeout")
+                         (if (str/includes? (str (.getMessage exception)) "Transaction timed out.")
                            {:error (str "Transaction timed out."
                                         " Your jobs may not have been created successfully."
                                         " Please query your jobs and check whether they were created successfully.")}


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for handling transaction timeouts during job submit

## Why are we making these changes?

If we know that jobs have been created successfully despite reporting a transaction timeout, we should respond with a success.


### Example logs:
```
DEBUG [main]: Response String for submitting jobs{...} is {"error":"Exception occurred while creating job - :db.error/transaction-timeout Transaction timed out."}
WARN  [main]: POST experienced transaction timeout via uri http://127.0.0.1:12321/rawscheduler
INFO  [main]: Sleeping 10000ms to allow transaction opportunity to complete
INFO  [main]: Verifying if all the jobs were created despite the transaction timeout message
INFO  [main]: All 100 jobs were created despite the transaction timeout message
```

```
DEBUG [main]: Response String for submitting jobs{...} is {"error":"Exception occurred while creating job - :db.error/transaction-timeout Transaction timed out."}
WARN  [main]: POST experienced transaction timeout via uri http://127.0.0.1:12321/rawscheduler
INFO  [main]: Sleeping 10000ms to allow transaction opportunity to complete
INFO  [main]: Verifying if all the jobs were created despite the transaction timeout message
ERROR [main]: POST failed: all queried jobs were not found: The response of GET request [job=...] via uri http://127.0.0.1:12321/rawscheduler: Not Found, 404
ERROR [main]: Failed to submit jobs {...}
```
