### PR TITLE
Fix bugs in /retry endpoint

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1841,6 +1841,13 @@
                              jobs)))
       [true {::error (str "Increment would exceed the maximum retry limit of " retry-limit)}]
 
+      (and retries (let [db (d/db conn)]
+                     (some (fn [job]
+                             (> (d/invoke db :job/attempts-consumed db (d/entity db [:job/uuid job]))
+                                retries))
+                           jobs)))
+      [true {::error (str "Retries would be less than attempts-consumed")}]
+
       :else
       (let [db (d/db conn)
             group-jobs (for [guuid groups

--- a/scheduler/test/cook/test/mesos/util.clj
+++ b/scheduler/test/cook/test/mesos/util.clj
@@ -568,7 +568,9 @@
   (let [uri "datomic:mem://test-retry-job"
         conn (restore-fresh-database! uri)]
     (testing "increment retries on running job"
-      (let [[job _] (create-dummy-job-with-instances conn :job-state :job.state/running
+      (let [[job _] (create-dummy-job-with-instances conn
+                                                     :job-state :job.state/running
+                                                     :retry-count 5
                                                      :instances [{:instance-status :instance.status/running}])
             uuid (:job/uuid (d/entity (d/db conn) job))]
         (util/retry-job! conn uuid 10)
@@ -611,7 +613,9 @@
           (is (= :job.state/completed (:job/state job-ent))))))
 
     (testing "increment retries on waiting job"
-      (let [job (create-dummy-job conn :job-state :job.state/waiting)
+      (let [job (create-dummy-job conn
+                                  :job-state :job.state/waiting
+                                  :retry-count 5)
             job-uuid (:job/uuid (d/entity (d/db conn) job))]
         (util/retry-job! conn job-uuid 20)
         (let [job-ent (d/entity (d/db conn) job)]


### PR DESCRIPTION
## Changes proposed in this PR
- Only put job in waiting state if there are still attempts remaining
- Do not allow setting retries to less than attempts consumed

## Why are we making these changes?
Prevents jobs getting into a bad state, where they have negative attempts remaining.
