### PR TITLE
Adds exit-code-syncer to handle a high rate of incoming exit-code messages in a graceful manner

### DIFF
--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -86,6 +86,15 @@ If need it to bind to another port, you can specify that with the `:local-port` 
   `max-size` is the maximum number of elements in the cache before the LRU eviction semantics apply. The default is 1000.
   `ttl-ms` is the default time in milliseconds that entries are allowed to reside in the cache. The default is 60000, i.e. 1 minute.
 
+`:exit-code-syncer`::
+  The Cook scheduler throttles the rate at which it publishes task exit-codes.
+  This allows us to handle high rate of incoming exit-code messages in a graceful manner.
+  `exit-code-syncer` is a map with the following possible keys: `publish-batch-size` and `publish-interval-ms`.
+  The `publish-batch-size` is an integer representing the number of facts that are updated in individual datomic instance exit-code directory update transactions.
+  The default value is 100.
+  The `publish-interval-ms` is an integer representing the number of millisecond intervals at which exit-code directories updates will be published to datomic.
+  The default value is 2500.
+
 `:sandbox-syncer`::
   The Cook scheduler throttles the rate at which it publishes task sandbox directories.
   This allows us to handle high rate of incoming progress messages in a graceful manner.

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -86,7 +86,7 @@
                            mesos-gpu-enabled mesos-leader-path mesos-master mesos-principal
                            mesos-role mesos-run-as-user offer-incubate-time-ms optimizer progress rebalancer server-port
                            task-constraints]
