### PR TITLE
Guards against invalid default pool configuration

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1671,7 +1671,7 @@ class CookTest(unittest.TestCase):
         job_resources = {'cpus': 0.1, 'mem': 123}
         job_uuid, resp = util.submit_job(self.cook_url, command='sleep 120', **job_resources)
         self.assertEqual(resp.status_code, 201, resp.content)
-        pools, _ = util.pools(self.cook_url)
+        pools, _ = util.all_pools(self.cook_url)
         try:
             user = util.get_user(self.cook_url, job_uuid)
             # Don't query until the job starts
@@ -1789,7 +1789,7 @@ class CookTest(unittest.TestCase):
         job_uuids, resp = util.submit_jobs(self.cook_url, job_specs)
         self.assertEqual(resp.status_code, 201, resp.content)
 
-        pools, _ = util.pools(self.cook_url)
+        pools, _ = util.all_pools(self.cook_url)
         try:
             user = util.get_user(self.cook_url, job_uuids[0])
             # Don't query until both of the jobs start
@@ -1894,7 +1894,6 @@ class CookTest(unittest.TestCase):
                     resp = util.get_limit(self.cook_url, limit, user, pool=pool)
                     self.assertEqual(resp.status_code, 200, resp.text)
                     self.assertEqual(1000, resp.json()['cpus'], resp.text)
-
 
     def test_submit_with_no_name(self):
         # We need to manually set the 'uuid' to avoid having the
@@ -2107,6 +2106,7 @@ class CookTest(unittest.TestCase):
 
         def origin_allowed(cors_patterns, origin):
             return any([re.search(pattern, origin) for pattern in cors_patterns])
+
         resp = util.session.get(f"{self.cook_url}/settings", headers={"Origin": self.cors_origin})
         self.assertEqual(200, resp.status_code)
         self.assertTrue(origin_allowed(resp.json()["cors-origins"], self.cors_origin), resp.json())
@@ -2149,7 +2149,7 @@ class CookTest(unittest.TestCase):
 
     def test_ssl(self):
         settings = util.settings(self.cook_url)
-        if not 'server-https-port' in settings or settings['server-https-port'] is None:
+        if 'server-https-port' not in settings or settings['server-https-port'] is None:
             self.logger.info('SSL not configured: skipping test')
             return
         ssl_port = settings['server-https-port']

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1631,8 +1631,7 @@ class CookTest(unittest.TestCase):
             util.kill_jobs(self.cook_url, uuids)
 
     def test_retrieve_jobs_with_deprecated_api(self):
-        pools, _ = util.pools(self.cook_url)
-        pools = [p for p in pools if p['state'] == 'active']
+        pools, _ = util.active_pools(self.cook_url)
         pool = pools[0]['name'] if len(pools) > 0 else None
         job_uuid_1, resp = util.submit_job(self.cook_url, pool=pool)
         self.assertEqual(201, resp.status_code, msg=resp.content)
@@ -1735,7 +1734,7 @@ class CookTest(unittest.TestCase):
             self.assertEqual(usage_data['total_usage']['gpus'], breakdowns_total['gpus'], usage_data)
             self.assertEqual(usage_data['total_usage']['jobs'], breakdowns_total['jobs'], usage_data)
             # Pool-specific checks
-            pools, _ = util.pools(self.cook_url)
+            pools, _ = util.all_pools(self.cook_url)
             for pool in pools:
                 # There should be a sub-map under pools for each pool in the
                 # system, since we didn't specify the pool in the usage request
@@ -1859,7 +1858,7 @@ class CookTest(unittest.TestCase):
                 self.assertEqual(resp.status_code, 200, resp.text)
                 self.assertEqual(sys.float_info.max, resp.json()['cpus'], resp.text)
 
-                pools, _ = util.pools(self.cook_url)
+                pools, _ = util.all_pools(self.cook_url)
                 non_default_pools = [p['name'] for p in pools if p['name'] != default_pool]
 
                 for pool in non_default_pools:
@@ -2114,7 +2113,7 @@ class CookTest(unittest.TestCase):
         self.assertEqual(b"", resp.content)
 
     def test_submit_with_pool(self):
-        pools, _ = util.pools(self.cook_url)
+        pools, _ = util.all_pools(self.cook_url)
         if len(pools) == 0:
             self.logger.info('There are no pools to submit jobs to')
         for pool in pools:

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1632,6 +1632,7 @@ class CookTest(unittest.TestCase):
 
     def test_retrieve_jobs_with_deprecated_api(self):
         pools, _ = util.pools(self.cook_url)
+        pools = [p for p in pools if p['state'] == 'active']
         pool = pools[0]['name'] if len(pools) > 0 else None
         job_uuid_1, resp = util.submit_job(self.cook_url, pool=pool)
         self.assertEqual(201, resp.status_code, msg=resp.content)

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -1,11 +1,14 @@
 import logging
-import pytest
 import unittest
 
-from tests.cook import reasons, util
+import pytest
+
+from tests.cook import util
+
 
 @pytest.mark.multi_user
