### PR TITLE
Fix flaky unit test

### DIFF
--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1575,7 +1575,7 @@
         handler (basic-handler conn)
         before (t/now)
         list-jobs-fn #(list-jobs-with-jobs handler "user" ["running" "waiting" "completed"]
-                                           (.getMillis before) (.getMillis (t/now)))
+                                           (.getMillis before) (+ 1 (.getMillis (t/now))))
         response-1 (submit-job handler "user")
         response-2 (submit-job handler "user")
         _ @(d/transact conn [[:db/add [:job/uuid (UUID/fromString (:uuid response-1))] :job/custom-executor true]])


### PR DESCRIPTION
If the computation takes 0ms, then before=after, and the filter
  before <= X < after never matches any job.

## Changes proposed in this PR
- 
- 
- 

## Why are we making these changes?
- Fix flaky unit test

