### PR TITLE
Allows for connecting to datomic in docker from host

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -40,6 +40,10 @@ RUN lein uberjar
 RUN cp "target/cook-$(lein print :version | tr -d '"').jar" datomic-free-0.9.5394/lib/cook-$(lein print :version | tr -d '"').jar
 
 # Run cook
-EXPOSE 12321
+EXPOSE \
+    4334 \
+    4335 \
+    4336 \
+    12321
 ENTRYPOINT ["/opt/cook/docker/run-cook.sh"]
 CMD ["config.edn"]

--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -112,6 +112,9 @@ docker create \
     --name=${NAME} \
     --publish=${COOK_NREPL_PORT}:${COOK_NREPL_PORT} \
     --publish=${COOK_PORT}:${COOK_PORT} \
+    --publish=4334:4334 \
+    --publish=4335:4335 \
+    --publish=4336:4336 \
     -e "COOK_EXECUTOR=file://${SCHEDULER_EXECUTOR_DIR}/${EXECUTOR_NAME}.tar.gz" \
     -e "COOK_EXECUTOR_COMMAND=${COOK_EXECUTOR_COMMAND}" \
     -e "COOK_PORT=${COOK_PORT}" \

--- a/scheduler/datomic/datomic_transactor.properties
+++ b/scheduler/datomic/datomic_transactor.properties
@@ -1,5 +1,5 @@
 protocol=free
-host=localhost
+host=0.0.0.0
 port=4334
 
 memory-index-threshold=32m

--- a/scheduler/docker/run-cook.sh
+++ b/scheduler/docker/run-cook.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
-/opt/cook/datomic-free-0.9.5394/bin/transactor /opt/cook/datomic/datomic_transactor.properties &
+DATOMIC_PROPERTIES_FILE=/opt/cook/datomic/datomic_transactor.properties
+
+echo "alt-host=$(hostname -i | cut -d' ' -f2)" >> ${DATOMIC_PROPERTIES_FILE}
+/opt/cook/datomic-free-0.9.5394/bin/transactor ${DATOMIC_PROPERTIES_FILE} &
 lein with-profiles +docker run $1


### PR DESCRIPTION
## Changes proposed in this PR

- exposing the ports that datomic uses from the docker container
- setting the `alt-host` property in the datomic properties file

## Why are we making these changes?

So that we can connect to the datomic running inside docker from the host machine, in order to run (for example) scripts that seed data for testing.