### PR TITLE
Set COOK_KEYSTORE_PATH in run-docker.sh

### DIFF
--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -134,6 +134,7 @@ docker create \
     -e "COOK_HTTP_BASIC_AUTH=${COOK_HTTP_BASIC_AUTH:-false}" \
     -e "COOK_ONE_USER_AUTH=root" \
     -e "COOK_EXECUTOR_PORTION=${COOK_EXECUTOR_PORTION:-0}" \
+    -e "COOK_KEYSTORE_PATH=/opt/ssl/cook.p12" \
     -v ${DIR}/../log:/opt/cook/log \
     cook-scheduler:latest ${COOK_CONFIG:-}
 


### PR DESCRIPTION
## Changes proposed in this PR
- Set COOK_KEYSTORE_PATH in run-docker.sh

## Why are we making these changes?
Fixes running via docker
