### PR TITLE
Makes test_ports more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1074,11 +1074,11 @@ class CookTest(unittest.TestCase):
 
     def test_ports(self):
         job_uuid, resp = util.submit_job(self.cook_url, ports=1)
-        job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
-        self.assertEqual(1, len(job['instances'][0]['ports']))
+        instance = util.wait_for_instance(self.cook_url, job_uuid)
+        self.assertEqual(1, len(instance['ports']))
         job_uuid, resp = util.submit_job(self.cook_url, ports=10)
-        job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
-        self.assertEqual(10, len(job['instances'][0]['ports']))
+        instance = util.wait_for_instance(self.cook_url, job_uuid)
+        self.assertEqual(10, len(instance['ports']))
 
     def test_allow_partial_for_groups(self):
         def absent_uuids(response):


### PR DESCRIPTION
## Changes proposed in this PR

- instead of waiting for the job to complete, simply wait for an instance to appear

## Why are we making these changes?

We've seen this test fail because the job doesn't complete within the timeout, but the instance does show the correct number of ports, which is all we really care about in this particular test.
