### PR TITLE
Un-marks balanced host constraint test as xfail

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1732,8 +1732,7 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, uuids)
 
-    @pytest.mark.xfail(reason='Sometimes fails on Travis')
-    def test_balanced_host_constraint(self):
+    def test_balanced_host_constraint_can_place(self):
         state = util.get_mesos_state(self.mesos_url)
         num_hosts = len(state['slaves'])
         minimum_hosts = min(10, num_hosts)


### PR DESCRIPTION
## Changes proposed in this PR

- renaming `test_balanced_host_constraint` to `test_balanced_host_constraint_can_place`
- removing `xfail` from it

## Why are we making these changes?

The rename is to allow for running using `pytest -k ...` and not having to also run `test_balanced_host_constraint_cannot_place`. The removal of `xfail` is because the test now passes.