### PR TITLE
Fixes cs show inside Jupyter notebooks

### DIFF
--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -377,21 +377,24 @@ def query_with_stdin_support(clusters, entity_refs, pred_jobs=None, pred_instanc
     The above example would wait for all of sally's running and waiting jobs to complete. Returns a pair where the
     first element is the query result map, and the second element is the subset of clusters that are of interest.
     """
-    stdin_from_pipe = not sys.stdin.isatty()
+    is_stdin_from_pipe = not sys.stdin.isatty()
+    text_read_from_pipe = sys.stdin.read() if is_stdin_from_pipe else None
 
-    if entity_refs and stdin_from_pipe:
+    if entity_refs and text_read_from_pipe:
         raise Exception(f'You cannot supply entity references both as arguments and from stdin.')
 
     clusters_of_interest = clusters
     if not entity_refs:
-        if not stdin_from_pipe:
+        if is_stdin_from_pipe:
+            text = text_read_from_pipe
+        else:
             print_info('Enter the UUIDs or URLs, one per line (press Ctrl+D on a blank line to submit)')
+            text = sys.stdin.read()
 
-        stdin = sys.stdin.read()
-        if not stdin:
+        if not text:
             raise Exception('You must specify at least one UUID or URL.')
 
-        ref_strings = stdin.splitlines()
+        ref_strings = text.splitlines()
         entity_refs, clusters_of_interest = parse_entity_refs(clusters, ref_strings)
 
     query_result = query(clusters_of_interest, entity_refs, pred_jobs, pred_instances, pred_groups, timeout, interval)

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.0'
+VERSION = '2.5.0'

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,3 +1,7 @@
+beakerx==0.16.1
+jupyter_client==5.2.3
+nbconvert==5.3.1
+nbformat==4.4.0
 numpy==1.14.0
 pip==9.0.1; python_version >= '3.6'
 pytest==3.3.1

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -11,6 +11,8 @@ import uuid
 
 from urllib.parse import urlparse
 
+from nbconvert.preprocessors import ExecutePreprocessor
+
 from tests.cook import cli, util
 
 
@@ -1792,7 +1794,6 @@ class CookCliTest(unittest.TestCase):
         self.assertIn('is not a valid pool name', cli.stdout(cp))
 
     def test_show_from_jupyter(self):
-        from nbconvert.preprocessors import ExecutePreprocessor
         notebook = {
             "cells": [
                 {

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+
+import nbformat
 import pytest
 import subprocess
 import time
@@ -1788,3 +1790,68 @@ class CookCliTest(unittest.TestCase):
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--pool {uuid.uuid4()}')
         self.assertEqual(1, cp.returncode, cp.stderr)
         self.assertIn('is not a valid pool name', cli.stdout(cp))
+
+    def test_show_from_jupyter(self):
+        from nbconvert.preprocessors import ExecutePreprocessor
+        notebook = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "execution_count": None,
+                    "metadata": {},
+                    "outputs": [],
+                    "source": [
+                        "%%bash\n",
+                        f"uuid=$(cs --url {self.cook_url} submit ls | tail -1)\n",
+                        f"cs --url {self.cook_url} show $uuid"
+                    ]
+                }
+            ],
+            "metadata": {
+                "kernelspec": {
+                    "display_name": "Python 3",
+                    "language": "python",
+                    "name": "python3"
+                },
+                "language_info": {
+                    "codemirror_mode": {
+                        "name": "ipython",
+                        "version": 3
+                    },
+                    "file_extension": ".py",
+                    "mimetype": "text/x-python",
+                    "name": "python",
+                    "nbconvert_exporter": "python",
+                    "pygments_lexer": "ipython3",
+                    "version": "3.6.5"
+                }
+            },
+            "nbformat": 4,
+            "nbformat_minor": 2
+        }
+        notebook_filename = 'unexecuted_notebook.ipynb'
+        executed_notebook_filename = 'executed_notebook.ipynb'
+        try:
+            with open(notebook_filename, 'w') as f:
+                f.write(json.dumps(notebook, indent=2))
+            with open(notebook_filename) as f:
+                nb = nbformat.read(f, as_version=4)
+            ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+            ep.preprocess(nb, {'metadata': {'path': './'}})
+            with open(executed_notebook_filename, 'wt') as f:
+                nbformat.write(nb, f)
+            with open(executed_notebook_filename) as f:
+                notebook_json = f.read()
+            notebook = json.loads(notebook_json)
+            cell = notebook['cells'][0]
+            output = cell['outputs'][0]
+            self.assertEqual(1, len(notebook['cells']))
+            self.assertEqual('code', cell['cell_type'])
+            self.assertEqual(1, cell['execution_count'])
+            self.assertEqual(1, len(cell['outputs']))
+            self.assertEqual('stdout', output['name'], ''.join(output['text']))
+            self.assertEqual('\n', output['text'][0])
+            self.assertIn('=== Job: ', output['text'][1])
+        finally:
+            os.remove(notebook_filename)
+            os.remove(executed_notebook_filename)


### PR DESCRIPTION
## Changes proposed in this PR

- avoiding throwing when `sys.stdin.isatty()` returns  `False` if there is nothing to actually be read from `stdin`

## Why are we making these changes?

Inside Jupyter notebooks, `sys.stdin.isatty()` returns `False`, but that doesn't mean something is actually available to read from `stdin`. Therefore, we need to be more precise about when we display the `You cannot supply entity references both as arguments and from stdin` error.

## Example

Before:
![before](https://user-images.githubusercontent.com/444778/40144742-3f3d2d8e-5925-11e8-9601-1e8f9108d4ce.png)

After:
![after](https://user-images.githubusercontent.com/444778/40144751-43ef1e14-5925-11e8-9a43-ec6bfd07e089.png)
