### PR TITLE
Uses the minimesos from /travis

### DIFF
--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -52,7 +52,7 @@ if [ "$(docker ps -aq -f name=${NAME})" ]; then
     docker stop ${NAME}
 fi
 
-$(minimesos info | grep MINIMESOS)
+$(${DIR}/../../travis/minimesos info | grep MINIMESOS)
 EXIT_CODE=$?
 if [ ${EXIT_CODE} -eq 0 ]
 then


### PR DESCRIPTION
## Changes proposed in this PR

- using the `minimesos` from the `/travis` directory instead of assuming the user has one on the path

## Why are we making these changes?

We already have a `minimesos` in the repo, so it's nice to not make the caller have their own.
