### PR TITLE
Adds debugging info to the memory-limit tests

### DIFF
--- a/integration/tests/cook/mesos.py
+++ b/integration/tests/cook/mesos.py
@@ -117,9 +117,12 @@ def dump_sandbox_files(session, instance, job):
         directory = retrieve_instance_sandbox_directory(session, instance, job)
         entries = browse_files(session, instance, directory, None)
         for entry in entries:
-            if is_directory(entry):
-                logging.info(f'Skipping over directory {entry}')
-            else:
-                cat_for_instance(session, instance, directory, entry['path'])
+            try:
+                if is_directory(entry):
+                    logging.info(f'Skipping over directory {entry}')
+                else:
+                    cat_for_instance(session, instance, directory, entry['path'])
+            except Exception as e:
+                logging.info(f'Unable to dump sandbox file {entry}: {e}')
     except Exception as e:
         logging.info(f'Unable to dump sandbox files: {e}')

--- a/integration/tests/cook/mesos.py
+++ b/integration/tests/cook/mesos.py
@@ -17,7 +17,7 @@ def instance_to_agent_url(instance):
     return f'http://{netloc}'
 
 
-def sandbox_directory(instance):
+def sandbox_directory(session, instance, job):
     """Given an instance and its parent job, determines the Mesos agent sandbox directory"""
 
     # Check if we've simply been handed the sandbox directory
@@ -36,8 +36,29 @@ def sandbox_directory(instance):
                 logging.debug('parsed sandbox directory from output url')
                 return path_list[0]
 
+    # As a last resort, query the Mesos agent state
+    agent_url = instance_to_agent_url(instance)
+    resp = session.get(f'{agent_url}/state')
+    if resp.status_code != 200:
+        logging.error(f'mesos agent returned status code {resp.status_code} and body {resp.text}')
+        raise Exception('Encountered error when querying Mesos agent for the sandbox directory.')
+
+    # Parse the Mesos agent state and look for a matching executor
+    resp_json = resp.json()
+    frameworks = resp_json['completed_frameworks'] + resp_json['frameworks']
+    cook_framework = next(f for f in frameworks if f['id'] == job['framework_id'])
+    cook_executors = cook_framework['completed_executors'] + cook_framework['executors']
     instance_id = instance['task_id']
-    raise Exception(f'Unable to determine sandbox directory for job instance {instance_id}.')
+    directories = [e['directory'] for e in cook_executors if e['id'] == instance_id]
+
+    if len(directories) == 0:
+        raise Exception(f'Unable to retrieve sandbox directory for job instance {instance_id}.')
+
+    if len(directories) > 1:
+        # This should not happen, but we'll be defensive anyway
+        raise Exception(f'Found more than one Mesos executor with ID {instance_id}')
+
+    return directories[0]
 
 
 def browse_files(session, instance, sandbox_dir, path):
@@ -90,10 +111,10 @@ def cat_for_instance(session, instance, sandbox_dir, path):
         logging.exception(bpe)
 
 
-def dump_sandbox_files(session, instance):
+def dump_sandbox_files(session, instance, job):
     """Logs the contents of each file in the root of the given instance's sandbox."""
     try:
-        directory = sandbox_directory(instance)
+        directory = sandbox_directory(session, instance, job)
         entries = browse_files(session, instance, directory, None)
         for entry in entries:
             try:

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -409,6 +409,7 @@ class CookTest(unittest.TestCase):
         self.assertEqual(201, resp.status_code, msg=resp.content)
         instance = util.wait_for_instance(self.cook_url, job_uuid)
         self.logger.debug('instance: %s' % instance)
+        job = instance['parent']
         try:
             job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
             job_details = f"Job details: {json.dumps(job, sort_keys=True)}"
@@ -430,7 +431,7 @@ class CookTest(unittest.TestCase):
             else:
                 self.fail('Unknown reason code {}, details {}'.format(instance['reason_code'], instance_details))
         finally:
-            mesos.dump_sandbox_files(util.session, instance, instance['parent'])
+            mesos.dump_sandbox_files(util.session, instance, job)
             util.kill_jobs(self.cook_url, [job_uuid])
 
     @pytest.mark.memlimit

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -430,7 +430,7 @@ class CookTest(unittest.TestCase):
             else:
                 self.fail('Unknown reason code {}, details {}'.format(instance['reason_code'], instance_details))
         finally:
