### PR TITLE
Travis log uploads

### DIFF
--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -136,9 +136,9 @@ export COOK_MASTER_SLAVE=
 export COOK_SLAVE_URL=http://localhost:12323
 pytest -n4 -v --color=no --timeout-method=thread --boxed -m "${PYTEST_MARKS}" || test_failures=true
 
-# If there were failures, dump the executor logs
+# If there were failures, then we should save the logs
 if [ "$test_failures" = true ]; then
-  echo "Displaying scheduler logs"
-  ${TRAVIS_BUILD_DIR}/travis/show_scheduler_logs.sh
+  echo "Uploading logs..."
+  ${TRAVIS_BUILD_DIR}/travis/upload_logs.sh
   exit 1
 fi

--- a/travis/gdrive_upload
+++ b/travis/gdrive_upload
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import base64
+import os
+import requests
+import sys
+import warnings
+
+if len(sys.argv) != 3:
+    print('USAGE: {} JOB-ID XZ-FILE', sys.argv[0])
+    print('Upload an xz-compressed file to our Google Drive stash')
+    sys.exit(1)
+
+tarball_path = sys.argv[2]
+
+# upload to google drive
+app_url = os.environ.get('GDRIVE_LOG_POST_URL')
+
+if not app_url:
+    print('Missing application url. Please set GDRIVE_LOG_POST_URL in the environment.')
+    sys.exit(1)
+
+with open(tarball_path, 'rb') as tarball:
+    post_data = {
+        'job_id': sys.argv[1],
+        'tarball': base64.b64encode(tarball.read())
+    }
+
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    response = requests.post(app_url, data=post_data, timeout=10)
+
+print()
+print('==============================')
+print('== UPLOAD RESPONSE:')
+print('==============================')
+print(response.text)
+print('==============================')
+print()
+
+if not response.text.strip().endswith('successfully'):
+    print('UPLOAD FAILED!')
+    sys.exit(1)

--- a/travis/upload_logs.sh
+++ b/travis/upload_logs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cd ${TRAVIS_BUILD_DIR}
+
+tarball=./dump.txz
+tar -cJf $tarball --transform='s|\./[^/]*/\.*||' ./scheduler/log ./travis/.minimesos
+./travis/gdrive_upload "travis-${TRAVIS_JOB_NUMBER:-dump}" $tarball


### PR DESCRIPTION
## Changes proposed in this PR

Upload logs when the integration tests fail in Travis-CI.

## Why are we making these changes?

We need the logs for debugging failures, but there are too many to simply dump them on stdout. (Travis has a hard limit on the length of your job output.)