### PR TITLE
Makes wait_for_output_url more robust

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -787,13 +787,16 @@ def wait_for_output_url(cook_url, job_uuid):
         return load_job(cook_url, job_uuid, assert_response=False)
 
     def predicate(job):
-        if 'output_url' in job['instances'][0]:
-            return True
-        else:
-            logger.info(f"Job {job['uuid']} had no output_url")
+        for instance in job['instances']:
+            if 'output_url' in instance:
+                return True
+            else:
+                logger.info(f"Job {job['uuid']} instance {instance['task_id']} had no output_url")
 
-    response = wait_until(query, predicate)
-    return response['instances'][0]
+    job = wait_until(query, predicate)
+    for instance in job['instances']:
+        if 'output_url' in instance:
+            return instance
 
 
 def list_jobs(cook_url, **kwargs):


### PR DESCRIPTION
## Changes proposed in this PR

- instead of assuming that the 0th instance will be the one with the `output_url`, checking if *any* instance has an `output_url`

## Why are we making these changes?

Tests that use this helper function will fail in cases where the 0th instance encountered an error, e.g. `Agent removed`.
