### PR TITLE
Adds optional waiting to cs tail

### DIFF
--- a/cli/cook/exceptions.py
+++ b/cli/cook/exceptions.py
@@ -1,0 +1,2 @@
+class CookRetriableException(Exception):
+    pass

--- a/cli/cook/mesos.py
+++ b/cli/cook/mesos.py
@@ -3,6 +3,7 @@ import os
 from urllib.parse import urlparse, parse_qs
 
 from cook import http
+from cook.exceptions import CookRetriableException
 
 
 def instance_to_agent_url(instance):
@@ -53,7 +54,7 @@ def retrieve_instance_sandbox_directory(instance, job):
     directories = [e['directory'] for e in cook_executors if e['id'] == instance_id]
 
     if len(directories) == 0:
-        raise Exception(f'Unable to retrieve sandbox directory for job instance {instance_id}.')
+        raise CookRetriableException(f'Unable to retrieve sandbox directory for job instance {instance_id}.')
 
     if len(directories) > 1:
         # This should not happen, but we'll be defensive anyway
@@ -74,11 +75,11 @@ def read_file(instance, sandbox_dir, path, offset=None, length=None):
 
     resp = http.__get(f'{agent_url}/files/read', params=params)
     if resp.status_code == 404:
-        raise Exception(f"Cannot open '{path}' for reading (file was not found).")
+        raise CookRetriableException(f"Cannot open '{path}' for reading (file was not found).")
 
     if resp.status_code != 200:
         logging.error(f'mesos agent returned status code {resp.status_code} and body {resp.text}')
-        raise Exception('Could not read the file.')
+        raise CookRetriableException('Could not read the file.')
 
     return resp.json()
 

--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -260,7 +260,8 @@ def query_unique_and_run(clusters, entity_ref, command_fn, wait_seconds=None):
 
     if wait_seconds:
         r = tenacity.Retrying(wait=tenacity.wait_fixed(5),
-                              stop=tenacity.stop_after_delay(wait_seconds))
+                              stop=tenacity.stop_after_delay(wait_seconds),
+                              reraise=True)
         r.call(query_unique_and_run)
     else:
         query_unique_and_run()

--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -261,8 +261,11 @@ def query_unique_and_run(clusters, entity_ref, command_fn, wait=False):
         # Importing tenacity locally to prevent startup time
         # from increasing in the default (i.e. don't wait) case
         import tenacity
+        one_day_in_seconds = 24 * 60 * 60
         r = tenacity.Retrying(wait=tenacity.wait_fixed(5),
-                              retry=tenacity.retry_if_exception_type(CookRetriableException))
+                              retry=tenacity.retry_if_exception_type(CookRetriableException),
+                              stop=tenacity.stop_after_delay(one_day_in_seconds),
+                              reraise=True)
         r.call(query_unique_and_run)
     else:
         query_unique_and_run()

--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -239,7 +239,7 @@ def __get_latest_instance(job):
     raise Exception(f'Job {job["uuid"]} currently has no instances.')
 
 
-def query_unique_and_run(clusters, entity_ref, command_fn, wait_seconds=None):
+def query_unique_and_run(clusters, entity_ref, command_fn, wait=False):
     """Calls query_unique and then calls the given command_fn on the resulting job instance"""
 
     def query_unique_and_run():
@@ -258,10 +258,8 @@ def query_unique_and_run(clusters, entity_ref, command_fn, wait_seconds=None):
             # only return a map with type "job" or type "instance"
             raise Exception(f'Encountered error when querying for {entity_ref}.')
 
-    if wait_seconds:
-        r = tenacity.Retrying(wait=tenacity.wait_fixed(5),
-                              stop=tenacity.stop_after_delay(wait_seconds),
-                              reraise=True)
+    if wait:
+        r = tenacity.Retrying(wait=tenacity.wait_fixed(5))
         r.call(query_unique_and_run)
     else:
         query_unique_and_run()

--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -239,7 +239,7 @@ def __get_latest_instance(job):
     raise Exception(f'Job {job["uuid"]} currently has no instances.')
 
 
-def query_unique_and_run(clusters, entity_ref, command_fn, retry_seconds=None):
+def query_unique_and_run(clusters, entity_ref, command_fn, wait_seconds=None):
     """Calls query_unique and then calls the given command_fn on the resulting job instance"""
 
     def query_unique_and_run():
