### PR TITLE
Add data local service integration

### DIFF
--- a/integration/bin/run-data-local-server.sh
+++ b/integration/bin/run-data-local-server.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Usage: run-data-local-server.sh
+# Builds a docker image and launches the data local service.
+
+INTEGRATION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+SRC_DIR="${INTEGRATION_DIR}/src"
+NAME=data-local
+
+echo "Building docker images for ${NAME}"
+docker build -t ${NAME} ${SRC_DIR}
+
+docker create \
+       -i \
+       -t \
+       --rm \
+       -p 5000:5000 \
+       --name=$NAME \
+       ${NAME}:latest
+
+docker network connect bridge ${NAME}
+docker network connect cook_nw ${NAME}
+
+docker start -ai ${NAME}

--- a/integration/bin/run-integration.sh
+++ b/integration/bin/run-integration.sh
@@ -74,12 +74,15 @@ then
    COOK_MULTICLUSTER_ENV="${COOK_MULTICLUSTER_ENV} -e COOK_SLAVE_URL=${COOK_SLAVE_URL} -e COOK_MASTER_SLAVE=${COOK_MASTER_SLAVE}"
 fi
 
+DATA_LOCAL_IP=$(docker inspect data-local | jq -r '.[].NetworkSettings.IPAddress')
+
 docker create \
        --rm \
        --name=cook-integration \
        -e "COOK_SCHEDULER_URL=${COOK_URL}" \
        -e "USER=root" \
        -e "COOK_MESOS_LEADER_URL=http://${MESOS_MASTER_IP}:5050" \
+       -e "DATA_LOCAL_SERVICE=http://${DATA_LOCAL_IP}:5000" \
        ${COOK_MULTICLUSTER_ENV} ${DOCKER_VOLUME_ARGS} \
        cook-integration:latest \
        "$@"

--- a/integration/bin/run-integration.sh
+++ b/integration/bin/run-integration.sh
@@ -75,6 +75,11 @@ then
 fi
 
 DATA_LOCAL_IP=$(docker inspect data-local | jq -r '.[].NetworkSettings.IPAddress')
+DATA_LOCAL_ENV=""
+if [ ! "${DATA_LOCAL_IP}" = "null" ];
+then
+    DATA_LOCAL_ENV="-e DATA_LOCAL_SERVICE=http://${DATA_LOCAL_IP}:5000"
+fi
 
 docker create \
        --rm \
@@ -82,8 +87,7 @@ docker create \
        -e "COOK_SCHEDULER_URL=${COOK_URL}" \
        -e "USER=root" \
        -e "COOK_MESOS_LEADER_URL=http://${MESOS_MASTER_IP}:5050" \
-       -e "DATA_LOCAL_SERVICE=http://${DATA_LOCAL_IP}:5000" \
-       ${COOK_MULTICLUSTER_ENV} ${DOCKER_VOLUME_ARGS} \
+       ${DATA_LOCAL_ENV} ${COOK_MULTICLUSTER_ENV} ${DOCKER_VOLUME_ARGS} \
        cook-integration:latest \
        "$@"
 

--- a/integration/src/Dockerfile
+++ b/integration/src/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.6
+
+RUN pip install flask
+
+COPY . /opt/cook/integration
+ENV FLASK_APP /opt/cook/integration/data_locality_service.py
+
+EXPOSE 5000
+
+ENTRYPOINT ["flask", "run", "--host=0.0.0.0"]

--- a/integration/src/data_locality_service.py
+++ b/integration/src/data_locality_service.py
@@ -1,0 +1,27 @@
+from flask import Flask, make_response, request
+import json
+
+app = Flask(__name__)
+
+costs = {}
+
+@app.route('/api/v1/lookup', methods=['POST'])
+def get_costs():
+    request_data = json.loads(request.data)
+    batch = request_data['batch']
+    tasks = request_data['tasks']
+
+    response = {'batch': batch, 'costs': []}
+    for task in tasks:
+        if task in costs:
+            response['costs'].append({'task_id': task, 'node_costs': costs[task]})
+
+    return make_response(json.dumps(response))
+
+@app.route('/api/v1/set', methods=['POST'])
+def set_costs():
+    global costs
+    payload = json.loads(request.data)
+    costs = payload
+
+    return make_response('Updated cost data')

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import math
@@ -2466,6 +2467,7 @@ class CookTest(util.CookTest):
                 self.assertFalse('pools' in resp.json())
 
     @pytest.mark.serial
+    @unittest.skipUnless(util.data_local_service_is_set(), "Requires a data local service")
     def test_data_local_support(self):
         max_cost = util.settings(self.cook_url)['data-local-fitness-calculator']['maximum-cost']
         slaves = util.get_mesos_state(self.mesos_url)['slaves']
@@ -2489,10 +2491,10 @@ class CookTest(util.CookTest):
 
 
     def test_data_local_constraint(self):
