### PR TITLE
Add SSL support to scheduler

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -11,6 +11,7 @@ from collections import Counter
 import dateutil.parser
 import pytest
 from retrying import retry
+from urllib.parse import urlparse
 
 from tests.cook import reasons
 from tests.cook import util
@@ -2050,3 +2051,16 @@ class CookTest(unittest.TestCase):
         self.assertEqual("http://cors.example.com", resp.headers["Access-Control-Allow-Origin"])
         self.assertEqual("86400", resp.headers["Access-Control-Max-Age"])
         self.assertEqual(b"", resp.content)
+
+
+    def test_ssl(self):
+        settings = util.settings(self.cook_url)
+        if not 'server-https-port' in settings:
+            self.logger.info('SSL not configured: skipping test')
+            return
+        ssl_port = settings['server-https-port']
+
+        host = urlparse(self.cook_url).hostname
+
+        resp = util.session.get(f"https://{host}:{ssl_port}/settings", verify=False)
+        self.assertEqual(200, resp.status_code)

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -1,4 +1,8 @@
 {:port #config/env-int "COOK_PORT"
+ :ssl {:port #config/env-int "COOK_SSL_PORT"
+       :keystore-path #config/env "COOK_KEYSTORE_PATH"
+       :keystore-type "pkcs12"
+       :keystore-pass "cookstore"}
  :hostname "172.17.0.1"
  :authorization {;; Note that internally, Cook will select :http-basic if it's set to true,
                  ;; and fall back to :one-user only if :http-basic is false.

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -15,6 +15,10 @@ ENV LEIN_ROOT true
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
 ENV JAVA_CMD=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
 
+# Generate SSL certificate
+RUN mkdir /opt/ssl
+RUN keytool -genkeypair -keystore /opt/ssl/cook.p12 -storetype PKCS12 -storepass cookstore -dname "CN=cook, OU=Cook Developers, O=Two Sigma Investments, L=New York, ST=New York, C=US" -keyalg RSA -keysize 2048
+
 # Lein setup
 RUN mkdir $HOME/bin
 ENV PATH $PATH:$HOME/bin
@@ -44,6 +48,7 @@ EXPOSE \
     4334 \
     4335 \
     4336 \
-    12321
+    12321 \
+    12322
 ENTRYPOINT ["/opt/cook/docker/run-cook.sh"]
 CMD ["config.edn"]

--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -9,6 +9,7 @@ set -e
 
 # Defaults (overridable via environment)
 : ${COOK_PORT:=12321}
+: ${COOK_SSL_PORT:=12322}
 : ${COOK_NREPL_PORT:=8888}
 : ${COOK_FRAMEWORK_ID:=cook-framework-$(date +%s)}
 : ${COOK_AUTH:=one-user}
@@ -112,12 +113,15 @@ docker create \
     --name=${NAME} \
     --publish=${COOK_NREPL_PORT}:${COOK_NREPL_PORT} \
     --publish=${COOK_PORT}:${COOK_PORT} \
+    --publish=${COOK_SSL_PORT}:${COOK_SSL_PORT} \
     --publish=4334:4334 \
     --publish=4335:4335 \
     --publish=4336:4336 \
     -e "COOK_EXECUTOR=file://${SCHEDULER_EXECUTOR_DIR}/${EXECUTOR_NAME}.tar.gz" \
     -e "COOK_EXECUTOR_COMMAND=${COOK_EXECUTOR_COMMAND}" \
     -e "COOK_PORT=${COOK_PORT}" \
+    -e "COOK_SSL_PORT=${COOK_SSL_PORT}" \
+    -e "COOK_KEYSTORE_PATH=${COOK_KEYSTORE_PATH}" \
     -e "COOK_NREPL_PORT=${COOK_NREPL_PORT}" \
     -e "COOK_FRAMEWORK_ID=${COOK_FRAMEWORK_ID}" \
     -e "MESOS_MASTER=${ZK}" \

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -37,6 +37,10 @@
          :port #config/env-int "COOK_NREPL_PORT"}
  :pools {:default "gamma"}
  :port #config/env-int "COOK_PORT"
+ :ssl {:port #config/env-int "COOK_SSL_PORT"
+       :keystore-path #config/env "COOK_KEYSTORE_PATH"
+       :keystore-type "pkcs12"
+       :keystore-pass "cookstore"}
  :rate-limit {:user-limit-per-m 1000000}
  :rebalancer {:dru-scale 1}
  :sandbox-syncer {:sync-interval-ms 1000}

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -116,8 +116,18 @@
                           ;; The default should ideally be lower than the agent-query-cache ttl-ms
                           :sync-interval-ms 15000}
                          sandbox-syncer))
