### PR TITLE
Adds build number directory to tarball

### DIFF
--- a/travis/upload_logs.sh
+++ b/travis/upload_logs.sh
@@ -3,5 +3,5 @@
 cd ${TRAVIS_BUILD_DIR}
 
 tarball=./dump.txz
-tar -cJf $tarball --transform='s|\./[^/]*/\.*||' ./scheduler/log ./travis/.minimesos
+tar -cJf $tarball --transform="s|\./[^/]*/\.*|${TRAVIS_JOB_NUMBER}/|" ./scheduler/log ./travis/.minimesos
 ./travis/gdrive_upload "travis-${TRAVIS_JOB_NUMBER:-dump}" $tarball


### PR DESCRIPTION
## Changes proposed in this PR

- adding a top-level directory named with the build number to the tarball

## Why are we making these changes?

When extracting to the same directory, it will separate out the contents by build, which is much nicer.
