### PR TITLE
Adds debugging info to group_submit_kill_retry

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1758,7 +1758,7 @@ class CookCliTest(unittest.TestCase):
         self.assertIn('submit: error: argument --gpus: 0 is not a positive integer', cli.decode(cp.stderr))
 
     def test_submit_with_pool(self):
-        pools, _ = util.pools(self.cook_url)
+        pools, _ = util.all_pools(self.cook_url)
         if len(pools) == 0:
             self.logger.info('There are no pools to submit jobs to')
         for pool in pools:


### PR DESCRIPTION
## Changes proposed in this PR

- logging job details and sandbox files in `group_submit_kill_retry`

## Why are we making these changes?

We've seen test failures like this:

```bash
=================================== FAILURES ===================================
__________________ CookTest.test_group_change_killed_retries ___________________
[gw2] linux -- Python 3.6.3 /opt/python/3.6.3/bin/python3.6
self = <tests.cook.test_basic.CookTest testMethod=test_group_change_killed_retries>
    def test_group_change_killed_retries(self):
        jobs = util.group_submit_kill_retry(self.cook_url, retry_failed_jobs_only=False)
        # ensure none of the jobs are still in a failed state
        for job in jobs:
>           self.assertNotEqual('failed', job['state'], f'Job details: {json.dumps(job, sort_keys=True)}')
E           AssertionError: 'failed' == 'failed' : Job details: {"command": "sleep 1", "constraints": [], "cpus": 1.0, "disable_mea_culpa_retries": false, "env": {}, "framework_id": "cook-framework-1", "gpus": 0, "groups": [{"name": "cookgroup", "uuid": "163ca4a5-a52b-4b06-b689-50d4ca85a7cc"}], "instances": [{"backfilled": false, "end_time": 1524591676398, "executor": "cook", "executor_id": "133fcef0-281a-41c2-968d-3bcb200205fc", "hostname": "172.17.0.7", "ports": [], "preempted": false, "progress": 0, "reason_code": 3004, "reason_string": "Invalid task", "slave_id": "7a8669df-eef9-43cb-9282-6698120166f8-S2", "start_time": 1524591676190, "status": "failed", "task_id": "133fcef0-281a-41c2-968d-3bcb200205fc"}, {"backfilled": false, "end_time": 1524591672297, "executor": "cook", "executor_id": "2918e4e9-f25a-4c44-8773-1b400d301327", "hostname": "172.17.0.9", "ports": [], "preempted": false, "progress": 0, "reason_code": 6002, "reason_string": "Mesos executor unregistered", "slave_id": "7a8669df-eef9-43cb-9282-6698120166f8-S4", "start_time": 1524591671130, "status": "failed", "task_id": "2918e4e9-f25a-4c44-8773-1b400d301327"}], "labels": {}, "max_retries": 2, "max_runtime": 9223372036854775807, "mem": 256.0, "name": "default_test_job", "ports": 0, "priority": 1, "retries_remaining": 0, "state": "failed", "status": "completed", "submit_time": 1524591669708, "uris": [], "user": "root", "uuid": "27ef6697-989e-45c5-8a5e-1cb680a51bbd"}
```

And we want to have more information to help track down the root cause.