-                          curator-framework framework-id mesos-datomic-mult mesos-leadership-atom
+                          curator-framework exit-code-syncer-state framework-id mesos-datomic-mult mesos-leadership-atom
                           mesos-agent-attributes-cache pool->pending-jobs-atom sandbox-syncer-state]
                       (if (cook.config/api-only-mode?)
                         (if curator-framework
@@ -108,6 +108,7 @@
                                 (Class/forName "org.apache.mesos.Scheduler")
                                 ((util/lazy-load-var 'cook.mesos/start-mesos-scheduler)
                                   {:curator-framework curator-framework
+                                   :exit-code-syncer-state exit-code-syncer-state
                                    :fenzo-config {:fenzo-max-jobs-considered fenzo-max-jobs-considered
                                                   :fenzo-scaleback fenzo-scaleback
                                                   :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn
@@ -291,6 +292,9 @@
                                     (cache/lru-cache-factory :threshold max-size)
                                     (cache/ttl-cache-factory :ttl ttl-ms)
                                     atom))
+     :exit-code-syncer-state (fnk [[:settings [:exit-code-syncer publish-batch-size publish-interval-ms]]]
+                               ((util/lazy-load-var 'cook.mesos.sandbox/prepare-exit-code-publisher)
+                                 datomic/conn publish-batch-size publish-interval-ms))
      :sandbox-syncer-state (fnk [[:settings [:sandbox-syncer max-consecutive-sync-failure
                                              publish-batch-size publish-interval-ms sync-interval-ms]]
                                  framework-id mesos-agent-query-cache]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -140,6 +140,11 @@
                             agent-query-cache))
      :cors-origins (fnk [[:config {cors-origins nil}]]
                      (map re-pattern (or cors-origins [])))
+     :exit-code-syncer (fnk [[:config {exit-code-syncer nil}]]
+                       (merge
+                         {:publish-batch-size 100
+                          :publish-interval-ms 2500}
+                         exit-code-syncer))
      :sandbox-syncer (fnk [[:config {sandbox-syncer nil}]]
                        (merge
                          {:max-consecutive-sync-failure 15

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -163,7 +163,7 @@
    framework-id                  -- str, the Mesos framework id from the cook settings
    fenzo-config                  -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details
    sandbox-syncer-state          -- map, representing the sandbox syncer object"
-  [{:keys [curator-framework fenzo-config framework-id gpu-enabled? make-mesos-driver-fn
+  [{:keys [curator-framework exit-code-syncer-state fenzo-config framework-id gpu-enabled? make-mesos-driver-fn
            mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom pool->pending-jobs-atom
            mesos-run-as-user agent-attributes-cache offer-incubate-time-ms optimizer-config progress-config rebalancer-config
            sandbox-syncer-state server-config task-constraints trigger-chans zk-prefix]}]
@@ -192,6 +192,7 @@
                                         (sched/create-datomic-scheduler
                                          {:conn mesos-datomic-conn
                                           :driver-atom current-driver
+                                          :exit-code-syncer-state exit-code-syncer-state
                                           :fenzo-fitness-calculator fenzo-fitness-calculator
                                           :fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-reset
                                           :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1055,16 +1055,20 @@
         (let [task-id (str (UUID/randomUUID))]
           (let [progress-aggregator-promise (promise)
                 handle-progress-message (handle-progress-message-factory progress-aggregator-promise)
+                handle-exit-code (constantly true)
+                handlers {:handle-exit-code handle-exit-code :handle-progress-message handle-progress-message}
                 message (make-message {:dummy-data task-id})]
-            (is (nil? (sched/handle-framework-message conn handle-progress-message message)))
+            (is (nil? (sched/handle-framework-message conn handlers message)))
             (is (nil? (deref progress-aggregator-promise 1000 nil))))))
 
       (testing "no transactions"
         (let [task-id (str (UUID/randomUUID))]
           (let [progress-aggregator-promise (promise)
                 handle-progress-message (handle-progress-message-factory progress-aggregator-promise)
+                handle-exit-code (constantly true)
+                handlers {:handle-exit-code handle-exit-code :handle-progress-message handle-progress-message}
                 message (make-message {:task-id task-id})]
-            (is (nil? (sched/handle-framework-message conn handle-progress-message message)))
+            (is (nil? (sched/handle-framework-message conn handlers message)))
             (is (nil? (deref progress-aggregator-promise 1000 nil))))))
 
       (testing "progress-message update"
@@ -1073,10 +1077,12 @@
               instance-id (create-dummy-instance conn job-id :instance-status :instance.status/running :task-id task-id)]
           (let [progress-aggregator-promise (promise)
                 handle-progress-message (handle-progress-message-factory progress-aggregator-promise)
+                handle-exit-code (constantly true)
+                handlers {:handle-exit-code handle-exit-code :handle-progress-message handle-progress-message}
                 progress-message "Almost complete..."
                 message (make-message {:task-id task-id :progress-message progress-message})]
             ;; no asynchronous transaction should be created
-            (is (nil? (sched/handle-framework-message conn handle-progress-message message)))
+            (is (nil? (sched/handle-framework-message conn handlers message)))
             (is (nil? (query-instance-field instance-id :instance/progress-message)))
             (is (= {:instance-id instance-id :progress-message progress-message :progress-percent nil :progress-sequence nil}
                    (deref progress-aggregator-promise 1000 nil))))))
@@ -1088,11 +1094,13 @@
 
           (let [progress-aggregator-promise (promise)
                 handle-progress-message (handle-progress-message-factory progress-aggregator-promise)
+                handle-exit-code (constantly true)
+                handlers {:handle-exit-code handle-exit-code :handle-progress-message handle-progress-message}
                 progress-percent 20
                 progress-sequence 11
                 message (make-message {:task-id task-id :progress-percent progress-percent :progress-sequence progress-sequence})]
             ;; no asynchronous transaction should be created
-            (is (nil? (sched/handle-framework-message conn handle-progress-message message)))
+            (is (nil? (sched/handle-framework-message conn handlers message)))
             (is (= 0 (query-instance-field instance-id :instance/progress)))
             (is (nil? (query-instance-field instance-id :instance/progress-message)))
             (is (= {:instance-id instance-id
@@ -1103,11 +1111,13 @@
 
           (let [progress-aggregator-promise (promise)
                 handle-progress-message (handle-progress-message-factory progress-aggregator-promise)
+                handle-exit-code (constantly true)
+                handlers {:handle-exit-code handle-exit-code :handle-progress-message handle-progress-message}
                 progress-percent 50
                 progress-sequence 19
                 message (make-message {:task-id task-id :progress-percent progress-percent :progress-sequence progress-sequence})]
             ;; no asynchronous transaction should be created
-            (is (nil? (sched/handle-framework-message conn handle-progress-message message)))
+            (is (nil? (sched/handle-framework-message conn handlers message)))
             (is (= 0 (query-instance-field instance-id :instance/progress)))
             (is (nil? (query-instance-field instance-id :instance/progress-message)))
             (is (= {:instance-id instance-id
@@ -1122,9 +1132,12 @@
               instance-id (create-dummy-instance conn job-id :instance-status :instance.status/running :task-id task-id)]
           (let [progress-aggregator-promise (promise)
                 handle-progress-message (handle-progress-message-factory progress-aggregator-promise)
+                handle-exit-code (fn [task-id exit-code]
+                                   @(d/transact conn [[:db/add [:instance/task-id task-id] :instance/exit-code exit-code]]))
+                handlers {:handle-exit-code handle-exit-code :handle-progress-message handle-progress-message}
                 exit-code 0
                 message (make-message {:task-id task-id :exit-code exit-code})]
-            (async/<!! (sched/handle-framework-message conn handle-progress-message message))
+            (sched/handle-framework-message conn handlers message)
             (is (= exit-code (query-instance-field instance-id :instance/exit-code)))
             (is (nil? (deref progress-aggregator-promise 1000 nil))))))
 
@@ -1134,6 +1147,9 @@
               instance-id (create-dummy-instance conn job-id :instance-status :instance.status/running :task-id task-id)]
           (let [progress-aggregator-promise (promise)
                 handle-progress-message (handle-progress-message-factory progress-aggregator-promise)
+                handle-exit-code (fn [task-id exit-code]
+                                   @(d/transact conn [[:db/add [:instance/task-id task-id] :instance/exit-code exit-code]]))
+                handlers {:handle-exit-code handle-exit-code :handle-progress-message handle-progress-message}
                 exit-code 0
                 progress-percent 90
                 progress-message "Almost complete..."
@@ -1143,7 +1159,7 @@
                                        :progress-message progress-message
                                        :progress-percent progress-percent
                                        :sandbox-directory sandbox-directory})]
-            (async/<!! (sched/handle-framework-message conn handle-progress-message message))
+            (sched/handle-framework-message conn handlers message)
             (is (= exit-code (query-instance-field instance-id :instance/exit-code)))
             (is (nil? (query-instance-field instance-id :instance/sandbox-directory)))
             (is (= 0 (query-instance-field instance-id :instance/progress)))
@@ -1806,7 +1822,7 @@
                                                   (-> status mtypes/pb->data :state)))))
                     (Thread/sleep (rand-int 100))
                     (.countDown latch))]
-      (let [s (sched/create-mesos-scheduler nil true nil nil nil nil nil nil nil)]
+      (let [s (sched/create-mesos-scheduler nil true nil nil nil nil nil nil nil nil)]
 
         (.statusUpdate s nil (mtypes/->pb :TaskStatus {:task-id {} :state :task-starting}))
         (.statusUpdate s nil (mtypes/->pb :TaskStatus {:task-id {:value "T1"} :state :task-starting}))
@@ -1838,7 +1854,7 @@
                                            (swap! sandbox-store conj framework-message))
                   sched/handle-framework-message (fn [_ _ framework-message]
                                                    (swap! framework-message-store conj framework-message))]
-      (let [s (sched/create-mesos-scheduler nil true nil nil nil nil nil nil nil)
+      (let [s (sched/create-mesos-scheduler nil true nil nil nil nil nil nil nil nil)
             make-message (fn [message] (-> message json/write-str str (.getBytes "UTF-8")))]
 
         (testing "message delegation"
@@ -1874,7 +1890,7 @@
                       (swap! messages-store update (str task-id) (fn [messages] (conj (or messages []) message))))
                     (Thread/sleep (rand-int 100))
                     (.countDown latch))]
-      (let [s (sched/create-mesos-scheduler nil true nil nil nil nil nil nil nil)
+      (let [s (sched/create-mesos-scheduler nil true nil nil nil nil nil nil nil nil)
             foo 11
             bar 21
             fee 31

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -112,6 +112,7 @@
                            :sequence-cache-threshold 1000}
          rebalancer-config# (merge default-rebalancer-config (:rebalancer-config ~scheduler-config))
          framework-id# "cool-framework-id"
+         exit-code-syncer-state# {:task-id->exit-code-agent (agent {})}
          sandbox-syncer-state# {:task-id->sandbox-agent (agent {})}
          host-settings# {:server-port 12321 :hostname "localhost"}
          mesos-leadership-atom# (atom false)
@@ -124,6 +125,7 @@
        (with-redefs [executor-config (constantly executor-config#)]
          (c/start-mesos-scheduler
            {:curator-framework curator-framework#
+            :exit-code-syncer-state exit-code-syncer-state#
             :fenzo-config fenzo-config#
             :framework-id framework-id#
             :gpu-enabled? gpu-enabled?#


### PR DESCRIPTION

## Changes proposed in this PR

- adds exit-code-syncer to handle a high rate of incoming exit-code messages in a graceful manner

## Why are we making these changes?

We would like to aggregate sending exit code datomic updates for tasks to avoid potential load issues based on our previous experience with the sandbox syncer.

