### PR TITLE
Un-marks test_balanced_host_constraint_cannot_place as xfail

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1679,12 +1679,7 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, uuids)
 
-    @pytest.mark.xfail
     def test_balanced_host_constraint_cannot_place(self):
-        """
-        Marked as explicit due to broken constraints handling.
-        See GitHub issue #579.
-        """
         state = util.get_mesos_state(self.mesos_url)
         num_hosts = len(state['slaves'])
         if num_hosts > 10:


### PR DESCRIPTION
## Changes proposed in this PR

- removing `xfail` from `test_balanced_host_constraint_cannot_place`

## Why are we making these changes?

The test passes consistently now.