-@unittest.skipUnless(util.multi_user_tests_enabled(), 'Requires using multi-user coniguration (e.g., BasicAuth) for Cook Scheduler')
+@unittest.skipUnless(util.multi_user_tests_enabled(), 'Requires using multi-user coniguration '
+                                                      '(e.g., BasicAuth) for Cook Scheduler')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class MultiUserCookTest(unittest.TestCase):
 
@@ -57,7 +60,7 @@ class MultiUserCookTest(unittest.TestCase):
         users = self.user_factory.new_users(6)
         job_resources = {'cpus': 0.1, 'mem': 123}
         all_job_uuids = []
-        pools, _ = util.pools(self.cook_url)
+        pools, _ = util.all_pools(self.cook_url)
         try:
             # Start jobs for several users
             for i, user in enumerate(users):
@@ -198,4 +201,3 @@ class MultiUserCookTest(unittest.TestCase):
             with admin:
                 util.kill_jobs(self.cook_url, all_job_uuids)
                 util.reset_limit(self.cook_url, 'quota', user.name)
-

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -941,6 +941,7 @@ def query_queue(cook_url):
     """Get current jobs via the queue endpoint (admin-only)"""
     return session.get(f'{cook_url}/queue')
 
+
 def get_limit(cook_url, limit_type, user, pool=None):
     params = {'user': user}
     if pool is not None:
@@ -1015,7 +1016,13 @@ def default_pool(cook_url):
     return default_pool
 
 
-def pools(cook_url):
+def all_pools(cook_url):
     """Returns the list of all pools that exist"""
     resp = session.get(f'{cook_url}/pools')
     return resp.json(), resp
+
+
+def active_pools(cook_url):
+    """Returns the list of all active pools that exist"""
+    pools, _ = all_pools(cook_url)
+    return [p for p in pools if p['state'] == 'active']

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1024,5 +1024,5 @@ def all_pools(cook_url):
 
 def active_pools(cook_url):
     """Returns the list of all active pools that exist"""
-    pools, _ = all_pools(cook_url)
-    return [p for p in pools if p['state'] == 'active']
+    pools, resp = all_pools(cook_url)
+    return [p for p in pools if p['state'] == 'active'], resp

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -98,7 +98,7 @@ cd ${SCHEDULER_DIR}
 ## available for processes inside minimesos containers to connect to
 export COOK_EXECUTOR_COMMAND=${COOK_EXECUTOR_COMMAND}
 # Start one cook listening on port 12321, this will be the master of the "cook-framework-1" framework
-LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12321 COOK_SSL_PORT=12322 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12321.log" lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
+LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12321 COOK_SSL_PORT=12322 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12321.log" COOK_DEFAULT_POOL="gamma" lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
 # Start a second cook listening on port 22321, this will be the master of the "cook-framework-2" framework
 LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_2}" COOK_PORT=22321 COOK_SSL_PORT=22322 COOK_ZOOKEEPER_LOCAL=true COOK_ZOOKEEPER_LOCAL_PORT=4291 COOK_FRAMEWORK_ID=cook-framework-2 COOK_LOGFILE="log/cook-22321.log" lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
 

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -111,7 +111,7 @@ if [ "$curl_error" = true ]; then
 fi
 
 # Start a third cook listening on port 12323, this will be a slave on the "cook-framework-1" framework
-LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12323 COOK_SSL_PORT=12324 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12323.log" lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
+LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12323 COOK_SSL_PORT=12324 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12323.log" COOK_DEFAULT_POOL="gamma" lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
 
 timeout 180s bash -c "wait_for_cook 12323" || curl_error=true
 if [ "$curl_error" = true ]; then

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -50,4 +50,4 @@
                 "cook.mesos.rebalancer" :debug
                 "cook.mesos.scheduler" :debug
                 :default :info}}
- :pools {:default "gamma"}}
+ :pools {:default #config/env "COOK_DEFAULT_POOL"}}

--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -142,9 +142,5 @@ docker network connect bridge ${NAME}
 docker network connect cook_nw ${NAME}
 docker start ${NAME}
 
-echo "Seeding test data..."
-cd ${SCHEDULER_DIR}
-lein exec -p test-resources/data/seed_pools.clj ${COOK_DATOMIC_URI}
-
 echo "Attaching to container..."
 docker attach ${NAME}

--- a/scheduler/datomic/data/seed_pools.clj
+++ b/scheduler/datomic/data/seed_pools.clj
@@ -1,5 +1,6 @@
 (ns data.seed-pools
-  (:require [datomic.api :as d]))
+  (:require [cook.datomic :as datomic]
+            [datomic.api :as d]))
 
 (def uri (second *command-line-args*))
 (println "Datomic URI is" uri)
