### PR TITLE
Add data local fitness calculator

### DIFF
--- a/integration/bin/run-integration.sh
+++ b/integration/bin/run-integration.sh
@@ -74,10 +74,6 @@ then
    COOK_MULTICLUSTER_ENV="${COOK_MULTICLUSTER_ENV} -e COOK_SLAVE_URL=${COOK_SLAVE_URL} -e COOK_MASTER_SLAVE=${COOK_MASTER_SLAVE}"
 fi
 
-MESOS_MASTER_NAME=$(docker ps -q -f name=minimesos-master)
-MESOS_MASTER_IP=$(docker inspect $MESOS_MASTER_NAME | jq -r '.[].NetworkSettings.IPAddress')
-
-
 docker create \
        --rm \
        --name=cook-integration \

--- a/integration/bin/run-integration.sh
+++ b/integration/bin/run-integration.sh
@@ -74,6 +74,9 @@ then
    COOK_MULTICLUSTER_ENV="${COOK_MULTICLUSTER_ENV} -e COOK_SLAVE_URL=${COOK_SLAVE_URL} -e COOK_MASTER_SLAVE=${COOK_MASTER_SLAVE}"
 fi
 
+MESOS_MASTER_NAME=$(docker ps -q -f name=minimesos-master)
+MESOS_MASTER_IP=$(docker inspect $MESOS_MASTER_NAME | jq -r '.[].NetworkSettings.IPAddress')
+
 
 docker create \
        --rm \

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2468,3 +2468,10 @@ class CookTest(util.CookTest):
             else:
                 resp = util.get_limit(self.cook_url, limit, user)
                 self.assertFalse('pools' in resp.json())
+
+
+    def test_data_local_support(self):
+        uuid, resp = util.submit_job(self.cook_url, supports_data_locality=True)
+        self.assertEqual(201, resp.status_code, resp.text)
+        job = util.load_job(self.cook_url, uuid)
+        self.assertEqual(True, job['supports_data_locality'], job)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2471,7 +2471,7 @@ class CookTest(util.CookTest):
 
 
     def test_data_local_support(self):
-        uuid, resp = util.submit_job(self.cook_url, supports_data_locality=True)
+        uuid, resp = util.submit_job(self.cook_url, data_local=True)
         self.assertEqual(201, resp.status_code, resp.text)
         job = util.load_job(self.cook_url, uuid)
-        self.assertEqual(True, job['supports_data_locality'], job)
+        self.assertEqual(True, job['data_local'], job)

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -460,3 +460,8 @@
 (defn data-local-fitness-config
   []
   (-> config :settings :data-local-fitness-calculator))
+
+(defn fitness-calculator
+  "Returns the fitness calculator specified by fitness-calculator, or the default if nil"
+  [fitness-calculator]
+  (config-string->fitness-calculator (or fitness-calculator default-fitness-calculator)))

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -55,6 +55,7 @@
             [swiss.arrows :refer :all])
   (:import (clojure.lang Atom Var)
            com.codahale.metrics.ScheduledReporter
+           com.netflix.fenzo.VMTaskFitnessCalculator
            (java.io OutputStreamWriter)
            (java.net ServerSocket URLEncoder)
            (java.util Date UUID)
@@ -2268,6 +2269,7 @@
     (instance? ServerSocket v) (str v)
     (instance? Var v) (str v)
     (instance? ScheduledReporter v) (str v)
+    (instance? VMTaskFitnessCalculator v) (.getName v)
     :else v))
 
 (defn settings-handler

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -888,6 +888,7 @@
           progress-regex-string (:job/progress-regex-string job)
           pool (:job/pool job)
           container (:job/container job)
+          supports-data-locality (:job/supports-data-locality job)
           state (util/job-ent->state job)
           constraints (->> job
                            :job/constraint
@@ -917,7 +918,6 @@
                    :state state
                    :status (name (:job/state job))
                    :submit_time submit-time
-                   :supports_data_locality (:job/supports-data-locality job false)
                    :uris (:uris resources)
                    :user (:job/user job)
                    :uuid (:job/uuid job)}]
@@ -929,7 +929,8 @@
               progress-output-file (assoc :progress-output-file progress-output-file)
               progress-regex-string (assoc :progress-regex-string progress-regex-string)
               pool (assoc :pool (:pool/name pool))