-        num_slaves = len(util.get_mesos_state(self.mesos_url)['slaves'])
         uuid, resp = util.submit_job(self.cook_url, data_local=True)
         self.assertEqual(201, resp.status_code, resp.text)
 
+        # Because the job has no data in the data locality service, it shouldn't be scheduled for a period of time.
         def query_unscheduled():
             resp = util.unscheduled_jobs(self.cook_url, uuid)[0][0]
             placement_reasons = [reason for reason in resp['reasons']
@@ -2506,3 +2508,38 @@ class CookTest(util.CookTest):
         data_locality_reasons = [r for r in reason['data']['reasons']
                                  if r['reason'] == 'data-locality-constraint']
         self.assertEqual(1, len(data_locality_reasons))
+
+
+    @pytest.mark.serial
+    @unittest.skipUnless(util.data_local_service_is_set(), "Requires a data local service")
+    def test_data_local_debug_endpoint(self):
+        try:
+            job_uuid, resp = util.submit_job(self.cook_url, constraints=[["HOSTNAME",
+                                                                          "EQUALS",
+                                                                          "lol won't get scheduled"]],
+                                             data_local=True)
+            slaves = util.get_mesos_state(self.mesos_url)['slaves']
+            costs = []
+            for slave in slaves:
+                costs.append({'node': slave['hostname'], 'cost': 0})
+            data_local_service = os.getenv('DATA_LOCAL_SERVICE')
+            util.session.post(f'{data_local_service}/api/v1/set', json={str(job_uuid): costs})
+
+            def get_last_update_time():
+                resp = util.session.get(f'{self.cook_url}/data-local')
+                return resp.json()
+
+            last_update = util.wait_until(get_last_update_time, lambda x: str(job_uuid) in x)
+            datetime.datetime.strptime(last_update[str(job_uuid)], '%Y-%m-%dT%H:%M:%S.%fZ')
+
+            cost_resp = util.session.get(f'{self.cook_url}/data-local/{str(job_uuid)}')
+            self.assertEqual(200, cost_resp.status_code)
+            expected_costs = {}
+            for slave in slaves:
+                expected_costs[slave['hostname']] = 0
+            self.assertEqual(expected_costs, cost_resp.json())
+
+            missing_resp = util.session.get(f'{self.cook_url}/data-local/{str(uuid.uuid4())}')
+            self.assertEqual(404, missing_resp.status_code, missing_resp.text)
+        finally:
+            util.kill_jobs(self.cook_url, [job_uuid])

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1185,3 +1185,7 @@ def is_preemption_enabled():
 def current_milli_time():
     """Returns the current epoch time in milliseconds"""
     return int(round(time.time() * 1000))
+
+
+def data_local_service_is_set():
+    return os.getenv('DATA_LOCAL_SERVICE', None) is not None

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -106,6 +106,11 @@ case "$COOK_POOLS" in
     exit 1
 esac
 
+pip install flask
+export DATA_LOCAL_SERVICE="http://localhost:5000"
+export DATA_LOCAL_ENDPOINT="${DATA_LOCAL_SERVICE}/api/v1/lookup"
+FLASK_APP=${PROJECT_DIR}/src/data_locality_service.py flask run &
+
 # Start three cook schedulers. We want one cluster with two cooks to run MasterSlaveTest, and a second cluster to run MultiClusterTest.
 # The basic tests will run against cook-framework-1
 cd ${SCHEDULER_DIR}

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -18,10 +18,13 @@
                         :impersonators #{"poser" "travis"}}
  :cors-origins ["https?://cors.example.com"]
  :database {:datomic-uri #config/env "COOK_DATOMIC"}
+ :data-local-fitness-calculator {:update-interval-ms 1000
+                                 :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"}
  :zookeeper {:connection #config/env "COOK_ZOOKEEPER"
              :local? #config/env-bool "COOK_ZOOKEEPER_LOCAL"
              :local-port #config/env-int-default ["COOK_ZOOKEEPER_LOCAL_PORT" -1]}
- :scheduler {:offer-incubate-ms 15000
+ :scheduler {:fenzo-fitness-calculator "cook.mesos.data-locality/make-data-local-fitness-calculator"
+             :offer-incubate-ms 15000
              :task-constraints {:timeout-hours 1
                                 :timeout-interval-minutes 1
                                 :memory-gb 48
@@ -50,6 +53,7 @@
        :levels {"datomic.db" :warn
                 "datomic.peer" :warn
                 "datomic.kv-cluster" :warn
+                "cook.mesos.data-locality" :debug
                 "cook.mesos.rebalancer" :debug
                 "cook.mesos.scheduler" :debug
                 :default :info}}

--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -101,6 +101,21 @@ else
     COOK_ZOOKEEPER_LOCAL=true
 fi
 
+DATA_LOCAL_IP=$(docker inspect data-local | jq -r '.[].NetworkSettings.IPAddress')
+if [ "${DATA_LOCAL_IP}" = "null" ];
+then
+    echo "Starting data local server"
+    PROJECT_ROOT="$( dirname ${SCHEDULER_DIR} )"
+    ${PROJECT_ROOT}/integration/bin/run-data-local-server.sh &
+    sleep 5
+    DATA_LOCAL_IP=$(docker inspect data-local | jq -r '.[].NetworkSettings.IPAddress')
+    if [ "${DATA_LOCAL_IP}" = "null" ];
+    then
+        echo "Unable to start data local server"
+        exit 1
+    fi
+fi
+
 echo "Starting cook..."
 
 # NOTE: since the cook scheduler directory is mounted as a volume
@@ -134,6 +149,7 @@ docker create \
     -e "COOK_ONE_USER_AUTH=root" \
     -e "COOK_EXECUTOR_PORTION=${COOK_EXECUTOR_PORTION:-0}" \
     -e "COOK_KEYSTORE_PATH=/opt/ssl/cook.p12" \
+    -e "DATA_LOCAL_ENDPOINT=http://${DATA_LOCAL_IP}:5000/api/v1/lookup" \
     -v ${DIR}/../log:/opt/cook/log \
     cook-scheduler:latest ${COOK_CONFIG:-}
 

--- a/scheduler/bin/run-local.sh
+++ b/scheduler/bin/run-local.sh
@@ -48,6 +48,14 @@ then
     keytool -genkeypair -keystore ${COOK_KEYSTORE_PATH} -storetype PKCS12 -storepass cookstore -dname "CN=cook, OU=Cook Developers, O=Two Sigma Investments, L=New York, ST=New York, C=US" -keyalg RSA -keysize 2048
 fi
 
+if ! [ -x "$(command -v flask)" ]; then
+    echo "Please install flask"
+    exit 1
+fi
+
+INTEGRATION_DIR="$(dirname ${SCHEDULER_DIR})/integration"
+FLASK_APP=${INTEGRATION_DIR}/src/data_locality_service.py flask run &
+
 echo "Mesos Master IP is ${MASTER_IP}"
 
 echo "Creating environment variables..."
@@ -68,6 +76,7 @@ export MESOS_MASTER="${MASTER_IP}:5050"
 export MESOS_NATIVE_JAVA_LIBRARY="${MESOS_NATIVE_JAVA_LIBRARY}"
 export COOK_SSL_PORT="${COOK_SSL_PORT}"
 export COOK_KEYSTORE_PATH="${COOK_KEYSTORE_PATH}"
+export DATA_LOCAL_ENDPOINT="http://localhost:5000/api/v1/lookup"
 
 echo "Starting cook..."
 lein run config.edn

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -13,6 +13,8 @@
                         :impersonators #{"poser" "other-impersonator"}}
  :cors-origins ["https?://cors.example.com"]
  :database {:datomic-uri #config/env "COOK_DATOMIC_URI"}
+ :data-local-fitness-calculator {:update-interval-ms 1000
+                                 :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"}
  :executor {:command #config/env "COOK_EXECUTOR_COMMAND"
             :environment {"EXECUTOR_DEFAULT_PROGRESS_OUTPUT_NAME" "stdout"}
             :portion #config/env-int "COOK_EXECUTOR_PORTION"
@@ -47,7 +49,8 @@
               :min-dru-diff 1.0
               :safe-dru-threshold 1.0}
  :sandbox-syncer {:sync-interval-ms 1000}
- :scheduler {:offer-incubate-ms 15000
+ :scheduler {:fenzo-fitness-calculator "cook.mesos.data-locality/make-data-local-fitness-calculator"
+             :offer-incubate-ms 15000
              :task-constraints {:cpus 10
                                 :memory-gb 48
                                 :retry-limit 15

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -390,7 +390,11 @@
                                          {:base-calculator (config-string->fitness-calculator
                                                             (get data-local-fitness-calculator :base-calculator  "com.netflix.fenzo.plugins.BinPackingFitnessCalculators/cpuMemBinPacker"))
                                           :data-locality-weight (get data-local-fitness-calculator :data-locality-weight 0.95)
-                                          :maximum-cost (get data-local-fitness-calculator :maximum-cost 100)})}))
+                                          :maximum-cost (get data-local-fitness-calculator :maximum-cost 100)
+                                          :cost-endpoint (get data-local-fitness-calculator :cost-endpoint nil)
+                                          :batch-size (get data-local-fitness-calculator :batch-size 500)
+                                          :update-interval-ms (get data-local-fitness-calculator :update-interval-ms nil)
+                                          :launch-wait-seconds (get data-local-fitness-calculator :launch-wait-seconds 60)})}))
 
 (defn read-config
   "Given a config file path, reads the config and returns the map"
@@ -459,6 +463,10 @@
 (defn data-local-fitness-config
   []
   (-> config :settings :data-local-fitness-calculator))
+
+(defn fitness-calculator-config
+  []
+  (-> config :settings :fenzo-fitness-calculator))
 
 (defn fitness-calculator
   "Returns the fitness calculator specified by fitness-calculator, or the default if nil"

--- a/scheduler/src/cook/mesos/data_locality.clj
+++ b/scheduler/src/cook/mesos/data_locality.clj
@@ -1,32 +1,118 @@
 (ns cook.mesos.data-locality
-  (:require [cook.config :as config]
-            [plumbing.core :as pc])
+  (:require [cheshire.core :as cheshire]
+            [clj-http.client :as http]
+            [clj-time.core :as t]
+            [clojure.set :as set]
+            [cook.config :as config]
+            [cook.mesos.util :as util]
+            [plumbing.core :as pc]
+            [clojure.tools.logging :as log]
+            [datomic.api :as d])
   (:import com.netflix.fenzo.VMTaskFitnessCalculator
-           com.netflix.fenzo.plugins.BinPackingFitnessCalculators))
+           com.netflix.fenzo.plugins.BinPackingFitnessCalculators
+           java.util.UUID))
 
-(let [data-local-costs (atom {})]
+(let [data-local-costs (atom {})
+      last-update-time (atom {})]
+
+  (defn reset-data-local-costs! []
+    (reset! data-local-costs {})
+    (reset! last-update-time {}))
+
   (defn update-data-local-costs
     "Updates the current data local costs. Costs larger than the configured max-cost will be capped at max-cost
      and negative costs will be reset to 0."
-    [job->host->cost]
-    (let [{:keys [maximum-cost]} (config/data-local-fitness-config)]
-      (->> job->host->cost
-           (pc/map-vals (fn [host->cost]
-                          (pc/map-vals (fn [cost] (-> cost (min maximum-cost) (max 0)))
-                                       host->cost)))
-           (reset! data-local-costs))))
+    [job->host->cost uuids-to-remove]
+    (let [{:keys [maximum-cost]} (config/data-local-fitness-config)
+          clean-job->host->cost (pc/map-vals (fn [host->cost]
+                                               (pc/map-vals (fn [cost] (-> cost (min maximum-cost) (max 0)))
+                                                            host->cost))
+                                             job->host->cost)]
+      (swap! data-local-costs (fn update-data-local-costs-atom
+                                [current]
+                                (let [remove-old-values (apply dissoc current uuids-to-remove)]
+                                  (merge remove-old-values clean-job->host->cost))))
+      (swap! last-update-time (fn update-last-update-time
+                                [current]
+                                (let [remove-old-values (apply dissoc current uuids-to-remove)
+                                      new-values (pc/map-from-keys (constantly (t/now)) (keys clean-job->host->cost))]
+                                  (merge remove-old-values new-values))))))
 
   (defn get-data-local-costs
     "Returns the current cost for jobs to run on each host"
     []
-    @data-local-costs))
+    @data-local-costs)
+
+  (defn job-ids-to-update
+    "Return the list of job ids to update data locality costs for in the next iteration.
+     The number of jobs is limited by the configured batch size."
+    [db]
+    (let [{:keys [batch-size]} (config/data-local-fitness-config)
+          pending-jobs (->> db
+                            util/get-pending-job-ents
+                            (filter :job/data-local))
+          last-update-time-val @last-update-time
+          have-data?->job (group-by (fn [job] (contains? last-update-time-val (:job/uuid job)))
+                                    pending-jobs)
+          missing-data (->> (get have-data?->job false [])
+                            (sort-by :job/submit-time)
+                            (map :job/uuid))
+          sorted-have-data (->> (get have-data?->job true [])
+                                (map :job/uuid)
+                                (sort-by last-update-time-val))
+          pending-job-uuids (->> pending-jobs
+                                 (map :job/uuid)
+                                 (into (hash-set)))
+          no-longer-waiting (set/difference (into (hash-set) (keys last-update-time-val))
+                                            pending-job-uuids)]
+      {:to-fetch (into [] (take batch-size (concat missing-data sorted-have-data)))
+       :to-remove no-longer-waiting})))
+
+(defn fetch-data-local-costs
+  "Contacts the server to obtain the data local costs for the given job ids"
+  [job-ids]
+  (let [{:keys [cost-endpoint]} (config/data-local-fitness-config)
+        request {:batch (UUID/randomUUID)
+                 :tasks job-ids}
+        _ (log/debug "Updating data local costs for: " job-ids)
+        {:keys [body]} (http/post cost-endpoint {:body (cheshire/generate-string request)
+                                                 :content-type :json
+                                                 :accept :json
+                                                 :as :json-string-keys
+                                                 :spnego-auth true})
+        costs (body "costs")]
+    (->> costs
+         (map (fn [{:strs [task_id node_costs]}]
+                (let [costs (->> node_costs
+                                 (map (fn [{:strs [node cost]}]
+                                        [node cost]))
+                                 (into {}))]
+                  [task_id costs])))
+         (into {}))))
+
+(defn fetch-and-update-data-local-costs
+  [db]
+  (let [{:keys [to-fetch to-remove]} (job-ids-to-update db)]
+    (when (not (empty? to-fetch))
+      (log/debug "Updating data local costs for " to-fetch)
+      (let [new-costs (fetch-data-local-costs to-fetch)]
+        (log/debug "Got updated costs " new-costs)
+        (update-data-local-costs new-costs to-remove)))))
+
+(defn start-update-cycles!
+  [datomic-conn trigger-chan]
+  (log/info "Starting data local service update chan")
+  (util/chime-at-ch trigger-chan
+                    (fn [] (fetch-and-update-data-local-costs (d/db datomic-conn)))
+                    {:error-handler (fn [e]
+                                      (log/error e "Error updating data local costs"))}))
 
 (defn get-normalized-fitness
   "Returns the fitness for the job to run on the given host, normalized by max-cost.
    If the host doesn't have a cost specified, assume max-cost."
   [uuid hostname max-cost]
   (let [data-local-costs (get-data-local-costs)
-        cost (get-in data-local-costs [uuid hostname] max-cost)]
+        cost (get-in data-local-costs [(str uuid) hostname] max-cost)]
     (- 1 (double (/ cost max-cost)))))
 
 (deftype DataLocalFitnessCalculator [^VMTaskFitnessCalculator base-calculator data-locality-weight maximum-cost]
@@ -40,6 +126,8 @@
               data-local-fitness (* data-locality-weight normalized-fitness)]
           (+ data-local-fitness (* (- 1 data-locality-weight) base-fitness)))
         base-fitness))))