-            mesos.dump_sandbox_files(util.session, instance)
+            mesos.dump_sandbox_files(util.session, instance, instance['parent'])
             util.kill_jobs(self.cook_url, [job_uuid])
 
     @pytest.mark.memlimit
@@ -1411,7 +1411,7 @@ class CookTest(unittest.TestCase):
             job = util.load_job(self.cook_url, job_uuid)
             self.logger.info(f'Job status is {job["status"]}: {job}')
             util.session.delete('%s/rawscheduler?job=%s' % (self.cook_url, job_uuid))
-            mesos.dump_sandbox_files(util.session, instance)
+            mesos.dump_sandbox_files(util.session, instance, job)
 
     def test_unscheduled_jobs(self):
         unsatisfiable_constraint = ['HOSTNAME', 'EQUALS', 'fakehost']

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -407,8 +407,7 @@ class CookTest(unittest.TestCase):
         the job should be killed by Mesos as it exceeds its memory limits."""
         job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=executor_type, mem=128)
         self.assertEqual(201, resp.status_code, msg=resp.content)
-        job = util.wait_for_job(self.cook_url, job_uuid, 'running')
-        instance = job['instances'][0]
+        instance = util.wait_for_instance(self.cook_url, job_uuid)
         self.logger.debug('instance: %s' % instance)
         try:
             job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
@@ -431,7 +430,7 @@ class CookTest(unittest.TestCase):
             else:
                 self.fail('Unknown reason code {}, details {}'.format(instance['reason_code'], instance_details))
         finally:
-            mesos.dump_sandbox_files(util.session, instance, job)
+            mesos.dump_sandbox_files(util.session, instance)
             util.kill_jobs(self.cook_url, [job_uuid])
 
     @pytest.mark.memlimit
@@ -1412,7 +1411,7 @@ class CookTest(unittest.TestCase):
             job = util.load_job(self.cook_url, job_uuid)
             self.logger.info(f'Job status is {job["status"]}: {job}')
             util.session.delete('%s/rawscheduler?job=%s' % (self.cook_url, job_uuid))
-            mesos.dump_sandbox_files(util.session, instance, job)
+            mesos.dump_sandbox_files(util.session, instance)
 
     def test_unscheduled_jobs(self):
         unsatisfiable_constraint = ['HOSTNAME', 'EQUALS', 'fakehost']

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -398,6 +398,7 @@ class CookTest(unittest.TestCase):
                   '    V="${V}.${R}"; ' \
                   '    echo "progress: ${p} ${p}-percent iter-${i}" ; ' \
                   '  done ; ' \
+                  '  echo "Length of V is ${#V}" ; ' \
                   'done'
         return command
 
@@ -405,8 +406,11 @@ class CookTest(unittest.TestCase):
         """Given a command that needs more memory than it is allocated, when the command is submitted to cook,
         the job should be killed by Mesos as it exceeds its memory limits."""
         job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=executor_type, mem=128)
+        self.assertEqual(201, resp.status_code, msg=resp.content)
+        job = util.wait_for_job(self.cook_url, job_uuid, 'running')
+        instance = job['instances'][0]
+        self.logger.debug('instance: %s' % instance)
         try:
-            self.assertEqual(201, resp.status_code, msg=resp.content)
             job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
             job_details = f"Job details: {json.dumps(job, sort_keys=True)}"
             self.assertEqual('failed', job['state'], job_details)
@@ -427,6 +431,7 @@ class CookTest(unittest.TestCase):
             else:
                 self.fail('Unknown reason code {}, details {}'.format(instance['reason_code'], instance_details))
         finally:
+            mesos.dump_sandbox_files(util.session, instance, job)
             util.kill_jobs(self.cook_url, [job_uuid])
 
     @pytest.mark.memlimit


### PR DESCRIPTION
## Changes proposed in this PR

- adding tighter exception handling to `dump_sandbox_files`
- dumping all sandbox files in the `finally` block of `memory_limit_exceeded_helper`

## Why are we making these changes?

We've seen test failures where the job that is supposed to exceed its memory and get killed doesn't get killed within the timeout we expect. We want to have more information in order to track down the root cause(s).
