### PR TITLE
Releases Cook Scheduler v1.17.2

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.17.2] - 2018-06-01
+### Fixed
+- Issue where task reconciliation was failing, from @pschorf
+
 ## [1.17.1] - 2018-05-23
 ### Fixed
 - Issue where nil instance timestamps would cause NPEs, from @dposada

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.17.2-SNAPSHOT"
+(defproject cook "1.17.2"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.17.2"
+(defproject cook "1.17.3-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]


### PR DESCRIPTION
## Changes proposed in this PR

- updating the changelog
- bumping the version

## Why are we making these changes?

To release the task reconciliation fix.
