### PR TITLE
Add UUID generator to JobClient.

### DIFF
--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
@@ -1235,4 +1235,23 @@ public class JobClient implements Closeable, JobClientInterface {
             JobClient.this.abort(uuids, _impersonatedUser);
         }
     }
+
+    /** If UUID's are generated purely randomly, they have poor locality. This code generates random (variant 4, RFC4122)
+     * UUID's that are temporally clustered, such that two UUID's generated closer in time, will share a longer prefix than
+     * those generated further apart in time. These should be used for Cook job UUID's, group UUID's and any
+     * other UUID's passed to cook. They can be worth a 10x-30x performance improvement, increasing job submission rate
+     * to over 1000 jobs/second.
+     *
+     * Implementation details (do not depend on this): We generate these UUID's by taking the lowest 40 bits of the
+     * system time (in milliseconds) and using those as the most significant 5 bytes. When the timestamp rolls over
+     * (after 30 years) we lose a tiny bit of locality.
+     * @return
+     */
+    public static UUID makeTemporalUUID() {
+        long millis = System.currentTimeMillis();
+        long millisMasked = millis & ((1L<<40)-1);
+        UUID baseUUID = UUID.randomUUID();
+        long baseUUIDHighMasked = baseUUID.getMostSignificantBits() & ((1<<24)-1);
+        return new UUID(baseUUIDHighMasked | (millisMasked<<24),baseUUID.getLeastSignificantBits());
+    }
 }


### PR DESCRIPTION
## Changes proposed in this PR
- Make temporal UUID code in our JobClient API that can be used by our customers.

## Why are we making these changes?
- Investigation found that random ID's could be a bottleneck in job submission.
- Using temporal UUID's would let us increase the job submission rate by 10x-30x, to 1000-3000 jobs/second, if used for commitlatch and by client code.
- This includes code that customers can call that makes appropriate UUID's.
