### PR TITLE
Adds more logging to test_docker_port_mapping

### DIFF
--- a/integration/tests/cook/mesos.py
+++ b/integration/tests/cook/mesos.py
@@ -1,0 +1,122 @@
+import logging
+import os
+import sys
+from urllib.parse import urlparse, parse_qs
+
+
+def instance_to_agent_url(instance):
+    """Given a job instance, returns the base Mesos agent URL, e.g. http://agent123.example.com:5051"""
+    hostname = instance['hostname']
+    if 'output_url' in instance:
+        output_url = instance['output_url']
+        url = urlparse(output_url)
+        netloc = url.netloc
+    else:
+        logging.info('assuming default agent port of 5051')
+        netloc = f'{hostname}:5051'
+    return f'http://{netloc}'
+
+
+def retrieve_instance_sandbox_directory(session, instance, job):
+    """Given an instance and its parent job, determines the Mesos agent sandbox directory"""
+
+    # Check if we've simply been handed the sandbox directory
+    if 'sandbox_directory' in instance:
+        logging.debug('found sandbox directory directly on instance')
+        return instance['sandbox_directory']
+
+    # Try parsing it from the output url if present
+    if 'output_url' in instance:
+        output_url = instance['output_url']
+        url = urlparse(output_url)
+        query_dict = parse_qs(url.query)
+        if 'path' in query_dict:
+            path_list = query_dict['path']
+            if len(path_list) == 1:
+                logging.debug('parsed sandbox directory from output url')
+                return path_list[0]
+
+    # As a last resort, query the Mesos agent state
+    agent_url = instance_to_agent_url(instance)
+    resp = session.get(f'{agent_url}/state')
+    if resp.status_code != 200:
+        logging.error(f'mesos agent returned status code {resp.status_code} and body {resp.text}')
+        raise Exception('Encountered error when querying Mesos agent for the sandbox directory.')
+
+    # Parse the Mesos agent state and look for a matching executor
+    resp_json = resp.json()
+    frameworks = resp_json['completed_frameworks'] + resp_json['frameworks']
+    cook_framework = next(f for f in frameworks if f['id'] == job['framework_id'])
+    cook_executors = cook_framework['completed_executors'] + cook_framework['executors']
+    instance_id = instance['task_id']
+    directories = [e['directory'] for e in cook_executors if e['id'] == instance_id]
+
+    if len(directories) == 0:
+        raise Exception(f'Unable to retrieve sandbox directory for job instance {instance_id}.')
+
+    if len(directories) > 1:
+        # This should not happen, but we'll be defensive anyway
+        raise Exception(f'Found more than one Mesos executor with ID {instance_id}')
+
+    return directories[0]
+
+
+def browse_files(session, instance, sandbox_dir, path):
+    """
+    Calls the files/browse endpoint on the Mesos agent corresponding to
+    the given instance, and for the provided sandbox directory and path
+    """
+    agent_url = instance_to_agent_url(instance)
+    resp = session.get(f'{agent_url}/files/browse', params={'path': os.path.join(sandbox_dir, path or '')})
+    if resp.status_code == 404:
+        raise Exception(f"Cannot access '{path}' (no such file or directory).")
+
+    if resp.status_code != 200:
+        logging.error(f'mesos agent returned status code {resp.status_code} and body {resp.text}')
+        raise Exception('Encountered error when querying Mesos agent for its files.')
+
+    return resp.json()
+
+
+def is_directory(entry):
+    """Returns true if the given entry is a directory"""
+    return entry['nlink'] > 1
+
+
+def download_file(session, instance, sandbox_dir, path):
+    """Calls the Mesos agent files/download API for the given path"""
+    logging.info(f'downloading file from sandbox {sandbox_dir} with path {path}')
+    agent_url = instance_to_agent_url(instance)
+    params = {'path': os.path.join(sandbox_dir, path)}
+    resp = session.get(f'{agent_url}/files/download', params=params, stream=True)
+    if resp.status_code == 404:
+        raise Exception(f"Cannot download '{path}' (file was not found).")
+
+    if resp.status_code != 200:
+        logging.error(f'mesos agent returned status code {resp.status_code} and body {resp.text}')
+        raise Exception('Could not download the file.')
+
+    return resp
+
+
+def cat_for_instance(session, instance, sandbox_dir, path):
+    """Outputs the contents of the Mesos sandbox path for the given instance."""
+    resp = download_file(session, instance, sandbox_dir, path)
+    try:
+        for data in resp.iter_content(chunk_size=4096):
+            if data:
+                logging.info(data.decode())
+    except BrokenPipeError as bpe:
+        sys.stderr.close()
+        logging.exception(bpe)
+
+
+def dump_sandbox_files(session, instance, job):
+    """Logs the contents of each file in the root of the given instance's sandbox."""
+    directory = retrieve_instance_sandbox_directory(session, instance, job)
+    entries = browse_files(session, instance, directory, None)
+    for entry in entries:
+        if is_directory(entry):
+            logging.info(f'Skipping over directory {entry}')
+        else:
+            cat_for_instance(session, instance, directory, entry['path'])

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1392,6 +1392,8 @@ class CookTest(unittest.TestCase):
 
             @retry(stop_max_delay=60000, wait_fixed=1000)  # Wait for docker container to start
             def get_docker_info():