@@ -38,7 +39,7 @@
 (defn connect
   []
   (println "Attempting to connect to" uri)
-  (d/connect uri))
+  (datomic/create-connection {:settings {:mesos-datomic-uri uri}}))
 
 (try
   (let [conn (retry 10 connect)]

--- a/scheduler/docker/run-cook.sh
+++ b/scheduler/docker/run-cook.sh
@@ -4,4 +4,6 @@ DATOMIC_PROPERTIES_FILE=/opt/cook/datomic/datomic_transactor.properties
 
 echo "alt-host=$(hostname -i | cut -d' ' -f2)" >> ${DATOMIC_PROPERTIES_FILE}
 /opt/cook/datomic-free-0.9.5394/bin/transactor ${DATOMIC_PROPERTIES_FILE} &
+echo "Seeding test data..."
+lein exec -p /opt/cook/datomic/data/seed_pools.clj ${COOK_DATOMIC_URI}
 lein with-profiles +docker run $1

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -25,7 +25,9 @@
             [cook.curator :as curator]
             [cook.datomic :as datomic]
             [cook.impersonation :refer (impersonation-authorized-wrapper)]
+            [cook.mesos.pool :as pool]
             [cook.util :as util]
+            [datomic.api :as d]
             [metrics.jvm.core :as metrics-jvm]
             [metrics.ring.instrument :refer (instrument)]
             [mount.core :as mount]
@@ -299,6 +301,7 @@
   (println "Cook" @util/version "( commit" @util/commit ")")
   (try
     (mount/start-with-args (cook.config/read-config config-file-path))
+    (pool/guard-invalid-default-pool (d/db datomic/conn))
     (metrics-jvm/instrument-jvm)
     (let [server (scheduler-server config)]
       (intern 'user 'main-graph server)

--- a/scheduler/test/cook/test/mesos/pool.clj
+++ b/scheduler/test/cook/test/mesos/pool.clj
@@ -4,7 +4,7 @@
             [cook.mesos.pool :as pool])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest test-guard-no-default-pool
+(deftest test-guard-invalid-default-pool
   (with-redefs [pool/all-pools (constantly [{:pool/name "foo"}])
                 config/default-pool (constantly "foo")]
     (is (nil? (pool/guard-invalid-default-pool nil))))

--- a/scheduler/test/cook/test/mesos/pool.clj
+++ b/scheduler/test/cook/test/mesos/pool.clj
@@ -13,10 +13,16 @@
     (is (nil? (pool/guard-invalid-default-pool nil))))
   (with-redefs [pool/all-pools (constantly [{}])
                 config/default-pool (constantly nil)]
-    (is (thrown? ExceptionInfo (pool/guard-invalid-default-pool nil))))
+    (is (thrown-with-msg? ExceptionInfo
+                          #"There are pools in the database, but no default pool is configured"
+                          (pool/guard-invalid-default-pool nil))))
   (with-redefs [pool/all-pools (constantly [])
                 config/default-pool (constantly "foo")]
-    (is (thrown? ExceptionInfo (pool/guard-invalid-default-pool nil))))
+    (is (thrown-with-msg? ExceptionInfo
+                          #"There is no pool in the database matching the configured default pool"
+                          (pool/guard-invalid-default-pool nil))))
   (with-redefs [pool/all-pools (constantly [{:pool/name "bar"}])
                 config/default-pool (constantly "foo")]
-    (is (thrown? ExceptionInfo (pool/guard-invalid-default-pool nil)))))
+    (is (thrown-with-msg? ExceptionInfo
+                          #"There is no pool in the database matching the configured default pool"
+                          (pool/guard-invalid-default-pool nil)))))

--- a/scheduler/test/cook/test/mesos/pool.clj
+++ b/scheduler/test/cook/test/mesos/pool.clj
@@ -1,0 +1,22 @@
+(ns cook.test.mesos.pool
+  (:require [clojure.test :refer :all]
+            [cook.config :as config]
+            [cook.mesos.pool :as pool])
+  (:import (clojure.lang ExceptionInfo)))
+
+(deftest test-guard-no-default-pool
+  (with-redefs [pool/all-pools (constantly [{:pool/name "foo"}])
+                config/default-pool (constantly "foo")]
+    (is (nil? (pool/guard-invalid-default-pool nil))))
+  (with-redefs [pool/all-pools (constantly [])
+                config/default-pool (constantly nil)]
+    (is (nil? (pool/guard-invalid-default-pool nil))))
+  (with-redefs [pool/all-pools (constantly [{}])
+                config/default-pool (constantly nil)]
+    (is (thrown? ExceptionInfo (pool/guard-invalid-default-pool nil))))
+  (with-redefs [pool/all-pools (constantly [])
+                config/default-pool (constantly "foo")]
+    (is (thrown? ExceptionInfo (pool/guard-invalid-default-pool nil))))
+  (with-redefs [pool/all-pools (constantly [{:pool/name "bar"}])
+                config/default-pool (constantly "foo")]
+    (is (thrown? ExceptionInfo (pool/guard-invalid-default-pool nil)))))


### PR DESCRIPTION
## Changes proposed in this PR

- moving the seeding of pools to before starting cook scheduler, so that they're already there at startup
- making the pool-seeding setup the database schema
- adding guards on cook scheduler startup against:
  - pools in the database, but no default pool configured
  - the configured default pool does not match any pool in the database

## Why are we making these changes?

We want to prevent the situation where there are pools in the database, but we don't have a valid configuration for which of those pools is the default. Resolves #813.