-              container (assoc :container (container->response-map container))))))
+              container (assoc :container (container->response-map container))
+              supports-data-locality (assoc :supports-data-locality supports-data-locality)))))
 
 (defn fetch-group-live-jobs
   "Get all jobs from a group that are currently running or waiting (not complete)"

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -250,6 +250,7 @@
    (s/optional-key :progress-regex-string) NonEmptyString
    (s/optional-key :group) s/Uuid
    (s/optional-key :disable-mea-culpa-retries) s/Bool
+   (s/optional-key :supports-data-locality) s/Bool
    :cpus PosDouble
    :mem PosDouble
    (s/optional-key :gpus) (s/both s/Int (s/pred pos? 'pos?))
@@ -529,7 +530,8 @@
   [pool commit-latch-id job :- Job]
   (let [{:keys [uuid command max-retries max-runtime expected-runtime priority cpus mem gpus
                 user name ports uris env labels container group application disable-mea-culpa-retries
-                constraints executor progress-output-file progress-regex-string]
+                constraints executor progress-output-file progress-regex-string
+                supports-data-locality]
          :or {group nil
               disable-mea-culpa-retries false}} job
         db-id (d/tempid :db.part/user)
@@ -612,7 +614,8 @@
                     executor (assoc :job/executor executor)
                     progress-output-file (assoc :job/progress-output-file progress-output-file)
                     progress-regex-string (assoc :job/progress-regex-string progress-regex-string)
-                    pool (assoc :job/pool (:db/id pool)))]
+                    pool (assoc :job/pool (:db/id pool))
+                    supports-data-locality (assoc :job/supports-data-locality supports-data-locality))]
 
     ;; TODO batch these transactions to improve performance
     (-> ports
@@ -703,7 +706,8 @@
   [db user task-constraints gpu-enabled? new-group-uuids
    {:keys [cpus mem gpus uuid command priority max-retries max-runtime expected-runtime name
            uris ports env labels container group application disable-mea-culpa-retries
-           constraints executor progress-output-file progress-regex-string]
+           constraints executor progress-output-file progress-regex-string
+           supports-data-locality]
     :or {group nil
          disable-mea-culpa-retries false}
     :as job}
@@ -740,7 +744,8 @@
                  (when executor {:executor executor})
                  (when progress-output-file {:progress-output-file progress-output-file})
                  (when progress-regex-string {:progress-regex-string progress-regex-string})
-                 (when application {:application application}))]
+                 (when application {:application application})
+                 (when supports-data-locality {:supports-data-locality supports-data-locality}))]
     (s/validate Job munged)
     (when (and (:gpus munged) (not gpu-enabled?))
       (throw (ex-info (str "GPU support is not enabled") {:gpus gpus})))
@@ -911,6 +916,7 @@
                    :state state
                    :status (name (:job/state job))
                    :submit_time submit-time
+                   :supports_data_locality (:job/supports-data-locality job false)
                    :uris (:uris resources)
                    :user (:job/user job)
                    :uuid (:job/uuid job)}]

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -251,7 +251,7 @@
    (s/optional-key :progress-regex-string) NonEmptyString
    (s/optional-key :group) s/Uuid
    (s/optional-key :disable-mea-culpa-retries) s/Bool
-   (s/optional-key :supports-data-locality) s/Bool
+   (s/optional-key :data-local) s/Bool
    :cpus PosDouble
    :mem PosDouble
    (s/optional-key :gpus) (s/both s/Int (s/pred pos? 'pos?))
@@ -532,7 +532,7 @@
   (let [{:keys [uuid command max-retries max-runtime expected-runtime priority cpus mem gpus
                 user name ports uris env labels container group application disable-mea-culpa-retries
                 constraints executor progress-output-file progress-regex-string
-                supports-data-locality]
+                data-local]
          :or {group nil
               disable-mea-culpa-retries false}} job
         db-id (d/tempid :db.part/user)
@@ -616,7 +616,7 @@
                     progress-output-file (assoc :job/progress-output-file progress-output-file)
                     progress-regex-string (assoc :job/progress-regex-string progress-regex-string)
                     pool (assoc :job/pool (:db/id pool))
-                    supports-data-locality (assoc :job/supports-data-locality supports-data-locality))]
+                    data-local (assoc :job/data-local data-local))]
 
     ;; TODO batch these transactions to improve performance
     (-> ports
@@ -708,7 +708,7 @@
    {:keys [cpus mem gpus uuid command priority max-retries max-runtime expected-runtime name
            uris ports env labels container group application disable-mea-culpa-retries
            constraints executor progress-output-file progress-regex-string
-           supports-data-locality]
+           data-local]
     :or {group nil
          disable-mea-culpa-retries false}
     :as job}
@@ -746,7 +746,7 @@
                  (when progress-output-file {:progress-output-file progress-output-file})
                  (when progress-regex-string {:progress-regex-string progress-regex-string})
                  (when application {:application application})
-                 (when supports-data-locality {:supports-data-locality supports-data-locality}))]
+                 (when data-local {:data-local data-local}))]
     (s/validate Job munged)
     (when (and (:gpus munged) (not gpu-enabled?))
       (throw (ex-info (str "GPU support is not enabled") {:gpus gpus})))
@@ -888,7 +888,7 @@
           progress-regex-string (:job/progress-regex-string job)
           pool (:job/pool job)
           container (:job/container job)
