### PR TITLE
Add support for x-forwarded-proto in CORS requests

### DIFF
--- a/scheduler/src/cook/cors.clj
+++ b/scheduler/src/cook/cors.clj
@@ -8,10 +8,10 @@
   "Returns true if the request is from the same origin as the provided origin header"
   [{:keys [headers scheme]}]
   (let [{:strs [host origin x-forwarded-proto]} headers
-        scheme (or x-forwarded-proto
-                   (when scheme (name scheme)))]
-    (when (and host origin scheme)
-      (= origin (str scheme "://" host)))))
+        forwarded-or-scheme (or x-forwarded-proto
+                                (when scheme (name scheme)))]
+    (when (and host origin forwarded-or-scheme)
+      (= origin (str forwarded-or-scheme "://" host)))))
 
 (defn request-allowed?
   "Returns true if the request is either from the same origin or matches a pattern in cors-origins.

--- a/scheduler/src/cook/cors.clj
+++ b/scheduler/src/cook/cors.clj
@@ -7,9 +7,11 @@
 (defn same-origin?
   "Returns true if the request is from the same origin as the provided origin header"
   [{:keys [headers scheme]}]
-  (let [{:strs [host origin]} headers]
+  (let [{:strs [host origin x-forwarded-proto]} headers
+        scheme (or x-forwarded-proto
+                   (when scheme (name scheme)))]
     (when (and host origin scheme)
-      (= origin (str (name scheme) "://" host)))))
+      (= origin (str scheme "://" host)))))
 
 (defn request-allowed?
   "Returns true if the request is either from the same origin or matches a pattern in cors-origins.

--- a/scheduler/test/cook/test/cors.clj
+++ b/scheduler/test/cook/test/cors.clj
@@ -13,6 +13,14 @@
   (is (cors/same-origin? {:headers {"host" "example.com"
                                     "origin" "http://example.com"}
                           :scheme :http}))
+  (is (cors/same-origin? {:headers {"host" "example.com"
+                                    "origin" "https://example.com"
+                                    "x-forwarded-proto" "https"}
+                          :scheme :http}))
+  (is (not (cors/same-origin? {:headers {"host" "example.com"
+                                         "origin" "https://example.com"
+                                         "x-forwarded-proto" "http"}
+                               :scheme :https})))
   (is (not (cors/same-origin? {:headers {"host" "example.com"}
                                :scheme :http})))
   (is (not (cors/same-origin? {:headers {"origin" "http://bad.example.com"


### PR DESCRIPTION
## Changes proposed in this PR
- Adds support for `x-forwarded-proto` header for validating CORS requests

## Why are we making these changes?
Support configurations where Cook could be running behind a reverse proxy.

