### PR TITLE
Lets capture the time it takes to get a list endpoint out.

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -2159,8 +2159,10 @@
     :handle-malformed ::error
     :handle-forbidden ::error
     :handle-ok (fn [ctx]
-                 (let [job-uuids (list-jobs db false ctx)]
-                   (mapv (partial fetch-job-map db framework-id) job-uuids)))))
+                 (timers/time!
+                   (timers/timer ["cook-scheduler" "handler" "list-endpoint-duration"])
+                   (let [job-uuids (list-jobs db false ctx)]
+                     (doall (mapv (partial fetch-job-map db framework-id) job-uuids)))))))
 
 ;;
 ;; /unscheduled_jobs


### PR DESCRIPTION
## Changes proposed in this PR

-  Put a metric on the actual response generation time for the `/list` API call

## Why are we making these changes?

- We don't actually metric this user-visible time.

