### PR TITLE
Improves logging when Datomic task transactions time out

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -460,7 +460,7 @@ class CookTest(unittest.TestCase):
             self.logger.info("Skipping test_memory_limit_exceeded_cook_script, executor={}".format(job_executor_type))
 
     @pytest.mark.memlimit
-    @unittest.skipUnless(util.continuous_integration(), "Doesn't work in our local test environments")
+    # @unittest.skipUnless(util.continuous_integration(), "Doesn't work in our local test environments")
     def test_memory_limit_exceeded_mesos_script(self):
         command = self.memory_limit_script_command()
         self.memory_limit_exceeded_helper(command, 'mesos')

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -460,7 +460,7 @@ class CookTest(unittest.TestCase):
             self.logger.info("Skipping test_memory_limit_exceeded_cook_script, executor={}".format(job_executor_type))
 
     @pytest.mark.memlimit
-    # @unittest.skipUnless(util.continuous_integration(), "Doesn't work in our local test environments")
+    @unittest.skipUnless(util.continuous_integration(), "Doesn't work in our local test environments")
     def test_memory_limit_exceeded_mesos_script(self):
         command = self.memory_limit_script_command()
         self.memory_limit_exceeded_helper(command, 'mesos')

--- a/scheduler/src/cook/datomic.clj
+++ b/scheduler/src/cook/datomic.clj
@@ -16,6 +16,7 @@
 (ns cook.datomic
   (:require [clojure.core.async :as async]
             [clojure.pprint :refer (pprint)]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [cook.config :refer (config)]
             [cook.util :as util]
@@ -104,3 +105,23 @@
          (log/warn "Retrying txn" txn "attempt" (- (count retry-schedule) (count sched)) "of" (count retry-schedule))
          (async/<! (async/timeout sleep))
          (recur sched))))))
+
+(defn transaction-timeout?
+  "Returns true if the given exception is due to a transaction timeout"
+  [exception]
+  (str/includes? (str (.getMessage exception)) "Transaction timed out."))
+
+(defn transact
+  "Like datomic.api/transact, except the caller provides
+  a handler function for transaction timeout exceptions"
+  [conn tx-data handle-timeout-fn]
+  (try
+    @(d/transact conn tx-data)
+    (catch Exception e
+      (if (transaction-timeout? e)
+        (do
+          (log/warn e "Datomic transaction timed out")
+          (handle-timeout-fn e))
+        (do
+          (log/warn e "Datomic transaction caused exception")
+          (throw e))))))

--- a/scheduler/src/cook/datomic.clj
+++ b/scheduler/src/cook/datomic.clj
@@ -123,5 +123,5 @@
           (log/warn e "Datomic transaction timed out")
           (handle-timeout-fn e))
         (do
-          (log/warn e "Datomic transaction caused exception")
+          (log/error e "Datomic transaction caused exception")
           (throw e))))))

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1529,7 +1529,7 @@
 
      :post! (partial create-jobs! conn)
      :handle-exception (fn [{:keys [exception]}]
-                         (if (str/includes? (str (.getMessage exception)) "Transaction timed out.")
+                         (if (datomic/transaction-timeout? exception)
                            {:error (str "Transaction timed out."
                                         " Your jobs may not have been created successfully."
                                         " Please query your jobs and check whether they were created successfully.")}

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -25,7 +25,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [cook.config :refer (default-fitness-calculator)]
-            [cook.datomic :refer (transact-with-retries) :as datomic]
+            [cook.datomic :as datomic]
             [cook.mesos.constraints :as constraints]
             [cook.mesos.dru :as dru]
             [cook.mesos.fenzo-utils :as fenzo]
@@ -285,7 +285,7 @@
              (log/debug "Transacting updated state for instance" instance "to status" instance-status)
              ;; The database can become inconsistent if we make multiple calls to :instance/update-state in a single
              ;; transaction; see the comment in the definition of :instance/update-state for more details
-             (transact-with-retries
+             (datomic/transact-with-retries
                conn
                (reduce
                  into
@@ -464,7 +464,7 @@
                                         :progress-sequence progress-sequence}))
             (when exit-code
               (log/info "Updating instance" instance-id "exit-code to" exit-code)
-              (transact-with-retries conn [[:db/add instance-id :instance/exit-code (int exit-code)]])))))
+              (datomic/transact-with-retries conn [[:db/add instance-id :instance/exit-code (int exit-code)]])))))
       (catch Exception e
         (log/error e "Mesos scheduler framework message error")))))
 
@@ -1080,10 +1080,10 @@
                            (db conn) [:job.state/waiting
                                       :job.state/running]))]
     (doseq [js (partition-all 25 jobs)]
-      (async/<!! (transact-with-retries conn
-                                        (mapv (fn [j]
-                                                [:job/update-state j])
-                                              js))))))
+      (async/<!! (datomic/transact-with-retries conn
+                                                (mapv (fn [j]
+                                                        [:job/update-state j])
+                                                      js))))))
 
 ;; TODO test that this fenzo recovery system actually works
 (defn reconcile-tasks
@@ -1414,12 +1414,12 @@
               ;; Transact synchronously so that it won't accidentally put a huge
               ;; spike of load on the transactor.
               (async/<!!
-                (transact-with-retries conn
-                                       (mapv
-                                         (fn [job]
-                                           [:db/add [:job/uuid (:job/uuid job)]
-                                            :job/state :job.state/completed])
-                                         jobs))))
+                (datomic/transact-with-retries conn
+                                               (mapv
+                                                 (fn [job]
+                                                   [:db/add [:job/uuid (:job/uuid job)]
+                                                    :job/state :job.state/completed])
+                                                 jobs))))
             (log/warn "Suppressed offensive" (count offensive-jobs) "jobs" (mapv :job/uuid offensive-jobs))
             (catch Exception e
               (log/error e "Failed to kill the offensive job!")))

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -41,7 +41,8 @@
                               TaskRequest TaskScheduler VMTaskFitnessCalculator)
            (com.netflix.fenzo.plugins BinPackingFitnessCalculators)
            (java.util UUID)
-           (java.util.concurrent CountDownLatch TimeUnit)))
+           (java.util.concurrent CountDownLatch TimeUnit)
+           (org.mockito Mockito)))
 
 (def datomic-uri "datomic:mem://test-mesos-jobs")
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding `datomic/transact`, which requires a handler function for transaction timeouts
- calling `datomic/transact` from `launch-matched-tasks!` and logging the matches that are in question when the transaction times out
- adding a unit test

## Why are we making these changes?

To have better logs if/when this situation occurs in the wild. We've seen it happen in test environments.