### PR TITLE
Adds Slack badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Cook Scheduler
 
 [![Build Status](https://travis-ci.org/twosigma/Cook.svg)](https://travis-ci.org/twosigma/Cook)
+[![Slack Status](http://cookscheduler.herokuapp.com/badge.svg)](http://cookscheduler.herokuapp.com/)
 
 Welcome to Two Sigma's Cook Scheduler!
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding the Slack sign-up badge to the top-level README

## Why are we making these changes?

So that people can easily find our Slack and ask questions / provide feedback.

## Screenshot

![image](https://user-images.githubusercontent.com/444778/41302682-b7507234-6e30-11e8-8c69-5498776ef093.png)