+
+(def data-local-fitness-calculator "cook.mesos.data-locality/make-data-local-fitness-calculator")
 
 (defn make-data-local-fitness-calculator
   "Loads settings from configuration to build a data local fitness calculator"

--- a/scheduler/test/cook/test/mesos.clj
+++ b/scheduler/test/cook/test/mesos.clj
@@ -16,6 +16,7 @@
 (ns cook.test.mesos
   (:use clojure.test)
   (:require [clojure.core.async :as async]
+            [cook.config :as config]
             [cook.curator :as curator]
             [cook.datomic]
             [cook.mesos :as mesos]
@@ -276,3 +277,19 @@
         (async/untap mult chan)
         (async/close! chan)
         (d/delete-database test-db-uri)))))
+
+
+(deftest test-make-trigger-chans
+  (with-redefs [config/data-local-fitness-config (constantly {:update-interval-ms nil})]
+    (let [trigger-chans (mesos/make-trigger-chans {:interval-seconds 1}
+                                                  {:publish-interval-ms 1000}
+                                                  {:optimizer-interval-seconds 1}
+                                                  {})]
+      (is (nil? (:update-data-local-costs-trigger-chan trigger-chans)))))
+
+  (with-redefs [config/data-local-fitness-config (constantly {:update-interval-ms 1000})]
+    (let [trigger-chans (mesos/make-trigger-chans {:interval-seconds 1}
+                                                  {:publish-interval-ms 1000}
+                                                  {:optimizer-interval-seconds 1}
+                                                  {})]
+      (is (:update-data-local-costs-trigger-chan trigger-chans)))))

