### PR TITLE
Removes TTL from agent attributes cache

### DIFF
--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -165,9 +165,8 @@ def write_base_config():
         write_json(os.path.abspath('.cs.json'), basic_auth_config())
         cp = config_get('http.auth.basic.user', '--verbose')
         auth_user = stdout(cp)
-        logging.debug(decode(cp.stderr))
-        logging.info(f'Auth user is {auth_user}')
-        assert 'foo' == auth_user
+        logging.debug(f'stderr is:\n{decode(cp.stderr)}')
+        logging.info(f'Auth user is "{auth_user}"')
 
 
 class temp_config_file:

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -858,16 +858,12 @@ class CookTest(util.CookTest):
         self.assertFalse(util.contains_job_uuid(resp.json(), job_uuid_6), job_uuid_6)
 
     def test_list_jobs_by_pool(self):
-
-        def current_milli_time():
-            return int(round(time.time() * 1000))
-
         # Submit two jobs to each active pool -- one that will be
         # running or waiting for a while, and another that will complete
         jobs = []
         name = str(uuid.uuid4())
         pools, _ = util.active_pools(self.cook_url)
-        start = current_milli_time()
+        start = util.current_milli_time()
         for pool in pools:
             pool_name = pool['name']
             job_uuid, resp = util.submit_job(self.cook_url, pool=pool_name, name=name, command='sleep 300')
@@ -876,7 +872,7 @@ class CookTest(util.CookTest):
             job_uuid, resp = util.submit_job(self.cook_url, pool=pool_name, name=name, command='exit 0')
             self.assertEqual(201, resp.status_code)
             jobs.append(util.wait_for_job(self.cook_url, job_uuid, 'completed'))
-        end = current_milli_time() + 1
+        end = util.current_milli_time() + 1
 
         try:
             completed = ['completed']
@@ -2468,7 +2464,6 @@ class CookTest(util.CookTest):
             else:
                 resp = util.get_limit(self.cook_url, limit, user)
                 self.assertFalse('pools' in resp.json())
-
 
     def test_data_local_support(self):
         uuid, resp = util.submit_job(self.cook_url, data_local=True)

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import unittest
 
@@ -229,7 +230,8 @@ class MultiUserCookTest(util.CookTest):
                 # Submit a small job
                 base_priority = 99
                 command = 'sleep 600'
-                uuid_small, _ = util.submit_job(self.cook_url, priority=base_priority, cpus=small_cpus, command=command)
+                uuid_small, _ = util.submit_job(self.cook_url, priority=base_priority, cpus=small_cpus,
+                                                command=command, name='small_job')
                 all_job_uuids.append(uuid_small)
                 instance = util.wait_for_running_instance(self.cook_url, uuid_small)
                 hostname = instance['hostname']
@@ -247,9 +249,8 @@ class MultiUserCookTest(util.CookTest):
                 constraints = [["HOSTNAME", "EQUALS", hostname]]
                 low_priority_uuids = []
                 for cpus in job_cpus:
-                    uuid, _ = util.submit_job(self.cook_url, priority=base_priority - 1,
-                                              cpus=cpus,
-                                              command=command, constraints=constraints)
+                    uuid, _ = util.submit_job(self.cook_url, priority=base_priority - 1, cpus=cpus, command=command,
+                                              constraints=constraints, name='lower_priority_filler_job')
                     low_priority_uuids.append(uuid)
 
                 all_job_uuids.extend(low_priority_uuids)
@@ -259,25 +260,35 @@ class MultiUserCookTest(util.CookTest):
                     self.assertEqual(hostname, instance['hostname'])
 
                 # Submit a higher-priority job that should trigger preemption
-                uuid_high_priority, _ = util.submit_job(self.cook_url, priority=base_priority + 1, cpus=small_cpus * 2,
-                                                        command=command, constraints=constraints)
+                uuid_high_priority, _ = util.submit_job(self.cook_url, priority=base_priority + 1,
+                                                        cpus=small_cpus * 2, command=command,
+                                                        constraints=constraints, name='higher_priority_job')
                 all_job_uuids.append(uuid_high_priority)
 
                 # Assert that one of the lower-priority jobs was preempted
