### PR TITLE
Fix Travis-CI apt-get cached installation

### DIFF
--- a/travis/install_mesos.sh
+++ b/travis/install_mesos.sh
@@ -15,11 +15,12 @@ else
     cp -f /var/cache/apt/archives/*.deb $PACKAGE_CACHE_DIR/
 fi
 
-dpkg --force-all --install /var/cache/apt/archives/mesos_*.deb && apt-get install -fy
+set -x
+
+apt-get install --allow-downgrades --fix-broken --no-download --yes $PACKAGE_CACHE_DIR/*.deb
 APT_EXIT_CODE=$?
 
-if [ $APT_EXIT_CODE -ne 0 ]; then
-    echo 'Mesos installation error! Wiping package cache...'
-    rm -rf $PACKAGE_CACHE_DIR
+if [ $APT_EXIT_CODE -ne 0 ] || ! [ -f $MESOS_NATIVE_JAVA_LIBRARY ]; then
+    echo 'Mesos installation error!'
     exit $APT_EXIT_CODE
 fi


### PR DESCRIPTION
## Changes proposed in this PR

Fix the `apt-get` commands in our Mesos install script.

## Why are we making these changes?

Cached installs of Mesos are no longer working because the cached debian packages now have conflicts with the default packages in the default travis-ci debian image.