### PR TITLE
Uploads Mesos master logs even when container stopped

### DIFF
--- a/travis/upload_logs.sh
+++ b/travis/upload_logs.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+set -e
+
 cd ${TRAVIS_BUILD_DIR}
 
 # Grab the Mesos master logs
 mkdir -p ./mesos/master-logs
-mesos_master_container=$(docker ps --filter "name=minimesos-master-" --format "{{.ID}}")
+docker ps --all --last 10
+mesos_master_container=$(docker ps --all --latest --filter "name=minimesos-master-" --format "{{.ID}}")
 docker cp --follow-link $mesos_master_container:/var/log/mesos-master.INFO ./mesos/master-logs/
 docker cp --follow-link $mesos_master_container:/var/log/mesos-master.WARNING ./mesos/master-logs/
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding `--all` to the `docker ps` that is responsible for uploading the Mesos master logs

## Why are we making these changes?

We've seen cases where the Mesos master seems to crash, and we want to be able to inspect its logs in these cases.