+                job = util.load_job(self.cook_url, job_uuid)
+                self.logger.info(f'Job status is {job["status"]}: {job}')
                 self.logger.info('Running containers: %s' % subprocess.check_output(['docker', 'ps']).decode('utf-8'))
                 return json.loads(subprocess.check_output(['docker', 'inspect', container_id]).decode('utf-8'))
 
@@ -1403,6 +1405,8 @@ class CookTest(unittest.TestCase):
             self.assertTrue('9090/udp' in ports)
             self.assertEqual(instance['ports'][1], int(ports['9090/udp'][0]['HostPort']))
         finally:
+            job = util.load_job(self.cook_url, job_uuid)
+            self.logger.info(f'Job status is {job["status"]}: {job}')
             util.session.delete('%s/rawscheduler?job=%s' % (self.cook_url, job_uuid))
 
     def test_unscheduled_jobs(self):

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -941,6 +941,7 @@ def query_queue(cook_url):
     """Get current jobs via the queue endpoint (admin-only)"""
     return session.get(f'{cook_url}/queue')
 
+
 def get_limit(cook_url, limit_type, user, pool=None):
     params = {'user': user}
     if pool is not None:


### PR DESCRIPTION
## Changes proposed in this PR

- logging the job status before each `docker inspect`
- logging the job status in the `finally` block, right before killing the job
- logging the contents of all files in the root of the instance's sandbox, e.g.:

