### PR TITLE
Outgoing/temporal UUID

### DIFF
--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
@@ -44,7 +44,6 @@ import org.apache.http.ParseException;
 import org.apache.http.StatusLine;
 import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.auth.AuthScope;
-
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -521,7 +521,7 @@
   (let [commit-latch-id (d/tempid :db.part/user)
         commit-latch {:db/id commit-latch-id
                       :commit-latch/committed? true
-                      :commit-latch/uuid (UUID/randomUUID)}]
+                      :commit-latch/uuid (d/squuid)}]
     [commit-latch-id commit-latch]))
 
 (s/defn make-job-txn

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -666,7 +666,7 @@
         _ (log/debug "offer to scheduleOnce" offers)
         _ (log/debug "tasks to scheduleOnce" considerable)
         leases (mapv #(->VirtualMachineLeaseAdapter % t) offers)
-        considerable->task-id (plumbing.core/map-from-keys (fn [_] (str (java.util.UUID/randomUUID))) considerable)
+        considerable->task-id (plumbing.core/map-from-keys (fn [_] (str (d/squuid))) considerable)
         guuid->considerable-cotask-ids (util/make-guuid->considerable-cotask-ids considerable->task-id)
         running-cotask-cache (atom (cache/fifo-cache-factory {} :threshold (max 1 (count considerable))))
         job-uuid->reserved-host (or (:job-uuid->reserved-host @rebalancer-reservation-atom) {})


### PR DESCRIPTION
## Changes proposed in this PR

- Use the datomic temporal UUID in two spots in the cook scheduler, the task_id and commit latch. 
- Make temporal UUID code in our JobClient API that can be used by our customers. 
- Change two UUID generation stacks to use datomic/squuid (the datomic temporal UUID generator)

## Why are we making these changes?

- Investigation found that random ID's could be a bottleneck in job submission.
- Using temporal UUID's would let us increase the job submission rate by 10x-30x, to 1000-3000 jobs/second, if used for commitlatch and by client code.
- I'm changing the task ID UUID on general principals. We know from earlier information that random UUID's are expensive, so remove an extra one.