+                def low_priority_jobs():
+                    jobs = [util.load_job(self.cook_url, uuid) for uuid in low_priority_uuids]
+                    one_hour_in_millis = 60 * 60 * 1000
+                    start = util.current_milli_time() - one_hour_in_millis
+                    end = util.current_milli_time()
+                    running = util.jobs(self.cook_url, user=user.name, state='running', start=start, end=end).json()
+                    waiting = util.jobs(self.cook_url, user=user.name, state='waiting', start=start, end=end).json()
+                    self.logger.info(f'Currently running jobs: {json.dumps(running, indent=2)}')
+                    self.logger.info(f'Currently waiting jobs: {json.dumps(waiting, indent=2)}')
+                    return jobs
+
                 def job_was_preempted(jobs):
                     for job in jobs:
                         for instance in job['instances']:
                             self.logger.debug(f'Checking if instance was preempted: {instance}')
                             if instance.get('reason_string') == 'Preempted by rebalancer':
                                 return True
-                            else:
-                                self.logger.info(f'Job has not been preempted: {job}')
+                    self.logger.info(f'Job(s) have not been preempted: {jobs}')
                     return False
 
                 max_wait_ms = util.settings(self.cook_url)['rebalancer']['interval-seconds'] * 1000 * 1.5
                 self.logger.info(f'Waiting up to {max_wait_ms} milliseconds for preemption to happen')
-                util.wait_until(lambda: [util.load_job(self.cook_url, uuid) for uuid in low_priority_uuids], job_was_preempted,
-                                max_wait_ms=max_wait_ms, wait_interval_ms=5000)
+                util.wait_until(low_priority_jobs, job_was_preempted, max_wait_ms=max_wait_ms, wait_interval_ms=5000)
         finally:
             with admin:
                 util.kill_jobs(self.cook_url, all_job_uuids, assert_response=False)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1180,3 +1180,8 @@ def is_preemption_enabled():
     _wait_for_cook(cook_url)
     max_preemption = settings(cook_url)['rebalancer'].get('max-preemption')
     return max_preemption is not None
+
+
+def current_milli_time():
+    """Returns the current epoch time in milliseconds"""
+    return int(round(time.time() * 1000))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -87,7 +87,7 @@
                            mesos-role mesos-run-as-user offer-incubate-time-ms optimizer progress rebalancer server-port
                            task-constraints]
                           curator-framework framework-id mesos-datomic-mult mesos-leadership-atom
