### PR TITLE
Makes test_cat_large_file_no_newlines more debuggable

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1554,8 +1554,7 @@ class CookCliTest(unittest.TestCase):
                                'mv file2.txt file.txt; done\'',
                                self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        cp = cli.wait(uuids, self.cook_url)
-        self.assertEqual(0, cp.returncode, cp.stderr)
+        util.wait_for_job(self.cook_url, uuids[0], 'completed')
         cp = cli.cat(uuids[0], 'file.txt', self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual('helloworld' * pow(2, iterations), cli.decode(cp.stdout))


### PR DESCRIPTION
## Changes proposed in this PR

- replacing `cli.wait` with `util.wait` in `test_cat_large_file_no_newlines`

## Why are we making these changes?

We've seen this test fail sporadically on the "wait until completed" step, and when it does, we don't get much information out of `cs wait`. Since the point of this test is not to make sure `cs wait` works, let's replace it with the more debuggable `util.wait`.