@@ -258,9 +258,9 @@ def query_unique_and_run(clusters, entity_ref, command_fn, retry_seconds=None):
             # only return a map with type "job" or type "instance"
             raise Exception(f'Encountered error when querying for {entity_ref}.')
 
-    if retry_seconds:
+    if wait_seconds:
         r = tenacity.Retrying(wait=tenacity.wait_fixed(5),
-                              stop=tenacity.stop_after_delay(retry_seconds))
+                              stop=tenacity.stop_after_delay(wait_seconds))
         r.call(query_unique_and_run)
     else:
         query_unique_and_run()

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -124,6 +124,7 @@ def tail(clusters, args, _):
     lines = args.get('lines')
     follow = args.get('follow')
     sleep_interval = args.get('sleep-interval')
+    retry_seconds = args.get('retry_seconds', None)
 
     if len(entity_refs) > 1:
         # argparse should prevent this, but we'll be defensive anyway
@@ -131,7 +132,7 @@ def tail(clusters, args, _):
 
     command_fn = partial(tail_for_instance, path=path, num_lines_to_print=lines,
                          follow=follow, follow_sleep_seconds=sleep_interval)
-    query_unique_and_run(clusters_of_interest, entity_refs[0], command_fn)
+    query_unique_and_run(clusters_of_interest, entity_refs[0], command_fn, retry_seconds)
 
 
 def register(add_parser, add_defaults):
@@ -142,6 +143,9 @@ def register(add_parser, add_defaults):
     parser.add_argument('--follow', '-f', help='output appended data as the file grows', action='store_true')
     parser.add_argument('--sleep-interval', '-s',
                         help=f'with -f, sleep for N seconds (default {DEFAULT_FOLLOW_SLEEP_SECS}) between iterations',
+                        metavar='N', type=float)
+    parser.add_argument('--retry-seconds', '-r',
+                        help=f'retry for a maximum of N seconds (default is to not retry)',
                         metavar='N', type=float)
     parser.add_argument('uuid', nargs=1)
     parser.add_argument('path', nargs='?')

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -1,6 +1,8 @@
 import time
 from functools import partial
 
+import sys
+
 from cook.mesos import read_file
 from cook.querying import query_unique_and_run, parse_entity_refs
 from cook.util import check_positive, guard_no_cluster
@@ -124,7 +126,12 @@ def tail(clusters, args, _):
     lines = args.get('lines')
     follow = args.get('follow')
     sleep_interval = args.get('sleep-interval')
-    wait_seconds = args.get('wait_seconds', None)
+    wait_seconds = args.get('wait')
+
+    if wait_seconds == -1:
+        wait_seconds = None
+    elif not wait_seconds:
+        wait_seconds = sys.maxsize
 
     if len(entity_refs) > 1:
         # argparse should prevent this, but we'll be defensive anyway
@@ -144,9 +151,9 @@ def register(add_parser, add_defaults):
     parser.add_argument('--sleep-interval', '-s',
                         help=f'with -f, sleep for N seconds (default {DEFAULT_FOLLOW_SLEEP_SECS}) between iterations',
                         metavar='N', type=float)
-    parser.add_argument('--wait-seconds', '-w',
-                        help=f'wait for up to N seconds (default is to not wait)',
-                        metavar='N', type=float)
+    parser.add_argument('--wait', '-w',
+                        help=f'wait for up to N seconds (default is to wait indefinitely)',
+                        metavar='N', type=float, nargs='?', default=-1)
     parser.add_argument('uuid', nargs=1)
     parser.add_argument('path', nargs='?')
 

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -147,7 +147,7 @@ def register(add_parser, add_defaults):
                         help=f'with -f, sleep for N seconds (default {DEFAULT_FOLLOW_SLEEP_SECS}) between iterations',
                         metavar='N', type=float)
     parser.add_argument('--wait', '-w',
-                        help=f'wait indefinitely for the job to be running and for the file to become available',
+                        help='wait indefinitely for the job to be running and for the file to become available',
                         action='store_true')
     parser.add_argument('uuid', nargs=1)
     parser.add_argument('path', nargs='?')

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -126,12 +126,7 @@ def tail(clusters, args, _):
     lines = args.get('lines')
     follow = args.get('follow')
     sleep_interval = args.get('sleep-interval')
