### PR TITLE
Un-marks test_unique_host_constraint as xfail

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1624,7 +1624,6 @@ class CookTest(util.CookTest):
         self.assertEqual(1, len(jobs))
         self.assertEqual(job_uuid_1, jobs[0]['uuid'])
 
-    @pytest.mark.xfail(reason='Sometimes fails on Travis')
     def test_unique_host_constraint(self):
         state = util.get_mesos_state(self.mesos_url)
         num_hosts = len(state['slaves'])


### PR DESCRIPTION
## Changes proposed in this PR

- removing `xfail` from `test_unique_host_constraint`

## Why are we making these changes?

This test is now passing.