### PR TITLE
Adds debugging info to group_submit_retry

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1272,7 +1272,7 @@ class CookTest(unittest.TestCase):
 
     def test_group_failed_only_change_retries_all_active(self):
         statuses = ['running', 'waiting']
-        jobs = util.group_submit_retry(self.cook_url, command='sleep 10', predicate_statuses=statuses)
+        jobs = util.group_submit_retry(self.cook_url, command='sleep 120', predicate_statuses=statuses)
         for job in jobs:
             job_details = f'Job details: {json.dumps(job, sort_keys=True)}'
             self.assertIn(job['status'], statuses, job_details)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1,6 +1,7 @@
 import functools
 import importlib
 import itertools
+import json
 import logging
 import os
 import os.path
@@ -906,13 +907,19 @@ def group_submit_retry(cook_url, command, predicate_statuses, retry_failed_jobs_
 
     def status_condition(response):
         group = response.json()[0]
-        logger.debug(f'Group: {group}')
         statuses_map = {x: group[x] for x in predicate_statuses}
         status_counts = statuses_map.values()
         # for running & waiting, we want at least one running (not all waiting)
         not_all_waiting = group['waiting'] != job_count
         logger.debug(f"Currently {statuses_map} jobs in group {group['uuid']}")
-        return not_all_waiting and sum(status_counts) == job_count
+        if not_all_waiting and sum(status_counts) == job_count:
+            return True
+        else:
+            logger.debug(f'Group details: {group}')
+            jobs = query_jobs(cook_url, assert_response=True, uuid=group['jobs']).json()
+            for job in jobs:
+                logger.debug(f'Job details: {json.dumps(job, sort_keys=True)}')
+            return False
 
     try:
         jobs, resp = submit_jobs(cook_url, job_spec, job_count, groups=[group_spec])

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -906,6 +906,7 @@ def group_submit_retry(cook_url, command, predicate_statuses, retry_failed_jobs_
 
     def status_condition(response):
         group = response.json()[0]
+        logger.debug(f'Group: {group}')
         statuses_map = {x: group[x] for x in predicate_statuses}
         status_counts = statuses_map.values()
         # for running & waiting, we want at least one running (not all waiting)


### PR DESCRIPTION
## Changes proposed in this PR

- logging the complete group and member jobs json in `group_submit_retry`
- increasing the sleep from 10 to 120 seconds in `test_group_failed_only_change_retries_all_active`

## Why are we making these changes?

We've seen `test_group_failed_only_change_retries_all_active` fail with:

```bash
...
2018-04-23 21:29:20,889 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:20,897 [DEBUG] Currently {'running': 0, 'waiting': 5} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:20,897 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:21,910 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:21,911 [DEBUG] Currently {'running': 0, 'waiting': 5} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:21,911 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:22,922 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:22,923 [DEBUG] Currently {'running': 0, 'waiting': 5} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:22,923 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:23,937 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:23,938 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:23,938 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:24,959 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:24,960 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:24,960 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:25,970 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:25,972 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:25,972 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:26,997 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:26,998 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:27,013 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:28,025 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:28,026 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:28,027 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:29,034 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:29,038 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:29,038 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:30,047 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:30,048 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:30,048 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:31,079 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:31,080 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:31,080 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:32,090 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:32,091 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:32,091 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:33,102 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:33,103 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:33,103 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:34,137 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:34,141 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:34,141 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:35,166 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:35,167 [DEBUG] Currently {'running': 4, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:35,167 [DEBUG] wait_until condition not yet met, retrying...
2018-04-23 21:29:36,176 [DEBUG] http://localhost:12321 "GET /group?uuid=00807c9e-ecd5-4229-865b-49eff5512cb8&detailed=true HTTP/1.1" 200 None
2018-04-23 21:29:36,177 [DEBUG] Currently {'running': 0, 'waiting': 0} jobs in group 00807c9e-ecd5-4229-865b-49eff5512cb8
2018-04-23 21:29:36,177 [DEBUG] wait_until condition not yet met, retrying...
...
```

It's clear from this that 1 of the 5 jobs completed, but it's not clear whether it succeeded or failed, or if it failed, what the cause was. This PR adds a little more debugging info to help track this down.