### PR TITLE
introduces ranker.clj to move ranker functions from the sheduler.clj file

### DIFF
--- a/scheduler/src/cook/mesos/ranker.clj
+++ b/scheduler/src/cook/mesos/ranker.clj
@@ -1,0 +1,170 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.mesos.ranker
+  (:require [clojure.core.async :as async]
+            [clojure.tools.logging :as log]
+            [cook.datomic :as datomic]
+            [cook.mesos.dru :as dru]
+            [cook.mesos.share :as share]
+            [cook.mesos.util :as util]
+            [datomic.api :as d]
+            [metrics.meters :as meters]
+            [metrics.timers :as timers]
+            [plumbing.core :as pc]))
+
+(timers/deftimer [cook-mesos scheduler filter-offensive-jobs-duration])
+
+(defn is-offensive?
+  [max-memory-mb max-cpus job]
+  (let [{memory-mb :mem
+         cpus :cpus} (util/job-ent->resources job)]
+    (or (> memory-mb max-memory-mb)
+        (> cpus max-cpus))))
+
+(defn filter-offensive-jobs
+  "Base on the constraints on memory and cpus, given a list of job entities it
+   puts the offensive jobs into offensive-job-ch asynchronously and returns
+   the inoffensive jobs.
+
+   A job is offensive if and only if its required memory or cpus exceeds the
+   limits"
+  ;; TODO these limits should come from the largest observed host from Fenzo
+  ;; .getResourceStatus on TaskScheduler will give a map of hosts to resources; we can compute the max over those
+  [{max-memory-gb :memory-gb max-cpus :cpus} offensive-jobs-ch jobs]
+  (timers/time!
+    filter-offensive-jobs-duration
+    (let [max-memory-mb (* 1024.0 max-memory-gb)
+          is-offensive? (partial is-offensive? max-memory-mb max-cpus)
+          inoffensive (remove is-offensive? jobs)
+          offensive (filter is-offensive? jobs)]
+      ;; Put offensive jobs asynchronously such that it could return the
+      ;; inoffensive jobs immediately.
+      (async/go
+        (when (seq offensive)
+          (log/info "Found" (count offensive) "offensive jobs")
+          (async/>! offensive-jobs-ch offensive)))
+      inoffensive)))
+
+(defn make-offensive-job-stifler
+  "It returns an async channel which will be used to receive offensive jobs expected to be killed or aborted.
+   It asynchronously pulls offensive jobs from the channel and abort these offensive jobs by marking job state as completed."
+  [conn]
+  (let [offensive-jobs-ch (async/chan (async/sliding-buffer 256))]
+    (async/thread
+      (loop []
+        (when-let [offensive-jobs (async/<!! offensive-jobs-ch)]
+          (try
+            (doseq [jobs (partition-all 32 offensive-jobs)]
+              ;; Transact synchronously so that it won't accidentally put a huge
+              ;; spike of load on the transactor.
+              (async/<!!
+                (datomic/transact-with-retries conn
+                                               (mapv
+                                                 (fn [job]
+                                                   [:db/add [:job/uuid (:job/uuid job)]
+                                                    :job/state :job.state/completed])
+                                                 jobs))))
+            (log/warn "Suppressed offensive" (count offensive-jobs) "jobs" (mapv :job/uuid offensive-jobs))
+            (catch Exception e
+              (log/error e "Failed to kill the offensive job!")))
+          (recur))))
+    offensive-jobs-ch))
+
+(defn sort-jobs-by-dru-helper
+  "Return a list of job entities ordered by the provided sort function"
+  [pending-task-ents running-task-ents user->dru-divisors sort-task-scored-task-pairs sort-jobs-duration]
+  (let [tasks (into (vec running-task-ents) pending-task-ents)
+        task-comparator (util/same-user-task-comparator tasks)
+        pending-task-ents-set (into #{} pending-task-ents)
+        jobs (timers/time!
+               sort-jobs-duration
+               (->> tasks
+                    (group-by util/task-ent->user)
+                    (pc/map-vals (fn [task-ents] (sort task-comparator task-ents)))
+                    (sort-task-scored-task-pairs user->dru-divisors)
+                    (filter (fn [[task _]] (contains? pending-task-ents-set task)))
+                    (map (fn [[task _]] (:job/_instance task)))))]
+    jobs))
+
+(timers/deftimer [cook-mesos scheduler sort-jobs-hierarchy-duration])
+
+(defn- sort-normal-jobs-by-dru
+  "Return a list of normal job entities ordered by dru"
+  [pending-task-ents running-task-ents user->dru-divisors]
+  (sort-jobs-by-dru-helper pending-task-ents running-task-ents user->dru-divisors
+                           dru/sorted-task-scored-task-pairs sort-jobs-hierarchy-duration))
+
+(timers/deftimer [cook-mesos scheduler sort-gpu-jobs-hierarchy-duration])
+
+(defn- sort-gpu-jobs-by-dru
+  "Return a list of gpu job entities ordered by dru"
+  [pending-task-ents running-task-ents user->dru-divisors]
+  (sort-jobs-by-dru-helper pending-task-ents running-task-ents user->dru-divisors
+                           dru/sorted-task-cumulative-gpu-score-pairs sort-gpu-jobs-hierarchy-duration))
+
+(defn sort-jobs-by-dru-category
+  "Returns a map from job category to a list of job entities, ordered by dru"
+  [unfiltered-db]
+  ;; This function does not use the filtered db when it is not necessary in order to get better performance
+  ;; The filtered db is not necessary when an entity could only arrive at a given state if it was already committed
+  ;; e.g. running jobs or when it is always considered committed e.g. shares
+  ;; The unfiltered db can also be used on pending job entities once the filtered db is used to limit
+  ;; to only those jobs that have been committed.
+  (let [category->pending-job-ents (group-by util/categorize-job (util/get-pending-job-ents unfiltered-db))
+        category->pending-task-ents (pc/map-vals #(map util/create-task-ent %1) category->pending-job-ents)
+        category->running-task-ents (group-by (comp util/categorize-job :job/_instance)
+                                              (util/get-running-task-ents unfiltered-db))
+        user->dru-divisors (share/create-user->share-fn unfiltered-db nil)
+        category->sort-jobs-by-dru-fn {:normal sort-normal-jobs-by-dru, :gpu sort-gpu-jobs-by-dru}]
+    (letfn [(sort-jobs-by-dru-category-helper [[category sort-jobs-by-dru]]
+              (let [pending-tasks (category->pending-task-ents category)
+                    running-tasks (category->running-task-ents category)]
+                [category (sort-jobs-by-dru pending-tasks running-tasks user->dru-divisors)]))]
+      (into {} (map sort-jobs-by-dru-category-helper) category->sort-jobs-by-dru-fn))))
+
+(timers/deftimer [cook-mesos scheduler rank-jobs-duration])
+(meters/defmeter [cook-mesos scheduler rank-jobs-failures])
+
+(defn rank-jobs
+  "Return a map of lists of job entities ordered by dru, keyed by category.
+
+   It ranks the jobs by dru first and then apply several filters if provided."
+  [unfiltered-db offensive-job-filter]
+  (timers/time!
+    rank-jobs-duration
+    (try
+      (let [jobs (->> (sort-jobs-by-dru-category unfiltered-db)
+                      ;; Apply the offensive job filter first before taking.
+                      (pc/map-vals offensive-job-filter)
+                      (pc/map-vals #(map util/job-ent->map %))
+                      (pc/map-vals #(remove nil? %)))]
+        (log/debug "Total number of pending jobs is:" (apply + (map count (vals jobs)))
+                   "The first 20 pending normal jobs:" (take 20 (:normal jobs))
+                   "The first 5 pending gpu jobs:" (take 5 (:gpu jobs)))
+        jobs)
+      (catch Throwable t
+        (log/error t "Failed to rank jobs")
+        (meters/mark! rank-jobs-failures)
+        {}))))
+
+(defn start-jobs-prioritizer!
+  [conn pending-jobs-atom task-constraints trigger-chan]
+  (let [offensive-jobs-ch (make-offensive-job-stifler conn)
+        offensive-job-filter (partial filter-offensive-jobs task-constraints offensive-jobs-ch)]
+    (util/chime-at-ch trigger-chan
+                      (fn rank-jobs-event []
+                        (reset! pending-jobs-atom
+                                (rank-jobs (d/db conn) offensive-job-filter))))))

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -27,15 +27,14 @@
             [cook.config :refer (default-fitness-calculator)]
             [cook.datomic :as datomic]
             [cook.mesos.constraints :as constraints]
-            [cook.mesos.dru :as dru]
             [cook.mesos.fenzo-utils :as fenzo]
             [cook.mesos.task :as task]
             [cook.mesos.group :as group]
             [cook.mesos.heartbeat :as heartbeat]
             [cook.mesos.quota :as quota]
+            [cook.mesos.ranker :as ranker]
             [cook.mesos.reason :as reason]
             [cook.mesos.sandbox :as sandbox]
-            [cook.mesos.share :as share]
             [cook.mesos.task :as task]
             [cook.mesos.util :as util]
             [datomic.api :as d :refer (q)]
@@ -1278,192 +1277,6 @@
     {:error-handler (fn [e]
                       (log/error e "Failed to kill cancelled tasks!"))}))
 
-(defn get-user->used-resources
-  "Return a map from user'name to his allocated resources, in the form of
-   {:cpus cpu :mem mem}
-   If a user does NOT has any running jobs, then there is NO such
-   user in this map.
-
-   (get-user-resource-allocation [db user])
-   Return a map from user'name to his allocated resources, in the form of
-   {:cpus cpu :mem mem}
-   If a user does NOT has any running jobs, all the values in the
-   resource map is 0.0"
-  ([db]
-   (let [user->used-resources (->> (q '[:find ?j
-                                        :in $
-                                        :where
-                                        [?j :job/state :job.state/running]]
-                                      db)
-                                   (map (fn [[eid]]
-                                          (d/entity db eid)))
-                                   (group-by :job/user)
-                                   (map (fn [[user job-ents]]
-                                          [user (util/sum-resources-of-jobs job-ents)]))
-                                   (into {}))]
-     user->used-resources))
-  ([db user]
-   (let [used-resources (->> (q '[:find ?j
-                                  :in $ ?u
-                                  :where
-                                  [?j :job/state :job.state/running]
-                                  [?j :job/user ?u]]
-                                db user)
-                             (map (fn [[eid]]
-                                    (d/entity db eid)))
-                             (util/sum-resources-of-jobs))]
-     {user (if (seq used-resources)
-             used-resources
-             ;; Return all 0's for a user who does NOT have any running job.
-             (zipmap (util/get-all-resource-types db) (repeat 0.0)))})))
-
-(defn sort-jobs-by-dru-helper
-  "Return a list of job entities ordered by the provided sort function"
-  [pending-task-ents running-task-ents user->dru-divisors sort-task-scored-task-pairs sort-jobs-duration]
-  (let [tasks (into (vec running-task-ents) pending-task-ents)
-        task-comparator (util/same-user-task-comparator tasks)
-        pending-task-ents-set (into #{} pending-task-ents)
-        jobs (timers/time!
-               sort-jobs-duration
-               (->> tasks
-                    (group-by util/task-ent->user)
-                    (pc/map-vals (fn [task-ents] (sort task-comparator task-ents)))
-                    (sort-task-scored-task-pairs user->dru-divisors)
-                    (filter (fn [[task _]] (contains? pending-task-ents-set task)))
-                    (map (fn [[task _]] (:job/_instance task)))))]
-    jobs))
-
-(timers/deftimer [cook-mesos scheduler sort-jobs-hierarchy-duration])
-
-(defn- sort-normal-jobs-by-dru
-  "Return a list of normal job entities ordered by dru"
-  [pending-task-ents running-task-ents user->dru-divisors]
-  (sort-jobs-by-dru-helper pending-task-ents running-task-ents user->dru-divisors
-                           dru/sorted-task-scored-task-pairs sort-jobs-hierarchy-duration))
-
-(timers/deftimer [cook-mesos scheduler sort-gpu-jobs-hierarchy-duration])
-
-(defn- sort-gpu-jobs-by-dru
-  "Return a list of gpu job entities ordered by dru"
-  [pending-task-ents running-task-ents user->dru-divisors]
-  (sort-jobs-by-dru-helper pending-task-ents running-task-ents user->dru-divisors
-                           dru/sorted-task-cumulative-gpu-score-pairs sort-gpu-jobs-hierarchy-duration))
-
-(defn sort-jobs-by-dru-category
-  "Returns a map from job category to a list of job entities, ordered by dru"
-  [unfiltered-db]
-  ;; This function does not use the filtered db when it is not necessary in order to get better performance
-  ;; The filtered db is not necessary when an entity could only arrive at a given state if it was already committed
-  ;; e.g. running jobs or when it is always considered committed e.g. shares
-  ;; The unfiltered db can also be used on pending job entities once the filtered db is used to limit
-  ;; to only those jobs that have been committed.
-  (let [category->pending-job-ents (group-by util/categorize-job (util/get-pending-job-ents unfiltered-db))
-        category->pending-task-ents (pc/map-vals #(map util/create-task-ent %1) category->pending-job-ents)
-        category->running-task-ents (group-by (comp util/categorize-job :job/_instance)
-                                              (util/get-running-task-ents unfiltered-db))
-        user->dru-divisors (share/create-user->share-fn unfiltered-db nil)
-        category->sort-jobs-by-dru-fn {:normal sort-normal-jobs-by-dru, :gpu sort-gpu-jobs-by-dru}]
-    (letfn [(sort-jobs-by-dru-category-helper [[category sort-jobs-by-dru]]
-             (let [pending-tasks (category->pending-task-ents category)
-                   running-tasks (category->running-task-ents category)]
-               [category (sort-jobs-by-dru pending-tasks running-tasks user->dru-divisors)]))]
-      (into {} (map sort-jobs-by-dru-category-helper) category->sort-jobs-by-dru-fn))))
-
-(timers/deftimer [cook-mesos scheduler filter-offensive-jobs-duration])
-
-(defn is-offensive?
-  [max-memory-mb max-cpus job]
-  (let [{memory-mb :mem
-         cpus :cpus} (util/job-ent->resources job)]
-    (or (> memory-mb max-memory-mb)
-        (> cpus max-cpus))))
-
-(defn filter-offensive-jobs
-  "Base on the constraints on memory and cpus, given a list of job entities it
-   puts the offensive jobs into offensive-job-ch asynchronically and returns
-   the inoffensive jobs.
-
-   A job is offensive if and only if its required memory or cpus exceeds the
-   limits"
-  ;; TODO these limits should come from the largest observed host from Fenzo
-  ;; .getResourceStatus on TaskScheduler will give a map of hosts to resources; we can compute the max over those
-  [{max-memory-gb :memory-gb max-cpus :cpus} offensive-jobs-ch jobs]
-  (timers/time!
-    filter-offensive-jobs-duration
-    (let [max-memory-mb (* 1024.0 max-memory-gb)
-          is-offensive? (partial is-offensive? max-memory-mb max-cpus)
-          inoffensive (remove is-offensive? jobs)
-          offensive (filter is-offensive? jobs)]
-      ;; Put offensive jobs asynchronically such that it could return the
-      ;; inoffensive jobs immediately.
-      (async/go
-        (when (seq offensive)
-          (log/info "Found" (count offensive) "offensive jobs")
-          (async/>! offensive-jobs-ch offensive)))
-      inoffensive)))
-
-(defn make-offensive-job-stifler
-  "It returns an async channel which will be used to receive offensive jobs expected
-   to be killed / aborted.
-
-   It asynchronically pulls offensive jobs from the channel and abort these
-   offensive jobs by marking job state as completed."
-  [conn]
-  (let [offensive-jobs-ch (async/chan (async/sliding-buffer 256))]
-    (async/thread
-      (loop []
-        (when-let [offensive-jobs (async/<!! offensive-jobs-ch)]
-          (try
-            (doseq [jobs (partition-all 32 offensive-jobs)]
-              ;; Transact synchronously so that it won't accidentally put a huge
-              ;; spike of load on the transactor.
-              (async/<!!
-                (datomic/transact-with-retries conn
-                                               (mapv
-                                                 (fn [job]
-                                                   [:db/add [:job/uuid (:job/uuid job)]
-                                                    :job/state :job.state/completed])
-                                                 jobs))))
-            (log/warn "Suppressed offensive" (count offensive-jobs) "jobs" (mapv :job/uuid offensive-jobs))
-            (catch Exception e
-              (log/error e "Failed to kill the offensive job!")))
-          (recur))))
-    offensive-jobs-ch))
-
-(timers/deftimer [cook-mesos scheduler rank-jobs-duration])
-(meters/defmeter [cook-mesos scheduler rank-jobs-failures])
-
-(defn rank-jobs
-  "Return a map of lists of job entities ordered by dru, keyed by category.
-
-   It ranks the jobs by dru first and then apply several filters if provided."
-  [unfiltered-db offensive-job-filter]
-  (timers/time!
-    rank-jobs-duration
-    (try
-      (let [jobs (->> (sort-jobs-by-dru-category unfiltered-db)
-                      ;; Apply the offensive job filter first before taking.
-                      (pc/map-vals offensive-job-filter)
-                      (pc/map-vals #(map util/job-ent->map %))
-                      (pc/map-vals #(remove nil? %)))]
-        (log/debug "Total number of pending jobs is:" (apply + (map count (vals jobs)))
-                   "The first 20 pending normal jobs:" (take 20 (:normal jobs))
-                   "The first 5 pending gpu jobs:" (take 5 (:gpu jobs)))
-        jobs)
-      (catch Throwable t
-        (log/error t "Failed to rank jobs")
-        (meters/mark! rank-jobs-failures)
-        {}))))
-
-(defn- start-jobs-prioritizer!
-  [conn pending-jobs-atom task-constraints trigger-chan]
-  (let [offensive-jobs-ch (make-offensive-job-stifler conn)
-        offensive-job-filter (partial filter-offensive-jobs task-constraints offensive-jobs-ch)]
-    (util/chime-at-ch trigger-chan
-                      (fn rank-jobs-event []
-                        (reset! pending-jobs-atom
-                                (rank-jobs (d/db conn) offensive-job-filter))))))
-
 (meters/defmeter [cook-mesos scheduler mesos-error])
 (meters/defmeter [cook-mesos scheduler offer-chan-full-error])
 
@@ -1674,7 +1487,7 @@
         progress-aggregator-chan (progress-update-aggregator progress-config progress-state-chan)
         handle-progress-message (fn handle-progress-message-curried [progress-message-map]
                                   (handle-progress-message! progress-aggregator-chan progress-message-map))]
-    (start-jobs-prioritizer! conn pending-jobs-atom task-constraints rank-trigger-chan)
+    (ranker/start-jobs-prioritizer! conn pending-jobs-atom task-constraints rank-trigger-chan)
     {:scheduler (create-mesos-scheduler framework-id gpu-enabled? conn heartbeat-ch fenzo offers-chan
                                         match-trigger-chan handle-progress-message sandbox-syncer-state)
      :view-incubating-offers (fn get-resources-atom [] @resources-atom)}))

--- a/scheduler/test/cook/test/benchmark.clj
+++ b/scheduler/test/cook/test/benchmark.clj
@@ -17,7 +17,7 @@
 (ns cook.test.benchmark
   (:use clojure.test)
   (:require [cook.mesos.dru :as dru]
-            [cook.mesos.scheduler :as sched]
+            [cook.mesos.ranker :as ranker]
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
             [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance init-offer-cache poll-until)]
@@ -42,15 +42,15 @@
     (testing "rank-jobs"
       (let [db (d/db conn)
             task-constraints {:memory-gb 100 :cpus 30}
-            offensive-jobs-ch (sched/make-offensive-job-stifler conn)
-            offensive-job-filter (partial sched/filter-offensive-jobs task-constraints offensive-jobs-ch)]
+            offensive-jobs-ch (ranker/make-offensive-job-stifler conn)
+            offensive-job-filter (partial ranker/filter-offensive-jobs task-constraints offensive-jobs-ch)]
         (println "============ rank-jobs timing ============")
-        (cc/quick-bench (sched/rank-jobs db offensive-job-filter))))
+        (cc/quick-bench (ranker/rank-jobs db offensive-job-filter))))
     (testing "rank-jobs minus offensive-job-filter"
       (let [db (d/db conn)
             offensive-job-filter identity]
         (println "============ rank-jobs minus offensive-job-filter timing ============")
-        (cc/quick-bench (sched/rank-jobs db offensive-job-filter))))
+        (cc/quick-bench (ranker/rank-jobs db offensive-job-filter))))
     (testing "sort-jobs-by-dru-helper"
       (let [db (d/db conn)
             pending-task-ents (util/get-pending-job-ents db)
@@ -59,9 +59,9 @@
             user->dru-divisors (share/create-user->share-fn db nil)]
         (do
           (println "============ sort-jobs-by-dru timing ============")
-          (cc/quick-bench (sched/sort-jobs-by-dru-helper pending-task-ents
-                                                         running-task-ents
-                                                         user->dru-divisors
-                                                         sort-task-scored-task-pairs
-                                                         sched/sort-jobs-hierarchy-duration))
+          (cc/quick-bench (ranker/sort-jobs-by-dru-helper pending-task-ents
+                                                          running-task-ents
+                                                          user->dru-divisors
+                                                          sort-task-scored-task-pairs
+                                                          ranker/sort-jobs-hierarchy-duration))
           nil)))))

