### PR TITLE
Makes test_group_failed_only_change_retries_all_success more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1450,10 +1450,10 @@ class CookTest(util.CookTest):
         statuses = ['completed']
         jobs = util.group_submit_retry(self.cook_url, command='exit 0', predicate_statuses=statuses)
         for job in jobs:
-            job_details = f'Job details: {json.dumps(job, sort_keys=True)}'
+            job_details = f'Job details: {json.dumps(job, sort_keys=True, indent=2)}'
             self.assertIn(job['status'], statuses, job_details)
-            self.assertEqual(job['retries_remaining'], 0, job_details)
-            self.assertEqual(len(job['instances']), 1, job_details)
+            self.assertEqual(0, job['retries_remaining'], job_details)
+            self.assertLessEqual(1, len(job['instances']), job_details)
 
     def test_group_failed_only_change_retries_all_failed(self):
         statuses = ['completed']


### PR DESCRIPTION
## Changes proposed in this PR

- instead of asserting exactly 1 instance, assert at least 1 instance

## Why are we making these changes?

It's possible for there to be an initial, failed instance (e.g. `Invalid task`), followed by the expected, successful instance.
