### PR TITLE
Run preemption test serially

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -214,6 +214,7 @@ class MultiUserCookTest(util.CookTest):
                 util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
 
     @unittest.skipUnless(util.is_preemption_enabled(), 'Preemption is not enabled on the cluster')
+    @pytest.mark.serial
     def test_preemption(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
@@ -267,7 +268,7 @@ class MultiUserCookTest(util.CookTest):
                     for job in jobs:
                         for instance in job['instances']:
                             self.logger.debug(f'Checking if instance was preempted: {instance}')
-                            if instance['reason_string'] == 'Preempted by rebalancer':
+                            if instance.get('reason_string') == 'Preempted by rebalancer':
                                 return True
                             else:
                                 self.logger.info(f'Job has not been preempted: {job}')

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -9,7 +9,6 @@ set -ev
 
 export PROJECT_DIR=`pwd`
 
-PYTEST_MARKS=''
 COOK_AUTH=one-user
 COOK_EXECUTOR=mesos
 COOK_POOLS=on
@@ -150,7 +149,8 @@ cd ${PROJECT_DIR}
 export COOK_MULTI_CLUSTER=
 export COOK_MASTER_SLAVE=
 export COOK_SLAVE_URL=http://localhost:12323
-pytest -n4 -v --color=no --timeout-method=thread --boxed -m "${PYTEST_MARKS}" || test_failures=true
+pytest -n4 -v --color=no --timeout-method=thread --boxed -m "not serial" || test_failures=true
+pytest -n0 -v --color=no --timeout-method=thread --boxed -m "serial" || test_failures=true
 
 # If there were failures, then we should save the logs
 if [ "$test_failures" = true ]; then


### PR DESCRIPTION
## Changes proposed in this PR
- Run preemption test serially

## Why are we making these changes?
Reduce flakiness by lowering contention on mesos for tests which have specific resource demands.