### PR TITLE
Makes instance stats tests more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1845,11 +1845,11 @@ class CookTest(unittest.TestCase):
 
     def test_instance_stats_running(self):
         name = str(uuid.uuid4())
-        job_uuid_1, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        job_uuid_1, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
         try:
@@ -1978,11 +1978,11 @@ class CookTest(unittest.TestCase):
 
     def test_instance_stats_supports_epoch_time_params(self):
         name = str(uuid.uuid4())
-        job_uuid_1, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        job_uuid_1, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 300', name=name)
+        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
         try:
@@ -1994,7 +1994,6 @@ class CookTest(unittest.TestCase):
                                                start=start_time,
                                                end=end_time + 1,
                                                name=name)
-            self.logger.info(json.dumps(stats, indent=2))
             user = util.get_user(self.cook_url, job_uuid_1)
             self.assertEqual(3, stats['overall']['count'])
             self.assertEqual(3, stats['by-reason']['']['count'])

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -726,10 +726,10 @@ def wait_for_running_instance(cook_url, job_id, max_wait_ms=DEFAULT_TIMEOUT_MS):
         if not job['instances']:
             logger.info(f"Job {job_id} has no instances.")
         else:
-            inst = job['instances'][0]
-            status = inst['status']
-            logger.info(f"Job {job_id} instance {inst['task_id']} has status {status}, expected running.")
-            return status == 'running'
+            for inst in job['instances']:
+                status = inst['status']
+                logger.info(f"Job {job_id} instance {inst['task_id']} has status {status}, expected running.")
+                return status == 'running'
 
     response = wait_until(query, predicate, max_wait_ms=max_wait_ms)
     return response.json()[0]['instances'][0]


### PR DESCRIPTION
## Changes proposed in this PR

- switching from 1 to 2 attempts in the instance stats test jobs
- making `wait_for_running_instance` look for any running instance, instead of just the first one

## Why are we making these changes?

We've seen these tests fail because the jobs fail due to Mesos. For example:

```bash
2018-04-06 17:14:09,884 INFO  cook.mesos.scheduler [clojure-agent-send-pool-0] - Mesos status is: #mesomatic.types.TaskStatus{:task-id #mesomatic.types.TaskID{:value 3564101f-2aef-4074-8ace-4aaa88d6e484}, :state :task-error, :message Task uses more resources mem(cook):256; cpus(cook):0; cpus(*):1 than available ports(cook):[32002-33000]; mem(cook):3072; disk(cook):10000; ports(*):[31000-32000]; disk(*):10000; cpus(*):4; mem(*):4096, :source :source-master, :reason :reason-task-invalid, :data #object[com.google.protobuf.LiteralByteString 0x2c795d19 <ByteString@2c795d19 size=0>], :slave-id #mesomatic.types.SlaveID{:value 0fdfda85-58ea-4b4d-97bd-05b401b5bc5a-S5}, :executor-id #mesomatic.types.ExecutorID{:value }, :timestamp 1.5230348498753479E9, :uuid #object[com.google.protobuf.LiteralByteString 0x2c795d19 <ByteString@2c795d19 size=0>], :healthy false}
```

This change should make the tests more robust to these "flaky" issues.