### PR TITLE
Make Job.java use the temporal ID by default.

### DIFF
--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -117,7 +117,7 @@ final public class Job {
 
             // Set the default values.
             if (_uuid == null) {
-                _uuid = UUID.randomUUID();
+                _uuid = JobClient.makeTemporalUUID();
             }
             if (_retries == null) {
                 _retries = 5;


### PR DESCRIPTION
Changes proposed in this PR

-  Make Job.java use new temporal ID by default.

Why are we making these changes?

-    Investigation found that random ID's could be a bottleneck in job submission.
-    Using temporal UUID's would let us increase the job submission rate by 10x-30x, to 1000-3000 jobs/second, if used for commitlatch and by client code.
-    This makes the default fast.
