### PR TITLE
Adds 'matching' to the 'no jobs found' message

### DIFF
--- a/cli/cook/subcommands/jobs.py
+++ b/cli/cook/subcommands/jobs.py
@@ -26,7 +26,7 @@ def print_no_data(clusters, states, user):
         states.remove('success')
         states.append('successful')
     states_text = ' / '.join(states)
-    print(colors.failed(f'No {states_text} jobs for {user} found in {clusters_text}.'))
+    print(colors.failed(f'No matching {states_text} jobs for {user} found in {clusters_text}.'))
 
 
 def list_jobs_on_cluster(cluster, state, user, start_ms, end_ms, name, limit, include_custom_executor):

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.0'
+VERSION = '2.6.0'

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -416,7 +416,7 @@ class CookCliTest(unittest.TestCase):
     def test_list_no_matching_jobs(self):
         cp = cli.jobs(self.cook_url, '--name %s' % uuid.uuid4())
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertIn('No running jobs', cli.stdout(cp))
+        self.assertIn('No matching running jobs', cli.stdout(cp))
         self.assertIn(f'found in {self.cook_url}.', cli.stdout(cp))
 
     def list_jobs(self, name, user, *states):


### PR DESCRIPTION
## Changes proposed in this PR

- adding the word "matching" to the "no jobs found" message

## Why are we making these changes?

To make it more clear that other filters (e.g. date filters) might be causing no jobs to be returned.