--- a/scheduler/test/cook/test/mesos/ranker.clj
+++ b/scheduler/test/cook/test/mesos/ranker.clj
@@ -1,0 +1,173 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+(ns cook.test.mesos.ranker
+  (:use [clojure.test])
+  (:require [clojure.core.async :as async]
+            [cook.mesos.ranker :as ranker]
+            [cook.mesos.share :as share]
+            [cook.mesos.util :as util]
+            [cook.test.testutil :as tu]
+            [datomic.api :as d]))
+
+(deftest test-sort-jobs-by-dru-category
+  (let [uri "datomic:mem://test-sort-jobs-by-dru"
+        conn (tu/restore-fresh-database! uri)
+        j1 (tu/create-dummy-job conn :user "u1" :ncpus 1.0 :memory 3.0 :job-state :job.state/running)
+        j2 (tu/create-dummy-job conn :user "u1" :ncpus 1.0 :memory 5.0)
+        j3 (tu/create-dummy-job conn :user "u1" :ncpus 1.0 :memory 2.0)
+        j4 (tu/create-dummy-job conn :user "u1" :ncpus 5.0 :memory 5.0)
+        j5 (tu/create-dummy-job conn :user "u2" :ncpus 6.0 :memory 6.0 :job-state :job.state/running)
+        j6 (tu/create-dummy-job conn :user "u2" :ncpus 5.0 :memory 5.0)
+        j7 (tu/create-dummy-job conn :user "sunil" :ncpus 5.0 :memory 10.0 :job-state :job.state/running)
+        j8 (tu/create-dummy-job conn :user "sunil" :ncpus 5.0 :memory 10.0)
+        _ (tu/create-dummy-instance conn j1)
+        _ (tu/create-dummy-instance conn j5)
+        _ (tu/create-dummy-instance conn j7)]
+
+    (testing "sort-jobs-by-dru default share for everyone"
+      (let [_ (share/set-share! conn "default" nil
+                                "limits for new cluster"
+                                :mem 10.0 :cpus 10.0)
+            db (d/db conn)]
+        (is (= [j2 j3 j6 j4 j8] (map :db/id (:normal (ranker/sort-jobs-by-dru-category db)))))))
+
+    (testing "sort-jobs-by-dru one user has non-default share"
+      (let [_ (share/set-share! conn "default" nil "limits for new cluster" :mem 10.0 :cpus 10.0)
+            _ (share/set-share! conn "sunil" nil "needs more resources" :mem 100.0 :cpus 100.0)
+            db (d/db conn)]
+        (is (= [j8 j2 j3 j6 j4] (map :db/id (:normal (ranker/sort-jobs-by-dru-category db))))))))
+
+  (testing "test-sort-jobs-by-dru:normal-jobs"
+    (let [uri "datomic:mem://test-sort-jobs-by-dru-normal-jobs"
+          conn (tu/restore-fresh-database! uri)
+          j1n (tu/create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0)
+          j2n (tu/create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :priority 90)
+          j3n (tu/create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0)
+          j4n (tu/create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :priority 30)
+          test-db (d/db conn)]
+      (is (= [j2n j3n j1n j4n] (map :db/id (:normal (ranker/sort-jobs-by-dru-category test-db)))))
+      (is (empty? (:gpu (ranker/sort-jobs-by-dru-category test-db))))))
+
+  (testing "test-sort-jobs-by-dru:gpu-jobs"
+    (let [uri "datomic:mem://test-sort-jobs-by-dru-gpu-jobs"
+          conn (tu/restore-fresh-database! uri)
+          j1g (tu/create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :gpus 10.0)
+          j2g (tu/create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :gpus 25.0 :priority 90)
+          j3g (tu/create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :gpus 20.0)
+          j4g (tu/create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :gpus 10.0 :priority 30)
+          test-db (d/db conn)]
+      (is (empty? (:normal (ranker/sort-jobs-by-dru-category test-db))))
+      (is (= [j3g j2g j4g j1g] (map :db/id (:gpu (ranker/sort-jobs-by-dru-category test-db)))))))
+
+  (testing "test-sort-jobs-by-dru:mixed-jobs"
+    (let [uri "datomic:mem://test-sort-jobs-by-dru-mixed-jobs"
+          conn (tu/restore-fresh-database! uri)
+          j1n (tu/create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0)
+          j2n (tu/create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :priority 90)
+          j3n (tu/create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0)
+          j4n (tu/create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :priority 30)
+          j1g (tu/create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :gpus 10.0)
+          j2g (tu/create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :gpus 25.0 :priority 90)
+          j3g (tu/create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :gpus 20.0)
+          j4g (tu/create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :gpus 10.0 :priority 30)
+          test-db (d/db conn)]
+      (is (= [j2n j3n j1n j4n] (map :db/id (:normal (ranker/sort-jobs-by-dru-category test-db)))))
+      (is (= [j3g j2g j4g j1g] (map :db/id (:gpu (ranker/sort-jobs-by-dru-category test-db))))))))
+
+(deftest test-gpu-share-prioritization
+  (let [uri "datomic:mem://test-gpu-shares"
+        conn (tu/restore-fresh-database! uri)
+        j1 (tu/create-dummy-job conn :user "u1" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        j2 (tu/create-dummy-job conn :user "u1" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        j3 (tu/create-dummy-job conn :user "u1" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        j4 (tu/create-dummy-job conn :user "u1" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        j5 (tu/create-dummy-job conn :user "u2" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        j6 (tu/create-dummy-job conn :user "u2" :ncpus 5.0 :memory 5.0 :gpus 1.0)
+        ; Update ljin-1 to running
+        inst (tu/create-dummy-instance conn j1 :instance-status :instance.status/unknown)
+        _ @(d/transact conn [[:instance/update-state inst :instance.status/running [:reason/name :unknown]]])
+        _ (share/set-share! conn "default" nil
+                            "limits for new cluster"
+                            :cpus 1.0 :mem 2.0 :gpus 1.0)]
+    (testing "one user has double gpu share"
+      (let [_ (share/set-share! conn "u1" nil
+                                "Needs some GPUs"
+                                :gpus 2.0)
+            db (d/db conn)]
+        (is (= [j2 j5 j3 j4 j6] (map :db/id (:gpu (ranker/sort-jobs-by-dru-category db)))))))
+    (testing "one user has single gpu share"
+      (let [_ (share/set-share! conn "u1" nil
+                                "Doesn't need lots of gpus"
+                                :gpus 1.0)
+            db (d/db conn)]
+        (is (= [j5 j6 j2 j3 j4] (map :db/id (:gpu (ranker/sort-jobs-by-dru-category db)))))))))
+
+(deftest test-filter-offensive-jobs
+  (let [uri "datomic:mem://test-filter-offensive-jobs"
+        conn (tu/restore-fresh-database! uri)
+        constraints {:memory-gb 10.0
+                     :cpus 5.0}
+        ;; a job which breaks the memory constraint
+        job-id-1 (tu/create-dummy-job conn :user "tsram"
+                                      :job-state :job.state/waiting
+                                      :memory (* 1024 (+ (:memory-gb constraints) 2.0))
+                                      :ncpus (- (:cpus constraints) 1.0))
+        ;; a job which breaks the cpu constraint
+        job-id-2 (tu/create-dummy-job conn :user "tsram"
+                                      :job-state :job.state/waiting
+                                      :memory (* 1024 (- (:memory-gb constraints) 2.0))
+                                      :ncpus (+ (:cpus constraints) 1.0))
+        ;; a job which follows all constraints
+        job-id-3 (tu/create-dummy-job conn :user "tsram"
+                                      :job-state :job.state/waiting
+                                      :memory (* 1024 (- (:memory-gb constraints) 2.0))
+                                      :ncpus (- (:cpus constraints) 1.0))
+        test-db (d/db conn)
+        job-entity-1 (d/entity test-db job-id-1)
+        job-entity-2 (d/entity test-db job-id-2)
+        job-entity-3 (d/entity test-db job-id-3)
+        jobs [job-entity-1 job-entity-2 job-entity-3]
+        offensive-jobs-ch (async/chan (count jobs))
+        offensive-jobs #{job-entity-1 job-entity-2}]
+    (is (= #{job-entity-3} (set (ranker/filter-offensive-jobs constraints offensive-jobs-ch jobs))))
+    (let [received-offensive-jobs (async/<!! offensive-jobs-ch)]
+      (is (= (set received-offensive-jobs) offensive-jobs))
+      (async/close! offensive-jobs-ch))))
+
+(deftest test-rank-jobs
+  (let [uri "datomic:mem://test-rank-jobs"
+        conn (tu/restore-fresh-database! uri)
+        constraints {:memory-gb 10.0
+                     :cpus 5.0}
+        ;; a job which breaks the memory constraint
+        job-id-1 (tu/create-dummy-job conn :user "tsram"
+                                      :job-state :job.state/waiting
+                                      :memory (* 1024 (+ (:memory-gb constraints) 2.0))
+                                      :ncpus (- (:cpus constraints) 1.0))
+        ;; a job which follows all constraints
+        job-id-2 (tu/create-dummy-job conn :user "tsram"
+                                      :job-state :job.state/waiting
+                                      :memory (* 1024 (- (:memory-gb constraints) 2.0))
+                                      :ncpus (- (:cpus constraints) 1.0))
+        test-db (d/db conn)
+        _ (d/entity test-db job-id-1)
+        job-entity-2 (d/entity test-db job-id-2)
+        offensive-jobs-ch (ranker/make-offensive-job-stifler conn)
+        offensive-job-filter (partial ranker/filter-offensive-jobs constraints offensive-jobs-ch)]
+    (is (= {:normal (list (util/job-ent->map job-entity-2))
+            :gpu ()}
+           (ranker/rank-jobs test-db offensive-job-filter)))))

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -27,7 +27,6 @@
             [cook.mesos.heartbeat :as heartbeat]
             [cook.mesos.sandbox :as sandbox]
             [cook.mesos.scheduler :as sched]
-            [cook.mesos.share :as share]
             [cook.mesos.util :as util]
             [cook.test.testutil :refer [restore-fresh-database! create-dummy-group create-dummy-job
                                         create-dummy-instance init-offer-cache poll-until wait-for
@@ -166,71 +165,6 @@
         ; Return
         {:scheduled scheduled :result result})
       {:result result})))
-
-(deftest test-sort-jobs-by-dru-category
-  (let [uri "datomic:mem://test-sort-jobs-by-dru"
-        conn (restore-fresh-database! uri)
-        j1 (create-dummy-job conn :user "ljin" :ncpus 1.0 :memory 3.0 :job-state :job.state/running)
-        j2 (create-dummy-job conn :user "ljin" :ncpus 1.0 :memory 5.0)
-        j3 (create-dummy-job conn :user "ljin" :ncpus 1.0 :memory 2.0)
-        j4 (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0)
-        j5 (create-dummy-job conn :user "wzhao" :ncpus 6.0 :memory 6.0 :job-state :job.state/running)
-        j6 (create-dummy-job conn :user "wzhao" :ncpus 5.0 :memory 5.0)
-        j7 (create-dummy-job conn :user "sunil" :ncpus 5.0 :memory 10.0 :job-state :job.state/running)
-        j8 (create-dummy-job conn :user "sunil" :ncpus 5.0 :memory 10.0)
-        _ (create-dummy-instance conn j1)
-        _ (create-dummy-instance conn j5)
-        _ (create-dummy-instance conn j7)]
-
-    (testing "sort-jobs-by-dru default share for everyone"
-      (let [_ (share/set-share! conn "default" nil
-                                "limits for new cluster"
-                                :mem 10.0 :cpus 10.0)
-            db (d/db conn)]
-        (is (= [j2 j3 j6 j4 j8] (map :db/id (:normal (sched/sort-jobs-by-dru-category db)))))))
-
-    (testing "sort-jobs-by-dru one user has non-default share"
-      (let [_ (share/set-share! conn "default" nil "limits for new cluster" :mem 10.0 :cpus 10.0)
-            _ (share/set-share! conn "sunil" nil "needs more resources" :mem 100.0 :cpus 100.0)
-            db (d/db conn)]
-        (is (= [j8 j2 j3 j6 j4] (map :db/id (:normal (sched/sort-jobs-by-dru-category db))))))))
-
-  (testing "test-sort-jobs-by-dru:normal-jobs"
-    (let [uri "datomic:mem://test-sort-jobs-by-dru-normal-jobs"
-          conn (restore-fresh-database! uri)
-          j1n (create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0)
-          j2n (create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :priority 90)
-          j3n (create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0)
-          j4n (create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :priority 30)
-          test-db (d/db conn)]
-      (is (= [j2n j3n j1n j4n] (map :db/id (:normal (sched/sort-jobs-by-dru-category test-db)))))
-      (is (empty? (:gpu (sched/sort-jobs-by-dru-category test-db))))))
-
-  (testing "test-sort-jobs-by-dru:gpu-jobs"
-    (let [uri "datomic:mem://test-sort-jobs-by-dru-gpu-jobs"
-          conn (restore-fresh-database! uri)
-          j1g (create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :gpus 10.0)
-          j2g (create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :gpus 25.0 :priority 90)
-          j3g (create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :gpus 20.0)
-          j4g (create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :gpus 10.0 :priority 30)
-          test-db (d/db conn)]
-      (is (empty? (:normal (sched/sort-jobs-by-dru-category test-db))))
-      (is (= [j3g j2g j4g j1g] (map :db/id (:gpu (sched/sort-jobs-by-dru-category test-db)))))))
-
-  (testing "test-sort-jobs-by-dru:mixed-jobs"
-    (let [uri "datomic:mem://test-sort-jobs-by-dru-mixed-jobs"
-          conn (restore-fresh-database! uri)
-          j1n (create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0)
-          j2n (create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :priority 90)
-          j3n (create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0)
-          j4n (create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :priority 30)
-          j1g (create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :gpus 10.0)
-          j2g (create-dummy-job conn :user "u1" :job-state :job.state/waiting :memory 1000 :ncpus 1.0 :gpus 25.0 :priority 90)
-          j3g (create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :gpus 20.0)
-          j4g (create-dummy-job conn :user "u2" :job-state :job.state/waiting :memory 1500 :ncpus 1.0 :gpus 10.0 :priority 30)
-          test-db (d/db conn)]
-      (is (= [j2n j3n j1n j4n] (map :db/id (:normal (sched/sort-jobs-by-dru-category test-db)))))
-      (is (= [j3g j2g j4g j1g] (map :db/id (:gpu (sched/sort-jobs-by-dru-category test-db))))))))
 
 (d/delete-database "datomic:mem://preemption-testdb")
 (d/create-database "datomic:mem://preemption-testdb")
@@ -409,24 +343,6 @@
                     (cons concat)
                     (apply merge-with))))))))
 
