### PR TITLE
Improves job-kill authorization error message

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -29,7 +29,9 @@ class MultiUserCookTest(unittest.TestCase):
         try:
             self.assertEqual(resp.status_code, 201, resp.text)
             with user2:
-                util.kill_jobs(self.cook_url, [job_uuid], expected_status_code=403)
+                resp = util.kill_jobs(self.cook_url, [job_uuid], expected_status_code=403)
+                self.assertEqual(f'You are not authorized to kill the following jobs: {job_uuid}',
+                                 resp.json()['error'])
             with user1:
                 util.kill_jobs(self.cook_url, [job_uuid])
             job = util.wait_for_job(self.cook_url, job_uuid, 'completed')


### PR DESCRIPTION
## Changes proposed in this PR

- improving the error message returned when a user is not authorized to kill a job

## Why are we making these changes?

We would like to expose this error in `cs`, and we want it to be as clear as possible.
