### PR TITLE
generalizes the sandbox aggregator functions

### DIFF
--- a/scheduler/src/cook/mesos/sandbox.clj
+++ b/scheduler/src/cook/mesos/sandbox.clj
@@ -28,77 +28,70 @@
             [metrics.meters :as meters]
             [metrics.timers :as timers]))
 
-(def sandbox-aggregator-message-rate (meters/meter ["cook-mesos" "scheduler" "sandbox-aggregator-message-rate"]))
-(def sandbox-aggregator-pending-count (counters/counter ["cook-mesos" "scheduler" "sandbox-aggregator-pending-count"]))
-(def sandbox-pending-sync-host-count (counters/counter ["cook-mesos" "scheduler" "sandbox-pending-sync-host-count"]))
-(def sandbox-updater-pending-entries (histograms/histogram ["cook-mesos" "scheduler" "sandbox-updater-pending-entries"]))
-(def sandbox-updater-publish-duration (timers/timer ["cook-mesos" "scheduler" "sandbox-updater-publish-duration"]))
-(def sandbox-updater-publish-rate (meters/meter ["cook-mesos" "scheduler" "sandbox-updater-publish-rate"]))
-(def sandbox-updater-tx-duration (timers/timer ["cook-mesos" "scheduler" "sandbox-updater-tx-duration"]))
-(def sandbox-updater-tx-rate (meters/meter ["cook-mesos" "scheduler" "sandbox-updater-tx-rate"]))
-(def sandbox-updater-unprocessed-count (counters/counter ["cook-mesos" "scheduler" "sandbox-updater-unprocessed-count"]))
-(def sandbox-updater-unprocessed-entries (histograms/histogram ["cook-mesos" "scheduler" "sandbox-updater-unprocessed-entries"]))
-
-(defn agent->task-id->sandbox
-  "Returns the sandbox in the current agent state."
-  [task-id->sandbox-agent task-id]
-  (get @task-id->sandbox-agent task-id))
-
 (defn clear-agent-state
   "Clears the published entries from the aggregated state of the agent.
-   Since we expect instances to have the same sandbox, we do not check for value equality."
-  [task-id->sandbox published-task-id->sandbox]
-  (let [task-id->sandbox' (apply dissoc task-id->sandbox (keys published-task-id->sandbox))]
-    (counters/clear! sandbox-aggregator-pending-count)
-    (counters/inc! sandbox-aggregator-pending-count (count task-id->sandbox'))
-    task-id->sandbox'))
+   Since we expect instances to have the same field value, we do not check for value equality."
+  [task-id->field-value field-name published-task-id->field-value]
+  (let [field-aggregator-pending-count (counters/counter ["cook-mesos" "scheduler" field-name "aggregator-pending-count"])
+        task-id->field-value' (apply dissoc task-id->field-value (keys published-task-id->field-value))]
+    (counters/clear! field-aggregator-pending-count)
+    (counters/inc! field-aggregator-pending-count (count task-id->field-value'))
+    task-id->field-value'))
 
-(defn aggregate-sandbox
-  "Aggregates the sandbox specified in `data` into the current sandbox state `task-id->sandbox`.
-   Existing entries in task-id->sandbox take precedence during aggregation.
+(defn aggregate-instance-field
+  "Aggregates the field-value specified in `data` into the current field-value state `task-id->field-value`.
+   Existing entries in task-id->field-value take precedence during aggregation.
    It provides two overloaded versions:
-   1. Aggregates an individual task-id and sandbox pair.
-   2. Aggregates a collection (map) of task-id to sandbox mappings.
-   It returns the new task-id->sandbox state."
-  ([task-id->sandbox task-id sandbox]
-   (meters/mark! sandbox-aggregator-message-rate)
-   (if (and task-id sandbox (not (contains? task-id->sandbox task-id)))
-     (let [task-id->sandbox' (assoc task-id->sandbox task-id sandbox)]
-       (counters/inc! sandbox-aggregator-pending-count)
-       task-id->sandbox')
-     task-id->sandbox))
-  ([task-id->sandbox candidate-task-id->sandbox]
-   (reduce (fn [accum-task-id->sandbox [task-id sandbox]]
-             (aggregate-sandbox accum-task-id->sandbox task-id sandbox))
-           task-id->sandbox
-           candidate-task-id->sandbox)))
+   1. Aggregates an individual task-id and field-value pair.
+   2. Aggregates a collection (map) of task-id to field-value mappings.
+   It returns the new task-id->field-value state."
+  ([task-id->field-value field-name task-id field-value]
+   (let [field-aggregator-message-rate (meters/meter ["cook-mesos" "scheduler" field-name "aggregator-message-rate"])
+         field-aggregator-pending-count (counters/counter ["cook-mesos" "scheduler" field-name "aggregator-pending-count"])]
+     (meters/mark! field-aggregator-message-rate)
+     (if (and task-id field-value (not (contains? task-id->field-value task-id)))
+       (let [task-id->field-value' (assoc task-id->field-value task-id field-value)]
+         (counters/inc! field-aggregator-pending-count)
+         task-id->field-value')
+       task-id->field-value)))
+  ([task-id->field-value field-name candidate-task-id->field-value]
+   (reduce (fn [accum-task-id->field-value [task-id field-value]]
+             (aggregate-instance-field accum-task-id->field-value field-name task-id field-value))
+           task-id->field-value
+           candidate-task-id->field-value)))
 
-(defn publish-sandbox-to-datomic!
-  "Transacts the latest aggregated task-id->sandbox to datomic.
+(defn publish-instance-field-to-datomic!
+  "Transacts the latest aggregated task-id->field-value to datomic.
    No more than batch-size facts are updated in individual datomic transactions."
-  [datomic-conn batch-size task-id->sandbox-agent]
-  (let [task-id->sandbox @task-id->sandbox-agent
-        task-count (count task-id->sandbox)]
-    (histograms/update! sandbox-updater-pending-entries task-count)
-    (meters/mark! sandbox-updater-publish-rate)
+  [instance-field datomic-conn batch-size task-id->field-value-agent]
+  (let [task-id->field-value @task-id->field-value-agent
+        task-count (count task-id->field-value)
+        field-name (name instance-field)
+        field-updater-pending-entries (histograms/histogram ["cook-mesos" "scheduler" field-name "updater-pending-entries"])
+        field-updater-publish-rate (meters/meter ["cook-mesos" "scheduler" field-name "updater-publish-rate"])
+        field-updater-publish-duration (timers/timer ["cook-mesos" "scheduler" field-name "updater-publish-duration"])
+        field-updater-tx-duration (timers/timer ["cook-mesos" "scheduler" field-name "updater-tx-duration"])
+        field-updater-tx-rate (meters/meter ["cook-mesos" "scheduler" field-name "updater-tx-rate"])]
+    (histograms/update! field-updater-pending-entries task-count)
+    (meters/mark! field-updater-publish-rate)
     (when (pos? task-count)
-      (log/info "Publishing" task-count "instance sandbox directories")
+      (log/info "Publishing" field-name "of" task-count "instance(s)")
       (timers/time!
-        sandbox-updater-publish-duration
-        (doseq [task-id->sandbox-partition (partition-all batch-size task-id->sandbox)]
+        field-updater-publish-duration
+        (doseq [task-id->field-value-partition (partition-all batch-size task-id->field-value)]
           (try
-            (letfn [(build-sandbox-txns [[task-id sandbox]]
-                      [:db/add [:instance/task-id task-id] :instance/sandbox-directory sandbox])]
-              (let [txns (map build-sandbox-txns task-id->sandbox-partition)]
+            (letfn [(build-txns [[task-id field-value]]
+                      [:db/add [:instance/task-id task-id] instance-field field-value])]
+              (let [txns (map build-txns task-id->field-value-partition)]
                 (when (seq txns)
-                  (log/info "Inserting" (count txns) "facts in sandbox state update")
-                  (meters/mark! sandbox-updater-tx-rate)
+                  (log/info "Inserting" (count txns) "facts in" field-name "state update")
+                  (meters/mark! field-updater-tx-rate)
                   (timers/time!
-                    sandbox-updater-tx-duration
+                    field-updater-tx-duration
                     @(d/transact datomic-conn txns)))))
-            (send task-id->sandbox-agent clear-agent-state task-id->sandbox-partition)
+            (send task-id->field-value-agent clear-agent-state field-name task-id->field-value-partition)
             (catch Exception e
-              (log/error e "Sandbox batch update error"))))))
+              (log/error e (str field-name " batch update error")))))))
     {}))
 
 (defn retrieve-sandbox-directories-on-agent
@@ -126,6 +119,10 @@
          (map (fn executor-state->task-id->sandbox-directory [{:strs [id directory]}]
                 [id directory]))
          (into {}))))
+
+(def sandbox-pending-sync-host-count (counters/counter ["cook-mesos" "scheduler" "sandbox-pending-sync-host-count"]))
+(def sandbox-updater-unprocessed-count (counters/counter ["cook-mesos" "scheduler" "sandbox-updater-unprocessed-count"]))
+(def sandbox-updater-unprocessed-entries (histograms/histogram ["cook-mesos" "scheduler" "sandbox-updater-unprocessed-entries"]))
 
 (defn- update-pending-sync-host-counter!
   "Updates the sandbox-pending-sync-host-count to the number of pending sync hosts and returns the input."
@@ -203,7 +200,7 @@
                 (str/join "," missing-task-ids)))
     (->> (set/union unprocessed-task-ids-prev filtered-task-ids)
          (remove-processed-task-ids! unprocessed-host->task-ids-atom host))
-    (send task-id->sandbox-agent aggregate-sandbox filtered-task-id->sandbox-directory)))
+    (send task-id->sandbox-agent aggregate-instance-field "sandbox-directory" filtered-task-id->sandbox-directory)))
 
 (defn refresh-agent-cache-entry
   "If the entry for the specified agent is not cached:
@@ -248,7 +245,7 @@
   "Sends a message to the agent to update the sandbox information."
   [{:keys [task-id->sandbox-agent]} {:strs [sandbox-directory task-id]}]
   (when task-id->sandbox-agent
-    (send task-id->sandbox-agent aggregate-sandbox task-id sandbox-directory)))
+    (send task-id->sandbox-agent aggregate-instance-field "sandbox-directory" task-id sandbox-directory)))
 
 (defn sync-agent-sandboxes
   "Asynchronously triggers state syncing from the mesos agent.
@@ -268,7 +265,8 @@
   (chime/chime-at
     (periodic/periodic-seq (time/now) (time/millis publish-interval-ms))
     (fn sandbox-publisher-task [_]
-      (publish-sandbox-to-datomic! datomic-conn publish-batch-size task-id->sandbox-agent))
+      (publish-instance-field-to-datomic!
+        :instance/sandbox-directory datomic-conn publish-batch-size task-id->sandbox-agent))
     {:error-handler (fn sandbox-publisher-error-handler [ex]
                       (log/error ex "Instance sandbox directory publish failed"))}))
 

--- a/scheduler/test/cook/test/mesos/sandbox.clj
+++ b/scheduler/test/cook/test/mesos/sandbox.clj
@@ -26,18 +26,18 @@
   (:import (java.util.concurrent CountDownLatch TimeUnit)))
 
 (deftest test-agent->task-id->sandbox
-  (let [agent->task-id->field-value (fn [an-agent task-id] (get @an-agent task-id))
+  (let [agent->task-id->value (fn [an-agent task-id] (get @an-agent task-id))
         task-id->sandbox-agent (agent {})]
     (send task-id->sandbox-agent sandbox/aggregate-instance-field "sandbox-directory" "t0" "s0")
     (send task-id->sandbox-agent sandbox/aggregate-instance-field "sandbox-directory" "t2" "s2")
     (send task-id->sandbox-agent sandbox/aggregate-instance-field "sandbox-directory" "t3" "s3")
     (await task-id->sandbox-agent)
 
-    (is (= "s0" (agent->task-id->field-value task-id->sandbox-agent "t0")))
-    (is (nil? (agent->task-id->field-value task-id->sandbox-agent "t1")))
-    (is (= "s2" (agent->task-id->field-value task-id->sandbox-agent "t2")))
-    (is (= "s3" (agent->task-id->field-value task-id->sandbox-agent "t3")))
-    (is (nil? (agent->task-id->field-value task-id->sandbox-agent "t4")))))
+    (is (= "s0" (agent->task-id->value task-id->sandbox-agent "t0")))
+    (is (nil? (agent->task-id->value task-id->sandbox-agent "t1")))
+    (is (= "s2" (agent->task-id->value task-id->sandbox-agent "t2")))
+    (is (= "s3" (agent->task-id->value task-id->sandbox-agent "t3")))
+    (is (nil? (agent->task-id->value task-id->sandbox-agent "t4")))))
 
 (defmacro assert-clear-agent-state-result
   [initial-state clear-data expected-state]

--- a/scheduler/test/cook/test/mesos/sandbox.clj
+++ b/scheduler/test/cook/test/mesos/sandbox.clj
@@ -26,29 +26,31 @@
   (:import (java.util.concurrent CountDownLatch TimeUnit)))
 
 (deftest test-agent->task-id->sandbox
-  (let [task-id->sandbox-agent (agent {})]
-    (send task-id->sandbox-agent sandbox/aggregate-sandbox "t0" "s0")
-    (send task-id->sandbox-agent sandbox/aggregate-sandbox "t2" "s2")
-    (send task-id->sandbox-agent sandbox/aggregate-sandbox "t3" "s3")
+  (let [agent->task-id->field-value (fn [an-agent task-id] (get @an-agent task-id))
+        task-id->sandbox-agent (agent {})]
+    (send task-id->sandbox-agent sandbox/aggregate-instance-field "sandbox-directory" "t0" "s0")
+    (send task-id->sandbox-agent sandbox/aggregate-instance-field "sandbox-directory" "t2" "s2")
+    (send task-id->sandbox-agent sandbox/aggregate-instance-field "sandbox-directory" "t3" "s3")
     (await task-id->sandbox-agent)
 
-    (is (= "s0" (sandbox/agent->task-id->sandbox task-id->sandbox-agent "t0")))
-    (is (nil? (sandbox/agent->task-id->sandbox task-id->sandbox-agent "t1")))
-    (is (= "s2" (sandbox/agent->task-id->sandbox task-id->sandbox-agent "t2")))
-    (is (= "s3" (sandbox/agent->task-id->sandbox task-id->sandbox-agent "t3")))
-    (is (nil? (sandbox/agent->task-id->sandbox task-id->sandbox-agent "t4")))))
+    (is (= "s0" (agent->task-id->field-value task-id->sandbox-agent "t0")))
+    (is (nil? (agent->task-id->field-value task-id->sandbox-agent "t1")))
+    (is (= "s2" (agent->task-id->field-value task-id->sandbox-agent "t2")))
+    (is (= "s3" (agent->task-id->field-value task-id->sandbox-agent "t3")))
+    (is (nil? (agent->task-id->field-value task-id->sandbox-agent "t4")))))
 
 (defmacro assert-clear-agent-state-result
   [initial-state clear-data expected-state]
-  `(let [task-id->sandbox-agent# (agent ~initial-state)]
-     (counters/clear! sandbox/sandbox-aggregator-pending-count)
-     (counters/inc! sandbox/sandbox-aggregator-pending-count (count ~initial-state))
+  `(let [task-id->sandbox-agent# (agent ~initial-state)
+         aggregator-pending-count# (counters/counter ["cook-mesos" "scheduler""sandbox-directory" "aggregator-pending-count"])]
+     (counters/clear! aggregator-pending-count#)
+     (counters/inc! aggregator-pending-count# (count ~initial-state))
 
-     (send task-id->sandbox-agent# sandbox/clear-agent-state ~clear-data)
+     (send task-id->sandbox-agent# sandbox/clear-agent-state "sandbox-directory" ~clear-data)
      (await task-id->sandbox-agent#)
 
      (is (= @task-id->sandbox-agent# ~expected-state))
-     (is (= (counters/value sandbox/sandbox-aggregator-pending-count) (count ~expected-state)))))
+     (is (= (counters/value aggregator-pending-count#) (count ~expected-state)))))
 
 (deftest test-clear-agent-state
   (assert-clear-agent-state-result nil nil nil)
@@ -65,42 +67,44 @@
   (assert-clear-agent-state-result {"a" 1, "b" 2} {"c" 3, "d" 4} {"a" 1, "b" 2})
   (assert-clear-agent-state-result {"a" 1, "b" 2, "c" 3, "d" 4} {"c" 3, "d" 4} {"a" 1, "b" 2}))
 
-(defmacro assert-aggregate-sandbox-single
+(defmacro assert-aggregate-instance-field-single
   [initial-state task-id sandbox expected-state]
-  `(let [task-id->sandbox-agent# (agent ~initial-state)]
-     (counters/clear! sandbox/sandbox-aggregator-pending-count)
-     (counters/inc! sandbox/sandbox-aggregator-pending-count (count ~initial-state))
+  `(let [task-id->sandbox-agent# (agent ~initial-state)
+         aggregator-pending-count# (counters/counter ["cook-mesos" "scheduler""sandbox-directory" "aggregator-pending-count"])]
+     (counters/clear! aggregator-pending-count#)
+     (counters/inc! aggregator-pending-count# (count ~initial-state))
 
-     (send task-id->sandbox-agent# sandbox/aggregate-sandbox ~task-id ~sandbox)
+     (send task-id->sandbox-agent# sandbox/aggregate-instance-field "sandbox-directory" ~task-id ~sandbox)
      (await task-id->sandbox-agent#)
 
      (is (= @task-id->sandbox-agent# ~expected-state))
-     (is (= (counters/value sandbox/sandbox-aggregator-pending-count) (count ~expected-state)))))
+     (is (= (counters/value aggregator-pending-count#) (count ~expected-state)))))
 
-(deftest test-aggregate-sandbox-single
-  (assert-aggregate-sandbox-single {} "a" 1 {"a" 1})
-  (assert-aggregate-sandbox-single {"a" 1} "a" 2 {"a" 1})
-  (assert-aggregate-sandbox-single {"x" 7, "y" 8, "z" 9} "a" 1 {"a" 1, "x" 7, "y" 8, "z" 9}))
+(deftest test-aggregate-instance-field-single
+  (assert-aggregate-instance-field-single {} "a" 1 {"a" 1})
+  (assert-aggregate-instance-field-single {"a" 1} "a" 2 {"a" 1})
+  (assert-aggregate-instance-field-single {"x" 7, "y" 8, "z" 9} "a" 1 {"a" 1, "x" 7, "y" 8, "z" 9}))
 
-(defmacro assert-aggregate-sandbox-multiple
+(defmacro assert-aggregate-instance-field-multiple
   [initial-state aggregate-data expected-state]
-  `(let [task-id->sandbox-agent# (agent ~initial-state)]
-     (counters/clear! sandbox/sandbox-aggregator-pending-count)
-     (counters/inc! sandbox/sandbox-aggregator-pending-count (count ~initial-state))
+  `(let [task-id->sandbox-agent# (agent ~initial-state)
+         aggregator-pending-count# (counters/counter ["cook-mesos" "scheduler""sandbox-directory" "aggregator-pending-count"])]
+     (counters/clear! aggregator-pending-count#)
+     (counters/inc! aggregator-pending-count# (count ~initial-state))
 
-     (send task-id->sandbox-agent# sandbox/aggregate-sandbox ~aggregate-data)
+     (send task-id->sandbox-agent# sandbox/aggregate-instance-field "sandbox-directory" ~aggregate-data)
      (await task-id->sandbox-agent#)
 
      (is (= @task-id->sandbox-agent# ~expected-state))
-     (is (= (counters/value sandbox/sandbox-aggregator-pending-count) (count ~expected-state)))))
+     (is (= (counters/value aggregator-pending-count#) (count ~expected-state)))))
 
-(deftest test-aggregate-sandbox-multiple
-  (assert-aggregate-sandbox-multiple {} {"a" 1} {"a" 1})
-  (assert-aggregate-sandbox-multiple {} {"a" 1, "b" 2, "c" 2} {"a" 1, "b" 2, "c" 2})
-  (assert-aggregate-sandbox-multiple {"a" 1} {"a" 2} {"a" 1})
-  (assert-aggregate-sandbox-multiple {"x" 7, "y" 8} {"a" 1, "x" 7} {"a" 1, "x" 7, "y" 8})
-  (assert-aggregate-sandbox-multiple {"x" 7, "y" 8} {"a" 1, "b" 2, "x" 7} {"a" 1, "b" 2, "x" 7, "y" 8})
-  (assert-aggregate-sandbox-multiple {"x" 7, "y" 8, "z" 9} {"a" 1} {"a" 1, "x" 7, "y" 8, "z" 9}))
+(deftest test-aggregate-instance-field-multiple
+  (assert-aggregate-instance-field-multiple {} {"a" 1} {"a" 1})
+  (assert-aggregate-instance-field-multiple {} {"a" 1, "b" 2, "c" 2} {"a" 1, "b" 2, "c" 2})
+  (assert-aggregate-instance-field-multiple {"a" 1} {"a" 2} {"a" 1})
+  (assert-aggregate-instance-field-multiple {"x" 7, "y" 8} {"a" 1, "x" 7} {"a" 1, "x" 7, "y" 8})
+  (assert-aggregate-instance-field-multiple {"x" 7, "y" 8} {"a" 1, "b" 2, "x" 7} {"a" 1, "b" 2, "x" 7, "y" 8})
+  (assert-aggregate-instance-field-multiple {"x" 7, "y" 8, "z" 9} {"a" 1} {"a" 1, "x" 7, "y" 8, "z" 9}))
 
 (defn- retrieve-sandbox
   [db-conn task-id]
@@ -131,7 +135,8 @@
         (doseq [[task-id sandbox] task-id->sandbox-in-db]
           (tu/create-dummy-instance db-conn (tu/create-dummy-job db-conn) :task-id task-id :sandbox-directory sandbox))
 
-        (sandbox/publish-sandbox-to-datomic! db-conn batch-size task-id->sandbox-agent)
+        (sandbox/publish-instance-field-to-datomic!
+          :instance/sandbox-directory db-conn batch-size task-id->sandbox-agent)
         (await task-id->sandbox-agent)
 
         (is (= num-tasks (-> task-id->sandbox-in-db (merge task-id->sandbox-not-in-db) count)))
@@ -149,13 +154,14 @@
         task-id->sandbox-publish-history-atom (atom [])
         task-id->sandbox-state {:a 1, :b 2, :c 3}
         task-id->sandbox-agent (agent task-id->sandbox-state)]
-    (with-redefs [sandbox/publish-sandbox-to-datomic!
-                  (fn [datomic-conn batch-size task-id->sandbox-agent]
+    (with-redefs [sandbox/publish-instance-field-to-datomic!
+                  (fn [instance-field datomic-conn batch-size task-id->sandbox-agent]
+                    (is (= :instance/sandbox-directory instance-field))
                     (is (= db-conn datomic-conn))
                     (is (= publish-batch-size batch-size))
                     (swap! task-id->sandbox-publish-history-atom conj @task-id->sandbox-agent)
                     (.countDown latch)
-                    (send task-id->sandbox-agent sandbox/clear-agent-state @task-id->sandbox-agent)
+                    (send task-id->sandbox-agent sandbox/clear-agent-state "sandbox-directory" @task-id->sandbox-agent)
                     (await task-id->sandbox-agent)
                     (Thread/sleep publish-interval-ms))]
 


### PR DESCRIPTION

## Changes proposed in this PR

- generalizes the sandbox aggregator functions (in preparation for exit-code)

## Why are we making these changes?

We would like to batch `exit-code` datomic writes and reuse the sandbox aggregator logic to achieve this.