-    wait_seconds = args.get('wait')
-
-    if wait_seconds == -1:
-        wait_seconds = None
-    elif not wait_seconds:
-        wait_seconds = sys.maxsize
+    wait = args.get('wait')
 
     if len(entity_refs) > 1:
         # argparse should prevent this, but we'll be defensive anyway
@@ -139,7 +134,7 @@ def tail(clusters, args, _):
 
     command_fn = partial(tail_for_instance, path=path, num_lines_to_print=lines,
                          follow=follow, follow_sleep_seconds=sleep_interval)
-    query_unique_and_run(clusters_of_interest, entity_refs[0], command_fn, wait_seconds)
+    query_unique_and_run(clusters_of_interest, entity_refs[0], command_fn, wait)
 
 
 def register(add_parser, add_defaults):
@@ -152,8 +147,8 @@ def register(add_parser, add_defaults):
                         help=f'with -f, sleep for N seconds (default {DEFAULT_FOLLOW_SLEEP_SECS}) between iterations',
                         metavar='N', type=float)
     parser.add_argument('--wait', '-w',
-                        help=f'wait for up to N seconds (default is to wait indefinitely)',
-                        metavar='N', type=float, nargs='?', default=-1)
+                        help=f'wait indefinitely for the job to be running and for the file to become available',
+                        action='store_true')
     parser.add_argument('uuid', nargs=1)
     parser.add_argument('path', nargs='?')
 

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -1,8 +1,6 @@
 import time
 from functools import partial
 
-import sys
-
 from cook.mesos import read_file
 from cook.querying import query_unique_and_run, parse_entity_refs
 from cook.util import check_positive, guard_no_cluster

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -124,7 +124,7 @@ def tail(clusters, args, _):
     lines = args.get('lines')
     follow = args.get('follow')
     sleep_interval = args.get('sleep-interval')
-    retry_seconds = args.get('retry_seconds', None)
+    wait_seconds = args.get('wait_seconds', None)
 
     if len(entity_refs) > 1:
         # argparse should prevent this, but we'll be defensive anyway
@@ -132,7 +132,7 @@ def tail(clusters, args, _):
 
     command_fn = partial(tail_for_instance, path=path, num_lines_to_print=lines,
                          follow=follow, follow_sleep_seconds=sleep_interval)
-    query_unique_and_run(clusters_of_interest, entity_refs[0], command_fn, retry_seconds)
+    query_unique_and_run(clusters_of_interest, entity_refs[0], command_fn, wait_seconds)
 
 
 def register(add_parser, add_defaults):
@@ -144,8 +144,8 @@ def register(add_parser, add_defaults):
     parser.add_argument('--sleep-interval', '-s',
                         help=f'with -f, sleep for N seconds (default {DEFAULT_FOLLOW_SLEEP_SECS}) between iterations',
                         metavar='N', type=float)
