### PR TITLE
disables parallelism in cook executor unit tests

### DIFF
--- a/executor/setup.cfg
+++ b/executor/setup.cfg
@@ -1,3 +1,3 @@
 [tool:pytest]
-addopts = -n10 -v --timeout-method=thread
+addopts = -n 1 -v --timeout-method=thread
 timeout = 1200


### PR DESCRIPTION
## Changes proposed in this PR

- disables parallelism in cook executor unit tests

## Why are we making these changes?

With parallel tests, it is possible that interleavings of method calls cause tests to fail, e.g. by `mkdir` failing as file already exists:

```
____________________ ExecutorTest.test_executor_launch_task ____________________
[gw1] linux -- Python 3.6.3 /opt/python/3.6.3/bin/python3.6
self = <tests.test_executor.ExecutorTest testMethod=test_executor_launch_task>
    def test_executor_launch_task(self):
    
        task_id = tu.get_random_task_id()
>       stdout_name = tu.ensure_directory('build/stdout.{}'.format(task_id))
tests/test_executor.py:747: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
output_filename = 'build/stdout.393667'
    def ensure_directory(output_filename):
        """"Ensures that the directory that contains output_filename is created before returning output_filename."""
        target_dir = os.path.dirname(output_filename)
        if not os.path.isdir(target_dir):
>           os.mkdir(target_dir)
E           FileExistsError: [Errno 17] File exists: 'build'
```

We'd rather have a longer running successful stage than a faster flaky stage.

