### PR TITLE
Dynamic fairness scheduler (including ranker and rebalancer)

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -103,7 +103,8 @@
                                                                  :mesos-role mesos-role
                                                                  :mesos-framework-name mesos-framework-name
                                                                  :gpu-enabled? mesos-gpu-enabled})
-                                  trigger-chans ((util/lazy-load-var 'cook.mesos/make-trigger-chans) rebalancer progress optimizer task-constraints)]
+                                  trigger-chans ((util/lazy-load-var 'cook.mesos/make-trigger-chans) rebalancer progress optimizer task-constraints)
+                                  rank-jobs-fn (util/lazy-load-var 'cook.mesos.ranker/rank-jobs)]
                               (try
                                 (Class/forName "org.apache.mesos.Scheduler")
                                 ((util/lazy-load-var 'cook.mesos/start-mesos-scheduler)
@@ -127,6 +128,7 @@
                                    :offer-incubate-time-ms offer-incubate-time-ms
                                    :optimizer-config optimizer
                                    :progress-config progress
+                                   :rank-jobs-fn rank-jobs-fn
                                    :rebalancer-config rebalancer
                                    :sandbox-syncer-state sandbox-syncer-state
                                    :server-config {:hostname hostname

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -165,8 +165,8 @@
    sandbox-syncer-state          -- map, representing the sandbox syncer object"
   [{:keys [curator-framework fenzo-config framework-id gpu-enabled? make-mesos-driver-fn
            mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom mesos-pending-jobs-atom
-           mesos-run-as-user offer-cache offer-incubate-time-ms optimizer-config progress-config rebalancer-config
-           sandbox-syncer-state server-config task-constraints trigger-chans zk-prefix]}]
+           mesos-run-as-user offer-cache offer-incubate-time-ms optimizer-config progress-config rank-jobs-fn
+           rebalancer-config sandbox-syncer-state server-config task-constraints trigger-chans zk-prefix]}]
   (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
                 fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness]} fenzo-config
         {:keys [cancelled-task-trigger-chan lingering-task-trigger-chan optimizer-trigger-chan
@@ -207,6 +207,7 @@
                                           :offer-incubate-time-ms offer-incubate-time-ms
                                           :pending-jobs-atom mesos-pending-jobs-atom
                                           :progress-config progress-config
+                                          :rank-jobs-fn rank-jobs-fn
                                           :rebalancer-reservation-atom rebalancer-reservation-atom
                                           :sandbox-syncer-state sandbox-syncer-state
                                           :task-constraints task-constraints

--- a/scheduler/src/cook/mesos/ranker.clj
+++ b/scheduler/src/cook/mesos/ranker.clj
@@ -161,10 +161,10 @@
         {}))))
 
 (defn start-jobs-prioritizer!
-  [conn pending-jobs-atom task-constraints trigger-chan]
+  [conn pending-jobs-atom task-constraints trigger-chan rank-jobs-fn]
   (let [offensive-jobs-ch (make-offensive-job-stifler conn)
         offensive-job-filter (partial filter-offensive-jobs task-constraints offensive-jobs-ch)]
     (util/chime-at-ch trigger-chan
                       (fn rank-jobs-event []
                         (reset! pending-jobs-atom
-                                (rank-jobs (d/db conn) offensive-job-filter))))))
+                                (rank-jobs-fn (d/db conn) offensive-job-filter))))))

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -293,6 +293,11 @@
       (histograms/update! positive-dru-diffs (dru-at-scale diff)))
     (> diff min-dru-diff)))
 
