### PR TITLE
Adds http basic auth support to cs

### DIFF
--- a/cli/cook/http.py
+++ b/cli/cook/http.py
@@ -33,6 +33,14 @@ def configure(config):
     session = session_module.Session()
     session.mount('http://', http_adapter)
     session.headers['User-Agent'] = f"cs/{cook.version.VERSION} ({session.headers['User-Agent']})"
+    auth_config = http_config.get('auth', None)
+    if auth_config:
+        auth_type = auth_config.get('type')
+        if auth_type == 'basic':
+            basic_auth_config = auth_config.get('basic')
+            session.auth = (basic_auth_config.get('user'), basic_auth_config.get('pass'))
+        else:
+            raise Exception(f'Encountered unsupported authentication type "{auth_type}".')
 
 
 def __post(url, json_body):

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -138,6 +138,27 @@ def wait(uuids=None, cook_url=None, flags=None, wait_flags=None, stdin=None):
     return cp
 
 
+def write_json(path, config):
+    """Writes the given config map as JSON to the given path."""
+    with open(path, 'w') as outfile:
+        logger.info('echo \'%s\' > %s' % (json.dumps(config), path))
+        json.dump(config, outfile)
+
+
+def basic_auth_config():
+    """Returns a config map with HTTP basic auth configured."""
+    config = {'http': {'auth': {'type': 'basic',
+                                'basic': {'user': 'foo',
+                                          'pass': 'bar'}}}}
+    return config
+
+
+def base_config():
+    """Returns a "base" config map that can be added to."""
+    config = basic_auth_config() if util.http_basic_auth_enabled() else {}
+    return config
+
+
 class temp_config_file:
     """
     A context manager used to generate and subsequently delete a temporary 
@@ -152,11 +173,22 @@ class temp_config_file:
         else:
             self.config = config
 
+    def deep_merge(self, a, b):
+        """Merges a and b, letting b win if there is a conflict"""
+        merged = a.copy()
+        for key in b:
+            b_value = b[key]
+            merged[key] = b_value
+            if key in a:
+                a_value = a[key]
+                if isinstance(a_value, dict) and isinstance(b_value, dict):
+                    merged[key] = self.deep_merge(a_value, b_value)
+        return merged
+
     def write_temp_json(self):
         path = tempfile.NamedTemporaryFile(delete=False).name
-        with open(path, 'w') as outfile:
-            logger.info('echo \'%s\' > %s' % (json.dumps(self.config), path))
-            json.dump(self.config, outfile)
+        config = self.deep_merge(base_config(), self.config)
+        write_json(path, config)
         return path
 
     def __enter__(self):

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -17,7 +17,6 @@ from tests.cook import cli, util
 
 
 @pytest.mark.cli
-@unittest.skipIf(util.http_basic_auth_enabled(), 'Cook CLI does not currently support HTTP Basic Auth')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class CookCliTest(unittest.TestCase):
 
@@ -25,6 +24,7 @@ class CookCliTest(unittest.TestCase):
     def setUpClass(cls):
         cls.cook_url = util.retrieve_cook_url()
         util.init_cook_session(cls.cook_url)
+        cli.write_json('.cs.json', cli.base_config())
 
     def current_name(self):
         """Returns the name of the currently running test function"""
@@ -513,7 +513,7 @@ class CookCliTest(unittest.TestCase):
             self.assertIn(success_uuid, uuids)
             self.assertIn(failed_uuid, uuids)
         finally:
-            util.kill_jobs(self.cook_url, jobs=[waiting_uuid, running_uuid])
+            cli.kill([waiting_uuid, running_uuid], self.cook_url)
 
     def test_list_invalid_state(self):
         cp = cli.jobs(self.cook_url, '--foo')
@@ -633,7 +633,7 @@ class CookCliTest(unittest.TestCase):
             self.assertEqual(1, cp.returncode, cp.stdout)
             self.assertIn('currently has no instances', cli.decode(cp.stderr))
         finally:
-            util.kill_jobs(self.cook_url, uuids)
+            cli.kill(uuids, self.cook_url)
 
     def test_ssh_invalid_uuid(self):
         cp = cli.ssh(uuid.uuid4(), self.cook_url)
@@ -773,7 +773,7 @@ class CookCliTest(unittest.TestCase):
                 self.assertEqual(f'{start+i+j+1}\n', line.decode())
         finally:
             proc.kill()
-            util.kill_jobs(self.cook_url, jobs=uuids)
+            cli.kill(uuids, self.cook_url)
 
     def test_tail_zero_byte_file(self):
         cp, uuids = cli.submit('touch file.txt', self.cook_url)
@@ -980,6 +980,7 @@ class CookCliTest(unittest.TestCase):
 
         return util.wait_until(query, lambda out: 'Executor completed execution' in out)
 
+    @unittest.skipIf(util.http_basic_auth_enabled(), 'Cook Executor does not currently support HTTP Basic Auth')
     def test_show_progress_message(self):
         executor = util.get_job_executor_type(self.cook_url)
         line = util.progress_line(self.cook_url, 99, 'We are so close!')
@@ -1008,6 +1009,7 @@ class CookCliTest(unittest.TestCase):
             self.assertIn('Command exited with status 0', stdout)
             self.assertIn('Executor completed execution', stdout)
 
+    @unittest.skipIf(util.http_basic_auth_enabled(), 'Cook Executor does not currently support HTTP Basic Auth')
     def test_show_progress_message_custom_progress_file(self):
         executor = util.get_job_executor_type(self.cook_url)
         progress_file_env = util.retrieve_progress_file_env(self.cook_url)
@@ -1632,7 +1634,7 @@ class CookCliTest(unittest.TestCase):
             self.assertEqual(1, cp.returncode, cp.stdout)
             self.assertIn('currently has no instances', cli.decode(cp.stderr))
         finally:
-            util.kill_jobs(self.cook_url, jobs=[waiting_uuid])
+            cli.kill([waiting_uuid], self.cook_url)
 
     def test_cat_with_broken_pipe(self):
         iterations = 20
@@ -1759,7 +1761,7 @@ class CookCliTest(unittest.TestCase):
             self.assertIn(uuid_8, custom_application_grouped_jobs)
             self.assertIn(uuid_9, custom_application_grouped_jobs)
         finally:
-            util.kill_jobs(self.cook_url, jobs=all_uuids)
+            cli.kill(all_uuids, self.cook_url)
 
     def test_avoid_exit_on_connection_error(self):
         name = uuid.uuid4()

--- a/integration/tests/cook/test_cli_multi_cluster.py
+++ b/integration/tests/cook/test_cli_multi_cluster.py
@@ -12,7 +12,6 @@ from tests.cook import cli, util
 
 @pytest.mark.cli
 @unittest.skipUnless(util.multi_cluster_tests_enabled(), 'Requires setting the COOK_MULTI_CLUSTER environment variable')
-@unittest.skipIf(util.http_basic_auth_enabled(), 'Cook CLI does not currently support HTTP Basic Auth')
 @pytest.mark.timeout(util.DEFAULT_TEST_TIMEOUT_SECS)  # individual test timeout
 class MultiCookCliTest(unittest.TestCase):
 
@@ -21,6 +20,7 @@ class MultiCookCliTest(unittest.TestCase):
         cls.cook_url_1 = util.retrieve_cook_url()
         cls.cook_url_2 = util.retrieve_cook_url('COOK_SCHEDULER_URL_2', 'http://localhost:22321')
         util.init_cook_session(cls.cook_url_1, cls.cook_url_2)
+        cli.write_json('.cs.json', cli.base_config())
 
     def setUp(self):
         self.cook_url_1 = type(self).cook_url_1


### PR DESCRIPTION
## Changes proposed in this PR

- adding support for http basic auth to `cs`
- allowing the `cs` integration tests to run when the cook under test is using basic auth

## Why are we making these changes?

This paves the way for writing multi-user integration tests for `cs`.