### PR TITLE
Adds states and user to 'no jobs found' message

### DIFF
--- a/cli/cook/subcommands/jobs.py
+++ b/cli/cook/subcommands/jobs.py
@@ -17,10 +17,16 @@ DEFAULT_LOOKBACK_HOURS = 6
 DEFAULT_LIMIT = 150
 
 
-def print_no_data(clusters):
+def print_no_data(clusters, states, user):
     """Prints a message indicating that no data was found in the given clusters"""
     clusters_text = ' / '.join([c['name'] for c in clusters])
-    print(colors.failed('No jobs found in %s.' % clusters_text))
+    if 'all' in states:
+        states = ['waiting', 'running', 'completed']
+    elif 'success' in states:
+        states.remove('success')
+        states.append('successful')
+    states_text = ' / '.join(states)
+    print(colors.failed(f'No {states_text} jobs for {user} found in {clusters_text}.'))
 
 
 def list_jobs_on_cluster(cluster, state, user, start_ms, end_ms, name, limit, include_custom_executor):
@@ -163,7 +169,7 @@ def jobs(clusters, args, _):
     elif found_jobs:
         print_as_table(query_result)
     else:
-        print_no_data(clusters)
+        print_no_data(clusters, states, user)
     return 0
 
 

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.2.0'
+VERSION = '2.3.0'

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -416,7 +416,8 @@ class CookCliTest(unittest.TestCase):
     def test_list_no_matching_jobs(self):
         cp = cli.jobs(self.cook_url, '--name %s' % uuid.uuid4())
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(f'No jobs found in {self.cook_url}.', cli.stdout(cp))
+        self.assertIn('No running jobs', cli.stdout(cp))
+        self.assertIn(f'found in {self.cook_url}.', cli.stdout(cp))
 
     def list_jobs(self, name, user, *states):
         """Invokes the jobs subcommand with the given name, user, and state filters"""


### PR DESCRIPTION
## Changes proposed in this PR

- changing the message from `No jobs found in CLUSTER.` to `No running / waiting jobs for USER found in CLUSTER.`

```bash
$ cs jobs --success
No successful jobs for dpo found in dev0.

$ cs jobs --failed                                                                                                                                                                                                                  
No failed jobs for dpo found in dev0.

$ cs jobs --running --waiting --all                                                                                                                                                                                                 
No waiting / running / completed jobs for dpo found in dev0.

$ cs jobs --running --waiting
No running / waiting jobs for dpo found in dev0.

$ cs jobs
No running jobs for dpo found in dev0.
```

## Why are we making these changes?

To make it more clear when, for example, the user has jobs in a state that was not the one queried for.
