### PR TITLE
Add estimated-completion-constraint

### DIFF
--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -240,6 +240,8 @@ Example: +
   This option is a map that allows you to configure limits for tasks, to ensure that impossible-to-schedule tasks and tasks that run forever won't bog down your cluster.
   It currently supports 4 parameters to defend the Cook scheduler, which are described in <<task_constraints>>.
 
+`:estimated-completion-constraint`::
+ This allows you to configure an optional constraint which will not launch jobs on VMs where the job is expected to run longer than the host's expected lifetime (for instance, on GCP spot VMs.) The configuration parameters are described in <<estimated_completion_constraint>>.
 
 [[rebalancer]]
 ==== Rebalancer configuration
@@ -340,6 +342,15 @@ Example optimizer config:
 `:retry-limit`::
   This limits the number of retries a job is allowed to request. Something in the low tens is often more than sufficient.
 
+[[estimated_completion_constraint]]
+==== Estimated Completion Constraint
+`:expected-runtime-multiplier`::
+ This is a configurable constant factor which will multiply the expected runtime on each job to compute
+ when the job will complete. For instance, if `estimated-runtime-multiplier` is 2.5 and a job has an expected
+ runtime of 60000 ms, it will not be scheduled on a host which will die in 2.5 minutes.
+`:host-lifetime-mins`::
+ This is the expected lifetime of hosts in the cluster. Each host should have a `host-start-time` attribute in it's mesos offer
+ which will be used with the `host-lifetime-mins` parameter to determine when the host is expected to die.
 [[cook_executor]]
 ==== Cook Executor
 

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -241,7 +241,7 @@ Example: +
   It currently supports 4 parameters to defend the Cook scheduler, which are described in <<task_constraints>>.
 
 `:estimated-completion-constraint`::
- This allows you to configure an optional constraint which will not launch jobs on VMs where the job is expected to run longer than the host's expected lifetime (for instance, on GCP spot VMs.) The configuration parameters are described in <<estimated_completion_constraint>>.
+ This allows you to configure an optional constraint which will not launch jobs on VMs where the job is expected to run longer than the host's expected lifetime (for instance, public cloud spot VMs.) The configuration parameters are described in <<estimated_completion_constraint>>.
 
 [[rebalancer]]
 ==== Rebalancer configuration
@@ -349,8 +349,7 @@ Example optimizer config:
  when the job will complete. For instance, if `estimated-runtime-multiplier` is 2.5 and a job has an expected
  runtime of 60000 ms, it will not be scheduled on a host which will die in 2.5 minutes.
 `:host-lifetime-mins`::
- This is the expected lifetime of hosts in the cluster. Each host should have a `host-start-time` attribute in it's mesos offer
- which will be used with the `host-lifetime-mins` parameter to determine when the host is expected to die.
+ This is the expected lifetime of hosts in the cluster. To apply the constraint, each host should have a `host-start-time` attribute in it's mesos offer which will be used with the `host-lifetime-mins` parameter to determine when the host is expected to die.
 [[cook_executor]]
 ==== Cook Executor
 

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -356,7 +356,9 @@
               pools)
 
      :api-only? (fnk [[:config {api-only? false}]]
-                  api-only?)}))
+                  api-only?)
+     :estimated-completion-constraint (fnk [[:config {estimated-completion-constraint nil}]]
+                                           estimated-completion-constraint)}))
 
 (defn read-config
   "Given a config file path, reads the config and returns the map"
@@ -414,3 +416,7 @@
   "Returns true if api-only? mode is turned on"
   []
   (-> config :settings :api-only?))
+
+(defn estimated-completion-config
+  []
+  (-> config :settings :estimated-completion-constraint))

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -168,7 +168,7 @@
     (if-let [host-start-time (get vm-attributes "host-start-time")]
       (let [host-death-time (+ (* 1000 (long host-start-time))
                                (* 60 1000 host-lifetime-mins))]
-        (if (< host-death-time estimated-end-time)
+        (if (< estimated-end-time host-death-time)
           [true ""]
           [false "host is expected to shutdown before job completion"]))
       [true ""])))

--- a/scheduler/test/cook/test/mesos/constraints.clj
+++ b/scheduler/test/cook/test/mesos/constraints.clj
@@ -191,6 +191,7 @@
   (testing "does not generate a constraint when turned off"
     (with-redefs [config/estimated-completion-config (constantly nil)]
       (is (nil? (constraints/build-estimated-completion-constraint {})))))
+
   (let [conn (restore-fresh-database! "datomic:mem://test-estimated-completion-constraint")]
     (with-redefs [config/estimated-completion-config (constantly {:expected-runtime-multiplier 1.2
                                                                   :host-lifetime-mins 60})
@@ -198,6 +199,7 @@
       (let [job-id (create-dummy-job conn)
             job (util/job-ent->map (d/entity (d/db conn) job-id))]
         (is (nil? (constraints/build-estimated-completion-constraint job))))
+
       (let [job-id (create-dummy-job conn :expected-runtime 1000)
             job (util/job-ent->map (d/entity (d/db conn) job-id))
             constraint (constraints/build-estimated-completion-constraint job)]

--- a/scheduler/test/cook/test/mesos/constraints.clj
+++ b/scheduler/test/cook/test/mesos/constraints.clj
@@ -229,5 +229,5 @@
         host-lifetime-mins 1
         constraint (constraints/->estimated-completion-constraint estimated-end-time host-lifetime-mins)]
     (is (first (constraints/job-constraint-evaluate constraint nil {})))
-    (is (first (constraints/job-constraint-evaluate constraint nil {"host-start-time" 0.0})))
-    (is (not (first (constraints/job-constraint-evaluate constraint nil {"host-start-time" 51.0}))))))
+    (is (not (first (constraints/job-constraint-evaluate constraint nil {"host-start-time" 0.0}))))
+    (is (first (constraints/job-constraint-evaluate constraint nil {"host-start-time" 51.0})))))


### PR DESCRIPTION
## Changes proposed in this PR
- Adds support for a new "estimated completion" constraint

## Why are we making these changes?
Some long-running jobs are scheduled on cloud spot VMs which are expected to be short-lived, leading to the jobs losing work and being rescheduled on different VMs. This constraint uses the `expected-runtime` of the job as a baseline as well as a configured age for each host to determine whether the job is expected to run to completion on the host before scheduling.
