### PR TITLE
Return 409 (Conflict) when call to /retry is a no-op

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2228,10 +2228,7 @@ class CookTest(unittest.TestCase):
         try:
             util.wait_for_job(self.cook_url, uuid, 'running')
             resp = util.retry_jobs(self.cook_url, job=uuid, assert_response=False, retries=1)
-            self.assertEqual(409, resp.status_code, msg=resp.content)
-            job = util.load_job(self.cook_url, uuid)
-            self.assertEqual('completed', job['status'], json.dumps(job, indent=2))
-            self.assertEqual(1, len(job['instances']), json.dumps(job, indent=2))
+            self.assertEqual(201, resp.status_code, msg=resp.content)
         finally:
             util.kill_jobs(self.cook_url, [uuid])
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2255,10 +2255,11 @@ class CookTest(unittest.TestCase):
 
     def test_set_retries_to_attempts_conflict(self):
         uuid, resp = util.submit_job(self.cook_url, command='sleep 30', max_retries=5, disable_mea_culpa_retries=True)
-        util.wait_for_instance(self.cook_url, uuid)
+        util.wait_until(lambda: util.load_job(self.cook_url, uuid),
+                        lambda j: (len(j['instances']) == 1) and (j['instances'][0]['status'] == 'running'))
         util.kill_jobs(self.cook_url, [uuid])
         def instances_complete(job):
-            return all([i['status'] != 'running' for i in job['instances']])
+            return all([i['status'] == 'failed' for i in job['instances']])
         job = util.wait_until(lambda: util.load_job(self.cook_url, uuid), instances_complete)
         self.assertEqual('completed', job['status'], json.dumps(job, indent=2))
         num_instances = len(job['instances'])

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2214,10 +2214,29 @@ class CookTest(unittest.TestCase):
         self.assertEqual('Retries would be less than attempts-consumed',
                          resp.json()['error'])
 
-    def test_retries_unchanged_does_not_restart_job(self):
-        uuid, resp = util.submit_job(self.cook_url, command='exit 0', max_retries=1)
+    def test_retries_unchanged_conflict(self):
+        uuid, resp = util.submit_job(self.cook_url, command='exit 0', max_retries=1, disable_mea_culpa_retries=True)
         util.wait_for_job(self.cook_url, uuid, 'completed')
-        util.retry_jobs(self.cook_url, job=uuid, retries=1)
+        resp = util.retry_jobs(self.cook_url, job=uuid, assert_response=False, retries=1)
+        self.assertEqual(409, resp.status_code, msg=resp.content)
+        job = util.load_job(self.cook_url, uuid)
+        self.assertEqual('completed', job['status'], json.dumps(job, indent=2))
+        self.assertEqual(1, len(job['instances']), json.dumps(job, indent=2))
+
+
+    def test_set_retries_to_attempts_conflict(self):
+        uuid, resp = util.submit_job(self.cook_url, command='sleep 30', max_retries=5, disable_mea_culpa_retries=True)
+        util.wait_for_instance(self.cook_url, uuid)
+        util.kill_jobs(self.cook_url, [uuid])
+        def instances_complete(job):
+            return all([i['status'] != 'running' for i in job['instances']])
+        job = util.wait_until(lambda: util.load_job(self.cook_url, uuid), instances_complete)
+        self.assertEqual('completed', job['status'], json.dumps(job, indent=2))
+        num_instances = len(job['instances'])
+        self.assertEqual(5-num_instances, job['retries_remaining'], json.dumps(job, indent=2))
+
+        resp = util.retry_jobs(self.cook_url, job=uuid, retries=num_instances, assert_response=False)
+        self.assertEqual(409, resp.status_code, msg=resp.content)
         job = util.load_job(self.cook_url, uuid)
         self.assertEqual('completed', job['status'])
-        self.assertEqual(1, len(job['instances']))
+        self.assertEqual(num_instances, len(job['instances']), json.dumps(job, indent=2))

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2228,7 +2228,7 @@ class CookTest(unittest.TestCase):
         try:
             util.wait_for_job(self.cook_url, uuid, 'running')
             resp = util.retry_jobs(self.cook_url, job=uuid, assert_response=False, retries=1)
-            self.assertEqual(201, resp.status_code, msg=resp.content)
+            self.assertEqual(409, resp.status_code, msg=resp.content)
         finally:
             util.kill_jobs(self.cook_url, [uuid])
 

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1895,8 +1895,8 @@
         db (d/db conn)]
     (if (not (nil? retries))
       (let [jobs-not-updated (filter (fn [uuid]
-                                       (let [job (d/entity db [:job/uuid uuid])]
-                                         (and (= :job.state/completed (:job/state job))
+                                       (let [{:keys [job/state] :as job} (d/entity db [:job/uuid uuid])]
+                                         (and (= :job.state/completed state)
                                               (= retries (d/invoke db :job/attempts-consumed db job)))))
                                      jobs)]
         (if (not (empty? jobs-not-updated))

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1895,7 +1895,7 @@
         db (d/db conn)]
     (if (not (nil? retries))
       (let [jobs-not-updated (filter (fn [uuid]
-                                       (let [job (d/entity (d/db conn) [:job/uuid uuid])]
+                                       (let [job (d/entity db [:job/uuid uuid])]
                                          (and (= :job.state/completed (:job/state job))
                                               (= retries (d/invoke db :job/attempts-consumed db job)))))
                                      jobs)]

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1886,6 +1886,9 @@
         true)))
 
 (defn check-retry-conflict
+  "Checks whether a 409 conflict should be returned during a retry operation. This should occur when one of the jobs:
+   - Is already completed
+   - Has already retried 'retries' times"
   [conn ctx]
   (let [jobs (::jobs ctx)
         retries (get-in ctx [:request :body-params :retries])


### PR DESCRIPTION
## Changes proposed in this PR
- Return a 409 (Conflict) when a write to /retry does not retry the job or change the max-retries

## Why are we making these changes?
Reduce user confusion around /retry requests which don't affect the job.

