### PR TITLE
Revert "Change JVM options. remove MaxPermSize and add +UseStringDedu…

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -207,9 +207,7 @@
 
   :main cook.components
   :jvm-opts ["-Dpython.cachedir.skip=true"
-             "-XX:+UseG1GC"
-             "-XX:+UseStringDeduplication"
-             "-XX:+PrintStringDeduplicationStatistics"
+             "-XX:MaxPermSize=500M"
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"


### PR DESCRIPTION
## Changes proposed in this PR

-  Revert old patch

## Why are we making these changes?

- Our integration test environment is based around mesos docker 1.3, which ends up running JDK7, which requires the old options.
- Fixes https://github.com/twosigma/Cook/issues/777
