### PR TITLE
Adds support for running test jobs with docker

### DIFF
--- a/integration/tests/cook/mesos.py
+++ b/integration/tests/cook/mesos.py
@@ -38,7 +38,7 @@ def sandbox_directory(session, instance, job):
 
     # As a last resort, query the Mesos agent state
     agent_url = instance_to_agent_url(instance)
-    resp = session.get(f'{agent_url}/state')
+    resp = session.get(f'{agent_url}/state', timeout=5)
     if resp.status_code != 200:
         logging.error(f'mesos agent returned status code {resp.status_code} and body {resp.text}')
         raise Exception('Encountered error when querying Mesos agent for the sandbox directory.')

--- a/integration/tests/cook/mesos.py
+++ b/integration/tests/cook/mesos.py
@@ -113,6 +113,10 @@ def cat_for_instance(session, instance, sandbox_dir, path):
 
 def dump_sandbox_files(session, instance, job):
     """Logs the contents of each file in the root of the given instance's sandbox."""
+    if os.getenv('COOK_TEST_SKIP_SANDBOX_DUMP') is not None:
+        logging.info(f'Skipping dumping of sandbox files for {job["uuid"]}')
+        return
+
     try:
         logging.info(f'Attempting to dump sandbox files for {instance}')
         directory = sandbox_directory(session, instance, job)

--- a/integration/tests/cook/mesos.py
+++ b/integration/tests/cook/mesos.py
@@ -114,7 +114,7 @@ def cat_for_instance(session, instance, sandbox_dir, path):
 def dump_sandbox_files(session, instance, job):
     """Logs the contents of each file in the root of the given instance's sandbox."""
     if os.getenv('COOK_TEST_SKIP_SANDBOX_DUMP') is not None:
-        logging.info(f'Skipping dumping of sandbox files for {job["uuid"]}')
+        logging.info(f'Skipping dumping of sandbox files for instance {instance["task_id"]}')
         return
 
     try:

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1945,7 +1945,7 @@ class CookTest(util.CookTest):
         resp = util.set_limit(self.cook_url, 'quota', user, cpus=10, reason=None)
         self.assertEqual(resp.status_code, 400, resp.text)
         # reset user quota back to default
-        resp = util.reset_limit(self.cook_url, 'quota', user)
+        resp = util.reset_limit(self.cook_url, 'quota', user, reason=self.current_name())
         self.assertEqual(resp.status_code, 204, resp.text)
         # reset user quota fails (malformed) if no reason is given
         resp = util.reset_limit(self.cook_url, 'quota', user, reason=None)
@@ -1957,7 +1957,7 @@ class CookTest(util.CookTest):
         resp = util.set_limit(self.cook_url, 'share', user, cpus=10, reason=None)
         self.assertEqual(resp.status_code, 400, resp.text)
         # reset user share back to default
-        resp = util.reset_limit(self.cook_url, 'share', user)
+        resp = util.reset_limit(self.cook_url, 'share', user, reason=self.current_name())
         self.assertEqual(resp.status_code, 204, resp.text)
         # reset user share fails (malformed) if no reason is given
         resp = util.reset_limit(self.cook_url, 'share', user, reason=None)
@@ -1987,7 +1987,7 @@ class CookTest(util.CookTest):
                 self.assertEqual(100, resp.json()['cpus'], resp.text)
 
                 # Delete the default pool limit (no pool argument)
-                resp = util.reset_limit(self.cook_url, limit, user)
+                resp = util.reset_limit(self.cook_url, limit, user, reason=self.current_name())
                 self.assertEqual(resp.status_code, 204, resp.text)
 
                 # Check that the default is returned for the default pool
@@ -2006,7 +2006,7 @@ class CookTest(util.CookTest):
                     default_cpus = resp.json()['cpus']
 
                     # delete the pool's limit
-                    resp = util.reset_limit(self.cook_url, limit, user, pool=pool)
+                    resp = util.reset_limit(self.cook_url, limit, user, pool=pool, reason=self.current_name())
                     self.assertEqual(resp.status_code, 204, resp.text)
 
                     # check that the default value is returned

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1116,18 +1116,15 @@ class CookTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 500)
 
     @pytest.mark.xfail
+    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
+                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
+                                                 'the process responsible for launching hosts to launch hosts that '
+                                                 'never get used')
     def test_constraints(self):
         """
         Marked as explicit due to:
         RuntimeError: Job ... had status running - expected completed
         """
-        if util.has_ephemeral_hosts(self.cook_url):
-            # If the cluster under test has ephemeral hosts, then it's generally a bad
-            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
-            # responsible for launching hosts to launch hosts that never get used
-            self.logger.info('Bailing out because the cluster has ephemeral hosts')
-            return
-
         state = util.get_mesos_state(self.mesos_url)
         hosts = [agent['hostname'] for agent in state['slaves']][:10]
 
@@ -1439,14 +1436,11 @@ class CookTest(unittest.TestCase):
         resp = util.query_groups(self.cook_url)
         self.assertEqual(400, resp.status_code)
 
+    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
+                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
+                                                 'the process responsible for launching hosts to launch hosts that '
+                                                 'never get used')
     def test_queue_endpoint(self):
-        if util.has_ephemeral_hosts(self.cook_url):
-            # If the cluster under test has ephemeral hosts, then it's generally a bad
-            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
-            # responsible for launching hosts to launch hosts that never get used
-            self.logger.info('Bailing out because the cluster has ephemeral hosts')
-            return
-
         constraints = [["HOSTNAME", "EQUALS", "lol won't get scheduled"]]
         group = {'uuid': str(uuid.uuid4())}
         job_spec = {'group': group['uuid'],
@@ -1553,14 +1547,11 @@ class CookTest(unittest.TestCase):
             util.session.delete('%s/rawscheduler?job=%s' % (self.cook_url, job_uuid))
             mesos.dump_sandbox_files(util.session, instance, job)
 
+    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
+                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
+                                                 'the process responsible for launching hosts to launch hosts that '
+                                                 'never get used')
     def test_unscheduled_jobs(self):
-        if util.has_ephemeral_hosts(self.cook_url):
-            # If the cluster under test has ephemeral hosts, then it's generally a bad
-            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
-            # responsible for launching hosts to launch hosts that never get used
-            self.logger.info('Bailing out because the cluster has ephemeral hosts')
-            return
-
         unsatisfiable_constraint = ['HOSTNAME', 'EQUALS', 'fakehost']
         job_uuid_1, resp = util.submit_job(self.cook_url, command='ls', constraints=[unsatisfiable_constraint])
         self.assertEqual(resp.status_code, 201, resp.content)
@@ -1591,14 +1582,11 @@ class CookTest(unittest.TestCase):
         finally:
             util.kill_jobs(self.cook_url, [job_uuid_1, job_uuid_2])
 