-    parser.add_argument('--retry-seconds', '-r',
-                        help=f'retry for a maximum of N seconds (default is to not retry)',
+    parser.add_argument('--wait-seconds', '-w',
+                        help=f'wait for up to N seconds (default is to not wait)',
                         metavar='N', type=float)
     parser.add_argument('uuid', nargs=1)
     parser.add_argument('path', nargs='?')

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.0'
+VERSION = '2.5.0'

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -12,6 +12,7 @@ requirements = [
     'pytz',
     'requests',
     'tabulate',
+    'tenacity',
     'tzlocal',
 ]
 

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -539,6 +539,10 @@ class ExecutorTest(unittest.TestCase):
         command = 'sleep 100'
         self.run_command_in_manage_task_runner(command, assertions, 2)
 
+    # FIXME - remove the xfail mark once the issue with this test crashing is resolved:
+    # https://github.com/twosigma/Cook/issues/856
+    @pytest.mark.xfail
+    @unittest.skip('This test fails occasionally')
     def test_manage_task_random_binary_output(self):
         def assertions(driver, task_id, sandbox_directory):
             expected_statuses = [{'task_id': {'value': task_id}, 'state': cook.TASK_STARTING},

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -796,23 +796,12 @@ class CookCliTest(unittest.TestCase):
         cp = cli.tail(uuids[0], 'foo', self.cook_url)
         self.assertEqual(1, cp.returncode, cp.stderr)
         # Indefinite wait should work
-        cp, uuids = cli.submit(f'bash -c \'sleep 10; echo hello > foo\'', self.cook_url)
-        self.assertEqual(0, cp.returncode, cp.stderr)
-        cp = cli.tail(uuids[0], 'foo', self.cook_url, '--wait --')
+        cp = cli.tail(uuids[0], 'foo', self.cook_url, '--wait')
         self.assertEqual(0, cp.returncode, cli.decode(cp.stderr))
         self.assertEqual('hello\n', cli.decode(cp.stdout))
-        # Waiting for 60 seconds should work
-        cp, uuids = cli.submit(f'bash -c \'sleep 10; echo hello > foo\'', self.cook_url)
-        self.assertEqual(0, cp.returncode, cp.stderr)
-        cp = cli.tail(uuids[0], 'foo', self.cook_url, '--wait 60')
-        self.assertEqual(0, cp.returncode, cli.decode(cp.stderr))
-        self.assertEqual('hello\n', cli.decode(cp.stdout))
-        # Waiting 1 second for a file that doesn't exist should fail
+        # Tailing a file that doesn't exist should fail
         path = uuid.uuid4()
         cp = cli.tail(uuids[0], path, self.cook_url)
-        self.assertEqual(1, cp.returncode, cli.decode(cp.stderr))
-        self.assertEqual(f"Cannot open '{path}' for reading (file was not found).\n", cli.decode(cp.stderr))
-        cp = cli.tail(uuids[0], path, self.cook_url, '--wait 1')
         self.assertEqual(1, cp.returncode, cli.decode(cp.stderr))
         self.assertEqual(f"Cannot open '{path}' for reading (file was not found).\n", cli.decode(cp.stderr))
 

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -789,6 +789,33 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertIn(text, cli.decode(cp.stdout))
 
+    def test_tail_wait(self):
+        # No --wait should fail
+        cp, uuids = cli.submit(f'bash -c \'sleep 10; echo hello > foo\'', self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp = cli.tail(uuids[0], 'foo', self.cook_url)
+        self.assertEqual(1, cp.returncode, cp.stderr)
+        # Indefinite wait should work
+        cp, uuids = cli.submit(f'bash -c \'sleep 10; echo hello > foo\'', self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp = cli.tail(uuids[0], 'foo', self.cook_url, '--wait --')
+        self.assertEqual(0, cp.returncode, cli.decode(cp.stderr))
+        self.assertEqual('hello\n', cli.decode(cp.stdout))
+        # Waiting for 60 seconds should work
+        cp, uuids = cli.submit(f'bash -c \'sleep 10; echo hello > foo\'', self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp = cli.tail(uuids[0], 'foo', self.cook_url, '--wait 60')
+        self.assertEqual(0, cp.returncode, cli.decode(cp.stderr))
+        self.assertEqual('hello\n', cli.decode(cp.stdout))
+        # Waiting 1 second for a file that doesn't exist should fail
+        path = uuid.uuid4()
+        cp = cli.tail(uuids[0], path, self.cook_url)
+        self.assertEqual(1, cp.returncode, cli.decode(cp.stderr))
+        self.assertEqual(f"Cannot open '{path}' for reading (file was not found).\n", cli.decode(cp.stderr))
+        cp = cli.tail(uuids[0], path, self.cook_url, '--wait 1')
+        self.assertEqual(1, cp.returncode, cli.decode(cp.stderr))
+        self.assertEqual(f"Cannot open '{path}' for reading (file was not found).\n", cli.decode(cp.stderr))
+
     def test_ls(self):
 
         def entry(name):

--- a/travis/upload_logs.sh
+++ b/travis/upload_logs.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+set -e
+
 cd ${TRAVIS_BUILD_DIR}
 
 # Grab the Mesos master logs
 mkdir -p ./mesos/master-logs
-mesos_master_container=$(docker ps --filter "name=minimesos-master-" --format "{{.ID}}")
+docker ps --all --last 10
+mesos_master_container=$(docker ps --all --latest --filter "name=minimesos-master-" --format "{{.ID}}")
 docker cp --follow-link $mesos_master_container:/var/log/mesos-master.INFO ./mesos/master-logs/
 docker cp --follow-link $mesos_master_container:/var/log/mesos-master.WARNING ./mesos/master-logs/
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding `--wait` flag to `cs tail`

## Why are we making these changes?

To allow waiting until the job is running and the file being tailed is available when running, for example, `cs tail -f ...` on a pending job.