-          supports-data-locality (:job/supports-data-locality job)
+          data-local (:job/data-local job)
           state (util/job-ent->state job)
           constraints (->> job
                            :job/constraint
@@ -930,7 +930,7 @@
               progress-regex-string (assoc :progress-regex-string progress-regex-string)
               pool (assoc :pool (:pool/name pool))
               container (assoc :container (container->response-map container))
-              supports-data-locality (assoc :supports-data-locality supports-data-locality)))))
+              data-local (assoc :data-local data-local)))))
 
 (defn fetch-group-live-jobs
   "Get all jobs from a group that are currently running or waiting (not complete)"

--- a/scheduler/src/cook/mesos/data_locality.clj
+++ b/scheduler/src/cook/mesos/data_locality.clj
@@ -34,8 +34,8 @@
   (getName [this] (-> this .getClass .getSimpleName))
   (calculateFitness [this task-request target-vm tracker-state]
     (let [base-fitness (.calculateFitness base-calculator task-request target-vm tracker-state)
-          {:keys [job/uuid job/supports-data-locality]} (:job task-request)]
-      (if supports-data-locality
+          {:keys [job/uuid job/data-local]} (:job task-request)]
+      (if data-local
         (let [normalized-fitness (get-normalized-fitness uuid (.getHostname target-vm) maximum-cost)
               data-local-fitness (* data-locality-weight normalized-fitness)]
           (+ data-local-fitness (* (- 1 data-locality-weight) base-fitness)))

--- a/scheduler/src/cook/mesos/data_locality.clj
+++ b/scheduler/src/cook/mesos/data_locality.clj
@@ -1,19 +1,36 @@
 (ns cook.mesos.data-locality
-  (:require [cook.config :as config])
+  (:require [cook.config :as config]
+            [plumbing.core :as pc])
   (:import com.netflix.fenzo.VMTaskFitnessCalculator
            com.netflix.fenzo.plugins.BinPackingFitnessCalculators))
 
-(def data-local-costs (atom {}))
+(let [data-local-costs (atom {})]
+  (defn update-data-local-costs
+    "Updates the current data local costs. Costs larger than the configured max-cost will be capped at max-cost
+     and negative costs will be reset to 0."
+    [job->host->cost]
+    (let [{:keys [maximum-cost]} (config/data-local-fitness-config)]
+      (->> job->host->cost
+           (pc/map-vals (fn [host->cost]
+                          (pc/map-vals (fn [cost] (-> cost (min maximum-cost) (max 0)))
+                                       host->cost)))
+           (reset! data-local-costs))))
+  (defn get-data-local-costs
+    "Returns the current cost for jobs to run on each host"
+    []
+    @data-local-costs))
 
 (defn get-normalized-fitness
-  "Returns the fitness for the job to run on the given host, normalized by max-cost"
+  "Returns the fitness for the job to run on the given host, normalized by max-cost.
+   If the host doesn't have a cost specified, assume max-cost."
   [uuid hostname max-cost]
-  (let [cost (get-in @data-local-costs [uuid hostname] max-cost)]
+  (let [data-local-costs (get-data-local-costs)
+        cost (get-in data-local-costs [uuid hostname] max-cost)]
     (- 1 (double (/ cost max-cost)))))
 
 (deftype DataLocalFitnessCalculator [^VMTaskFitnessCalculator base-calculator data-locality-weight maximum-cost]
   VMTaskFitnessCalculator
-  (getName [this] "DataLocalFitnessCalculator")
+  (getName [this] (-> this .getClass .getSimpleName))
   (calculateFitness [this task-request target-vm tracker-state]
     (let [base-fitness (.calculateFitness base-calculator task-request target-vm tracker-state)
           {:keys [job/uuid job/supports-data-locality]} (:job task-request)]

--- a/scheduler/src/cook/mesos/data_locality.clj
+++ b/scheduler/src/cook/mesos/data_locality.clj
@@ -1,0 +1,30 @@
+(ns cook.mesos.data-locality
+  (:require [cook.config :as config])
+  (:import com.netflix.fenzo.VMTaskFitnessCalculator
+           com.netflix.fenzo.plugins.BinPackingFitnessCalculators))
+
+(def data-local-costs (atom {}))
+
+(defn get-normalized-fitness
+  "Returns the fitness for the job to run on the given host, normalized by max-cost"
+  [uuid hostname max-cost]
+  (let [cost (get-in @data-local-costs [uuid hostname] max-cost)]
+    (- 1 (double (/ cost max-cost)))))
+
+(deftype DataLocalFitnessCalculator [^VMTaskFitnessCalculator base-calculator data-locality-weight maximum-cost]
+  VMTaskFitnessCalculator
+  (getName [this] "DataLocalFitnessCalculator")
+  (calculateFitness [this task-request target-vm tracker-state]
+    (let [base-fitness (.calculateFitness base-calculator task-request target-vm tracker-state)
+          {:keys [job/uuid job/supports-data-locality]} (:job task-request)]
+      (if supports-data-locality
+        (let [normalized-fitness (get-normalized-fitness uuid (.getHostname target-vm) maximum-cost)
+              data-local-fitness (* data-locality-weight normalized-fitness)]
+          (+ data-local-fitness (* (- 1 data-locality-weight) base-fitness)))
+        base-fitness))))
+
+(defn make-data-local-fitness-calculator
+  "Loads settings from configuration to build a data local fitness calculator"
+  []
+  (let [{:keys [base-calculator data-locality-weight maximum-cost]} (config/data-local-fitness-config)]
+    (->DataLocalFitnessCalculator base-calculator data-locality-weight maximum-cost)))

--- a/scheduler/src/cook/mesos/data_locality.clj
+++ b/scheduler/src/cook/mesos/data_locality.clj
@@ -15,6 +15,7 @@
                           (pc/map-vals (fn [cost] (-> cost (min maximum-cost) (max 0)))
                                        host->cost)))
            (reset! data-local-costs))))
+
   (defn get-data-local-costs
     "Returns the current cost for jobs to run on each host"
     []

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -1473,7 +1473,7 @@
       (disableShortfallEvaluation) ;; We're not using the autoscaling features
       (withLeaseOfferExpirySecs (max (-> offer-incubate-time-ms time/millis time/in-seconds) 1)) ;; should be at least 1 second
       (withRejectAllExpiredOffers)
-      (withFitnessCalculator (config/config-string->fitness-calculator (or fitness-calculator config/default-fitness-calculator)))
+      (withFitnessCalculator (config/fitness-calculator fitness-calculator))
       (withFitnessGoodEnoughFunction (reify Func1
                                        (call [_ fitness]
                                          (> fitness good-enough-fitness))))

--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -187,7 +187,7 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
-    :db/ident :job/supports-data-locality
+    :db/ident :job/data-local
     :db/valueType :db.type/boolean
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db

--- a/scheduler/src/cook/mesos/schema.clj
+++ b/scheduler/src/cook/mesos/schema.clj
@@ -186,6 +186,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/valueType :db.type/ref
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :job/supports-data-locality
+    :db/valueType :db.type/boolean
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db
+    :db/doc "Indicates whether or not the job participates in data local scheduling"}
    ;; Group attributes
    {:db/id (d/tempid :db.part/db)
     :db/ident :group/uuid

--- a/scheduler/test/cook/test/config.clj
+++ b/scheduler/test/cook/test/config.clj
@@ -51,8 +51,7 @@
   "This calculator simply returns 0.0 for every Fenzo fitness calculation."
   (reify VMTaskFitnessCalculator
     (getName [_] "Dummy Fitness Calculator")
-    (calculateFitness [_ task-request target-vm task-tracker-state]
-      0.0)))
+    (calculateFitness [_ _ _ _] 0.0)))
 
 (defn make-dummy-fitness-calculator []
   dummy-fitness-calculator)

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1208,7 +1208,6 @@
                    :retries_remaining 1
                    :state "waiting"
                    :status "waiting"
-                   :supports_data_locality false
                    :uris nil}
                   ;; Only assoc these fields if the job specifies one
                   application (assoc :application application)