+    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
+                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
+                                                 'the process responsible for launching hosts to launch hosts that '
+                                                 'never get used')
     def test_unscheduled_jobs_partial(self):
-        if util.has_ephemeral_hosts(self.cook_url):
-            # If the cluster under test has ephemeral hosts, then it's generally a bad
-            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
-            # responsible for launching hosts to launch hosts that never get used
-            self.logger.info('Bailing out because the cluster has ephemeral hosts')
-            return
-
         unsatisfiable_constraint = ['HOSTNAME', 'EQUALS', 'fakehost']
         job_uuid_1, resp = util.submit_job(self.cook_url, command='ls', constraints=[unsatisfiable_constraint])
         self.assertEqual(resp.status_code, 201, resp.content)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -56,15 +56,17 @@ class CookTest(unittest.TestCase):
         self.assertEqual(False, job['disable_mea_culpa_retries'])
         self.assertTrue(len(util.wait_for_output_url(self.cook_url, job_uuid)['output_url']) > 0)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        message = json.dumps(instance, sort_keys=True)
+        self.assertIsNotNone(instance['output_url'], message)
+        self.assertIsNotNone(instance['sandbox_directory'], message)
 
-        if job_executor_type == 'cook':
+        if instance['executor'] == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(0, job['instances'][0]['exit_code'], message)
+        else:
+            self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
     def test_no_cook_executor_on_subsequent_instances(self):
         retry_limit = util.get_in(util.settings(self.cook_url), 'executor', 'retry-limit')

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1138,6 +1138,13 @@ class CookTest(unittest.TestCase):
         Marked as explicit due to:
         RuntimeError: Job ... had status running - expected completed
         """
+        if util.has_ephemeral_hosts(self.cook_url):
+            # If the cluster under test has ephemeral hosts, then it's generally a bad
+            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
+            # responsible for launching hosts to launch hosts that never get used
+            self.logger.info('Bailing out because the cluster has ephemeral hosts')
+            return
+
         state = util.get_mesos_state(self.mesos_url)
         hosts = [agent['hostname'] for agent in state['slaves']][:10]
 
@@ -1450,6 +1457,13 @@ class CookTest(unittest.TestCase):
         self.assertEqual(400, resp.status_code)
 
     def test_queue_endpoint(self):
+        if util.has_ephemeral_hosts(self.cook_url):
+            # If the cluster under test has ephemeral hosts, then it's generally a bad
+            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
+            # responsible for launching hosts to launch hosts that never get used
+            self.logger.info('Bailing out because the cluster has ephemeral hosts')
+            return
+
         constraints = [["HOSTNAME", "EQUALS", "lol won't get scheduled"]]
         group = {'uuid': str(uuid.uuid4())}
         job_spec = {'group': group['uuid'],
@@ -1557,6 +1571,13 @@ class CookTest(unittest.TestCase):
             mesos.dump_sandbox_files(util.session, instance, job)
 
     def test_unscheduled_jobs(self):
+        if util.has_ephemeral_hosts(self.cook_url):
+            # If the cluster under test has ephemeral hosts, then it's generally a bad
+            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
+            # responsible for launching hosts to launch hosts that never get used
+            self.logger.info('Bailing out because the cluster has ephemeral hosts')
+            return
+
         unsatisfiable_constraint = ['HOSTNAME', 'EQUALS', 'fakehost']
         job_uuid_1, resp = util.submit_job(self.cook_url, command='ls', constraints=[unsatisfiable_constraint])
         self.assertEqual(resp.status_code, 201, resp.content)
@@ -1588,6 +1609,13 @@ class CookTest(unittest.TestCase):
             util.kill_jobs(self.cook_url, [job_uuid_1, job_uuid_2])
 
     def test_unscheduled_jobs_partial(self):
+        if util.has_ephemeral_hosts(self.cook_url):
+            # If the cluster under test has ephemeral hosts, then it's generally a bad
+            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
+            # responsible for launching hosts to launch hosts that never get used
+            self.logger.info('Bailing out because the cluster has ephemeral hosts')
+            return
+
         unsatisfiable_constraint = ['HOSTNAME', 'EQUALS', 'fakehost']
         job_uuid_1, resp = util.submit_job(self.cook_url, command='ls', constraints=[unsatisfiable_constraint])
         self.assertEqual(resp.status_code, 201, resp.content)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1036,6 +1036,9 @@ class CookTest(util.CookTest):
         util.wait_for_job(self.cook_url, jobs[0], 'completed')
         util.wait_for_job(self.cook_url, jobs[1], 'completed')
 
+    # Requires a longer timeout for clusters with a large timeout-interval-minutes,
+    # because the straggler-handling check only happens on this timeout interval
+    @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS * 2)
     def test_straggler_handling(self):
         straggler_handling = {
             'type': 'quantile-deviation',

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -56,15 +56,15 @@ class CookTest(unittest.TestCase):
         self.assertEqual(False, job['disable_mea_culpa_retries'])
         self.assertTrue(len(util.wait_for_output_url(self.cook_url, job_uuid)['output_url']) > 0)
 
-        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
         message = json.dumps(instance, sort_keys=True)
         self.assertIsNotNone(instance['output_url'], message)
         self.assertIsNotNone(instance['sandbox_directory'], message)
 
         if instance['executor'] == 'cook':
-            job = util.wait_for_exit_code(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(0, job['instances'][0]['exit_code'], message)
+            instance = util.wait_for_exit_code(self.cook_url, job_uuid)
+            message = json.dumps(instance, sort_keys=True)
+            self.assertEqual(0, instance['exit_code'], message)
         else:
             self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
@@ -200,15 +200,15 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('failed', job['instances'][0]['status'], message)
 
-        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
         message = json.dumps(instance, sort_keys=True)
         self.assertIsNotNone(instance['output_url'], message)
         self.assertIsNotNone(instance['sandbox_directory'], message)
 
         if instance['executor'] == 'cook':
-            job = util.wait_for_exit_code(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(1, job['instances'][0]['exit_code'], message)
+            instance = util.wait_for_exit_code(self.cook_url, job_uuid)
+            message = json.dumps(instance, sort_keys=True)
+            self.assertEqual(1, instance['exit_code'], message)
         else:
             self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
@@ -223,26 +223,21 @@ class CookTest(unittest.TestCase):
                                          executor=job_executor_type, max_runtime=60000)
         self.assertEqual(201, resp.status_code, msg=resp.content)
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
-        self.assertEqual(1, len(job['instances']))
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertEqual('success', job['instances'][0]['status'], message)
+        message = json.dumps(job['instances'], sort_keys=True)
+        self.assertIn('success', (i['status'] for i in job['instances']), message)
 
-        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
         message = json.dumps(instance, sort_keys=True)
         self.assertIsNotNone(instance['output_url'], message)
         self.assertIsNotNone(instance['sandbox_directory'], message)
 
         if instance['executor'] == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
-
-            job = util.wait_for_exit_code(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.load_job(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(25, job['instances'][0]['progress'], message)
-            self.assertEqual('Twenty-five percent in progress.txt', job['instances'][0]['progress_message'], message)
+            instance = util.wait_for_exit_code(self.cook_url, job_uuid)
+            message = json.dumps(instance, sort_keys=True)
+            self.assertEqual(0, instance['exit_code'], message)
+            self.assertEqual(25, instance['progress'], message)
+            self.assertEqual('Twenty-five percent in progress.txt', instance['progress_message'], message)
         else:
             self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
@@ -262,22 +257,18 @@ class CookTest(unittest.TestCase):
         self.assertEqual('success', job['instances'][0]['status'], message)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
         message = json.dumps(instance, sort_keys=True)
         self.assertIsNotNone(instance['output_url'], message)
         self.assertIsNotNone(instance['sandbox_directory'], message)
 
         if instance['executor'] == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
-
-            job = util.wait_for_exit_code(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.load_job(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(25, job['instances'][0]['progress'], message)
-            self.assertEqual('Twenty-five percent', job['instances'][0]['progress_message'], message)
+            instance = util.wait_for_exit_code(self.cook_url, job_uuid)
+            message = json.dumps(instance, sort_keys=True)
+            self.assertEqual(0, instance['exit_code'], message)
+            self.assertEqual(25, instance['progress'], message)
+            self.assertEqual('Twenty-five percent', instance['progress_message'], message)
         else:
             self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
@@ -298,22 +289,18 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
         message = json.dumps(instance, sort_keys=True)
         self.assertIsNotNone(instance['output_url'], message)
         self.assertIsNotNone(instance['sandbox_directory'], message)
 
         if instance['executor'] == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
-
-            job = util.wait_for_exit_code(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.load_job(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(75, job['instances'][0]['progress'], message)
-            self.assertEqual('Seventy-five percent', job['instances'][0]['progress_message'], message)
+            instance = util.wait_for_exit_code(self.cook_url, job_uuid)
+            message = json.dumps(instance, sort_keys=True)
+            self.assertEqual(0, instance['exit_code'], message)
+            self.assertEqual(75, instance['progress'], message)
+            self.assertEqual('Seventy-five percent', instance['progress_message'], message)
         else:
             self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
@@ -332,22 +319,18 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
         message = json.dumps(instance, sort_keys=True)
         self.assertIsNotNone(instance['output_url'], message)
         self.assertIsNotNone(instance['sandbox_directory'], message)
 
         if instance['executor'] == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
-
-            job = util.wait_for_exit_code(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(0, job['instances'][0]['exit_code'], message)
-
-            job = util.load_job(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertEqual(80, job['instances'][0]['progress'], message)
-            self.assertEqual('80%', job['instances'][0]['progress_message'], message)
+            instance = util.wait_for_exit_code(self.cook_url, job_uuid)
+            message = json.dumps(instance, sort_keys=True)
+            self.assertEqual(0, instance['exit_code'], message)
+            self.assertEqual(80, instance['progress'], message)
+            self.assertEqual('80%', instance['progress_message'], message)
         else:
             self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
@@ -395,16 +378,16 @@ class CookTest(unittest.TestCase):
             self.assertGreater(actual_running_time_ms, max_runtime_ms, job_details)
             self.assertGreater(job_sleep_ms, actual_running_time_ms, job_details)
 
-            instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+            instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
             message = json.dumps(instance, sort_keys=True)
             self.assertIsNotNone(instance['output_url'], message)
             self.assertIsNotNone(instance['sandbox_directory'], message)
 
             # verify additional fields set when the cook executor is used
             if instance['executor'] == 'cook':
-                job = util.wait_for_exit_code(self.cook_url, job_uuid)
-                message = json.dumps(job['instances'][0], sort_keys=True)
-                self.assertNotEqual(0, job['instances'][0]['exit_code'], message)
+                instance = util.wait_for_exit_code(self.cook_url, job_uuid)
+                message = json.dumps(instance, sort_keys=True)
+                self.assertNotEqual(0, instance['exit_code'], message)
             else:
                 self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
         finally:

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1066,9 +1066,7 @@ class CookTest(unittest.TestCase):
         expected_runtime = 1
         job_uuid, resp = util.submit_job(self.cook_url, expected_runtime=expected_runtime)
         self.assertEqual(resp.status_code, 201)
-        job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
-        instance = job['instances'][0]
-        self.assertEqual('success', instance['status'], 'Instance details: %s' % (json.dumps(instance, sort_keys=True)))
+        job = util.load_job(self.cook_url, job_uuid)
         self.assertEqual(expected_runtime, job['expected_runtime'])
 
         # Should disallow expected_runtime > max_runtime

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -298,12 +298,12 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        message = json.dumps(instance, sort_keys=True)
+        self.assertIsNotNone(instance['output_url'], message)
+        self.assertIsNotNone(instance['sandbox_directory'], message)
 
-        if job_executor_type == 'cook':
+        if instance['executor'] == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
@@ -314,6 +314,8 @@ class CookTest(unittest.TestCase):
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(75, job['instances'][0]['progress'], message)
             self.assertEqual('Seventy-five percent', job['instances'][0]['progress_message'], message)
+        else:
+            self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
     def test_multiple_rapid_progress_updates_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -52,7 +52,7 @@ class CookTest(util.CookTest):
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         self.assertEqual(resp.content, str.encode(f"submitted jobs {job_uuid}"))
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
-        self.assertEqual('success', job['instances'][0]['status'])
+        self.assertIn('success', (i['status'] for i in job['instances']))
         self.assertEqual(False, job['disable_mea_culpa_retries'])
         self.assertTrue(len(util.wait_for_output_url(self.cook_url, job_uuid)['output_url']) > 0)
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -124,6 +124,11 @@ class CookTest(unittest.TestCase):
 
         uuid, resp = util.submit_job(self.cook_url, command='sleep 30', env={'EXECUTOR_TEST_EXIT': '1'})
         try:
+            instance = util.wait_for_instance(self.cook_url, uuid)
+            if instance['executor'] != 'cook':
+                self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
+                return
+
             job = util.wait_until(lambda: util.load_job(self.cook_url, uuid),
                                   lambda job: len(job['instances']) > 1 and any(
                                       [i['status'] == 'failed' for i in job['instances']]))

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -332,12 +332,12 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        message = json.dumps(instance, sort_keys=True)
+        self.assertIsNotNone(instance['output_url'], message)
+        self.assertIsNotNone(instance['sandbox_directory'], message)
 
-        if job_executor_type == 'cook':
+        if instance['executor'] == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
@@ -348,6 +348,8 @@ class CookTest(unittest.TestCase):
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(80, job['instances'][0]['progress'], message)
             self.assertEqual('80%', job['instances'][0]['progress_message'], message)
+        else:
+            self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
     def test_max_runtime_exceeded(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -20,7 +20,7 @@ from tests.cook import util
 
 
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
-class CookTest(unittest.TestCase):
+class CookTest(util.CookTest):
 
     @classmethod
     def setUpClass(cls):
@@ -1117,8 +1117,7 @@ class CookTest(unittest.TestCase):
             host_to_job_uuid = {}
             for hostname in hosts:
                 constraints = [["HOSTNAME", "EQUALS", hostname]]
-                job_uuid, resp = util.submit_job(self.cook_url, constraints=constraints,
-                                                 name='test_hostname_equals_job_constraint')
+                job_uuid, resp = util.submit_job(self.cook_url, constraints=constraints, name=self.current_name())
                 self.assertEqual(resp.status_code, 201, resp.text)
                 host_to_job_uuid[hostname] = job_uuid
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -260,12 +260,12 @@ class CookTest(unittest.TestCase):
         self.assertEqual('success', job['instances'][0]['status'], message)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        message = json.dumps(instance, sort_keys=True)
+        self.assertIsNotNone(instance['output_url'], message)
+        self.assertIsNotNone(instance['sandbox_directory'], message)
 
-        if job_executor_type == 'cook':
+        if instance['executor'] == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
@@ -276,6 +276,8 @@ class CookTest(unittest.TestCase):
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(25, job['instances'][0]['progress'], message)
             self.assertEqual('Twenty-five percent', job['instances'][0]['progress_message'], message)
+        else:
+            self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
     def test_multiple_progress_updates_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1036,9 +1036,6 @@ class CookTest(util.CookTest):
         util.wait_for_job(self.cook_url, jobs[0], 'completed')
         util.wait_for_job(self.cook_url, jobs[1], 'completed')
 
-    # Requires a longer timeout for clusters with a large timeout-interval-minutes,
-    # because the straggler-handling check only happens on this timeout interval
-    @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS * 2)
     def test_straggler_handling(self):
         straggler_handling = {
             'type': 'quantile-deviation',

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -200,15 +200,17 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('failed', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        message = json.dumps(instance, sort_keys=True)
+        self.assertIsNotNone(instance['output_url'], message)
+        self.assertIsNotNone(instance['sandbox_directory'], message)
 
-        if job_executor_type == 'cook':
+        if instance['executor'] == 'cook':
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(1, job['instances'][0]['exit_code'], message)
+        else:
+            self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
     def test_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -227,12 +227,12 @@ class CookTest(unittest.TestCase):
         message = json.dumps(job['instances'][0], sort_keys=True)
         self.assertEqual('success', job['instances'][0]['status'], message)
 
-        job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-        message = json.dumps(job['instances'][0], sort_keys=True)
-        self.assertIsNotNone(job['instances'][0]['output_url'], message)
-        self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+        message = json.dumps(instance, sort_keys=True)
+        self.assertIsNotNone(instance['output_url'], message)
+        self.assertIsNotNone(instance['sandbox_directory'], message)
 
-        if job_executor_type == 'cook':
+        if instance['executor'] == 'cook':
             util.sleep_for_publish_interval(self.cook_url)
 
             job = util.wait_for_exit_code(self.cook_url, job_uuid)
@@ -243,6 +243,8 @@ class CookTest(unittest.TestCase):
             message = json.dumps(job['instances'][0], sort_keys=True)
             self.assertEqual(25, job['instances'][0]['progress'], message)
             self.assertEqual('Twenty-five percent in progress.txt', job['instances'][0]['progress_message'], message)
+        else:
+            self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
 
     def test_configurable_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1458,10 +1458,9 @@ class CookTest(unittest.TestCase):
     def test_basic_docker_job(self):
         job_uuid, resp = util.submit_job(
             self.cook_url,
-            name="check_alpine_version",
-            command="cat /etc/alpine-release",
-            container={"type": "DOCKER",
-                       "docker": {'image': "alpine:latest"}})
+            command='cat /.dockerenv',
+            container={'type': 'DOCKER',
+                       'docker': {'image': os.getenv('COOK_TEST_DOCKER_IMAGE', 'alpine:latest')}})
         self.assertEqual(resp.status_code, 201)
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
         self.assertEqual('success', job['instances'][0]['status'])

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -393,16 +393,18 @@ class CookTest(unittest.TestCase):
             self.assertGreater(actual_running_time_ms, max_runtime_ms, job_details)
             self.assertGreater(job_sleep_ms, actual_running_time_ms, job_details)
 
-            job = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(job['instances'][0], sort_keys=True)
-            self.assertIsNotNone(job['instances'][0]['output_url'], message)
-            self.assertIsNotNone(job['instances'][0]['sandbox_directory'], message)
+            instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)['instances'][0]
+            message = json.dumps(instance, sort_keys=True)
+            self.assertIsNotNone(instance['output_url'], message)
+            self.assertIsNotNone(instance['sandbox_directory'], message)
 
             # verify additional fields set when the cook executor is used
-            if job_executor_type == 'cook':
+            if instance['executor'] == 'cook':
                 job = util.wait_for_exit_code(self.cook_url, job_uuid)
                 message = json.dumps(job['instances'][0], sort_keys=True)
                 self.assertNotEqual(0, job['instances'][0]['exit_code'], message)
+            else:
+                self.logger.info(f'Bailing out because the cook executor is not being used: {instance}')
         finally:
             util.kill_jobs(self.cook_url, [job_uuid])
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -363,13 +363,13 @@ class CookTest(util.CookTest):
             self.assertGreater(actual_running_time_ms, max_runtime_ms, job_details)
             self.assertGreater(job_sleep_ms, actual_running_time_ms, job_details)
 
-            instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
-            message = json.dumps(instance, sort_keys=True)
-            self.assertIsNotNone(instance['output_url'], message)
-            self.assertIsNotNone(instance['sandbox_directory'], message)
-
             # verify additional fields set when the cook executor is used
             if instance['executor'] == 'cook':
+                instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+                message = json.dumps(instance, sort_keys=True)
+                self.assertIsNotNone(instance['output_url'], message)
+                self.assertIsNotNone(instance['sandbox_directory'], message)
+
                 instance = util.wait_for_exit_code(self.cook_url, job_uuid)
                 message = json.dumps(instance, sort_keys=True)
                 self.assertNotEqual(0, instance['exit_code'], message)

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -19,17 +19,12 @@ from tests.cook import cli, util
 @pytest.mark.cli
 @unittest.skipIf(util.http_basic_auth_enabled(), 'Cook CLI does not currently support HTTP Basic Auth')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
-class CookCliTest(unittest.TestCase):
+class CookCliTest(util.CookTest):
 
     @classmethod
     def setUpClass(cls):
         cls.cook_url = util.retrieve_cook_url()
         util.init_cook_session(cls.cook_url)
-
-    def current_name(self):
-        """Returns the name of the currently running test function"""
-        test_id = self.id()
-        return test_id.split('.')[-1]
 
     def setUp(self):
         self.cook_url = type(self).cook_url

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -430,6 +430,13 @@ class CookCliTest(unittest.TestCase):
         return cp, jobs
 
     def test_list_by_state(self):
+        if util.has_ephemeral_hosts(self.cook_url):
+            # If the cluster under test has ephemeral hosts, then it's generally a bad
+            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
+            # responsible for launching hosts to launch hosts that never get used
+            self.logger.info('Bailing out because the cluster has ephemeral hosts')
+            return
+
         name = f'{self.current_name()}_{uuid.uuid4()}'
 
         # Submit a job that will never run
@@ -624,6 +631,13 @@ class CookCliTest(unittest.TestCase):
         self.assertIn('; bash', stdout)
 
     def test_ssh_no_instances(self):
+        if util.has_ephemeral_hosts(self.cook_url):
+            # If the cluster under test has ephemeral hosts, then it's generally a bad
+            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
+            # responsible for launching hosts to launch hosts that never get used
+            self.logger.info('Bailing out because the cluster has ephemeral hosts')
+            return
+
         raw_job = {'command': 'ls', 'constraints': [['HOSTNAME', 'EQUALS', 'will not get scheduled']]}
         cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -1607,6 +1621,13 @@ class CookCliTest(unittest.TestCase):
         self.assertIn('No matching data found', cli.decode(cp.stderr))
 
     def test_cat_job_with_no_instances(self):
+        if util.has_ephemeral_hosts(self.cook_url):
+            # If the cluster under test has ephemeral hosts, then it's generally a bad
+            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
+            # responsible for launching hosts to launch hosts that never get used
+            self.logger.info('Bailing out because the cluster has ephemeral hosts')
+            return
+
         raw_job = {'command': 'ls', 'constraints': [['HOSTNAME', 'EQUALS', 'will not get scheduled']]}
         cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')
         self.assertEqual(0, cp.returncode, cp.stderr)

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -429,14 +429,11 @@ class CookCliTest(unittest.TestCase):
         cp, jobs = cli.jobs_json(self.cook_url, '--name %s --user %s %s' % (name, user, state_flags))
         return cp, jobs
 
+    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
+                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
+                                                 'the process responsible for launching hosts to launch hosts that '
+                                                 'never get used')
     def test_list_by_state(self):
-        if util.has_ephemeral_hosts(self.cook_url):
-            # If the cluster under test has ephemeral hosts, then it's generally a bad
-            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
-            # responsible for launching hosts to launch hosts that never get used
-            self.logger.info('Bailing out because the cluster has ephemeral hosts')
-            return
-
         name = f'{self.current_name()}_{uuid.uuid4()}'
 
         # Submit a job that will never run
@@ -630,14 +627,11 @@ class CookCliTest(unittest.TestCase):
         self.assertIn(f'-t {hostname} cd', stdout)
         self.assertIn('; bash', stdout)
 
+    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
+                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
+                                                 'the process responsible for launching hosts to launch hosts that '
+                                                 'never get used')
     def test_ssh_no_instances(self):
-        if util.has_ephemeral_hosts(self.cook_url):
-            # If the cluster under test has ephemeral hosts, then it's generally a bad
-            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
-            # responsible for launching hosts to launch hosts that never get used
-            self.logger.info('Bailing out because the cluster has ephemeral hosts')
-            return
-
         raw_job = {'command': 'ls', 'constraints': [['HOSTNAME', 'EQUALS', 'will not get scheduled']]}
         cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -1620,14 +1614,11 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(1, cp.returncode, cp.stdout)
         self.assertIn('No matching data found', cli.decode(cp.stderr))
 
+    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
+                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
+                                                 'the process responsible for launching hosts to launch hosts that '
+                                                 'never get used')
     def test_cat_job_with_no_instances(self):
-        if util.has_ephemeral_hosts(self.cook_url):
-            # If the cluster under test has ephemeral hosts, then it's generally a bad
-            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
-            # responsible for launching hosts to launch hosts that never get used
-            self.logger.info('Bailing out because the cluster has ephemeral hosts')
-            return
-
         raw_job = {'command': 'ls', 'constraints': [['HOSTNAME', 'EQUALS', 'will not get scheduled']]}
         cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')
         self.assertEqual(0, cp.returncode, cp.stderr)

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -429,10 +429,6 @@ class CookCliTest(unittest.TestCase):
         cp, jobs = cli.jobs_json(self.cook_url, '--name %s --user %s %s' % (name, user, state_flags))
         return cp, jobs
 
-    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
-                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
-                                                 'the process responsible for launching hosts to launch hosts that '
-                                                 'never get used')
     def test_list_by_state(self):
         name = f'{self.current_name()}_{uuid.uuid4()}'
 
@@ -627,10 +623,6 @@ class CookCliTest(unittest.TestCase):
         self.assertIn(f'-t {hostname} cd', stdout)
         self.assertIn('; bash', stdout)
 
-    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
-                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
-                                                 'the process responsible for launching hosts to launch hosts that '
-                                                 'never get used')
     def test_ssh_no_instances(self):
         raw_job = {'command': 'ls', 'constraints': [['HOSTNAME', 'EQUALS', 'will not get scheduled']]}
         cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')
@@ -1614,10 +1606,6 @@ class CookCliTest(unittest.TestCase):
         self.assertEqual(1, cp.returncode, cp.stdout)
         self.assertIn('No matching data found', cli.decode(cp.stderr))
 
-    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
-                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
-                                                 'the process responsible for launching hosts to launch hosts that '
-                                                 'never get used')
     def test_cat_job_with_no_instances(self):
         raw_job = {'command': 'ls', 'constraints': [['HOSTNAME', 'EQUALS', 'will not get scheduled']]}
         cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')

--- a/integration/tests/cook/test_impersonation.py
+++ b/integration/tests/cook/test_impersonation.py
@@ -1,14 +1,16 @@
-import itertools
 import logging
-import pytest
 import unittest
+
+import pytest
 
 from tests.cook import util
 
+
 @pytest.mark.multi_user
-@unittest.skipUnless(util.multi_user_tests_enabled(), 'Requires using multi-user coniguration (e.g., BasicAuth) for Cook Scheduler')
+@unittest.skipUnless(util.multi_user_tests_enabled(), 'Requires using multi-user coniguration (e.g., BasicAuth) for '
+                                                      'Cook Scheduler')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
-class ImpersonationCookTest(unittest.TestCase):
+class ImpersonationCookTest(util.CookTest):
 
     @classmethod
     def setUpClass(cls):
@@ -62,6 +64,7 @@ class ImpersonationCookTest(unittest.TestCase):
                 job_uuid, resp = util.submit_job(self.cook_url, command='sleep 1')
                 self.assertEqual(resp.status_code, 201, resp.text)
                 job_uuids.append(job_uuid)
+                util.reset_limit(self.cook_url, 'quota', user1.name, reason=self.current_name())
             # users can create jobs
             with user1:
                 job_uuid, resp = util.submit_job(self.cook_url, command='sleep 1')
@@ -77,7 +80,6 @@ class ImpersonationCookTest(unittest.TestCase):
 
     def test_cannot_impersonate_admin_endpoints(self):
         user1 = self.user_factory.new_user()
-        job_uuids = []
         # admin can do admin things
         with self.admin:
             # read queue endpoint
@@ -87,13 +89,13 @@ class ImpersonationCookTest(unittest.TestCase):
             resp = util.set_limit(self.cook_url, 'quota', user1.name, cpus=20)
             self.assertEqual(resp.status_code, 201, resp.text)
             # reset user quota back to default
-            resp = util.reset_limit(self.cook_url, 'quota', user1.name)
+            resp = util.reset_limit(self.cook_url, 'quota', user1.name, reason=self.current_name())
             self.assertEqual(resp.status_code, 204, resp.text)
             # set user share
             resp = util.set_limit(self.cook_url, 'share', user1.name, cpus=10)
             self.assertEqual(resp.status_code, 201, resp.text)
             # reset user share back to default
-            resp = util.reset_limit(self.cook_url, 'share', user1.name)
+            resp = util.reset_limit(self.cook_url, 'share', user1.name, reason=self.current_name())
             self.assertEqual(resp.status_code, 204, resp.text)
         # impersonator cannot indirectly do admin things
         with self.poser.impersonating(self.admin):
@@ -104,11 +106,11 @@ class ImpersonationCookTest(unittest.TestCase):
             resp = util.set_limit(self.cook_url, 'quota', user1.name, cpus=20)
             self.assertEqual(resp.status_code, 403, resp.text)
             # reset user quota back to default
-            resp = util.reset_limit(self.cook_url, 'quota', user1.name)
+            resp = util.reset_limit(self.cook_url, 'quota', user1.name, reason=self.current_name())
             self.assertEqual(resp.status_code, 403, resp.text)
             # set user share
             resp = util.set_limit(self.cook_url, 'share', user1.name, cpus=10)
             self.assertEqual(resp.status_code, 403, resp.text)
             # reset user share back to default
-            resp = util.reset_limit(self.cook_url, 'share', user1.name)
+            resp = util.reset_limit(self.cook_url, 'share', user1.name, reason=self.current_name())
             self.assertEqual(resp.status_code, 403, resp.text)

--- a/integration/tests/cook/test_master_slave.py
+++ b/integration/tests/cook/test_master_slave.py
@@ -40,4 +40,4 @@ class MasterSlaveTest(unittest.TestCase):
 
             check_queue()
         finally:
-            util.kill_jobs(self.cook_url, uuids)
+            util.kill_jobs(self.master_url, uuids)

--- a/integration/tests/cook/test_master_slave.py
+++ b/integration/tests/cook/test_master_slave.py
@@ -26,7 +26,7 @@ class MasterSlaveTest(unittest.TestCase):
         self.logger = logging.getLogger(__name__)
 
     def test_get_queue(self):
-        if util.has_ephemeral_hosts(self.cook_url):
+        if util.has_ephemeral_hosts(self.master_url):
             # If the cluster under test has ephemeral hosts, then it's generally a bad
             # idea to use HOSTNAME EQUALS constraints, because it can cause the process
             # responsible for launching hosts to launch hosts that never get used

--- a/integration/tests/cook/test_master_slave.py
+++ b/integration/tests/cook/test_master_slave.py
@@ -1,11 +1,12 @@
 import logging
 import os
-import pytest
-import time
 import unittest
 
+import pytest
 from retrying import retry
+
 from tests.cook import util
+
 
 @unittest.skipUnless(os.getenv('COOK_MASTER_SLAVE') is not None,
                      'Requires setting the COOK_MASTER_SLAVE environment variable')
@@ -25,6 +26,13 @@ class MasterSlaveTest(unittest.TestCase):
         self.logger = logging.getLogger(__name__)
 
     def test_get_queue(self):
+        if util.has_ephemeral_hosts(self.cook_url):
+            # If the cluster under test has ephemeral hosts, then it's generally a bad
+            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
+            # responsible for launching hosts to launch hosts that never get used
+            self.logger.info('Bailing out because the cluster has ephemeral hosts')
+            return
+
         job_uuid, resp = util.submit_job(self.master_url, constraints=[["HOSTNAME",
                                                                         "EQUALS",
                                                                         "can't schedule"]])
@@ -32,10 +40,11 @@ class MasterSlaveTest(unittest.TestCase):
         slave_queue = util.session.get('%s/queue' % self.slave_url, allow_redirects=False)
         self.assertEqual(307, slave_queue.status_code)
 
-        @retry(stop_max_delay=30000, wait_fixed=1000) # Need to wait for a rank cycle
+        @retry(stop_max_delay=30000, wait_fixed=1000)  # Need to wait for a rank cycle
         def check_queue():
             master_queue = util.session.get(slave_queue.headers['Location'])
             self.assertEqual(200, master_queue.status_code, master_queue.content)
             self.assertTrue(any([job['job/uuid'] == job_uuid for job in master_queue.json()['normal']]))
+
         check_queue()
         util.session.delete('%s/rawscheduler?job=%s' % (self.master_url, job_uuid))

--- a/integration/tests/cook/test_master_slave.py
+++ b/integration/tests/cook/test_master_slave.py
@@ -25,23 +25,19 @@ class MasterSlaveTest(unittest.TestCase):
         self.slave_url = type(self).slave_url
         self.logger = logging.getLogger(__name__)
 
-    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
-                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
-                                                 'the process responsible for launching hosts to launch hosts that '
-                                                 'never get used')
     def test_get_queue(self):
-        job_uuid, resp = util.submit_job(self.master_url, constraints=[["HOSTNAME",
-                                                                        "EQUALS",
-                                                                        "can't schedule"]])
+        uuids, resp = util.submit_jobs(self.cook_url, {'command': 'sleep 30'}, clones=100)
         self.assertEqual(201, resp.status_code, resp.content)
-        slave_queue = util.session.get('%s/queue' % self.slave_url, allow_redirects=False)
-        self.assertEqual(307, slave_queue.status_code)
+        try:
+            slave_queue = util.session.get('%s/queue' % self.slave_url, allow_redirects=False)
+            self.assertEqual(307, slave_queue.status_code)
 
-        @retry(stop_max_delay=30000, wait_fixed=1000)  # Need to wait for a rank cycle
-        def check_queue():
-            master_queue = util.session.get(slave_queue.headers['Location'])
-            self.assertEqual(200, master_queue.status_code, master_queue.content)
-            self.assertTrue(any([job['job/uuid'] == job_uuid for job in master_queue.json()['normal']]))
+            @retry(stop_max_delay=30000, wait_fixed=1000)  # Need to wait for a rank cycle
+            def check_queue():
+                master_queue = util.session.get(slave_queue.headers['Location'])
+                self.assertEqual(200, master_queue.status_code, master_queue.content)
+                self.assertTrue(any([job['job/uuid'] in uuids for job in master_queue.json()['normal']]))
 
-        check_queue()
-        util.session.delete('%s/rawscheduler?job=%s' % (self.master_url, job_uuid))
+            check_queue()
+        finally:
+            util.kill_jobs(self.cook_url, uuids)

--- a/integration/tests/cook/test_master_slave.py
+++ b/integration/tests/cook/test_master_slave.py
@@ -25,14 +25,11 @@ class MasterSlaveTest(unittest.TestCase):
         self.slave_url = type(self).slave_url
         self.logger = logging.getLogger(__name__)
 
+    @unittest.skipIf(util.has_ephemeral_hosts(), 'If the cluster under test has ephemeral hosts, then it is generally '
+                                                 'a bad idea to use HOSTNAME EQUALS constraints, because it can cause '
+                                                 'the process responsible for launching hosts to launch hosts that '
+                                                 'never get used')
     def test_get_queue(self):
-        if util.has_ephemeral_hosts(self.master_url):
-            # If the cluster under test has ephemeral hosts, then it's generally a bad
-            # idea to use HOSTNAME EQUALS constraints, because it can cause the process
-            # responsible for launching hosts to launch hosts that never get used
-            self.logger.info('Bailing out because the cluster has ephemeral hosts')
-            return
-
         job_uuid, resp = util.submit_job(self.master_url, constraints=[["HOSTNAME",
                                                                         "EQUALS",
                                                                         "can't schedule"]])

--- a/integration/tests/cook/test_master_slave.py
+++ b/integration/tests/cook/test_master_slave.py
@@ -26,7 +26,7 @@ class MasterSlaveTest(unittest.TestCase):
         self.logger = logging.getLogger(__name__)
 
     def test_get_queue(self):
-        uuids, resp = util.submit_jobs(self.cook_url, {'command': 'sleep 30'}, clones=100)
+        uuids, resp = util.submit_jobs(self.master_url, {'command': 'sleep 30'}, clones=100)
         self.assertEqual(201, resp.status_code, resp.content)
         try:
             slave_queue = util.session.get('%s/queue' % self.slave_url, allow_redirects=False)

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -10,7 +10,7 @@ from tests.cook import mesos, util
 @unittest.skipUnless(util.multi_user_tests_enabled(), 'Requires using multi-user coniguration '
                                                       '(e.g., BasicAuth) for Cook Scheduler')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
-class MultiUserCookTest(unittest.TestCase):
+class MultiUserCookTest(util.CookTest):
 
     @classmethod
     def setUpClass(cls):
@@ -127,7 +127,7 @@ class MultiUserCookTest(unittest.TestCase):
                 all_job_uuids.append(job_uuid)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
-                resp = util.reset_limit(self.cook_url, 'quota', user.name)
+                resp = util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
                 job_uuid, resp = util.submit_job(self.cook_url)
@@ -140,7 +140,7 @@ class MultiUserCookTest(unittest.TestCase):
         finally:
             with admin:
                 util.kill_jobs(self.cook_url, all_job_uuids)
-                util.reset_limit(self.cook_url, 'quota', user.name)
+                util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
 
     def test_job_mem_quota(self):
         admin = self.user_factory.admin()
@@ -166,7 +166,7 @@ class MultiUserCookTest(unittest.TestCase):
                 all_job_uuids.append(job_uuid)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
-                resp = util.reset_limit(self.cook_url, 'quota', user.name)
+                resp = util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
                 job_uuid, resp = util.submit_job(self.cook_url)
@@ -179,7 +179,7 @@ class MultiUserCookTest(unittest.TestCase):
         finally:
             with admin:
                 util.kill_jobs(self.cook_url, all_job_uuids)
-                util.reset_limit(self.cook_url, 'quota', user.name)
+                util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
 
     def test_job_count_quota(self):
         admin = self.user_factory.admin()
@@ -195,7 +195,7 @@ class MultiUserCookTest(unittest.TestCase):
                 self.assertEqual(resp.status_code, 422, msg=resp.text)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
-                resp = util.reset_limit(self.cook_url, 'quota', user.name)
+                resp = util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
                 job_uuid, resp = util.submit_job(self.cook_url)
@@ -208,4 +208,4 @@ class MultiUserCookTest(unittest.TestCase):
         finally:
             with admin:
                 util.kill_jobs(self.cook_url, all_job_uuids)
-                util.reset_limit(self.cook_url, 'quota', user.name)
+                util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -70,6 +70,8 @@ class MultiUserCookTest(unittest.TestCase):
                                                          max_retries=2, **job_resources)
                         self.assertEqual(resp.status_code, 201, resp.content)
                         all_job_uuids.append(job_uuid)
+                        job = util.load_job(self.cook_url, job_uuid)
+                        self.assertEqual(user, job['user'], job)
             # Don't query until the jobs are all running
             util.wait_for_jobs(self.cook_url, all_job_uuids, 'running')
             # Check the usage for each of our users

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -71,7 +71,7 @@ class MultiUserCookTest(unittest.TestCase):
                         self.assertEqual(resp.status_code, 201, resp.content)
                         all_job_uuids.append(job_uuid)
                         job = util.load_job(self.cook_url, job_uuid)
-                        self.assertEqual(user, job['user'], job)
+                        self.assertEqual(user.name, job['user'], job)
             # Don't query until the jobs are all running
             util.wait_for_jobs(self.cook_url, all_job_uuids, 'running')
             # Check the usage for each of our users

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -900,7 +900,6 @@ def group_submit_kill_retry(cook_url, retry_failed_jobs_only):
         for job in jobs:
             logger.info(f'Dumping sandbox files for job {job}')
             for instance in job['instances']:
-                logger.info(f'Dumping sandbox files for instance {instance}')
                 mesos.dump_sandbox_files(session, instance, job)
         return jobs
     finally:

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1096,6 +1096,7 @@ def _cook_executor_config():
     """Get the cook executor config from the /settings endpoint"""
     cook_url = retrieve_cook_url()
     _wait_for_cook(cook_url)
+    init_cook_session(cook_url)
     cook_executor_config = get_in(settings(cook_url), 'executor')
     logger.info(f"Cook's executor config is {cook_executor_config}")
     return cook_executor_config

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1061,7 +1061,17 @@ def active_pools(cook_url):
     return [p for p in pools if p['state'] == 'active'], resp
 
 
-def has_ephemeral_hosts(cook_url):
+@functools.lru_cache()
+def _cook_estimated_completion_constraint():
+    """Get the estimated completion constraint config from the /settings endpoint"""
+    cook_url = retrieve_cook_url()
+    _wait_for_cook(cook_url)
+    estimated_completion_constraint = settings(cook_url).get('estimated-completion-constraint', None)
+    logger.info(f"Cook's estimated completion constraint is {estimated_completion_constraint}")
+    return estimated_completion_constraint
+
+
+def has_ephemeral_hosts():
     """Returns True if the cluster under test has ephemeral hosts"""
     s = os.getenv('COOK_TEST_EPHEMERAL_HOSTS')
     if s is not None:
@@ -1069,4 +1079,4 @@ def has_ephemeral_hosts(cook_url):
     else:
         # If the estimated completion constraint is turned on, it's a
         # good indication that the hosts on the cluster are ephemeral
-        return settings(cook_url).get('estimated-completion-constraint', None) is not None
+        return _cook_estimated_completion_constraint() is not None

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -7,6 +7,7 @@ import os
 import os.path
 import subprocess
 import time
+import unittest
 import uuid
 from datetime import datetime
 from urllib.parse import urlencode
@@ -1132,3 +1133,10 @@ def max_cpus(mesos_url, cook_url):
     max_cpus = min(slave_cpus, constraint_cpus)
     logging.debug(f'Max cpus we can submit that will get scheduled is {max_cpus}')
     return max_cpus
+
+
+class CookTest(unittest.TestCase):
+    def current_name(self):
+        """Returns the name of the currently running test function"""
+        test_id = self.id()
+        return test_id.split('.')[-1]

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1077,6 +1077,9 @@ def has_ephemeral_hosts():
     if s is not None:
         return to_bool(s)
     else:
-        # If the estimated completion constraint is turned on, it's a
-        # good indication that the hosts on the cluster are ephemeral
-        return _cook_estimated_completion_constraint() is not None
+        try:
+            # If the estimated completion constraint is turned on, it's a
+            # good indication that the hosts on the cluster are ephemeral
+            return _cook_estimated_completion_constraint() is not None
+        except:
+            return False

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1068,4 +1068,4 @@ def has_ephemeral_hosts(cook_url):
     else:
         # If the estimated completion constraint is turned on, it's a
         # good indication that the hosts on the cluster are ephemeral
-        return settings(cook_url).get('estimated_completion_constraint', None) is not None
+        return settings(cook_url).get('estimated-completion-constraint', None) is not None

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -898,7 +898,6 @@ def group_submit_kill_retry(cook_url, retry_failed_jobs_only):
         # return final job details to caller for assertion checks
         jobs = query_jobs(cook_url, assert_response=True, uuid=jobs).json()
         for job in jobs:
-            logger.info(f'Dumping sandbox files for job {job}')
             for instance in job['instances']:
                 mesos.dump_sandbox_files(session, instance, job)
         return jobs

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -27,7 +27,7 @@ DEFAULT_TEST_TIMEOUT_SECS = 600
 
 # default time limit used by most wait_* utility functions
 # 2 minutes should be more than sufficient on most cases
-DEFAULT_TIMEOUT_MS = 120000
+DEFAULT_TIMEOUT_MS = int(os.getenv('COOK_TEST_DEFAULT_TIMEOUT_MS', 120000))
 
 # Name of our custom HTTP header for user impersonation
 IMPERSONATION_HEADER = 'X-Cook-Impersonate'

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -647,6 +647,9 @@ def wait_for_jobs(cook_url, job_ids, status, max_wait_ms=DEFAULT_TIMEOUT_MS):
         jobs = resp.json()
         for job in jobs:
             logger.info(f"Job {job['uuid']} has status {job['status']}, expecting {status}.")
+        if any(job['status'] == 'waiting' for job in jobs):
+            queue_length = len(query_queue(cook_url).json()['normal'])
+            logger.info(f'The queue length is {queue_length}.')
         return all([job['status'] == status for job in jobs])
 
     response = wait_until(query, predicate, max_wait_ms=max_wait_ms, wait_interval_ms=2000)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -712,10 +712,12 @@ def wait_for_sandbox_directory(cook_url, job_id):
                 else:
                     logger.info(
                         f"Job {job_id} instance {inst['task_id']} has sandbox directory {inst['sandbox_directory']}.")
-                    job['instance-with-sandbox'] = inst
                     return True
 
-    return wait_until(query, predicate, max_wait_ms=max_wait_ms, wait_interval_ms=250)['instance-with-sandbox']
+    job = wait_until(query, predicate, max_wait_ms=max_wait_ms, wait_interval_ms=250)
+    for inst in job['instances']:
+        if 'sandbox_directory' in inst:
+            return inst
 
 
 def wait_for_end_time(cook_url, job_id, max_wait_ms=DEFAULT_TIMEOUT_MS):

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -371,6 +371,16 @@ def minimal_job(**kwargs):
         'priority': 1,
         'uuid': str(uuid.uuid4())
     }
+    docker_image = os.getenv('COOK_TEST_DOCKER_IMAGE')
+    if docker_image:
+        job['container'] = {
+            'type': 'docker',
+            'docker': {
+                'image': docker_image,
+                'network': 'HOST',
+                'force-pull-image': False
+            }
+        }
     job.update(kwargs)
     return job
 


### PR DESCRIPTION
## Changes proposed in this PR

- if `COOK_TEST_DOCKER_IMAGE` is set, use it in `util.minimal_job`
- if `COOK_TEST_SKIP_SANDBOX_DUMP` is set, don't attempt to dump sandbox contents
- in several tests, switch from checking if the cook executor is configured to checking if the cook executor was actually used before assuming that the exit code is present
- introducing `util.has_ephemeral_hosts` which returns `True` if either `COOK_TEST_EPHEMERAL_HOSTS` is set, or if the estimated completion constraint is configured
- in several tests, if the cluster under test has ephemeral hosts, then bail out instead of using `HOSTNAME` `EQUALS` constraints
- if `COOK_TEST_DEFAULT_TIMEOUT_MS` is set, use it instead of the default-default timeout of 2 minutes

## Why are we making these changes?

We would like to be able to run our integration tests using docker containers for the test jobs.