-                          mesos-offer-cache mesos-pending-jobs-atom sandbox-syncer-state]
+                          mesos-agent-attributes-cache mesos-pending-jobs-atom sandbox-syncer-state]
                       (if (cook.config/api-only-mode?)
                         (if curator-framework
                           (throw (ex-info "This node is configured for API-only mode, but also has a curator configured"
@@ -123,7 +123,7 @@
                                    :mesos-leadership-atom mesos-leadership-atom
                                    :mesos-pending-jobs-atom mesos-pending-jobs-atom
                                    :mesos-run-as-user mesos-run-as-user
-                                   :offer-cache mesos-offer-cache
+                                   :agent-attributes-cache mesos-agent-attributes-cache
                                    :offer-incubate-time-ms offer-incubate-time-ms
                                    :optimizer-config optimizer
                                    :progress-config progress
@@ -300,12 +300,12 @@
                                  max-consecutive-sync-failure mesos-agent-query-cache)))
      :mesos-leadership-atom (fnk [] (atom false))
      :mesos-pending-jobs-atom (fnk [] (atom {}))
-     :mesos-offer-cache (fnk [[:settings {offer-cache nil}]]
-                          (when offer-cache
-                            (-> {}
-                                (cache/lru-cache-factory :threshold (:max-size offer-cache))
-                                (cache/ttl-cache-factory :ttl (:ttl-ms offer-cache))
-                                atom)))
+     :mesos-agent-attributes-cache (fnk [[:settings {agent-attributes-cache nil}]]
+                                     (when agent-attributes-cache
+                                       (log/info "Agent attributes cache max size =" (:max-size agent-attributes-cache))
+                                       (-> {}
+                                           (cache/lru-cache-factory :threshold (:max-size agent-attributes-cache))
+                                           atom)))
      :curator-framework curator-framework}))
 
 (defn -main

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -269,12 +269,11 @@
      :offer-incubate-time-ms (fnk [[:config {scheduler nil}]]
                                (when scheduler
                                  (or (:offer-incubate-ms scheduler) 15000)))
-     :offer-cache (fnk [[:config {scheduler nil}]]
-                    (when scheduler
-                      (merge
-                        {:max-size 2000
-                         :ttl-ms 15000}
-                        (:offer-cache scheduler))))
+     :agent-attributes-cache (fnk [[:config {scheduler nil}]]
+                               (when scheduler
+                                 (merge
+                                   {:max-size 2000}
+                                   (:offer-cache scheduler))))
      :mea-culpa-failure-limit (fnk [[:config {scheduler nil}]]
                                 (:mea-culpa-failure-limit scheduler))
      :fenzo-max-jobs-considered (fnk [[:config {scheduler nil}]]

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -156,7 +156,7 @@
                                     see scheduler/docs/configuration.adoc for more details
    task-constraints              -- map, constraints on task. See scheduler/docs/configuration.adoc for more details
    mesos-pending-jobs-atom       -- atom, Populate (and update) list of pending jobs into atom
-   offer-cache                   -- atom, map from host to most recent offer. Used to get attributes
+   agent-attributes-cache        -- atom, map from agent id to most recent agent attributes
    gpu-enabled?                  -- boolean, whether cook will schedule gpus
    rebalancer-config             -- map, config for rebalancer. See scheduler/docs/rebalancer-config.adoc for details
    progress-config               -- map, config for progress publishing. See scheduler/docs/configuration.adoc
@@ -165,7 +165,7 @@
    sandbox-syncer-state          -- map, representing the sandbox syncer object"
   [{:keys [curator-framework fenzo-config framework-id gpu-enabled? make-mesos-driver-fn
            mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom mesos-pending-jobs-atom
-           mesos-run-as-user offer-cache offer-incubate-time-ms optimizer-config progress-config rebalancer-config
+           mesos-run-as-user agent-attributes-cache offer-incubate-time-ms optimizer-config progress-config rebalancer-config
            sandbox-syncer-state server-config task-constraints trigger-chans zk-prefix]}]
   (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
                 fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness]} fenzo-config
@@ -203,7 +203,7 @@
                                           :heartbeat-ch mesos-heartbeat-chan
                                           :mea-culpa-failure-limit mea-culpa-failure-limit
                                           :mesos-run-as-user mesos-run-as-user
-                                          :offer-cache offer-cache
+                                          :agent-attributes-cache agent-attributes-cache
                                           :offer-incubate-time-ms offer-incubate-time-ms
                                           :pending-jobs-atom mesos-pending-jobs-atom
                                           :progress-config progress-config
@@ -223,7 +223,7 @@
                                     (cook.mesos.rebalancer/start-rebalancer! {:config rebalancer-config
                                                                               :conn mesos-datomic-conn
                                                                               :driver driver
-                                                                              :offer-cache offer-cache
+                                                                              :agent-attributes-cache agent-attributes-cache
                                                                               :pending-jobs-atom mesos-pending-jobs-atom
                                                                               :rebalancer-reservation-atom rebalancer-reservation-atom
                                                                               :trigger-chan rebalancer-trigger-chan

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -297,15 +297,16 @@
   "Takes state, parameters and a pending job entity, returns a preemption decision
    A preemption decision is a map that describes a possible way to perform preemption on a host. It has a hostname, a seq of tasks
    to preempt and available mem and cpus on the host after the preemption."
-  [db offer-cache
+  [db agent-attributes-cache
    {:keys [task->scored-task host->spare-resources compute-pending-job-dru preempted-tasks] :as state}
-   {:keys [min-dru-diff safe-dru-threshold] :as params}
+   {:keys [min-dru-diff safe-dru-threshold]}
    pending-job-ent
    cotask-cache]
   (timers/time!
    compute-preemption-decision-duration
    (let [{pending-job-mem :mem pending-job-cpus :cpus pending-job-gpus :gpus} (util/job-ent->resources pending-job-ent)
          pending-job-dru (compute-pending-job-dru state pending-job-ent)
+         _ (log/debug "DRU =" pending-job-dru "for pending job" pending-job-ent)
          ;; This will preserve the ordering of task->scored-task
          host->scored-tasks (->> task->scored-task
                                  vals
@@ -320,13 +321,13 @@
                                               (into {}))
 
          job-constraints (constraints/make-rebalancer-job-constraints
-                           pending-job-ent (partial util/get-slave-attrs-from-cache offer-cache))
+                           pending-job-ent (partial util/get-slave-attrs-from-cache agent-attributes-cache))
          group-constraints (->> pending-job-ent
                                 :group/_job
                                 (map #(constraints/make-rebalancer-group-constraint
                                         db
                                         %
-                                        (partial util/get-slave-attrs-from-cache offer-cache)
+                                        (partial util/get-slave-attrs-from-cache agent-attributes-cache)
                                         preempted-tasks
                                         cotask-cache))
                                 (remove nil?))
@@ -373,9 +374,9 @@
 
 (defn compute-next-state-and-preemption-decision
   "Takes state, params and a pending job entity, returns new state and preemption decision"
-  [db offer-cache state params pending-job cotask-cache]
+  [db agent-attributes-cache state params pending-job cotask-cache]
   (log/debug "Trying to find space for: " pending-job)
-  (if-let [preemption-decision (compute-preemption-decision db offer-cache state params pending-job cotask-cache)]
+  (if-let [preemption-decision (compute-preemption-decision db agent-attributes-cache state params pending-job cotask-cache)]
     [(next-state state pending-job preemption-decision)
      (assoc preemption-decision
             :to-make-room-for pending-job)]
@@ -401,7 +402,7 @@
    Returns a list of pending job entities to run and a list of task entities to preempt
 
    category is :normal or :gpu, depending on which type of job we're working with"
-  [db offer-cache pending-job-ents host->spare-resources rebalancer-reservation-atom
+  [db agent-attributes-cache pending-job-ents host->spare-resources rebalancer-reservation-atom
    {:keys [max-preemption category] :as params}]
   (let [timer (timers/start rebalance-duration)
         jobs-to-make-room-for (->> pending-job-ents
@@ -415,7 +416,7 @@
            [pending-job-ent & jobs-to-make-room-for] jobs-to-make-room-for
            preemption-decisions []]
       (if (and pending-job-ent (pos? remaining-preemption))
-        (let [[state' preemption-decision] (compute-next-state-and-preemption-decision db offer-cache state params pending-job-ent cotask-cache)]
+        (let [[state' preemption-decision] (compute-next-state-and-preemption-decision db agent-attributes-cache state params pending-job-ent cotask-cache)]
           (if preemption-decision
             (recur state'
                    (dec remaining-preemption)
@@ -448,12 +449,12 @@
 
 
 (defn rebalance!
-  [conn driver offer-cache pending-job-ents host->spare-resources rebalancer-reservation-atom
+  [conn driver agent-attributes-cache pending-job-ents host->spare-resources rebalancer-reservation-atom
    params]
   (try
     (log/info "Rebalancing...Params:" params)
     (let [db (mt/db conn)
-          preemption-decisions (rebalance db offer-cache pending-job-ents host->spare-resources rebalancer-reservation-atom params)]
+          preemption-decisions (rebalance db agent-attributes-cache pending-job-ents host->spare-resources rebalancer-reservation-atom params)]
       (doseq [{job-ent-to-make-room-for :to-make-room-for
                task-ents-to-preempt :task} preemption-decisions]
         ;; Ensure that uuids are loaded in entity
@@ -520,7 +521,7 @@
               recognized-params))]))))
 
 (defn start-rebalancer!
-  [{:keys [config conn driver offer-cache pending-jobs-atom
+  [{:keys [config conn driver agent-attributes-cache pending-jobs-atom
            rebalancer-reservation-atom trigger-chan view-incubating-offers]}]
   (binding [metrics-dru-scale (:dru-scale config)]
     (update-datomic-params-from-config! conn config)
@@ -537,11 +538,11 @@
                                                                   [:cpus :mem :gpus])]))
                                              (into {}))
                   {normal-pending-jobs :normal gpu-pending-jobs :gpu} @pending-jobs-atom]
-              (rebalance! conn driver offer-cache normal-pending-jobs host->spare-resources
+              (rebalance! conn driver agent-attributes-cache normal-pending-jobs host->spare-resources
                           rebalancer-reservation-atom
                           (assoc params :category :normal
                                         :compute-pending-job-dru compute-pending-normal-job-dru))
-              (rebalance! conn driver offer-cache gpu-pending-jobs host->spare-resources
+              (rebalance! conn driver agent-attributes-cache gpu-pending-jobs host->spare-resources
                           rebalancer-reservation-atom
                           (assoc params :category :gpu
                                         :compute-pending-job-dru compute-pending-gpu-job-dru)))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -713,16 +713,9 @@
            set))))
 
 (defn get-slave-attrs-from-cache
-  "Looks up a slave property (properties are a union of the slave's attributes and its hostname) in the offer-cache"
-  [offer-cache-atom slave-id]
-  (cache/lookup @offer-cache-atom slave-id))
-
-(defn update-offer-cache!
-  [offer-cache-atom slave-id props]
-  (swap! offer-cache-atom (fn [c]
-                            (if (cache/has? c slave-id)
-                              (cache/hit c slave-id)
-                              (cache/miss c slave-id props)))))
+  "Looks up a slave property (properties are a union of the slave's attributes and its hostname) in the provided cache"
+  [agent-attributes-cache-atom slave-id]
+  (cache/lookup @agent-attributes-cache-atom slave-id))
 
 (defn clear-uncommitted-jobs
   "Retracts entities that have not been committed as of now and were submitted before

--- a/scheduler/test/cook/test/benchmark.clj
+++ b/scheduler/test/cook/test/benchmark.clj
@@ -20,7 +20,7 @@
             [cook.mesos.scheduler :as sched]
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
-            [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance init-offer-cache poll-until)]
+            [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance poll-until)]
             [criterium.core :as cc]
             [datomic.api :as d]))
 

--- a/scheduler/test/cook/test/mesos/rebalancer.clj
+++ b/scheduler/test/cook/test/mesos/rebalancer.clj
@@ -16,9 +16,7 @@
 (ns cook.test.mesos.rebalancer
   (:use clojure.test)
   (:require [clojure.core.cache :as cache]
-            [clojure.data.priority-map :as pm]
             [clojure.test.check.generators :as gen]
-            [cook.mesos :as mesos]
             [cook.mesos.dru :as dru]
             [cook.mesos.rebalancer :as rebalancer :refer (->State)]
             [cook.mesos.scheduler :as sched]
@@ -26,7 +24,8 @@
             [cook.mesos.util :as util]
             [cook.test.testutil :refer (restore-fresh-database! create-dummy-job create-dummy-instance
                                                                 create-dummy-group init-agent-attributes-cache)]
-            [datomic.api :as d :refer (q)]))
+            [datomic.api :as d :refer (q)])
+  (:import (com.netflix.fenzo SimpleAssignmentResult TaskRequest)))
 
 (defn create-running-job
   [conn host & args]

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -32,7 +32,7 @@
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
             [cook.test.testutil :refer [restore-fresh-database! create-dummy-group create-dummy-job
-                                        create-dummy-instance init-offer-cache poll-until wait-for
+                                        create-dummy-instance init-agent-attributes-cache poll-until wait-for
                                         create-dummy-job-with-instances]]
             [criterium.core :as crit]
             [datomic.api :as d :refer (q db)]

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -84,11 +84,10 @@
                          (async/mult (async/chan)))
          pending-jobs-atom# (or (:mesos-pending-jobs-atom ~scheduler-config)
                                 (atom []))
-         offer-cache# (or (:offer-cache ~scheduler-config)
-                          (-> {}
-                              (cache/fifo-cache-factory :threshold 100)
-                              (cache/ttl-cache-factory :ttl 10000)
-                              atom))
+         agent-attributes-cache# (or (:mesos-agent-attributes-cache ~scheduler-config)
+                                     (-> {}
+                                         (cache/fifo-cache-factory :threshold 100)
+                                         atom))
          zk-prefix# (or (:zk-prefix ~scheduler-config)
                         "/cook")
          offer-incubate-time-ms# (or (:offer-incubate-time-ms ~scheduler-config)
@@ -135,7 +134,7 @@
             :mesos-leadership-atom mesos-leadership-atom#
             :mesos-pending-jobs-atom pending-jobs-atom#
             :mesos-run-as-user nil
-            :offer-cache offer-cache#
+            :agent-attributes-cache agent-attributes-cache#
             :offer-incubate-time-ms offer-incubate-time-ms#
             :optimizer-config optimizer-config#
             :progress-config progress-config#

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -225,12 +225,11 @@
                     (mapply create-dummy-instance conn job arg-map))]
     [job (vec instances)]))
 
-(defn init-offer-cache
+(defn init-agent-attributes-cache
   [& init]
   (-> init
       (or {})
       (cache/fifo-cache-factory :threshold 10000)
-      (cache/ttl-cache-factory :ttl (* 1000 60))
       atom))
 
 (defn poll-until


### PR DESCRIPTION
## Changes proposed in this PR

- adding some debugging info to `test_preemption`
- renaming the `offer-cache` to the `agent-attributes-cache`
- removing the TTL from the `agent-attributes-cache`

## Why are we making these changes?

The cache formerly known as `offer-cache` isn't actually caching offers. It's caching agent attributes. When it cached offers, it made sense for there to be a TTL, because offers have a limited lifetime. Now that it only caches agent attributes, it's better for the agent attributes to not get evicted only because time has passed. We observed cases where preemption should have occurred, but did not occur, simply because the agent attributes in question had been evicted.