```bash
2018-04-19 15:23:36,837 [DEBUG] http://172.17.0.7:5051 "GET /files/download?path=%2Fvar%2Flib%2Fmesos%2Fagent-2972150625%2Fslaves%2Fad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0%2Fframeworks%2Fcook-framework-1524152436%2Fexecutors%2Fd1af2ac7-a642-4c3b-b61a-668ff0830880%2Fruns%2F5cbb9ce3-3f7e-4a36-8e09-b57532388ac4%2Fstderr HTTP/1.1" 200 2267
2018-04-19 15:23:36,838 [INFO] I0419 20:23:36.269697 21616 logging.cpp:199] Logging to STDERR
I0419 20:23:36.270844 21616 process.cpp:1067] libprocess is initialized on 172.17.0.7:34095 with 8 worker threads
I0419 20:23:36.271612 21616 exec.cpp:161] Version: 1.0.0
I0419 20:23:36.272637 21622 exec.cpp:211] Executor started at: executor(1)@172.17.0.7:34095 with pid 21616
I0419 20:23:36.273465 21617 exec.cpp:236] Executor registered on agent ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0
I0419 20:23:36.274085 21617 exec.cpp:248] Executor::registered took 66753ns
I0419 20:23:36.274140 21617 exec.cpp:323] Executor asked to run task 'd1af2ac7-a642-4c3b-b61a-668ff0830880'
I0419 20:23:36.274174 21617 exec.cpp:332] Executor::launchTask took 24841ns
I0419 20:23:36.274278 21624 docker.cpp:809] Running docker -H unix:///var/run/docker.sock run --cpu-shares 1024 --memory 268435456 -e COOK_JOB_UUID=5e722a59-3d55-4a8d-b4be-44791aa8b9a2 -e COOK_JOB_CPUS=1.0 -e COOK_JOB_MEM_MB=256.0 -e PORT0=31004 -e PORT1=31005 -e MESOS_SANDBOX=/mnt/mesos/sandbox -e MESOS_CONTAINER_NAME=mesos-ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0.5cbb9ce3-3f7e-4a36-8e09-b57532388ac4 -v /var/lib/mesos/agent-2972150625/slaves/ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0/frameworks/cook-framework-1524152436/executors/d1af2ac7-a642-4c3b-b61a-668ff0830880/runs/5cbb9ce3-3f7e-4a36-8e09-b57532388ac4:/mnt/mesos/sandbox --net bridge -p 31005:9090/udp -p 31004:8080 --entrypoint /bin/sh --name mesos-ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0.5cbb9ce3-3f7e-4a36-8e09-b57532388ac4 python:3.6 -c python -m http.server 8080
I0419 20:23:36.274787 21624 docker.cpp:972] Running docker -H unix:///var/run/docker.sock inspect mesos-ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0.5cbb9ce3-3f7e-4a36-8e09-b57532388ac4
WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
I0419 20:23:36.375767 21619 docker.cpp:1019] Retrying inspect with non-zero status code. cmd: 'docker -H unix:///var/run/docker.sock inspect mesos-ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0.5cbb9ce3-3f7e-4a36-8e09-b57532388ac4', interval: 500ms
I0419 20:23:36.770596 21620 exec.cpp:343] Executor asked to kill task 'd1af2ac7-a642-4c3b-b61a-668ff0830880'
I0419 20:23:36.770625 21620 exec.cpp:352] Executor::killTask took 12423ns

2018-04-19 15:23:36,838 [INFO] downloading file from sandbox /var/lib/mesos/agent-2972150625/slaves/ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0/frameworks/cook-framework-1524152436/executors/d1af2ac7-a642-4c3b-b61a-668ff0830880/runs/5cbb9ce3-3f7e-4a36-8e09-b57532388ac4 with path /var/lib/mesos/agent-2972150625/slaves/ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0/frameworks/cook-framework-1524152436/executors/d1af2ac7-a642-4c3b-b61a-668ff0830880/runs/5cbb9ce3-3f7e-4a36-8e09-b57532388ac4/stdout
2018-04-19 15:23:36,838 [INFO] assuming default agent port of 5051
2018-04-19 15:23:36,843 [DEBUG] http://172.17.0.7:5051 "GET /files/download?path=%2Fvar%2Flib%2Fmesos%2Fagent-2972150625%2Fslaves%2Fad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0%2Fframeworks%2Fcook-framework-1524152436%2Fexecutors%2Fd1af2ac7-a642-4c3b-b61a-668ff0830880%2Fruns%2F5cbb9ce3-3f7e-4a36-8e09-b57532388ac4%2Fstdout HTTP/1.1" 200 1324
2018-04-19 15:23:36,843 [INFO] --container="mesos-ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0.5cbb9ce3-3f7e-4a36-8e09-b57532388ac4" --docker="docker" --docker_socket="/var/run/docker.sock" --help="false" --initialize_driver_logging="true" --launcher_dir="/usr/libexec/mesos" --logbufsecs="0" --logging_level="INFO" --mapped_directory="/mnt/mesos/sandbox" --quiet="false" --sandbox_directory="/var/lib/mesos/agent-2972150625/slaves/ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0/frameworks/cook-framework-1524152436/executors/d1af2ac7-a642-4c3b-b61a-668ff0830880/runs/5cbb9ce3-3f7e-4a36-8e09-b57532388ac4" --stop_timeout="0ns"
--container="mesos-ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0.5cbb9ce3-3f7e-4a36-8e09-b57532388ac4" --docker="docker" --docker_socket="/var/run/docker.sock" --help="false" --initialize_driver_logging="true" --launcher_dir="/usr/libexec/mesos" --logbufsecs="0" --logging_level="INFO" --mapped_directory="/mnt/mesos/sandbox" --quiet="false" --sandbox_directory="/var/lib/mesos/agent-2972150625/slaves/ad2f8ac9-3643-49f2-be8b-0786c22eaa78-S0/frameworks/cook-framework-1524152436/executors/d1af2ac7-a642-4c3b-b61a-668ff0830880/runs/5cbb9ce3-3f7e-4a36-8e09-b57532388ac4" --stop_timeout="0ns"
Registered docker executor on 172.17.0.7
Starting task d1af2ac7-a642-4c3b-b61a-668ff0830880
Received killTask for task d1af2ac7-a642-4c3b-b61a-668ff0830880
```

