### PR TITLE
Revert "Lets capture the time it takes to get a list endpoint out."

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -2159,10 +2159,8 @@
     :handle-malformed ::error
     :handle-forbidden ::error
     :handle-ok (fn [ctx]
-                 (timers/time!
-                   (timers/timer [cook-scheduler handler list-endpoint-duration])
-                   (let [job-uuids (list-jobs db false ctx)]
-                     (doall (mapv (partial fetch-job-map db framework-id) job-uuids)))))))
+                 (let [job-uuids (list-jobs db false ctx)]
+                   (mapv (partial fetch-job-map db framework-id) job-uuids)))))
 
 ;;
 ;; /unscheduled_jobs


### PR DESCRIPTION
Reverts twosigma/Cook#781