-     :server-port (fnk [[:config port]]
-                    port)
+     :server-port (fnk [[:config {port nil} {ssl nil}]]
+                     (when (and (nil? port) (nil? (get ssl :port)))
+                       (throw (ex-info "Must provide either port or https-port" {})))
+                     port)
+     :server-https-port (fnk [[:config {ssl nil}]]
+                           (get ssl :port))
+     :server-keystore-path (fnk [[:config {ssl nil}]]
+                              (get ssl :keystore-path))
+     :server-keystore-type (fnk [[:config {ssl nil}]]
+                              (get ssl :keystore-type))
+     :server-keystore-pass (fnk [[:config {ssl nil}]]
+                              (get ssl :keystore-pass))
      :is-authorized-fn (fnk [[:config {authorization-config default-authorization}]]
                          (let [auth-fn @(util/lazy-load-var 'cook.authorization/is-authorized?)]
                            ; we only wrap the authorization function if we have impersonators configured

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -191,7 +191,7 @@
                 fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness]} fenzo-config
         {:keys [cancelled-task-trigger-chan lingering-task-trigger-chan optimizer-trigger-chan
                 rebalancer-trigger-chan straggler-trigger-chan]} trigger-chans
-        {:keys [hostname server-port]} server-config
+        {:keys [hostname server-port server-https-port]} server-config
         datomic-report-chan (async/chan (async/sliding-buffer 4096))
         mesos-heartbeat-chan (async/chan (async/buffer 4096))
         current-driver (atom nil)
@@ -288,7 +288,8 @@
                                   (log/fatal "Lost leadership in zookeeper. Exitting. Expecting a supervisor to restart me!")
                                   (System/exit 0))))))]
     (.setId leader-selector (str hostname \#
-                                 server-port \#
+                                 (or server-port server-https-port) \#
+                                 (if server-port "http" "https") \#
                                  (java.util.UUID/randomUUID)))
     (.autoRequeue leader-selector)
     (.start leader-selector)

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1587,7 +1587,7 @@
 ;;
 ;; /queue
 
-(def leader-hostname-regex #"^([^#]*)#([0-9]*)#.*")
+(def leader-hostname-regex #"^([^#]*)#([0-9]*)#([a-z]*)#.*")
 
 (defn waiting-jobs
   [mesos-pending-jobs-fn is-authorized-fn mesos-leadership-atom leader-selector]
@@ -1620,8 +1620,9 @@
                                  leader-match (re-matcher leader-hostname-regex leader-id)]
                              (if (.matches leader-match)
                                (let [leader-hostname (.group leader-match 1)
-                                     leader-port (.group leader-match 2)]
-                                 [true {:location (str "http://" leader-hostname ":" leader-port "/queue")}])
+                                     leader-port (.group leader-match 2)
+                                     leader-protocol (.group leader-match 3)]
+                                 [true {:location (str leader-protocol "://" leader-hostname ":" leader-port "/queue")}])
                                (throw (IllegalStateException.
                                        (str "Unable to parse leader id: " leader-id)))))))
    :handle-forbidden (fn [ctx]

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -258,7 +258,7 @@
                       :mesos {:leader-path "", :master ""}
                       :metrics {}
                       :nrepl {}
-                      :port nil
+                      :port 80
                       :scheduler {}
                       :unhandled-exceptions {}
                       :zookeeper {:local? true}}]


### PR DESCRIPTION
## Changes proposed in this PR

- Add support for scheduler to listen on a separate port for SSL connections

## Why are we making these changes?
Some clients might want to have a secure connection to the scheduler