-(deftest test-get-user->used-resources
-  (let [uri "datomic:mem://test-get-used-resources"
-        conn (restore-fresh-database! uri)
-        j1 (create-dummy-job conn :user "u1" :job-state :job.state/running)
-        j2 (create-dummy-job conn :user "u1" :job-state :job.state/running)
-        j3 (create-dummy-job conn :user "u2" :job-state :job.state/running)
-        db (db conn)]
-    ;; Query u1
-    (is (= {"u1" {:mem 20.0 :cpus 2.0}} (sched/get-user->used-resources db "u1")))
-    ;; Query u2
-    (is (= {"u2" {:mem 10.0 :cpus 1.0}} (sched/get-user->used-resources db "u2")))
-    ;; Query unknow user
-    (is (= {"whoami" {:mem 0.0 :cpus 0.0}} (sched/get-user->used-resources db "whoami")))
-    ; Query all users
-    (is (= {"u1" {:mem 20.0 :cpus 2.0}
-            "u2" {:mem 10.0 :cpus 1.0}}
-           (sched/get-user->used-resources db)))))
-
 (defn joda-datetime->java-date
   [datetime]
   (java.util.Date. (tc/to-long datetime)))
@@ -554,63 +470,6 @@
                         [?i :instance/status ?s]
                         [?s :db/ident ?status]]
                       (db conn) instance-id-3))))))
