### PR TITLE
Adds travis build with pools turned off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,12 @@ matrix:
       before_script: cd integration && ./travis/prepare_integration.sh
       script: ./travis/run_integration.sh --executor=cook
 
+    - env: NAME='Cook Scheduler integration tests with no pools'
+      services: docker
+      install: sudo ./travis/install_mesos.sh
+      before_script: cd integration && ./travis/prepare_integration.sh
+      script: ./travis/run_integration.sh --pools=off
+
     - env: NAME='Cook Scheduler Simulator tests'
       services: docker
       install: sudo ./travis/install_mesos.sh

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1061,7 +1061,7 @@ def default_pool(cook_url):
     """Returns the configured default pool, or None if one is not configured"""
     cook_settings = settings(cook_url)
     default_pool = get_in(cook_settings, 'pools', 'default')
-    return default_pool
+    return default_pool if default_pool != '' else None
 
 
 def all_pools(cook_url):

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -411,7 +411,10 @@
 (defn default-pool
   "Returns the default pool name from the config map"
   []
-  (-> config :settings :pools :default))
+  (let [pool (-> config :settings :pools :default)]
+    (if (str/blank? pool)
+      nil
+      pool)))
 
 (defn api-only-mode?
   "Returns true if api-only? mode is turned on"

--- a/scheduler/src/cook/mesos/pool.clj
+++ b/scheduler/src/cook/mesos/pool.clj
@@ -71,7 +71,7 @@
   (let [pools (all-pools db)
         default-pool-name (config/default-pool)]
     (log/info "Pools in the database:" pools ", default pool:" default-pool-name)
-    (if (and default-pool-name (not (str/blank? default-pool-name)))
+    (if default-pool-name
       (when-not (some #(= default-pool-name (:pool/name %)) pools)
         (throw (ex-info "There is no pool in the database matching the configured default pool"
                         {:pools pools :default-pool-name default-pool-name})))

--- a/scheduler/src/cook/mesos/pool.clj
+++ b/scheduler/src/cook/mesos/pool.clj
@@ -1,5 +1,6 @@
 (ns cook.mesos.pool
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [cook.config :as config]
             [datomic.api :as d])
   (:import [java.util UUID]))
@@ -70,7 +71,7 @@
   (let [pools (all-pools db)
         default-pool-name (config/default-pool)]
     (log/info "Pools in the database:" pools ", default pool:" default-pool-name)
-    (if default-pool-name
+    (if (and default-pool-name (not (str/blank? default-pool-name)))
       (when-not (some #(= default-pool-name (:pool/name %)) pools)
         (throw (ex-info "There is no pool in the database matching the configured default pool"
                         {:pools pools :default-pool-name default-pool-name})))

--- a/scheduler/test/cook/test/config.clj
+++ b/scheduler/test/cook/test/config.clj
@@ -15,7 +15,7 @@
 ;;
 (ns cook.test.config
   (:require [clojure.test :refer :all]
-            [cook.config :refer (config env read-edn-config)]
+            [cook.config :refer (config default-pool env read-edn-config)]
             [cook.test.testutil :refer (setup)]))
 
 (deftest test-read-edn-config
@@ -33,3 +33,13 @@
   (with-redefs [config {:settings {:mesos-datomic-uri "bar"}}]
     (is (= "bar" (-> config :settings :mesos-datomic-uri))))
   (is (= "foo" (-> config :settings :mesos-datomic-uri))))
+
+(deftest test-default-pool
+  (with-redefs [config {:settings {:pools {:default "foo"}}}]
+    (is (= "foo" (default-pool))))
+  (with-redefs [config {:settings {:pools {:default ""}}}]
+    (is (nil? (default-pool))))
+  (with-redefs [config {:settings {:pools {:default nil}}}]
+    (is (nil? (default-pool))))
+  (with-redefs [config {:settings {}}]
+    (is (nil? (default-pool)))))

--- a/scheduler/test/cook/test/mesos/pool.clj
+++ b/scheduler/test/cook/test/mesos/pool.clj
@@ -11,9 +11,6 @@
   (with-redefs [pool/all-pools (constantly [])
                 config/default-pool (constantly nil)]
     (is (nil? (pool/guard-invalid-default-pool nil))))
-  (with-redefs [pool/all-pools (constantly [])
-                config/default-pool (constantly "")]
-    (is (nil? (pool/guard-invalid-default-pool nil))))
   (with-redefs [pool/all-pools (constantly [{}])
                 config/default-pool (constantly nil)]
     (is (thrown-with-msg? ExceptionInfo

--- a/scheduler/test/cook/test/mesos/pool.clj
+++ b/scheduler/test/cook/test/mesos/pool.clj
@@ -11,6 +11,9 @@
   (with-redefs [pool/all-pools (constantly [])
                 config/default-pool (constantly nil)]
     (is (nil? (pool/guard-invalid-default-pool nil))))
+  (with-redefs [pool/all-pools (constantly [])
+                config/default-pool (constantly "")]
+    (is (nil? (pool/guard-invalid-default-pool nil))))
   (with-redefs [pool/all-pools (constantly [{}])
                 config/default-pool (constantly nil)]
     (is (thrown-with-msg? ExceptionInfo


### PR DESCRIPTION
## Changes proposed in this PR

- adding `--pools={on/off}` to `run_integration.sh`
- adding a build to the travis job that runs with `--pools=off`

## Why are we making these changes?

We want to ensure that changes we make for pools don't break environments that don't have pools.
