### PR TITLE
Removes command from the 'Submitting jobs' log

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -1389,7 +1389,7 @@
   ::jobs and ::groups, which specify the jobs and job groups."
   [conn {:keys [::groups ::jobs ::pool]}]
   (try
-    (log/info "Submitting jobs through raw api:" jobs)
+    (log/info "Submitting jobs through raw api:" (map #(dissoc % :command) jobs))
     (let [group-uuids (set (map :uuid groups))
           group-asserts (map (fn [guuid] [:entity/ensure-not-exists [:group/uuid guuid]])
                              group-uuids)


### PR DESCRIPTION
## Changes proposed in this PR

- `dissoc`ing the `:command` field from jobs when logging the submission

## Why are we making these changes?

Commands in the wild can be very long, and there is very little value in being able to view the command in the log file, since we can view it by querying Datomic.
