### PR TITLE
Sets monitor metrics to 0 instead of removing them

### DIFF
--- a/scheduler/src/cook/mesos/monitor.clj
+++ b/scheduler/src/cook/mesos/monitor.clj
@@ -101,7 +101,7 @@
         users-to-clear (difference previous-users current-users)]
     (run! (fn [user]
             (run! (fn [[type _]]
-                    (metrics/remove-metric [state user (name type)]))
+                    (set-counter! (counters/counter [state user (name type)]) 0))
                   (get previous-stats user)))
           users-to-clear)))
 


### PR DESCRIPTION
## Changes proposed in this PR

- setting the counters in `monitor.clj` to 0 instead of removing them

## Why are we making these changes?

When using singlestat panels in Grafana, the `current` function uses the last non-null value from the series. As a result, the panels can show, for example, cpus and memory in use when the user in question actually has nothing running. Explicitly setting the counters to 0 resolves this.