### PR TITLE
Use `nil-pool` instead of a new random UUID

### DIFF
--- a/scheduler/src/cook/mesos/pool.clj
+++ b/scheduler/src/cook/mesos/pool.clj
@@ -33,9 +33,11 @@
   "Returns:
    - The given pool name if not-nil
    - The default pool name, if configured
-   - A random UUID"
+   - `nil-pool`
+   Returning `nil-pool` instead of `nil` allows this to be used as an argument to a datomic function
+   or comparison operator"
   [pool-name]
-  (or pool-name (config/default-pool) (str (UUID/randomUUID))))
+  (or pool-name (config/default-pool) nil-pool))
 
 (defn default-pool?
   "Returns true if pool-name is equal to the default pool name"


### PR DESCRIPTION
## Changes proposed in this PR
- Use `nil-pool` instead of a new random UUID as the default

## Why are we making these changes?
Save calling `(UUID/randomUUID)` unnecessarily. Also add a comment explaining why this is the default.