-
-(deftest test-filter-offensive-jobs
-  (let [uri "datomic:mem://test-filter-offensive-jobs"
-        conn (restore-fresh-database! uri)
-        constraints {:memory-gb 10.0
-                     :cpus 5.0}
-        ;; a job which breaks the memory constraint
-        job-id-1 (create-dummy-job conn :user "tsram"
-                                   :job-state :job.state/waiting
-                                   :memory (* 1024 (+ (:memory-gb constraints) 2.0))
-                                   :ncpus (- (:cpus constraints) 1.0))
-        ;; a job which breaks the cpu constraint
-        job-id-2 (create-dummy-job conn :user "tsram"
-                                   :job-state :job.state/waiting
-                                   :memory (* 1024 (- (:memory-gb constraints) 2.0))
-                                   :ncpus (+ (:cpus constraints) 1.0))
-        ;; a job which follows all constraints
-        job-id-3 (create-dummy-job conn :user "tsram"
-                                   :job-state :job.state/waiting
-                                   :memory (* 1024 (- (:memory-gb constraints) 2.0))
-                                   :ncpus (- (:cpus constraints) 1.0))
-        test-db (d/db conn)
-        job-entity-1 (d/entity test-db job-id-1)
-        job-entity-2 (d/entity test-db job-id-2)
-        job-entity-3 (d/entity test-db job-id-3)
-        jobs [job-entity-1 job-entity-2 job-entity-3]
-        offensive-jobs-ch (async/chan (count jobs))
-        offensive-jobs #{job-entity-1 job-entity-2}]
-    (is (= #{job-entity-3} (set (sched/filter-offensive-jobs constraints offensive-jobs-ch jobs))))
-    (let [received-offensive-jobs (async/<!! offensive-jobs-ch)]
-      (is (= (set received-offensive-jobs) offensive-jobs))
-      (async/close! offensive-jobs-ch))))
-
-(deftest test-rank-jobs
-  (let [uri "datomic:mem://test-rank-jobs"
-        conn (restore-fresh-database! uri)
-        constraints {:memory-gb 10.0
-                     :cpus 5.0}
-        ;; a job which breaks the memory constraint
-        job-id-1 (create-dummy-job conn :user "tsram"
-                                   :job-state :job.state/waiting
-                                   :memory (* 1024 (+ (:memory-gb constraints) 2.0))
-                                   :ncpus (- (:cpus constraints) 1.0))
-        ;; a job which follows all constraints
-        job-id-2 (create-dummy-job conn :user "tsram"
-                                   :job-state :job.state/waiting
-                                   :memory (* 1024 (- (:memory-gb constraints) 2.0))
-                                   :ncpus (- (:cpus constraints) 1.0))
-        test-db (d/db conn)
-        job-entity-1 (d/entity test-db job-id-1)
-        job-entity-2 (d/entity test-db job-id-2)
-        jobs [job-entity-1 job-entity-2]
-        offensive-jobs-ch (sched/make-offensive-job-stifler conn)
-        offensive-job-filter (partial sched/filter-offensive-jobs constraints offensive-jobs-ch)]
-    (is (= {:normal (list (util/job-ent->map job-entity-2))
-            :gpu ()}
-           (sched/rank-jobs test-db offensive-job-filter)))))
 
 (deftest test-virtual-machine-lease-adapter
   ;; ensure that the VirtualMachineLeaseAdapter can successfully handle an offer from Mesomatic.
@@ -836,34 +695,6 @@
         group (d/entity (d/db conn) group-id)]
     (println  "============ match offers with group constraints timing ============")
     (crit/bench (schedule-and-run-jobs conn framework-id scheduler (make-offers) jobs))))
-
-(deftest test-gpu-share-prioritization
-  (let [uri "datomic:mem://test-gpu-shares"
-        conn (restore-fresh-database! uri)
-        ljin-1 (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
-        ljin-2 (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
-        ljin-3 (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
-        ljin-4 (create-dummy-job conn :user "ljin" :ncpus 5.0 :memory 5.0 :gpus 1.0)
-        wzhao-1 (create-dummy-job conn :user "wzhao" :ncpus 5.0 :memory 5.0 :gpus 1.0)
-        wzhao-2 (create-dummy-job conn :user "wzhao" :ncpus 5.0 :memory 5.0 :gpus 1.0)
-        ; Update ljin-1 to running
-        inst (create-dummy-instance conn ljin-1 :instance-status :instance.status/unknown)
-        _ @(d/transact conn [[:instance/update-state inst :instance.status/running [:reason/name :unknown]]])
-        _ (share/set-share! conn "default" nil
-                            "limits for new cluster"
-                            :cpus 1.0 :mem 2.0 :gpus 1.0)]
-    (testing "one user has double gpu share"
-      (let [_ (share/set-share! conn "ljin" nil
-                                "Needs some GPUs"
-                                :gpus 2.0)
-            db (d/db conn)]
-        (is (= [ljin-2 wzhao-1 ljin-3 ljin-4 wzhao-2] (map :db/id (:gpu (sched/sort-jobs-by-dru-category db)))))))
-    (testing "one user has single gpu share"
-      (let [_ (share/set-share! conn "ljin" nil
-                                "Doesn't need lots of gpus"
-                                :gpus 1.0)
-            db (d/db conn)]
-        (is (= [wzhao-1 wzhao-2 ljin-2 ljin-3 ljin-4] (map :db/id (:gpu (sched/sort-jobs-by-dru-category db)))))))))
 
 (deftest test-cancelled-task-killer
   (let [uri "datomic:mem://test-gpu-shares"


### PR DESCRIPTION
## Changes proposed in this PR

- introduces ranker.clj

## Why are we making these changes?

Makes it easier to maintain (find and edit) ranker functions. Shortens the `scheduler.clj` file too in the process.
