### PR TITLE
Adds debugging info to test_retries_unchanged_does_not_restart_job

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2219,6 +2219,6 @@ class CookTest(unittest.TestCase):
         util.wait_for_job(self.cook_url, uuid, 'completed')
         util.retry_jobs(self.cook_url, job=uuid, retries=1)
         job = util.load_job(self.cook_url, uuid)
-        self.assertEqual('completed', job['status'])
-        self.assertEqual(1, len(job['instances']))
+        self.assertEqual('completed', job['status'], json.dumps(job, indent=2))
+        self.assertEqual(1, len(job['instances']), json.dumps(job, indent=2))
 


### PR DESCRIPTION
## Changes proposed in this PR

- logging the full job details when an assertion fails

## Why are we making these changes?

We've seen this test fail with:

```bash
_____________ CookTest.test_retries_unchanged_does_not_restart_job _____________
[gw1] linux -- Python 3.6.3 /opt/python/3.6.3/bin/python3.6
self = <tests.cook.test_basic.CookTest testMethod=test_retries_unchanged_does_not_restart_job>
    def test_retries_unchanged_does_not_restart_job(self):
        uuid, resp = util.submit_job(self.cook_url, command='exit 0', max_retries=1)
        util.wait_for_job(self.cook_url, uuid, 'completed')
        util.retry_jobs(self.cook_url, job=uuid, retries=1)
        job = util.load_job(self.cook_url, uuid)
        self.assertEqual('completed', job['status'])
>       self.assertEqual(1, len(job['instances']))
E       AssertionError: 1 != 2
```

And we want to track down why.
