### PR TITLE
Fixes changelog link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ What is Cook?
 
 ## Releases 
 
-Check the [changelog](CHANGELOG.md) for release info.
+Check the [changelog](scheduler/CHANGELOG.md) for release info.
 
 ## Subproject Summary
 


### PR DESCRIPTION
## Changes proposed in this PR

- fixing the link to the changelog from the README

## Why are we making these changes?

We moved the changelog a while back and didn't correct this link.