+;; TODO this should become a function and return a DI-ed function
+(def non-preemptable-scored-task?-atom
+  "allows external processes to configure which jobs are non-preemptable"
+  (atom (constantly false)))
+
 (defn compute-preemption-decision
   "Takes state, parameters and a pending job entity, returns a preemption decision
    A preemption decision is a map that describes a possible way to perform preemption on a host. It has a hostname, a seq of tasks
@@ -309,6 +314,7 @@
          ;; This will preserve the ordering of task->scored-task
          host->scored-tasks (->> task->scored-task
                                  vals
+                                 (remove @non-preemptable-scored-task?-atom)
                                  (remove #(< (:dru %) safe-dru-threshold))
                                  (filter (partial exceeds-min-diff? pending-job-dru min-dru-diff))
                                  (group-by (fn [{:keys [task]}]

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -1470,8 +1470,8 @@
   [{:keys [conn driver-atom fenzo-fitness-calculator fenzo-floor-iterations-before-reset
            fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback framework-id good-enough-fitness
            gpu-enabled? heartbeat-ch mea-culpa-failure-limit mesos-run-as-user offer-cache offer-incubate-time-ms
-           pending-jobs-atom progress-config rebalancer-reservation-atom sandbox-syncer-state task-constraints
-           trigger-chans]}]
+           pending-jobs-atom progress-config rank-jobs-fn rebalancer-reservation-atom sandbox-syncer-state
+           task-constraints trigger-chans]}]
 
   (persist-mea-culpa-failure-limit! conn mea-culpa-failure-limit)
 
@@ -1487,7 +1487,7 @@
         progress-aggregator-chan (progress-update-aggregator progress-config progress-state-chan)
         handle-progress-message (fn handle-progress-message-curried [progress-message-map]
                                   (handle-progress-message! progress-aggregator-chan progress-message-map))]
-    (ranker/start-jobs-prioritizer! conn pending-jobs-atom task-constraints rank-trigger-chan)
+    (ranker/start-jobs-prioritizer! conn pending-jobs-atom task-constraints rank-trigger-chan rank-jobs-fn)
     {:scheduler (create-mesos-scheduler framework-id gpu-enabled? conn heartbeat-ch fenzo offers-chan
                                         match-trigger-chan handle-progress-message sandbox-syncer-state)
      :view-incubating-offers (fn get-resources-atom [] @resources-atom)}))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -617,7 +617,7 @@
 
 (defn task->feature-vector
   "Vector of comparable features of a task.
-   Last two elements are aribitary tie breakers.
+   Last two elements are arbitrary tie breakers.
    Use :db/id because they guarantee uniqueness for different entities
    (:db/id task) is not sufficient because synthetic task entities don't have :db/id
    This assumes there are at most one synthetic task for a job, otherwise uniqueness invariant will break"

--- a/scheduler/test/cook/test/mesos/ranker.clj
+++ b/scheduler/test/cook/test/mesos/ranker.clj
@@ -17,11 +17,13 @@
 (ns cook.test.mesos.ranker
   (:use [clojure.test])
   (:require [clojure.core.async :as async]
+            [clojure.set :as set]
             [cook.mesos.ranker :as ranker]
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
             [cook.test.testutil :as tu]
-            [datomic.api :as d]))
+            [datomic.api :as d]
+            [plumbing.core :as pc]))
 
 (deftest test-sort-jobs-by-dru-category
   (let [uri "datomic:mem://test-sort-jobs-by-dru"
@@ -171,3 +173,174 @@
     (is (= {:normal (list (util/job-ent->map job-entity-2))
             :gpu ()}
            (ranker/rank-jobs test-db offensive-job-filter)))))
+
+(deftest test-fairly-sort-jobs-by-dru-category
+  (let [uri "datomic:mem://test-fairly-sort-jobs-by-dru-category"
+        conn (tu/restore-fresh-database! uri)
+        total-resources {:cpus 45 :mem 30}
+        j1 (tu/create-dummy-job conn :name "j1a" :user "u1" :ncpus 1.0 :memory 8.0 :job-state :job.state/running)
+        j2a (tu/create-dummy-job conn :name "j2a" :user "u1" :ncpus 2.0 :memory 1.0)
+        j2b (tu/create-dummy-job conn :name "j2b" :user "u1" :ncpus 2.0 :memory 1.0)
+        j2c (tu/create-dummy-job conn :name "j2c" :user "u1" :ncpus 2.0 :memory 1.0)
+        _ (tu/create-dummy-job conn :name "j2d" :user "u1" :ncpus 2.0 :memory 1.0)
+        _ (tu/create-dummy-job conn :name "j2e" :user "u1" :ncpus 2.0 :memory 1.0)
+        _ (tu/create-dummy-job conn :name "j2f" :user "u1" :ncpus 2.0 :memory 1.0)
+        j3 (tu/create-dummy-job conn :name "j3" :user "u1" :ncpus 1.0 :memory 7.0 :job-state :job.state/running)
+        j4 (tu/create-dummy-job conn :name "j4" :user "u2" :ncpus 9.0 :memory 2.0 :priority 75)
+        j5 (tu/create-dummy-job conn :name "j5" :user "u2" :ncpus 8.0 :memory 1.0 :job-state :job.state/running)
+        j6 (tu/create-dummy-job conn :name "j6" :user "u2" :ncpus 4.0 :memory 4.0 :job-state :job.state/running)
+        j7 (tu/create-dummy-job conn :name "j7" :user "u3" :ncpus 3.0 :memory 3.0)
+        j8 (tu/create-dummy-job conn :name "j8" :user "u4" :ncpus 4.0 :memory 2.0)
+        j9 (tu/create-dummy-job conn :name "j9" :user "u4" :ncpus 5.0 :memory 1.5)
+        ja (tu/create-dummy-job conn :name "ja" :user "u5" :ncpus 3.0 :memory 1.0)
+        jb (tu/create-dummy-job conn :name "jb" :user "u6" :ncpus 2.0 :memory 1.0)
+        jc (tu/create-dummy-job conn :name "jc" :user "u7" :ncpus 1.0 :memory 1.0)]
+
+    (tu/create-dummy-instance conn j1)
+    (tu/create-dummy-instance conn j3)
+    (tu/create-dummy-instance conn j5)
+    (tu/create-dummy-instance conn j6)
+
+    (share/set-share! conn "default" nil "test" :mem 10.0 :cpus 8.0)
+    (share/set-share! conn "u1" nil "test" :mem 60.0 :cpus 16.0)
+
+    (let [unfiltered-db (d/db conn)
+          {:keys [all-tasks pending-tasks running-tasks]} (ranker/get-running-and-pending-tasks unfiltered-db)
+          user->tasks (group-by #(-> % :job/_instance :job/user) all-tasks)
+          user->requested-resources (ranker/user->tasks-to-user->requested-resources user->tasks)
+          user->resource-weights (ranker/compute-user->resource-weights unfiltered-db (keys user->tasks))
+          {:keys [under-share-users user->allocated-resources]}
+          (ranker/compute-fair-share-resources total-resources user->requested-resources user->resource-weights)
+          task-comparator (util/same-user-task-comparator)
+          user->sorted-tasks (pc/map-vals #(sort task-comparator %) user->tasks)
+          user->scheduled-job-ids (ranker/allocate-tasks user->sorted-tasks user->allocated-resources under-share-users)
+          scheduled-job-ids (reduce set/union #{} (vals user->scheduled-job-ids))
+          scheduled-pending-tasks (filter #(contains? scheduled-job-ids (-> % :job/_instance :db/id)) pending-tasks)
+          category->sorted-jobs (ranker/sort-jobs-by-dru-category unfiltered-db scheduled-pending-tasks running-tasks)]
+
+      (is (= {:pending {:scheduled 10
+                        :total 13}
+              :running {:total 4}}
+             {:pending {:scheduled (count scheduled-pending-tasks)
+                        :total (count pending-tasks)}
+              :running {:total (count running-tasks)}}))
+
+      (is (= {"u1" {:cpus 14.0 :mem 21.0}
+              "u2" {:cpus 21.0 :mem 7.0}
+              "u3" {:cpus 3.0 :mem 3.0}
+              "u4" {:cpus 9.0 :mem 3.5}
+              "u5" {:cpus 3.0 :mem 1.0}
+              "u6" {:cpus 2.0 :mem 1.0}
+              "u7" {:cpus 1.0 :mem 1.0}}
+             user->requested-resources))
+
+      (is (= {"u1" {:cpus 14.0 :mem 18.0}
+              "u2" {:cpus 13.0 :mem 3.0}
+              "u3" {:cpus 3.0 :mem 3.0}
+              "u4" {:cpus 9.0 :mem 3.0}
+              "u5" {:cpus 3.0 :mem 1.0}
+              "u6" {:cpus 2.0 :mem 1.0}
+              "u7" {:cpus 1.0 :mem 1.0}}
+             user->allocated-resources))
+
+      (is (= {:normal [jc jb j2a j2b j7 ja j2c j8 j9 j4]
+              :gpu []}
+             (pc/map-vals #(map :db/id %) category->sorted-jobs))))))
+
+(defn exponential-cdf->x
+  "https://en.wikipedia.org/wiki/Exponential_distribution#Cumulative_distribution_function"
+  [lambda max-val]
+  (int (min max-val (* lambda (Math/log (/ 1.0 (- 1.0 (Math/random))))))))
+
+(comment
+  deftest test-ranking-performance-comparison
+  "Example output:
+test-ranking-performance-comparison: set the share...
+test-ranking-performance-comparison: creating 30000 jobs...
+test-ranking-performance-comparison: created 30000 jobs.
+test-ranking-performance-comparison: total-resources: {:cpus 100000.0, :mem 2.2E8}
+test-ranking-performance-comparison: running-resources: {:cpus 78874.0, :mem 1.58763177E8}
+test-ranking-performance-comparison: pending-resources: {:cpus 89831.0, :mem 1.81177645E8}
+test-ranking-performance-comparison: preempt-resources: {:cpus 68178.0, :mem 1.37695167E8}
+test-ranking-performance-comparison: non-preempt-resources: {:cpus 10696.0, :mem 2.106801E7}
+test-ranking-performance-comparison: scheduled-resources: {:cpus 100527.0, :mem 2.02245655E8}
+test-ranking-performance-comparison: currently running jobs: 3136
+test-ranking-performance-comparison: preempt jobs: 2718
+test-ranking-performance-comparison: num ideal-scheduled-job-ids: 3962
+test-ranking-performance-comparison: num normal job-ids: 3544
+...
+  4 sort-jobs-by-dru-category:
+{:normal 26864, :gpu 0}
+Elapsed time: 996.155086msecs
+  4 fairly-sort-jobs-by-dru-category:
+{:normal 3544, :gpu 0}
+Elapsed time: 650.760561msecs
+"
+  (let [uri "datomic:mem://test-ranking-performance-comparison"
+        conn (tu/restore-fresh-database! uri)
+        num-total-jobs 30000
+        percent-running-jobs 0.10
+        total-resources {:cpus 100000.0 :mem 220000000.0}
+        num-users 100]
+
+    (println "test-ranking-performance-comparison: set the share...")
+    (share/set-share! conn "default" nil "test" :mem 1000000.0 :cpus 200.0)
+
+    (println "test-ranking-performance-comparison: creating" num-total-jobs "jobs...")
+    (dotimes [j num-total-jobs]
+      (let [user (str "u" (exponential-cdf->x 12 num-users))
+            cpus (inc (int (* 50 (Math/random))))
+            mem (+ 256 (int (* 100000 (Math/random))))
+            job-running? (< (Math/random) percent-running-jobs)
+            job-state (if job-running? :job.state/running :job.state/waiting)]
+        (cond->> (tu/create-dummy-job
+                   conn
+                   :job-state job-state
+                   :memory mem
+                   :name (str "job-" j)
+                   :ncpus cpus
+                   :priority (int (* 100 (Math/random)))
+                   :user user)
+                 job-running?
+                 (tu/create-dummy-instance conn))))
+    (println "test-ranking-performance-comparison: created" num-total-jobs "jobs.")
+
+    (let [unfiltered-db (d/db conn)
+          running-tasks (util/get-running-task-ents unfiltered-db)
+          running-resources (->> (map #(-> % :job/_instance ranker/job->resources) running-tasks)
+                                 (apply merge-with +))]
+      (let [{:keys [category->sorted-pending-jobs ideal-scheduled-job-ids]} (ranker/fairly-sort-jobs-by-dru-category total-resources unfiltered-db)
+            pending-resources (->> (map ranker/job->resources (-> category->sorted-pending-jobs :normal))
+                                   (apply merge-with +))
+            preempt-tasks (remove #(contains? ideal-scheduled-job-ids (-> % :job/_instance :db/id)) running-tasks)
+            preempt-resources (->> preempt-tasks
+                                   (map #(-> % :job/_instance ranker/job->resources))
+                                   (apply merge-with +))
+            non-preempt-resources (->> running-tasks
+                                       (filter #(contains? ideal-scheduled-job-ids (-> % :job/_instance :db/id)))
+                                       (map #(-> % :job/_instance ranker/job->resources))
+                                       (apply merge-with +))
+            scheduled-resources (merge-with + pending-resources non-preempt-resources)]
+        (println "test-ranking-performance-comparison: total-resources:" total-resources)
+        (println "test-ranking-performance-comparison: running-resources:" running-resources)
+        (println "test-ranking-performance-comparison: pending-resources:" pending-resources)
+        (println "test-ranking-performance-comparison: preempt-resources:" preempt-resources)
+        (println "test-ranking-performance-comparison: non-preempt-resources:" non-preempt-resources)
+        (println "test-ranking-performance-comparison: scheduled-resources:" scheduled-resources)
+        (println "test-ranking-performance-comparison: currently running jobs:" (count running-tasks))
+        (println "test-ranking-performance-comparison: preempt jobs:" (count preempt-tasks))
+        (println "test-ranking-performance-comparison: num ideal-scheduled-job-ids:" (count ideal-scheduled-job-ids))
+        (println "test-ranking-performance-comparison: num normal job-ids:" (-> category->sorted-pending-jobs :normal count)))
+
+      (dotimes [i 5]
+        (println "  " i "sort-jobs-by-dru-category:")
+        (time
+          (->> (ranker/sort-jobs-by-dru-category unfiltered-db)
+               (pc/map-vals count)
+               (println)))
+        (println "  " i "fairly-sort-jobs-by-dru-category:")
+        (time
+          (->> (ranker/fairly-sort-jobs-by-dru-category total-resources unfiltered-db)
+               :category->sorted-pending-jobs
+               (pc/map-vals count)
+               (println)))))))

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -10,13 +10,14 @@
             [clojure.data.csv :as csv]
             [clojure.data.json :as json]
             [clojure.java.io :as io]
-            [clojure.tools.cli :refer  [parse-opts]]
+            [clojure.tools.cli :refer [parse-opts]]
             [clojure.tools.logging :as log]
             [clojure.walk :refer (keywordize-keys)]
             [com.rpl.specter :refer (transform ALL MAP-VALS MAP-KEYS select FIRST)]
             [cook.config :refer (executor-config, init-logger)]
             [cook.mesos :as c]
             [cook.mesos.mesos-mock :as mm]
+            [cook.mesos.ranker :as ranker]
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
             [cook.test.testutil :refer (restore-fresh-database! poll-until)]
@@ -139,6 +140,7 @@
             :offer-incubate-time-ms offer-incubate-time-ms#
             :optimizer-config optimizer-config#
             :progress-config progress-config#
+            :rank-jobs-fn ranker/rank-jobs
             :rebalancer-config rebalancer-config#
             :sandbox-syncer-state sandbox-syncer-state#
             :server-config host-settings#

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -121,7 +121,10 @@
          optimizer-config# (or (:optimizer-config ~scheduler-config)
                                {})
          trigger-chans# (or (:trigger-chans ~scheduler-config)
-                            (c/make-trigger-chans rebalancer-config# progress-config# optimizer-config# task-constraints#))]
+                            (c/make-trigger-chans rebalancer-config# progress-config# optimizer-config# task-constraints#))
+         rank-jobs-fn# (if (:ideally-fair-mode ~scheduler-config)
+                         ranker/fairness-based-rank-jobs
+                         ranker/rank-jobs)]
      (try
        (with-redefs [executor-config (constantly executor-config#)]
          (c/start-mesos-scheduler
@@ -140,7 +143,7 @@
             :offer-incubate-time-ms offer-incubate-time-ms#
             :optimizer-config optimizer-config#
             :progress-config progress-config#
-            :rank-jobs-fn ranker/rank-jobs
+            :rank-jobs-fn rank-jobs-fn#
             :rebalancer-config rebalancer-config#
             :sandbox-syncer-state sandbox-syncer-state#
             :server-config host-settings#
@@ -291,6 +294,13 @@
 
    Returns a list of the task entities run"
   [mesos-hosts trace cycle-step-ms config]
+  (let [total-resources (->> mesos-hosts
+                             (map :resources)
+                             (map #(select-keys % [:cpus :gpus :mem]))
+                             (map #(map-vals (fn [m] (get m "*")) %))
+                             (apply merge-with +))]
+    (log/info "simulate: total mesos hosts resources" total-resources)
+    (reset! ranker/total-resources-atom total-resources))
   (let [simulation-time (-> trace first :submit-time-ms)
         mesos-datomic-conn (restore-fresh-database! (get config :datomic-url "datomic:mem://mock-mesos"))
         offer-trigger-chan (async/chan)


### PR DESCRIPTION
## Changes proposed in this PR

- makes the rank-jobs function configurable
- adds support for fairness based scheduler
- adds support for non-preemptable jobs in the rebalancer hinted from the ranker
- adds support for fairness scheduler in the simulator

## Why are we making these changes?

The ideal fairness scheduler dynamically computes the fair share of every user and scheduler/pre-empts jobs based on the fair share. We want to be able to run the ideal fairness scheduler as a baseline for our scheduler comparisons.

**Note**: 

- This PR merges the code into the `ranker-clj` branch.

- The more interesting change is in this commit: https://github.com/twosigma/Cook/pull/915/commits/7cbf2989c2cb85715cae1395a27cce3d5207df0c