--- a/scheduler/test/cook/test/mesos/constraints.clj
+++ b/scheduler/test/cook/test/mesos/constraints.clj
@@ -16,14 +16,16 @@
 
 (ns cook.test.mesos.constraints
   (:use [clojure.test])
-  (:require [clj-time.core :as t]
+  (:require [clj-time.coerce :as tc]
+            [clj-time.core :as t]
             [cook.config :as config]
             [cook.mesos.constraints :as constraints]
+            [cook.mesos.data-locality :as dl]
             [cook.mesos.scheduler :as sched]
             [cook.mesos.util :as util]
             [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance create-dummy-job-with-instances)]
             [datomic.api :as d :refer (db)])
-  (:import java.util.Date
+  (:import [java.util Date UUID]
            org.joda.time.DateTime
            org.mockito.Mockito))
 
@@ -274,3 +276,52 @@
     (is (first (constraints/job-constraint-evaluate constraint nil {})))
     (is (not (first (constraints/job-constraint-evaluate constraint nil {"host-start-time" 0.0}))))
     (is (first (constraints/job-constraint-evaluate constraint nil {"host-start-time" 51.0})))))
+
+
+(deftest test-data-locality-constraint
+  (testing "disabled when not using data local fitness calculator"
+    (with-redefs [config/fitness-calculator-config (constantly config/default-fitness-calculator)
+                  config/data-local-fitness-config (constantly {:launch-wait-seconds 60})]
+      (is (nil? (constraints/build-data-locality-constraint {:job/uuid (UUID/randomUUID)
+                                                             :job/data-local false})))
+      (is (nil? (constraints/build-data-locality-constraint {:job/uuid (UUID/randomUUID)
+                                                             :job/data-local true})))))
+
+  (testing "disabled for non data-local jobs"
+    (with-redefs [config/fitness-calculator-config (constantly dl/data-local-fitness-calculator)
+                  config/data-local-fitness-config (constantly {:launch-wait-seconds 60})]
+      (is (nil? (constraints/build-data-locality-constraint {:job/uuid (UUID/randomUUID)
+                                                             :job/data-local false})))
+      (is (not (nil? (constraints/build-data-locality-constraint {:job/uuid (UUID/randomUUID)
+                                                                  :job/data-local true}))))))
+
+  (testing "passes jobs older than launch-wait-seconds"
+    (with-redefs [config/fitness-calculator-config (constantly dl/data-local-fitness-calculator)
+                  config/data-local-fitness-config (constantly {:launch-wait-seconds 60})]
+      (dl/reset-data-local-costs!)
+      (let [submit-time (tc/to-date (t/minus (t/now) (t/seconds 61)))
+            constraint (constraints/build-data-locality-constraint {:job/uuid (UUID/randomUUID)
+                                                                    :job/data-local true
+                                                                    :job/submit-time submit-time})
+            [passes reason] (constraints/job-constraint-evaluate constraint
+                                                                 nil
+                                                                 nil)]
+        (is passes))))
+
+  (testing "requires data for newer jobs"
+    (dl/reset-data-local-costs!)
+    (with-redefs [config/fitness-calculator-config (constantly dl/data-local-fitness-calculator)
+                  config/data-local-fitness-config (constantly {:launch-wait-seconds 60
+                                                                :maximum-cost 100})]
+      (let [with-data-uuid (UUID/randomUUID)
+            _ (dl/update-data-local-costs {(str with-data-uuid) {"hostA" 0}} [])
+            with-data-constraint (constraints/build-data-locality-constraint {:job/uuid with-data-uuid
+                                                                              :job/data-local true
+                                                                              :job/submit-time (tc/to-date (t/now))})
+            without-data-constraint (constraints/build-data-locality-constraint {:job/uuid (UUID/randomUUID)
+                                                                                 :job/data-local true
+                                                                                 :job/submit-time (tc/to-date (t/now))})
+            [with-data-result _] (constraints/job-constraint-evaluate with-data-constraint nil nil)
+            [without-data-result _] (constraints/job-constraint-evaluate without-data-constraint nil nil)]
+        (is with-data-result)
+        (is (not without-data-result))))))