--- a/scheduler/test/cook/test/mesos/data_locality.clj
+++ b/scheduler/test/cook/test/mesos/data_locality.clj
@@ -63,9 +63,9 @@
                                                       data-locality-weight
                                                       maximum-cost)
           job-1 {:job/uuid (UUID/randomUUID)
-                 :job/supports-data-locality true}
+                 :job/data-local true}
           job-2 {:job/uuid (UUID/randomUUID)
-                 :job/supports-data-locality false}]
+                 :job/data-local false}]
       (dl/update-data-local-costs {(:job/uuid job-1) {"hostA" 0
                                                       "hostB" 20}
                                    (:job/uuid job-2) {"hostA" 0

--- a/scheduler/test/cook/test/mesos/data_locality.clj
+++ b/scheduler/test/cook/test/mesos/data_locality.clj
@@ -1,0 +1,67 @@
+(ns cook.test.mesos.data-locality
+  (:use clojure.test)
+  (:require [cook.mesos.data-locality :as dl]
+            [datomic.api :as d])
+  (:import java.util.UUID
+           [com.netflix.fenzo TaskRequest
+                              VMTaskFitnessCalculator
+                              VirtualMachineCurrentState]))
+
+(deftest test-get-normalized-cost
+  (let [job-1 (UUID/randomUUID)
+        job-2 (UUID/randomUUID)
+        job-3 (UUID/randomUUID)]
+    (reset! dl/data-local-costs {job-1 {"hostA" 10
+                                        "hostB" 20}
+                                 job-2 {"hostA" 30}})
+    (testing "correctly normalizes costs"
+      (is (= 0.75 (dl/get-normalized-fitness job-1 "hostA" 40)))
+      (is (= 0.5 (dl/get-normalized-fitness job-1 "hostB" 40)))
+      (is (= 0.25 (dl/get-normalized-fitness job-2 "hostA" 40))))
+
+    (testing "uses max cost for missing host or job"
+      (is (= 0.0 (dl/get-normalized-fitness job-2 "hostB" 40)))
+      (is (= 0.0 (dl/get-normalized-fitness job-3 "hostA" 40))))))
+
+(deftype FixedFitnessCalculator [fitness]
+  VMTaskFitnessCalculator
+  (getName [this] "FixedFitnessCalculator")
+  (calculateFitness [this _ _ _] fitness))
+
+(defn fake-vm-for-host [hostname]
+  (reify
+    VirtualMachineCurrentState
+    (getHostname [this] hostname)))
+
+(defrecord FakeTaskRequest [job]
+    TaskRequest)
+
+(deftest test-data-local-fitness-calculator
+  (let [base-fitness 0.5
+        base-calculator (FixedFitnessCalculator. base-fitness)
+        maximum-cost 40
+        data-locality-weight 0.9
+        base-fitness-portion (* base-fitness (- 1 data-locality-weight))
+        calculator (dl/->DataLocalFitnessCalculator base-calculator
+                                                    data-locality-weight
+                                                    maximum-cost)
+        job-1 {:job/uuid (UUID/randomUUID)
+               :job/supports-data-locality true}
+        job-2 {:job/uuid (UUID/randomUUID)
+               :job/supports-data-locality false}]
+    (reset! dl/data-local-costs {(:job/uuid job-1) {"hostA" 0
+                                                    "hostB" 20}
+                                 (:job/uuid job-2) {"hostA" 0
+                                                    "hostB" 0}})
+    (testing "uses base fitness for jobs that do not support data locality"
+      (is (= base-fitness (.calculateFitness calculator (FakeTaskRequest. job-2) (fake-vm-for-host "hostA") nil)))
+      (is (= base-fitness (.calculateFitness calculator (FakeTaskRequest. job-2) (fake-vm-for-host "hostB") nil))))
+
+    (testing "calculates fitness for jobs that support data locality"
+      (is (= (+ data-locality-weight base-fitness-portion)
+             (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostA") nil)))
+      (is (= (+ (* 0.5 data-locality-weight) base-fitness-portion)
+             (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostB") nil)))
+      (is (= base-fitness-portion
+             (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostC") nil))))))
+

--- a/scheduler/test/cook/test/mesos/data_locality.clj
+++ b/scheduler/test/cook/test/mesos/data_locality.clj
@@ -1,6 +1,7 @@
 (ns cook.test.mesos.data-locality
   (:use clojure.test)
-  (:require [cook.mesos.data-locality :as dl]
+  (:require [cook.config :as config]
+            [cook.mesos.data-locality :as dl]
             [datomic.api :as d])
   (:import java.util.UUID
            [com.netflix.fenzo TaskRequest
@@ -8,20 +9,35 @@
                               VirtualMachineCurrentState]))
 
 (deftest test-get-normalized-cost
-  (let [job-1 (UUID/randomUUID)
-        job-2 (UUID/randomUUID)
-        job-3 (UUID/randomUUID)]
-    (reset! dl/data-local-costs {job-1 {"hostA" 10
-                                        "hostB" 20}
-                                 job-2 {"hostA" 30}})
-    (testing "correctly normalizes costs"
-      (is (= 0.75 (dl/get-normalized-fitness job-1 "hostA" 40)))
-      (is (= 0.5 (dl/get-normalized-fitness job-1 "hostB" 40)))
-      (is (= 0.25 (dl/get-normalized-fitness job-2 "hostA" 40))))
+  (with-redefs [config/data-local-fitness-config (constantly {:maximum-cost 100})]
+    (let [job-1 (UUID/randomUUID)
+          job-2 (UUID/randomUUID)
+          job-3 (UUID/randomUUID)]
+      (dl/update-data-local-costs {job-1 {"hostA" 10
+                                          "hostB" 20}
+                                   job-2 {"hostA" 30}})
+      (testing "correctly normalizes costs"
+        (is (= 0.75 (dl/get-normalized-fitness job-1 "hostA" 40)))
+        (is (= 0.5 (dl/get-normalized-fitness job-1 "hostB" 40)))
+        (is (= 0.25 (dl/get-normalized-fitness job-2 "hostA" 40))))
 
-    (testing "uses max cost for missing host or job"
-      (is (= 0.0 (dl/get-normalized-fitness job-2 "hostB" 40)))
-      (is (= 0.0 (dl/get-normalized-fitness job-3 "hostA" 40))))))
+      (testing "uses max cost for missing host or job"
+        (is (= 0.0 (dl/get-normalized-fitness job-2 "hostB" 40)))
+        (is (= 0.0 (dl/get-normalized-fitness job-3 "hostA" 40)))))))
+
+(deftest test-update-data-local-costs
+  (with-redefs [config/data-local-fitness-config (constantly {:maximum-cost 100})]
+    (let [job-1 (UUID/randomUUID)
+          job-2 (UUID/randomUUID)]
+      (dl/update-data-local-costs {job-1 {"hostA" 200
+                                          "hostB" 20
+                                          "hostC" -20}
+                                   job-2 {"hostB" 1000}})
+      (is (= {job-1 {"hostA" 100
+                     "hostB" 20
+                     "hostC" 0}
+              job-2 {"hostB" 100}}
+             (dl/get-data-local-costs))))))
 
 (deftype FixedFitnessCalculator [fitness]
   VMTaskFitnessCalculator
@@ -37,31 +53,32 @@
     TaskRequest)
 
 (deftest test-data-local-fitness-calculator
-  (let [base-fitness 0.5
-        base-calculator (FixedFitnessCalculator. base-fitness)
-        maximum-cost 40
-        data-locality-weight 0.9
-        base-fitness-portion (* base-fitness (- 1 data-locality-weight))
-        calculator (dl/->DataLocalFitnessCalculator base-calculator
-                                                    data-locality-weight
-                                                    maximum-cost)
-        job-1 {:job/uuid (UUID/randomUUID)
-               :job/supports-data-locality true}
-        job-2 {:job/uuid (UUID/randomUUID)
-               :job/supports-data-locality false}]
-    (reset! dl/data-local-costs {(:job/uuid job-1) {"hostA" 0
-                                                    "hostB" 20}
-                                 (:job/uuid job-2) {"hostA" 0
-                                                    "hostB" 0}})
-    (testing "uses base fitness for jobs that do not support data locality"
-      (is (= base-fitness (.calculateFitness calculator (FakeTaskRequest. job-2) (fake-vm-for-host "hostA") nil)))
-      (is (= base-fitness (.calculateFitness calculator (FakeTaskRequest. job-2) (fake-vm-for-host "hostB") nil))))
+  (with-redefs [config/data-local-fitness-config (constantly {:maximum-cost 100})]
+    (let [base-fitness 0.5
+          base-calculator (FixedFitnessCalculator. base-fitness)
+          maximum-cost 40
+          data-locality-weight 0.9
+          base-fitness-portion (* base-fitness (- 1 data-locality-weight))
+          calculator (dl/->DataLocalFitnessCalculator base-calculator
+                                                      data-locality-weight
+                                                      maximum-cost)
+          job-1 {:job/uuid (UUID/randomUUID)
+                 :job/supports-data-locality true}
+          job-2 {:job/uuid (UUID/randomUUID)
+                 :job/supports-data-locality false}]
+      (dl/update-data-local-costs {(:job/uuid job-1) {"hostA" 0
+                                                      "hostB" 20}
+                                   (:job/uuid job-2) {"hostA" 0
+                                                      "hostB" 0}})
+      (testing "uses base fitness for jobs that do not support data locality"
+        (is (= base-fitness (.calculateFitness calculator (FakeTaskRequest. job-2) (fake-vm-for-host "hostA") nil)))
+        (is (= base-fitness (.calculateFitness calculator (FakeTaskRequest. job-2) (fake-vm-for-host "hostB") nil))))
 
-    (testing "calculates fitness for jobs that support data locality"
-      (is (= (+ data-locality-weight base-fitness-portion)
-             (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostA") nil)))
-      (is (= (+ (* 0.5 data-locality-weight) base-fitness-portion)
-             (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostB") nil)))
-      (is (= base-fitness-portion
-             (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostC") nil))))))
+      (testing "calculates fitness for jobs that support data locality"
+        (is (= (+ data-locality-weight base-fitness-portion)
+               (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostA") nil)))
+        (is (= (+ (* 0.5 data-locality-weight) base-fitness-portion)
+               (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostB") nil)))
+        (is (= base-fitness-portion
+               (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostC") nil)))))))
 

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1698,82 +1698,82 @@
 
 
 (deftest test-handle-resource-offers-with-data-locality
-  (let [test-user (System/getProperty "user.name")
-        uri "datomic:mem://test-handle-resource-offers"
-        launched-tasks-atom (atom [])
-        driver (reify msched/SchedulerDriver
-                 (launch-tasks! [_ offer-id tasks]
-                   (swap! launched-tasks-atom concat tasks)))
-        offer-maker (fn [cpus mem gpus]
-                      {:resources [{:name "cpus", :scalar cpus, :type :value-scalar, :role "cook"}
-                                   {:name "mem", :scalar mem, :type :value-scalar, :role "cook"}
-                                   {:name "gpus", :scalar gpus, :type :value-scalar, :role "cook"}]
-                       :id {:value (str "id-" (UUID/randomUUID))}
-                       :slave-id {:value (str "slave-" (UUID/randomUUID))}
-                       :hostname (str "host-" (UUID/randomUUID))})
-        framework-id #mesomatic.types.FrameworkID{:value "my-framework-id"}
-        offers-chan (async/chan (async/buffer 10))
-        offer-1 (offer-maker 10 2048 0)
-        offer-2 (offer-maker 20 16384 0)
-        offer-3 (offer-maker 30 8192 0)
-        run-handle-resource-offers! (fn [num-considerable offers & {:keys [user-quota user->usage rebalancer-reservation-atom job-name->uuid]
-                                                                    :or {rebalancer-reservation-atom (atom {})
-                                                                         job-name->uuid {}}}]
-                                      (reset! launched-tasks-atom [])
-                                      (let [conn (restore-fresh-database! uri)
-                                            test-db (d/db conn)
-                                            driver-atom (atom nil)
+  (with-redefs [config/data-local-fitness-config (constantly {:maximum-cost 100
+                                                              :data-locality-weight 0.95
+                                                              :base-calculator BinPackingFitnessCalculators/cpuMemBinPacker})]
+    (let [test-user (System/getProperty "user.name")
+          uri "datomic:mem://test-handle-resource-offers"
+          launched-tasks-atom (atom [])
+          driver (reify msched/SchedulerDriver
+                   (launch-tasks! [_ offer-id tasks]
+                     (swap! launched-tasks-atom concat tasks)))
+          offer-maker (fn [cpus mem gpus]
+                        {:resources [{:name "cpus", :scalar cpus, :type :value-scalar, :role "cook"}
+                                     {:name "mem", :scalar mem, :type :value-scalar, :role "cook"}
+                                     {:name "gpus", :scalar gpus, :type :value-scalar, :role "cook"}]
+                         :id {:value (str "id-" (UUID/randomUUID))}
+                         :slave-id {:value (str "slave-" (UUID/randomUUID))}
+                         :hostname (str "host-" (UUID/randomUUID))})
+          framework-id #mesomatic.types.FrameworkID{:value "my-framework-id"}
+          offers-chan (async/chan (async/buffer 10))
+          offer-1 (offer-maker 10 2048 0)
+          offer-2 (offer-maker 20 16384 0)
+          offer-3 (offer-maker 30 8192 0)
+          run-handle-resource-offers! (fn [num-considerable offers & {:keys [user-quota user->usage rebalancer-reservation-atom job-name->uuid]
+                                                                      :or {rebalancer-reservation-atom (atom {})
+                                                                           job-name->uuid {}}}]
+                                        (reset! launched-tasks-atom [])
+                                        (let [conn (restore-fresh-database! uri)
+                                              test-db (d/db conn)
+                                              driver-atom (atom nil)
 
-                                            ^TaskScheduler fenzo (with-redefs [config/data-local-fitness-config (constantly {:maximum-cost 100
-                                                                                                                             :data-locality-weight 0.95
-                                                                                                                             :base-calculator BinPackingFitnessCalculators/cpuMemBinPacker})]
-                                                                   (sched/make-fenzo-scheduler driver-atom 1500
+                                              ^TaskScheduler fenzo (sched/make-fenzo-scheduler driver-atom 1500
                                                                                                "cook.mesos.data-locality/make-data-local-fitness-calculator"
-                                                                                               0.8))
-                                            group-ent-id (create-dummy-group conn)
-                                            get-uuid (fn [name] (get job-name->uuid name (d/squuid)))
-                                            job-1 (d/entity (d/db conn) (create-dummy-job conn
-                                                                                          :uuid (get-uuid "job-1")
-                                                                                          :group group-ent-id
-                                                                                          :name "job-1"
-                                                                                          :ncpus 3
-                                                                                          :memory 2048
-                                                                                          :supports-data-locality true))
-                                            job-2 (d/entity (d/db conn) (create-dummy-job conn
-                                                                                          :uuid (get-uuid "job-2")
-                                                                                          :group group-ent-id
-                                                                                          :name "job-2"
-                                                                                          :ncpus 13
-                                                                                          :memory 1024
-                                                                                          :supports-data-locality true))
-                                            _ (reset! dl/data-local-costs {(get-uuid "job-1") {(:hostname offer-1) 0.0
-                                                                                              (:hostname offer-2) 0.0
-                                                                                              (:hostname offer-3) 100.0}
-                                                                           (get-uuid "job-2") {(:hostname offer-1) 0.0
-                                                                                              (:hostname offer-2) 0.0
-                                                                                              (:hostname offer-3) 0.0}})
-                                            entity->map (fn [entity]
-                                                          (util/job-ent->map entity (d/db conn)))
-                                            category->pending-jobs (->> {:normal [job-1 job-2]}
-                                                                        (pc/map-vals (partial map entity->map)))
-                                            category->pending-jobs-atom (atom category->pending-jobs)
-                                            user->usage (or user->usage {test-user {:count 1, :cpus 2, :mem 1024, :gpus 0}})
-                                            user->quota (or user-quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}})
-                                            mesos-run-as-user nil
-                                            result (sched/handle-resource-offers!
-                                                     conn driver fenzo framework-id category->pending-jobs-atom mesos-run-as-user
-                                                     user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom)]
-                                        result))]
-    (testing "enough offers for all normal jobs"
-      (let [num-considerable 10
-            offers [offer-1 offer-2 offer-3]]
-        (is (run-handle-resource-offers! num-considerable offers :job-name->uuid {"job-1" (d/squuid) "job-2" (d/squuid)}))
-        (let [launched-tasks @launched-tasks-atom
-              task-1 (first (filter #(.startsWith (:name %) "job-1") launched-tasks))
-              task-2 (first (filter #(.startsWith (:name %) "job-2") launched-tasks))]
-          (is (= 2 (count launched-tasks)))
-          (is (= (:slave-id offer-1) (:slave-id task-1)))
-          (is (= (:slave-id offer-2) (:slave-id task-2))))))))
+                                                                                               0.8)
+                                              group-ent-id (create-dummy-group conn)
+                                              get-uuid (fn [name] (get job-name->uuid name (d/squuid)))
+                                              job-1 (d/entity (d/db conn) (create-dummy-job conn
+                                                                                            :uuid (get-uuid "job-1")
+                                                                                            :group group-ent-id
+                                                                                            :name "job-1"
+                                                                                            :ncpus 3
+                                                                                            :memory 2048
+                                                                                            :supports-data-locality true))
+                                              job-2 (d/entity (d/db conn) (create-dummy-job conn
+                                                                                            :uuid (get-uuid "job-2")
+                                                                                            :group group-ent-id
+                                                                                            :name "job-2"
+                                                                                            :ncpus 13
+                                                                                            :memory 1024
+                                                                                            :supports-data-locality true))
+                                              _ (dl/update-data-local-costs {(get-uuid "job-1") {(:hostname offer-1) 0.0
+                                                                                                 (:hostname offer-2) 0.0
+                                                                                                 (:hostname offer-3) 100.0}
+                                                                             (get-uuid "job-2") {(:hostname offer-1) 0.0
+                                                                                                 (:hostname offer-2) 0.0
+                                                                                                 (:hostname offer-3) 0.0}})
+                                              entity->map (fn [entity]
+                                                            (util/job-ent->map entity (d/db conn)))
+                                              category->pending-jobs (->> {:normal [job-1 job-2]}
+                                                                          (pc/map-vals (partial map entity->map)))
+                                              category->pending-jobs-atom (atom category->pending-jobs)
+                                              user->usage (or user->usage {test-user {:count 1, :cpus 2, :mem 1024, :gpus 0}})
+                                              user->quota (or user-quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}})
+                                              mesos-run-as-user nil
+                                              result (sched/handle-resource-offers!
+                                                      conn driver fenzo framework-id category->pending-jobs-atom mesos-run-as-user
+                                                      user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom)]
+                                          result))]
+      (testing "enough offers for all normal jobs"
+        (let [num-considerable 10
+              offers [offer-1 offer-2 offer-3]]
+          (is (run-handle-resource-offers! num-considerable offers :job-name->uuid {"job-1" (d/squuid) "job-2" (d/squuid)}))
+          (let [launched-tasks @launched-tasks-atom
+                task-1 (first (filter #(.startsWith (:name %) "job-1") launched-tasks))
+                task-2 (first (filter #(.startsWith (:name %) "job-2") launched-tasks))]
+            (is (= 2 (count launched-tasks)))
+            (is (= (:slave-id offer-1) (:slave-id task-1)))
+            (is (= (:slave-id offer-2) (:slave-id task-2)))))))))
 
 (deftest test-in-order-status-update-processing
   (let [status-store (atom {})

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1738,14 +1738,14 @@
                                                                                             :name "job-1"
                                                                                             :ncpus 3
                                                                                             :memory 2048
-                                                                                            :supports-data-locality true))
+                                                                                            :data-local true))
                                               job-2 (d/entity (d/db conn) (create-dummy-job conn
                                                                                             :uuid (get-uuid "job-2")
                                                                                             :group group-ent-id
                                                                                             :name "job-2"
                                                                                             :ncpus 13
                                                                                             :memory 1024
-                                                                                            :supports-data-locality true))
+                                                                                            :data-local true))
                                               _ (dl/update-data-local-costs {(get-uuid "job-1") {(:hostname offer-1) 0.0
                                                                                                  (:hostname offer-2) 0.0
                                                                                                  (:hostname offer-3) 100.0}

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -94,7 +94,7 @@
   "Return the entity id for the created dummy job."
   [conn & {:keys [command committed? container custom-executor? disable-mea-culpa-retries env executor gpus group
                   job-state max-runtime memory name ncpus pool priority retry-count submit-time under-investigation user
-                  uuid expected-runtime supports-data-locality]
+                  uuid expected-runtime data-local]
            :or {command "dummy command"
                 committed? true
                 disable-mea-culpa-retries false
@@ -106,7 +106,7 @@
                 priority 50
                 retry-count 5
                 submit-time (java.util.Date.)
-                supports-data-locality false
+                data-local false
                 under-investigation false
                 user (System/getProperty "user.name")
                 uuid (d/squuid)}}]
@@ -132,7 +132,7 @@
                                          :resource/amount (double memory)}]
                          :job/state job-state
                          :job/submit-time submit-time
-                         :job/supports-data-locality supports-data-locality
+                         :job/data-local data-local
                          :job/under-investigation under-investigation
                          :job/user user
                          :job/uuid uuid}

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -94,7 +94,7 @@
   "Return the entity id for the created dummy job."
   [conn & {:keys [command committed? container custom-executor? disable-mea-culpa-retries env executor gpus group
                   job-state max-runtime memory name ncpus pool priority retry-count submit-time under-investigation user
-                  uuid expected-runtime]
+                  uuid expected-runtime supports-data-locality]
            :or {command "dummy command"
                 committed? true
                 disable-mea-culpa-retries false
@@ -106,6 +106,7 @@
                 priority 50
                 retry-count 5
                 submit-time (java.util.Date.)
+                supports-data-locality false
                 under-investigation false
                 user (System/getProperty "user.name")
                 uuid (d/squuid)}}]
@@ -131,6 +132,7 @@
                                          :resource/amount (double memory)}]
                          :job/state job-state
                          :job/submit-time submit-time
+                         :job/supports-data-locality supports-data-locality
                          :job/under-investigation under-investigation
                          :job/user user
                          :job/uuid uuid}


### PR DESCRIPTION
## Changes proposed in this PR
- Adds a new fitness calculator incorporating data locality

## Why are we making these changes?
We want to support integrating Cook Scheduler with a service which will compute the cost of running jobs on different machines based on the effects of data locality. Once we have the service integrated, we could use this fitness calculator to enforce the scheduling constraints.
