### PR TITLE
Add "pools" submap to quota and share responses

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2389,3 +2389,18 @@ class CookTest(unittest.TestCase):
         job = util.load_job(self.cook_url, uuid)
         self.assertEqual('completed', job['status'])
         self.assertEqual(num_instances, len(job['instances']), json.dumps(job, indent=2))
+
+    def test_pools_in_default_limit_response(self):
+        pools, resp = util.all_pools(self.cook_url)
+        pool_names = [p['name'] for p in pools]
+
+        for limit in ['share', 'quota']:
+
+            resp = util.get_limit(self.cook_url, 'share', 'root')
+            self.assertEqual(200, resp.status_code)
+            for pool in pool_names:
+                self.assertTrue(pool in resp.json()['pools'])
+
+            if len(pool_names) > 0:
+                resp = util.get_limit(self.cook_url, limit, 'root', pool_names[0])
+                self.assertFalse('pools' in resp.json())

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2394,13 +2394,19 @@ class CookTest(unittest.TestCase):
         pools, resp = util.all_pools(self.cook_url)
         pool_names = [p['name'] for p in pools]
 
+        user = self.determine_user()
         for limit in ['share', 'quota']:
-
-            resp = util.get_limit(self.cook_url, 'share', 'root')
+            resp = util.get_limit(self.cook_url, limit, user)
             self.assertEqual(200, resp.status_code)
             for pool in pool_names:
                 self.assertTrue(pool in resp.json()['pools'])
+                for resource in ['cpus', 'gpus', 'mem']:
+                    self.assertTrue(resource in resp.json()['pools'][pool])
 
             if len(pool_names) > 0:
-                resp = util.get_limit(self.cook_url, limit, 'root', pool_names[0])
+                resp = util.get_limit(self.cook_url, limit, user, pool_names[0])
                 self.assertFalse('pools' in resp.json())
+            else:
+                resp = util.get_limit(self.cook_url, limit, user)
+                self.assertFalse('pools' in resp.json())
+

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1977,7 +1977,7 @@
    (s/optional-key :count) s/Num})
 
 (def UserLimitsResponse
-  (assoc UserLimitSchema (s/optional-key :pools) {String UserLimitSchema}))
+  (assoc UserLimitSchema (s/optional-key :pools) {s/Str UserLimitSchema}))
 
 (defn set-limit-params
   [limit-type]


### PR DESCRIPTION
## Changes proposed in this PR
- Adds a "pools" sub-map with the pool-specific limits in the quota and share response if the pool parameter is not specified.

## Why are we making these changes?
Provide a simple way for a user to learn about their share or quota across several pools.
