### PR TITLE
Makes test_show_from_jupyter use COOK_CLI_COMMAND

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1816,8 +1816,8 @@ class CookCliTest(util.CookTest):
                     "outputs": [],
                     "source": [
                         "%%bash\n",
-                        f"uuid=$(cs --url {self.cook_url} submit ls | tail -1)\n",
-                        f"cs --url {self.cook_url} show $uuid"
+                        f"uuid=$({cli.command()} --url {self.cook_url} submit ls | tail -1)\n",
+                        f"{cli.command()} --url {self.cook_url} show $uuid"
                     ]
                 }
             ],


### PR DESCRIPTION
## Changes proposed in this PR

- using `cli.command()` instead of hard-coding `"cs"` in `test_show_from_jupyter`

## Why are we making these changes?

Otherwise, the test can fail in cases where a custom `COOK_CLI_COMMAND` is provided.