## Why are we making these changes?

We've seen this test fail with:

```bash
2018-04-19 16:02:31,732 [INFO] Running containers: CONTAINER ID        IMAGE                                   COMMAND                  CREATED             STATUS              PORTS                          NAMES
db7ff6f647ed        containersol/mesos-agent:1.0.0-0.1.0    "mesos-slave --no-..."   2 minutes ago       Up 2 minutes        5051/tcp, 31000-32000/tcp      minimesos-agent-2880146163-1973990091
a742e324acfd        containersol/mesos-agent:1.0.0-0.1.0    "mesos-slave --no-..."   2 minutes ago       Up 2 minutes        5051/tcp, 31000-32000/tcp      minimesos-agent-2880146163-3288562531
e6170f060e5f        containersol/mesos-agent:1.0.0-0.1.0    "mesos-slave --no-..."   2 minutes ago       Up 2 minutes        5051/tcp, 31000-32000/tcp      minimesos-agent-2880146163-949413926
1415ba88bbc7        containersol/mesos-agent:1.0.0-0.1.0    "mesos-slave --no-..."   2 minutes ago       Up 2 minutes        5051/tcp, 31000-32000/tcp      minimesos-agent-2880146163-1908323426
aeb5022ddb43        containersol/mesos-agent:1.0.0-0.1.0    "mesos-slave --no-..."   2 minutes ago       Up 2 minutes        5051/tcp, 31000-32000/tcp      minimesos-agent-2880146163-2870460235
869d3413155d        containersol/mesos-agent:1.0.0-0.1.0    "mesos-slave --no-..."   2 minutes ago       Up 2 minutes        5051/tcp, 31000-32000/tcp      minimesos-agent-2880146163-2161463930
ac798228ade6        containersol/mesos-master:1.0.0-0.1.0   "mesos-master --no..."   2 minutes ago       Up 2 minutes        0.0.0.0:5050->5050/tcp         minimesos-master-2880146163-523198918
ef57e150a21b        jplock/zookeeper:3.4.6                  "/opt/zookeeper/bi..."   3 minutes ago       Up 3 minutes        2181/tcp, 2888/tcp, 3888/tcp   minimesos-zookeeper-2880146163-2751674848
Error response from daemon: no such image: mesos-ac79deb5-7fae-41bf-8d55-de31492d14ee-S5.407f27c2-e929-4d99-bd3e-f2cb6c2286ab: invalid reference format: repository name must be lowercase
```

We want to add some more troubleshooting info to this test so that we can determine how to improve it.