### PR TITLE
Adds reason_mea_culpa to instance json

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -180,6 +180,7 @@
    (s/optional-key :output_url) s/Str
    (s/optional-key :cancelled) s/Bool
    (s/optional-key :reason_string) s/Str
+   (s/optional-key :reason_mea_culpa) s/Bool
    (s/optional-key :executor) s/Str
    (s/optional-key :exit_code) s/Int
    (s/optional-key :progress) s/Int
@@ -832,7 +833,8 @@
             exit-code (assoc :exit_code exit-code)
             url-path (assoc :output_url url-path)
             reason (assoc :reason_code (:reason/code reason)
-                          :reason_string (:reason/string reason))
+                          :reason_string (:reason/string reason)
+                          :reason_mea_culpa (:reason/mea-culpa? reason))
             progress (assoc :progress progress)
             progress-message (assoc :progress_message progress-message)
             sandbox-directory (assoc :sandbox_directory sandbox-directory))))

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1503,6 +1503,7 @@
                              :progress_message "seventy-eight percent done"
                              :reason_code 1002
                              :reason_string "Preempted by rebalancer"
+                             :reason_mea_culpa true
                              :sandbox_directory "/path/to/working/directory"
                              :status "success")]
           (is (= expected-map (dissoc instance-map :start_time))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adding `reason_mea_culpa` (true/false) to the instance json

## Why are we making these changes?

Currently, users have to manually check whether each failure type is considered *mea culpa* using the `/failure_reasons` endpoint.