--- a/scheduler/test/cook/test/mesos/data_locality.clj
+++ b/scheduler/test/cook/test/mesos/data_locality.clj
@@ -2,20 +2,24 @@
   (:use clojure.test)
   (:require [cook.config :as config]
             [cook.mesos.data-locality :as dl]
-            [datomic.api :as d])
+            [cook.test.testutil :refer (restore-fresh-database! create-dummy-job)]
+            [datomic.api :as d]
+            [plumbing.core :as pc])
   (:import java.util.UUID
            [com.netflix.fenzo TaskRequest
-                              VMTaskFitnessCalculator
-                              VirtualMachineCurrentState]))
+            VMTaskFitnessCalculator
+            VirtualMachineCurrentState]))
 
 (deftest test-get-normalized-cost
   (with-redefs [config/data-local-fitness-config (constantly {:maximum-cost 100})]
     (let [job-1 (UUID/randomUUID)
           job-2 (UUID/randomUUID)
           job-3 (UUID/randomUUID)]
-      (dl/update-data-local-costs {job-1 {"hostA" 10
-                                          "hostB" 20}
-                                   job-2 {"hostA" 30}})
+      (dl/reset-data-local-costs!)
+      (dl/update-data-local-costs {(str job-1) {"hostA" 10
+                                                "hostB" 20}
+                                   (str job-2) {"hostA" 30}}
+                                  [])
       (testing "correctly normalizes costs"
         (is (= 0.75 (dl/get-normalized-fitness job-1 "hostA" 40)))
         (is (= 0.5 (dl/get-normalized-fitness job-1 "hostB" 40)))
@@ -27,17 +31,38 @@
 
 (deftest test-update-data-local-costs
   (with-redefs [config/data-local-fitness-config (constantly {:maximum-cost 100})]
-    (let [job-1 (UUID/randomUUID)
-          job-2 (UUID/randomUUID)]
-      (dl/update-data-local-costs {job-1 {"hostA" 200
-                                          "hostB" 20
-                                          "hostC" -20}
-                                   job-2 {"hostB" 1000}})
-      (is (= {job-1 {"hostA" 100
-                     "hostB" 20
-                     "hostC" 0}
-              job-2 {"hostB" 100}}
-             (dl/get-data-local-costs))))))
+    (testing "sanitizes input costs"
+      (let [job-1 (str (UUID/randomUUID))
+            job-2 (str (UUID/randomUUID))]
+        (dl/reset-data-local-costs!)
+        (dl/update-data-local-costs {job-1 {"hostA" 200
+                                            "hostB" 20
+                                            "hostC" -20}
+                                     job-2 {"hostB" 1000}}
+                                    [])
+        (is (= {job-1 {"hostA" 100
+                       "hostB" 20
+                       "hostC" 0}
+                job-2 {"hostB" 100}}
+               (dl/get-data-local-costs)))))
+
+    (testing "correctly updates existing values"
+      (let [job-1 (UUID/randomUUID)
+            job-2 (UUID/randomUUID)
+            job-3 (UUID/randomUUID)
+            job-4 (UUID/randomUUID)]
+        (dl/reset-data-local-costs!)
+        (dl/update-data-local-costs {job-1 {"hostA" 100}
+                                     job-2 {"hostB" 200}
+                                     job-4 {"hostC" 300}}
+                                    [])
+        (dl/update-data-local-costs {job-3 {"hostB" 300}
+                                     job-4 {"hostA" 200}}
+                                    [job-2])
+        (is (= {job-1 {"hostA" 100}
+                job-3 {"hostB" 300}
+                job-4 {"hostA" 200}})
+            (dl/get-data-local-costs))))))
 
 (deftype FixedFitnessCalculator [fitness]
   VMTaskFitnessCalculator
@@ -66,10 +91,11 @@
                  :job/data-local true}
           job-2 {:job/uuid (UUID/randomUUID)
                  :job/data-local false}]
-      (dl/update-data-local-costs {(:job/uuid job-1) {"hostA" 0
-                                                      "hostB" 20}
-                                   (:job/uuid job-2) {"hostA" 0
-                                                      "hostB" 0}})
+      (dl/update-data-local-costs {(str (:job/uuid job-1)) {"hostA" 0
+                                                            "hostB" 20}
+                                   (str (:job/uuid job-2)) {"hostA" 0
+                                                            "hostB" 0}}
+                                  [])
       (testing "uses base fitness for jobs that do not support data locality"
         (is (= base-fitness (.calculateFitness calculator (FakeTaskRequest. job-2) (fake-vm-for-host "hostA") nil)))
         (is (= base-fitness (.calculateFitness calculator (FakeTaskRequest. job-2) (fake-vm-for-host "hostB") nil))))
@@ -82,3 +108,124 @@
         (is (= base-fitness-portion
                (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostC") nil)))))))
 
+
+(deftest test-job-ids-to-update
+  (with-redefs [config/data-local-fitness-config (constantly {:batch-size 3
+                                                              :maximum-cost 100})]
+    (dl/reset-data-local-costs!)
+    (testing "does not update data for running and completed jobs"
+      (let [conn (restore-fresh-database! "datomic:mem://test-job-ids-to-update")
+            _ (create-dummy-job conn :job-state :job.state/running
+                                :data-local true)
+            _ (create-dummy-job conn :job-state :job.state/completed
+                                :data-local true)
+            _ (create-dummy-job conn :job-state :job.state/running
+                                :data-local true)
+            {:keys [to-fetch]} (dl/job-ids-to-update (d/db conn))]
+        (is (empty? to-fetch))))
+
+    (testing "ignores jobs which don't support data locality"
+      (let [conn (restore-fresh-database! "datomic:mem://test-job-ids-to-update")
+            _ (create-dummy-job conn :job-state :job.state/waiting)
+            {:keys [to-fetch]} (dl/job-ids-to-update (d/db conn))]
+        (is (empty? to-fetch))))
+
+    (testing "prefers jobs with missing data, sorted by submit time"
+      (let [conn (restore-fresh-database! "datomic:mem://test-job-ids-to-update")
+            j1 (create-dummy-job conn :job-state :job.state/waiting
+                                 :submit-time (java.util.Date. 0)
+                                 :data-local true)
+            j2 (create-dummy-job conn :job-state :job.state/waiting
+                                 :submit-time (java.util.Date. 1)
+                                 :data-local true)
+            j3 (create-dummy-job conn :job-state :job.state/waiting
+                                 :submit-time (java.util.Date. 3)
+                                 :data-local true)
+            j4 (create-dummy-job conn :job-state :job.state/waiting
+                                 :submit-time (java.util.Date. 2)
+                                 :data-local true)
+            db (d/db conn)
+            _ (dl/update-data-local-costs {(:job/uuid (d/entity db j1)) {"hostA" 100}} [])
+            {:keys [to-fetch to-remove]} (dl/job-ids-to-update db)]
+        (is (= to-fetch (map (fn [id] (:job/uuid (d/entity db id))) [j2 j4 j3])))
+        (is (= #{} to-remove))))
+
+    (testing "removes jobs which are no longer waiting"
+      (dl/reset-data-local-costs!)
+      (let [conn (restore-fresh-database! "datomic:mem://test-job-ids-to-update")
+            j1 (create-dummy-job conn :job-state :job.state/waiting
+                                 :data-local true)
+            j2 (create-dummy-job conn :job-state :job.state/running
+                                 :data-local true)
+            j3 (create-dummy-job conn :job-state :job.state/completed
+                                 :data-local true)
+            db (d/db conn)
+            [id1 id2 id3] (map #(:job/uuid (d/entity db %)) [j1 j2 j3])
+            _ (dl/update-data-local-costs {id1 {"hostA" 100}
+                                           id2 {"hostA" 100}
+                                           id3 {"hostA" 100}}
+                                          [])
+            {:keys [to-fetch to-remove]} (dl/job-ids-to-update db)]
+        (is (= to-fetch [id1]))
+        (is (= to-remove #{id2 id3}))))))
+
+
+(deftest test-fetch-and-update-data-local-costs
+  (let [first-cost {"hostA" 100}
+        second-cost {"hostA" 50}
+        third-cost {"hostA" 20}
+        current-cost-atom (atom first-cost)]
+    (with-redefs [config/data-local-fitness-config (constantly {:batch-size 2
+                                                                :maximum-cost 100})
+                  dl/fetch-data-local-costs (fn [uuids]
+                                              (pc/map-from-keys (fn [_] @current-cost-atom)
+                                                                uuids))]
+      (testing "calls service and updates jobs"
+        (dl/reset-data-local-costs!)
+        (let [conn (restore-fresh-database! "datomic:mem://test-fetch-and-update-data-local-costs")
+              j1 (create-dummy-job conn :job-state :job.state/waiting
+                                   :data-local true)
+              j2 (create-dummy-job conn :job-state :job.state/waiting
+                                   :data-local true)
+              db (d/db conn)
+              [id1 id2] (map #(:job/uuid (d/entity db %)) [j1 j2])]
+          (dl/update-data-local-costs {id1 first-cost} [])
+          (dl/fetch-and-update-data-local-costs db)
+          (is (= {id1 first-cost
+                  id2 first-cost}
+                 (dl/get-data-local-costs)))))
+
+      (testing "correctly computes update order"
+        (dl/reset-data-local-costs!)
+        (let [conn (restore-fresh-database! "datomic:mem://test-fetch-and-update-data-local-costs")
+              j1 (create-dummy-job conn :job-state :job.state/waiting
+                                   :data-local true
+                                   :submit-time (java.util.Date. 0))
+              j2 (create-dummy-job conn :job-state :job.state/waiting
+                                   :data-local true
+                                   :submit-time (java.util.Date. 1))
+              j3 (create-dummy-job conn :job-state :job.state/waiting
+                                   :data-local true
+                                   :submit-time (java.util.Date. 2))
+              db (d/db conn)
+              [id1 id2 id3] (map #(:job/uuid (d/entity db %)) [j1 j2 j3])]
+          (dl/fetch-and-update-data-local-costs db)
+          (is (= {id1 first-cost
+                  id2 first-cost}
+                 (dl/get-data-local-costs)))
+          (reset! current-cost-atom second-cost)
+          (dl/fetch-and-update-data-local-costs db)
+          (let [cost-data (dl/get-data-local-costs)
+                ; We should have updated id3 and one other uuid, let's grab that one
+                [updated-uuid] (filter #(= @current-cost-atom (cost-data %))
+                                       [id1 id2])
+                [other-uuid] (keys (dissoc cost-data id3 updated-uuid))]
+            (is (= {id3 second-cost
+                    updated-uuid second-cost
+                    other-uuid first-cost}
+                   cost-data))
+
+            (reset! current-cost-atom third-cost)
+            (dl/fetch-and-update-data-local-costs db)
+            ; Now, we should update the job we skipped last time
+            (is (= third-cost (get (dl/get-data-local-costs) other-uuid)))))))))

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1746,12 +1746,13 @@
                                                                                             :ncpus 13
                                                                                             :memory 1024
                                                                                             :data-local true))
-                                              _ (dl/update-data-local-costs {(get-uuid "job-1") {(:hostname offer-1) 0.0
-                                                                                                 (:hostname offer-2) 0.0
-                                                                                                 (:hostname offer-3) 100.0}
-                                                                             (get-uuid "job-2") {(:hostname offer-1) 0.0
-                                                                                                 (:hostname offer-2) 0.0
-                                                                                                 (:hostname offer-3) 0.0}})
+                                              _ (dl/update-data-local-costs {(str (get-uuid "job-1")) {(:hostname offer-1) 0.0
+                                                                                                       (:hostname offer-2) 0.0
+                                                                                                       (:hostname offer-3) 100.0}
+                                                                             (str (get-uuid "job-2")) {(:hostname offer-1) 0.0
+                                                                                                       (:hostname offer-2) 0.0
+                                                                                                       (:hostname offer-3) 0.0}}
+                                                                            [])
                                               entity->map (fn [entity]
                                                             (util/job-ent->map entity (d/db conn)))
                                               category->pending-jobs (->> {:normal [job-1 job-2]}


### PR DESCRIPTION
## Changes proposed in this PR
- Adds support for fetching data local costs from a remote server

## Why are we making these changes?
Support a server which provides a notion of the cost to run a job on a given host incorporating data locality. This can then optionally be used by the data local fitness calculator to prefer matching jobs on VMs that support data locality.

