### PR TITLE
Adds pool to cs submit, show

### DIFF
--- a/cli/cook/subcommands/show.py
+++ b/cli/cook/subcommands/show.py
@@ -39,6 +39,7 @@ def juxtapose_text(text_a, text_b, buffer_len=15):
 def tabulate_job(cluster_name, job):
     """Given a job, returns a string containing tables for the job and instance fields"""
     job_definition = [['Cluster', cluster_name],
+                      ['Pool', job.get('pool', '-')],
                       ['Memory', format_job_memory(job)],
                       ['CPUs', job['cpus']],
                       ['User', job['user']],

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.1.0'
+VERSION = '2.2.0'


### PR DESCRIPTION
## Changes proposed in this PR

- adding `--pool` / `-P` to `cs submit`
- adding the pool to the `cs show` output

## Why are we making these changes?

We want to allow specifying the pool to submit to, and viewing it, from `cs`.
