### PR TITLE
Make Group.java use temporal ID by default.

### DIFF
--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/Group.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/Group.java
@@ -90,7 +90,7 @@ final public class Group {
 
             // set the default values
             if (_uuid == null)
-                _uuid = UUID.randomUUID();
+                _uuid = JobClient.makeTemporalUUID();
             if (_status == null)
                 _status = Status.INITIALIZED;
             if (_name == null)


### PR DESCRIPTION
Changes proposed in this PR

-    Make Group.java use new temporal ID by default.

Why are we making these changes?

-    Investigation found that random ID's could be a bottleneck in job submission.
-    Using temporal UUID's would let us increase the job submission rate by 10x-30x, to 1000-3000 jobs/second, if used for commitlatch and by client code.
-    This makes the default fast.
