### PR TITLE
New Token Bucket Filter and Rate Limit core code.

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -226,6 +226,7 @@ class MultiUserCookTest(util.CookTest):
         if bucket_size > 3000 or extra_size > 1000:
             raise pytest.skip() # Don't run if we'd have to create a whole lot of jobs to run the test.
         with user:
+            jobs1 = jobs2 = []
             try:
                 # First, empty most but not all of the tocken bucket.
                 jobs1, resp1 = util.submit_jobs(self.cook_url, {}, bucket_size - 60)
@@ -240,10 +241,8 @@ class MultiUserCookTest(util.CookTest):
                 expectedPrefix = """{"error":"User rate_limit_while_creating_job0 is inserting too quickly. Not allowed to insert for"""
                 self.assertEqual(resp3.text[:len(expectedPrefix)], expectedPrefix)
             finally:
-                util.kill_jobs(self.cook_url,jobs1, assert_response=False)
-                util.kill_jobs(self.cook_url,jobs2, assert_response=False)
-                util.kill_jobs(self.cook_url,jobs3, assert_response=False)
-
+                util.kill_jobs(self.cook_url,jobs1)
+                util.kill_jobs(self.cook_url,jobs2)
 
     def trigger_preemption(self, pool):
         """

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -236,8 +236,9 @@ class MultiUserCookTest(util.CookTest):
                 # And finally a request that gets cut off.
                 jobs3, resp3 = util.submit_jobs(self.cook_url, {}, 10)
                 self.assertEqual(resp3.status_code, 400)
-                self.assertEqual(resp3.text, "FOO")
-                self.assertEqual(dir(resp3), 400)
+                # The timestamp can change so we should only match on the prefix.
+                expectedPrefix = """{"error":"User rate_limit_while_creating_job0 is inserting too quickly. Not allowed to insert for"""
+                self.assertEqual(resp3.text[:len(expectedPrefix)], expectedPrefix)
             finally:
                 util.kill_jobs(self.cook_url,jobs1, assert_response=False)
                 util.kill_jobs(self.cook_url,jobs2, assert_response=False)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -464,10 +464,16 @@ def retry_jobs(cook_url, assert_response=True, use_deprecated_post=False, **kwar
 
 def kill_jobs(cook_url, jobs, assert_response=True, expected_status_code=204):
     """Kill one or more jobs"""
-    params = {'job': [unpack_uuid(j) for j in jobs]}
-    response = session.delete(f'{cook_url}/rawscheduler', params=params)
-    if assert_response:
-        assert expected_status_code == response.status_code, response.text
+    chunksize = 100
+    chunks = [jobs[i:i+chunksize] for i in range(0,len(jobs),chunksize)]
+    response = []
+    for chunk in chunks:
+        params = {'job': [unpack_uuid(j) for j in chunk]}
+        print("Params: "+repr(params))
+        response = session.delete(f'{cook_url}/rawscheduler', params=params)
+        if assert_response:
+            print("Response was: "+str(response.status_code)+" and " + str(response.text))
+            assert expected_status_code == response.status_code, response.text
     return response
 
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -469,10 +469,8 @@ def kill_jobs(cook_url, jobs, assert_response=True, expected_status_code=204):
     response = []
     for chunk in chunks:
         params = {'job': [unpack_uuid(j) for j in chunk]}
-        print("Params: "+repr(params))
         response = session.delete(f'{cook_url}/rawscheduler', params=params)
         if assert_response:
-            print("Response was: "+str(response.status_code)+" and " + str(response.text))
             assert expected_status_code == response.status_code, response.text
     return response
 

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -33,7 +33,7 @@
                                 :cpus 10}}
  :rate-limit {:expire-minutes 120 ; Expire unused rate limit entries after 2 hours.
               ; Keep these job-submisison values as they are for integration tests. Making them smaller can cause
-              ; spurious failures,  and making them larger will cause the rate-limit unit test to fail.
+              ; spurious failures, and making them larger will cause the rate-limit integration test to skip itself.
               :job-submission {:bucket-size 1000
                                :enforce? true
                                :tokens-replenished-per-minute 600}

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -31,7 +31,13 @@
                                 :memory-gb 48
                                 :retry-limit 200
                                 :cpus 10}}
- :rate-limit {:user-limit-per-m 1000000}
+ :rate-limit {:expire-minutes 120 ; Expire unused rate limit entries after 2 hours.
+              ; Keep these job-submisison values as they are for integration tests. Making them smaller can cause
+              ; spurious failures,  and making them larger will cause the rate-limit unit test to fail.
+              :job-submission {:bucket-size 1000
+                               :enforce? true
+                               :tokens-replenished-per-minute 600}
+              :user-limit-per-m 1000000}
  :rebalancer {:dru-scale 1
               :interval-seconds 30
               :max-preemption 500.0

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -49,7 +49,7 @@
        :keystore-pass "cookstore"}
  :rate-limit {:expire-minutes 120 ; Expire unused rate limit entries after 2 hours.
               ; Keep these job-submisison values as they are for integration tests. Making them smaller can cause
-              ; spurious failures,  and making them larger will cause the rate-limit unit test to fail.
+              ; spurious failures, and making them larger will cause the rate-limit integration test to skip itself.
               :job-submission {:bucket-size 1000
                                :enforce? true
                                :tokens-replenished-per-minute 600}

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -47,7 +47,13 @@
        :keystore-path #config/env "COOK_KEYSTORE_PATH"
        :keystore-type "pkcs12"
        :keystore-pass "cookstore"}
- :rate-limit {:user-limit-per-m 1000000}
+ :rate-limit {:expire-minutes 120 ; Expire unused rate limit entries after 2 hours.
+              ; Keep these job-submisison values as they are for integration tests. Making them smaller can cause
+              ; spurious failures,  and making them larger will cause the rate-limit unit test to fail.
+              :job-submission {:bucket-size 1000
+                               :enforce? true
+                               :tokens-replenished-per-minute 600}
+              :user-limit-per-m 1000000}
  :rebalancer {:dru-scale 1
               :interval-seconds 30
               :max-preemption 500.0

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -78,7 +78,14 @@ If need it to bind to another port, you can specify that with the `:local-port` 
   The value of this key is a set of usernames who should be considered administrators when using the `configfile-admins-auth` authorization-fn.
 
 `:rate-limit`::
-  Configure rate limits for the scheduler. `rate-limit` is a map with two possible keys, `user-limit-per-m`. `user-limit-per-m` is the max requests a single user can send in a minute. The default is 600 requests.
+  Configure rate limits for the scheduler. `rate-limit` is a map with three possible keys `:user-limit-per-m` , `:job-submission`, `:expire-minutes`. These keys control rate limits.
+
+ * `:user-limit-per-m` is the max REST requests a single user can send in a minute. The default is 600 requests.
+
+ * `:job-submission` is a dictionary with a _token bucket filter configuration_ that allows per-user restriction of the job creation rate.
+ * `:expire-minutes` For our token-bucket-filter rate limits, we will create one token bucket filter rate limit object for each user. If a user has become very idle, we expire old unused rate-limit entries after a time period. This should be set to several hours, or at least as high as (`:bucket-size`/`:tokens-replenished-per-minute`)
+
+A _token bucket filter configuration_ has 3 keys `:enforce?` If this is off, the rate limit is not enforced however, violations of the rate limit are logged. Tokens are added to a bucket of maximum size `:bucket-size` at a rate of `:tokens-replenished-per-minute`. See https://en.wikipedia.org/wiki/Token_bucket.
 
 `:agent-query-cache`::
   Configure the cache used to store sandbox locations of tasks on different mesos agents.

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -78,7 +78,7 @@ If need it to bind to another port, you can specify that with the `:local-port` 
   The value of this key is a set of usernames who should be considered administrators when using the `configfile-admins-auth` authorization-fn.
 
 `:rate-limit`::
-  Configure rate limits for the scheduler. `rate-limit` is a map with three possible keys `:user-limit-per-m` , `:job-submission`, `:expire-minutes`. These keys control rate limits.
+  Configure rate limits for the scheduler. `rate-limit` is a map with three possible keys: `:user-limit-per-m` , `:job-submission`, `:expire-minutes`. These keys control rate limits.
 
  * `:user-limit-per-m` is the max REST requests a single user can send in a minute. The default is 600 requests.
 

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -82,10 +82,10 @@ If need it to bind to another port, you can specify that with the `:local-port` 
 
  * `:user-limit-per-m` is the max REST requests a single user can send in a minute. The default is 600 requests.
 
- * `:job-submission` is a dictionary with a _token bucket filter configuration_ that allows per-user restriction of the job creation rate.
+ * `:job-submission` is a dictionary with a _token bucket filter configuration_ that allows per-user restriction of the job submission rate.
  * `:expire-minutes` For our token-bucket-filter rate limits, we will create one token bucket filter rate limit object for each user. If a user has become very idle, we expire old unused rate-limit entries after a time period. This should be set to several hours, or at least as high as (`:bucket-size`/`:tokens-replenished-per-minute`)
 
-A _token bucket filter configuration_ has 3 keys `:enforce?` If this is off, the rate limit is not enforced however, violations of the rate limit are logged. Tokens are added to a bucket of maximum size `:bucket-size` at a rate of `:tokens-replenished-per-minute`. See https://en.wikipedia.org/wiki/Token_bucket.
+A _token bucket filter configuration_ has 3 keys, `:enforce`, `:tokens-replenished-per-minute` and `:bucket-size`. Tokens are added to a bucket of maximum size `:bucket-size` at a rate of `:tokens-replenished-per-minute`, `:enforce` is used to decide whether we reject requests that violate this rate limit. Even if enforcement is off violations of the rate limit are logged.  See https://en.wikipedia.org/wiki/Token_bucket.
 
 `:agent-query-cache`::
   Configure the cache used to store sandbox locations of tasks on different mesos agents.

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -27,7 +27,7 @@
             [cook.impersonation :refer (impersonation-authorized-wrapper)]
             [cook.mesos.pool :as pool]
             ; This explicit require is needed so that mount can see the defstate defined in this namespace.
-            ; cook.rate-limit and everything else under cook.mesos.api is normally hidden from defstate because
+            ; cook.rate-limit and everything else under cook.mesos.api is normally hidden from mount's defstate because
             ; cook.mesos.api is loaded via util/lazy-load-var, not via 'ns :require'
             [cook.rate-limit]
             [cook.util :as util]
@@ -322,11 +322,9 @@
   [config-file-path & _]
   (println "Cook" @util/version "( commit" @util/commit ")")
   (try
-    (mount/start-with-args (cook.config/read-config config-file-path))
     ; Note: If the mount/start-with-args fails to initialize a defstate S, and/or you get weird errors on startup,
     ; you need to require S's namespace with ns :require. 'ns :require' is how mount finds defstates to initialize.
-    ; Note, we cannot directly require cook.mesos.api. This namespace is normally hidden from mount because cook.mesos.api is
-    ; loaded via util/lazy-load-var.
+    (mount/start-with-args (cook.config/read-config config-file-path))
     (pool/guard-invalid-default-pool (d/db datomic/conn))
     (metrics-jvm/instrument-jvm)
     (let [server (scheduler-server config)]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -204,9 +204,12 @@
                                      ((util/lazy-load-var 'cook.impersonation/create-impersonation-middleware) impersonators)
                                      {:json-value "config-impersonation"})))
      :rate-limit (fnk [[:config {rate-limit nil}]]
-                   (let [{:keys [user-limit-per-m]
-                          :or {user-limit-per-m 600}} rate-limit]
-                     {:user-limit (->UserRateLimit :user-limit user-limit-per-m (t/minutes 1))}))
+                   (let [{:keys [expire-minutes user-limit-per-m job-submission]
+                          :or {expire-minutes 120
+                               user-limit-per-m 600}} rate-limit]
+                     {:expire-minutes expire-minutes
+                      :job-submission job-submission
+                      :user-limit (->UserRateLimit :user-limit user-limit-per-m (t/minutes 1))}))
      :sim-agent-path (fnk [] "/usr/bin/sim-agent")
      :executor (fnk [[:config {executor {}}]]
                  (if (str/blank? (:command executor))

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -39,6 +39,8 @@
             [cook.mesos.unscheduled :as unscheduled]
             [cook.mesos.util :as util]
             [cook.mesos]
+            [cook.rate-limit :refer [job-submission-rate-limiter]]
+            [cook.rate-limit.generic :as rt]
             [cook.util :refer [ZeroInt PosNum NonNegNum PosInt NonNegInt PosDouble UserName NonEmptyString]]
             [datomic.api :as d :refer [q]]
             [liberator.core :as liberator]
@@ -1524,7 +1526,7 @@
   to Datomic.
   Preconditions:  The context must already have been populated with both
   ::jobs and ::groups, which specify the jobs and job groups."
-  [conn {:keys [::groups ::jobs ::pool]}]
+  [conn {:keys [::groups ::jobs ::pool] :as ctx}]
   (try
     (log/info "Submitting jobs through raw api:" (map #(dissoc % :command) jobs))
     (let [group-uuids (set (map :uuid groups))
@@ -1555,6 +1557,10 @@
                                                   (:uuid %)
                                                   []))
                           groups)]
+
+      (let [user (get-in ctx [:request :authorization/user])]
+        (rt/spend-tokens! job-submission-rate-limiter user (count jobs)))
+
       @(d/transact
          conn
          (-> (vec group-asserts)
@@ -1629,9 +1635,18 @@
                          override-group-immutability? (boolean (get params :override-group-immutability))
                          pool-name (get params :pool)
                          pool (when pool-name (d/entity (d/db conn) [:pool/name pool-name]))
-                         uuid->count (pc/map-vals count (group-by :uuid jobs))]
+                         uuid->count (pc/map-vals count (group-by :uuid jobs))
+                         time-until-out-of-debt (rt/time-until-out-of-debt-millis! job-submission-rate-limiter user)
+                         in-debt? (not (zero? time-until-out-of-debt))]
                      (try
+                       (when in-debt?
+                         (log/info (str "User " user " is inserting too quickly (will be out of debt in "
+                                        (/ time-until-out-of-debt 1000.0) " seconds)")))
                        (cond
+                         (and in-debt? (rt/enforce? job-submission-rate-limiter))
+                         [true {::error (str "User " user " is inserting too quickly. Not allowed to insert for "
+                                             (/ time-until-out-of-debt 1000.0) " seconds")}]
+
                          (empty? params)
                          [true {::error (str "Must supply at least one job or group to start."
                                              "Are you specifying that this is application/json?")}]
@@ -1648,7 +1663,6 @@
                                                                           (map first)
                                                                           (map str)
                                                                           (into [])))}]
-
                          :else
                          (let [groups (mapv #(validate-and-munge-group (db conn) %) groups)
                                jobs (mapv #(validate-and-munge-job
@@ -1690,7 +1704,6 @@
      ;; (see :allowed-methods above). It is simply what liberator eventually calls to persist
      ;; resource changes when conflict? has returned false.
      :put! (partial create-jobs! conn)
-
      :post! (partial create-jobs! conn)
      :handle-exception (fn [{:keys [exception]}]
                          (if (datomic/transaction-timeout? exception)
@@ -2763,7 +2776,6 @@
                                 400 {:description "One or more of the jobs were incorrectly specified."}
                                 409 {:description "One or more of the jobs UUIDs are already in use."}}
                     :handler (create-jobs-handler conn task-constraints gpu-enabled? is-authorized-fn)}}))
-
         (c-api/context
           "/info" []
           (c-api/resource

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -16,8 +16,14 @@
 (ns cook.rate-limit
   (:require [clojure.tools.logging :as log]
             [cook.config :refer [config]]
-            [mount.core :as mount]
-            [cook.rate-limit.generic :as rt]))
+            [cook.rate-limit.generic :as rtg]
+            [mount.core :as mount]))
+
+; Import from cook.rate-limit.generic some relevant functions.
+(def spend! rtg/spend!)
+(def time-until-out-of-debt-millis! rtg/time-until-out-of-debt-millis!)
+(def enforce? rtg/enforce?)
+(def AllowAllRateLimiter rtg/AllowAllRateLimiter)
 
 (defn create-job-submission-rate-limiter
   "From the configuration map, extract the keys that setup the job-submission rate limiter and return
@@ -28,8 +34,8 @@
         {:keys [expire-minutes job-submission]} rate-limit]
     (if (seq job-submission)
       (let [{:keys [bucket-size enforce? tokens-replenished-per-minute]} job-submission]
-        (rt/make-token-bucket-filter bucket-size tokens-replenished-per-minute expire-minutes enforce?))
-      rt/AllowAllRateLimiter)))
+        (rtg/make-token-bucket-filter bucket-size tokens-replenished-per-minute expire-minutes enforce?))
+      AllowAllRateLimiter)))
 
 (mount/defstate job-submission-rate-limiter
   :start (create-job-submission-rate-limiter config))

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -1,0 +1,35 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.rate-limit
+  (:require [clojure.tools.logging :as log]
+            [cook.config :refer [config]]
+            [mount.core :as mount]
+            [cook.rate-limit.generic :as rt]))
+
+(defn create-job-submission-rate-limiter
+  "From the configuration map, extract the keys that setup the job-submission rate limiter and return
+  the constructed object. If the configuration map is not found, the AllowAllRateLimiter is returned."
+  [config]
+  (let [{:keys [settings]} config
+        {:keys [rate-limit]} settings
+        {:keys [expire-minutes job-submission]} rate-limit]
+    (if (seq job-submission)
+      (let [{:keys [bucket-size enforce? tokens-replenished-per-minute]} job-submission]
+        (rt/make-token-bucket-filter bucket-size tokens-replenished-per-minute expire-minutes enforce?))
+      rt/AllowAllRateLimiter)))
+
+(mount/defstate job-submission-rate-limiter
+  :start (create-job-submission-rate-limiter config))

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -1,0 +1,104 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.rate-limit.generic
+  (:require [clj-time.core]
+            [clj-time.coerce]
+            [cook.rate-limit.token-bucket-filter :as tbf])
+  (:import (com.google.common.cache CacheBuilder Cache)
+           (java.util.concurrent TimeUnit)))
+
+(defprotocol RateLimiter
+  (spend-tokens! [this key tokens]
+    "Request this number of tokens. Does not block (or otherwise indicate we're in debt")
+  (time-until-out-of-debt-millis! [this key]
+    "Time, in milliseconds, until this rate limiter is out of debt for this key. Earns tokens first.")
+  (enforce? [this]
+    "Are we enforcing this policy?"))
+
+(defn current-time-in-millis
+  []
+  (clj-time.coerce/to-long (clj-time.core/now)))
+
+(defn get-key
+  "Guava cache key cannot be nil/null"
+  [key]
+  (or key "*NULL_TBF_KEY*"))
+
+(defn get-token-bucket-filter
+  "Get or create a TBF for the requested key. Buckets start off full, so users whose first request is a lot of
+  fast requests don't get throttled immediately. This doesn't let users get much above their quota ---
+  The fact that we don't have a TBF says that we are either just starting up (not likely) or haven't
+  gotten anything from them in a long time. (Assuming the TTL is set at least as high as
+  (:bucket-size/:tokens-replenished-per-minute)."
+  [limiter key]
+  (let [{:keys [tokens-replenished-per-minute max-tokens]} limiter
+        supplier (proxy [Callable] []
+                   (call []
+                     (tbf/create-tbf (/ tokens-replenished-per-minute 60000.)
+                                     max-tokens
+                                     (current-time-in-millis)
+                                     max-tokens)))]
+    (.get (:cache limiter) key supplier)))
+
+(defn earn-tokens!
+  "Account for any earned tokens for the requested key."
+  [{:keys [cache] :as this} key]
+  (let [key (get-key key)]
+    (locking cache
+      (let [tbf (tbf/earn-tokens (get-token-bucket-filter this key) (current-time-in-millis))]
+        (.put cache key tbf)))))
+
+(defrecord TBF-RateLimiter
+  [^long max-tokens ^double tokens-replenished-per-minute cache ^Boolean enforce?]
+  RateLimiter
+  (spend-tokens!
+    [this key tokens]
+    (let [key (get-key key)]
+      (locking cache
+        (let [tbf (tbf/spend-tokens (get-token-bucket-filter this key) (current-time-in-millis) tokens)]
+          (.put cache key tbf)
+          nil))))
+
+  (time-until-out-of-debt-millis!
+    [this key]
+    (let [key (get-key key)]
+      (earn-tokens! this key)
+      (tbf/time-until (get-token-bucket-filter this key))))
+
+  (enforce?
+    [_]
+    enforce?))
+
+(defn ^RateLimiter make-token-bucket-filter
+  [^long max-tokens ^double tokens-replenished-per-minute ^long bucket-expire-minutes enforce?]
+  {:pre [(> max-tokens 0)
+         (> tokens-replenished-per-minute 0)
+         (> bucket-expire-minutes 0)
+         (or (true? enforce?) (false? enforce?))]}
+  (->TBF-RateLimiter max-tokens tokens-replenished-per-minute
+                     (-> (CacheBuilder/newBuilder)
+                         (.expireAfterAccess bucket-expire-minutes (TimeUnit/MINUTES))
+                         (.build))
+                     enforce?))
+
+
+(def AllowAllRateLimiter
+  "A noop rate limiter that doesn't put a limit on anything. Has {:enforce? false} as the policy key."
+  (reify
+    RateLimiter
+    (spend-tokens! [_ _ _] 0)
+    (time-until-out-of-debt-millis! [_ _] 0)
+    (enforce? [_] false)))

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -45,8 +45,8 @@
   (:bucket-size/:tokens-replenished-per-minute))."
   [limiter key]
   (let [{:keys [tokens-replenished-per-minute max-tokens]} limiter
-        supplier (proxy [Callable] []
-                   (call []
+        supplier (reify Callable
+                   (call [_]
                      (tbf/create-tbf (/ tokens-replenished-per-minute 60000.)
                                      max-tokens
                                      (current-time-in-millis)

--- a/scheduler/src/cook/rate_limit/token_bucket_filter.clj
+++ b/scheduler/src/cook/rate_limit/token_bucket_filter.clj
@@ -1,0 +1,96 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.rate-limit.token-bucket-filter)
+
+(defn create-tbf
+  "Make a token bucket filter (tbf), with a given refill rate (units per timestep), a maximum token capacity, and give it the
+  current timestamp.
+
+  This token bucket filter is a bit unusual, instead of earning tokens that you can later spend, we allow the current
+  tokens to be negative. Thus, you can (in one request) spend an unbounded number of tokens. However, you will be
+  in debt until your token balance is at least 0. This design allows the tokens in a single request to exceed the max-tokens
+  in the tbf. (If we didn't do it this way, max-tokens is an implicit maximum limit on request size.) This way
+  we can independently pick the burst size in the tbf and the maximum request size.
+
+  This library does not handle blocking or other operations. Typical workflows are to:
+
+  ** Admission control **
+  This is good when you don't know how big a request will be until afterwards.
+
+  Use in-debt? as part of request admission control, rejecting a request if it returns true. When a request completes (or is aborted),
+  take the tokens that it used, affecting the next request.
+
+  ** Delaying requests **
+  If you want to delay requests instead of rejecting. Take the tokens the request needs, pause for the returned pause time.
+  (E.g., schedule the message to be sent at that particular pause time.
+  "
+  ([^double token-rate ^long max-tokens ^long current-time ^long current-tokens]
+   {:pre [(> token-rate 0)
+          (>= max-tokens 0)
+          (>= current-time 0)]}
+   {:token-rate token-rate :max-tokens max-tokens :last-update current-time :current-tokens current-tokens})
+  ([^double token-rate ^long max-tokens ^long current-time]
+   (create-tbf token-rate max-tokens current-time 0)))
+
+(defn- update-tbf
+  "Add tokens (if there are any). If less than a whole token added, keep the current state. Returns the current state.
+  Enforces max-tokens limit. Allows tokens to be removed or added. If no timestamp supplied, just alters the token count."
+  [{:keys [current-tokens max-tokens] :as tbf} ^long tokens-to-dispense ^long current-time]
+  (if (zero? tokens-to-dispense)
+    ; Only dispense when we have at least a whole token to add on.
+    tbf
+    (-> tbf
+        (assoc :last-update current-time)
+        (update :current-tokens #(-> % (+ tokens-to-dispense) (min max-tokens))))))
+
+(defn earn-tokens
+  "Earn tokens. Helper function, takes the current timestamp and adds in any newly earned tokens. It is numerically
+  robust to the timestamp being out of order."
+  [{:keys [last-update token-rate] :as tbf} ^long current-time]
+  {:pre [(>= current-time 0)]}
+  (let [current-time (max current-time last-update)]
+    (cond-> tbf
+            (not (= current-time last-update))
+            (update-tbf
+              (-> current-time
+                  (- last-update)
+                  (* token-rate)
+                  long)
+              current-time))))
+
+(defn time-until
+  "Assumes tokens have been dispensed. Reports how many time units until the balance is positive and a request can be granted."
+  [{:keys [current-tokens token-rate] :as tbf}]
+  (-> current-tokens
+      -
+      (/ token-rate)
+      Math/ceil
+      long
+      (max 0)))
+
+(defn spend-tokens
+  "Returns a new TBF. Takes the tokens from the result; the new TBF reflects the tokens being earned and taken.
+  This does not block and will always succeed, even if the balance is negative."
+  [tbf ^long current-time ^long wanted-tokens]
+  {:pre [(>= wanted-tokens 0)]}
+  (let [{:keys [last-update] :as tbf} (earn-tokens tbf current-time)
+        tbf (update-tbf tbf (- wanted-tokens) last-update)]
+    tbf))
+
+(defn in-debt?
+  "Reports if the tbf is currently in debt."
+  [{:keys [current-tokens]}]
+  (< current-tokens 0))

--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -1218,11 +1218,11 @@
                      :state "waiting"
                      :status "waiting"
                      :uris nil}
-              ;; Only assoc these fields if the job specifies one
-              application (assoc :application application)
-              expected-runtime (assoc :expected-runtime expected-runtime)
-              executor (assoc :executor executor)
-              datasets (assoc :datasets datasets)))]
+                    ;; Only assoc these fields if the job specifies one
+                    application (assoc :application application)
+                    expected-runtime (assoc :expected-runtime expected-runtime)
+                    executor (assoc :executor executor)
+                    datasets (assoc :datasets datasets)))]
 
       (testing "Job creation"
         (testing "should work with a minimal job manually inserted"
@@ -1247,7 +1247,7 @@
             (is (= (expected-job-map job framework-id)
                    (dissoc job-resp :submit_time)))
             (s/validate api/JobResponseDeprecated
-                                        ; fetch-job-map returns a FrameworkID object instead of a string
+                        ; fetch-job-map returns a FrameworkID object instead of a string
                         (assoc job-resp :framework_id (str (:framework_id job-resp))))))
 
         (testing "should work with a minimal job"
@@ -1255,7 +1255,7 @@
                 {:keys [uuid] :as job} (minimal-job)
                 framework-id #mesomatic.types.FrameworkID{:value "framework-id"}]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                 (create-jobs!-wrapper conn {::api/jobs [job]})))
+                   (create-jobs!-wrapper conn {::api/jobs [job]})))
             (is (= (expected-job-map job framework-id)
                    (dissoc (api/fetch-job-map (db conn) framework-id uuid) :submit_time)))))
 
@@ -1263,10 +1263,10 @@
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
                 {:keys [uuid] :as job} (minimal-job)]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                 (create-jobs!-wrapper conn {::api/jobs [job]})))
+                   (create-jobs!-wrapper conn {::api/jobs [job]})))
             (is (thrown-with-msg? ExecutionException
                                   (re-pattern (str ".*:job/uuid.*" uuid ".*already exists"))
-                                (create-jobs!-wrapper conn {::api/jobs [job]})))))
+                                  (create-jobs!-wrapper conn {::api/jobs [job]})))))
 
         (testing "should work with datasets"
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1289,7 +1289,7 @@
                 {:keys [uuid] :as job} (assoc (minimal-job) :application application)
                 framework-id #mesomatic.types.FrameworkID{:value "framework-id"}]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                 (create-jobs!-wrapper conn {::api/jobs [job]})))
+                   (create-jobs!-wrapper conn {::api/jobs [job]})))
             (is (= (expected-job-map job framework-id)
                    (dissoc (api/fetch-job-map (db conn) framework-id uuid) :submit_time)))))
 
@@ -1298,7 +1298,7 @@
                 {:keys [uuid] :as job} (assoc (minimal-job) :expected-runtime 1)
                 framework-id #mesomatic.types.FrameworkID{:value "framework-id"}]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                 (create-jobs!-wrapper conn {::api/jobs [job]})))
+                   (create-jobs!-wrapper conn {::api/jobs [job]})))
             (is (= (expected-job-map job framework-id)
                    (-> (api/fetch-job-map (db conn) framework-id uuid)
                        (dissoc :submit_time))))))
@@ -1308,7 +1308,7 @@
                 {:keys [uuid] :as job} (assoc (minimal-job) :disable-mea-culpa-retries true)
                 framework-id #mesomatic.types.FrameworkID{:value "framework-id"}]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                 (create-jobs!-wrapper conn {::api/jobs [job]})))
+                   (create-jobs!-wrapper conn {::api/jobs [job]})))
             (is (= (expected-job-map job framework-id)
                    (-> (api/fetch-job-map (db conn) framework-id uuid)
                        (dissoc :submit_time))))))
@@ -1318,7 +1318,7 @@
                 {:keys [uuid] :as job} (assoc (minimal-job) :executor "cook")
                 framework-id #mesomatic.types.FrameworkID{:value "framework-id"}]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                 (create-jobs!-wrapper conn {::api/jobs [job]})))
+                   (create-jobs!-wrapper conn {::api/jobs [job]})))
             (is (= (expected-job-map job framework-id)
                    (-> (api/fetch-job-map (db conn) framework-id uuid)
                        (dissoc :submit_time)
@@ -1329,7 +1329,7 @@
                 {:keys [uuid] :as job} (assoc (minimal-job) :executor "mesos")
                 framework-id #mesomatic.types.FrameworkID{:value "framework-id"}]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                 (create-jobs!-wrapper conn {::api/jobs [job]})))
+                   (create-jobs!-wrapper conn {::api/jobs [job]})))
             (is (= (expected-job-map job framework-id)
                    (-> (api/fetch-job-map (db conn) framework-id uuid)
                        (dissoc :submit_time)
@@ -1340,7 +1340,7 @@
                 {:keys [uuid] :as job} (assoc (minimal-job) :supports_data_locality true)
                 framework-id #mesomatic.types.FrameworkID{:value "framework-id"}]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                 (create-jobs!-wrapper conn {::api/jobs [job]})))
+                   (create-jobs!-wrapper conn {::api/jobs [job]})))
             (is (= (expected-job-map job framework-id)
                    (-> (api/fetch-job-map (db conn) framework-id uuid)
                        (dissoc :submit_time))))))))))
@@ -1863,7 +1863,7 @@
     (with-redefs [api/no-job-exceeds-quota? (constantly true)]
       (testing "successful-job-creation-response"
         (with-redefs [api/create-jobs! (fn [in-conn _]
-                                     (is (= conn in-conn)))
+                                         (is (= conn in-conn)))
                       job-submission-rate-limiter rt/AllowAllRateLimiter]
           (let [handler (api/create-jobs-handler conn task-constraints gpu-enabled? is-authorized-fn)
                 {:keys [status]} (handler (new-request))]

--- a/scheduler/test/cook/test/mesos/monitor.clj
+++ b/scheduler/test/cook/test/mesos/monitor.clj
@@ -20,7 +20,7 @@
             [cook.mesos.api :as api]
             [cook.mesos.monitor :as monitor]
             [cook.mesos.share :as share]
-            [cook.test.testutil :refer [restore-fresh-database! setup create-jobs!-wrapper]]
+            [cook.test.testutil :refer [restore-fresh-database! setup] :as testutil]
             [datomic.api :as d :refer [db]]
             [metrics.counters :as counters])
   (:import (java.util UUID)
@@ -50,7 +50,7 @@
     (is (= 0 (counter ["hungry" "users"])))
     (is (= 0 (counter ["satisfied" "users"])))
 
-    (create-jobs!-wrapper conn {::api/jobs [job1 job2]})
+    (testutil/create-jobs! conn {::api/jobs [job1 job2]})
 
     (monitor/set-stats-counters! (db conn) stats-atom)
     (is (= 0 (counter ["running" "all" "jobs"])))
@@ -197,7 +197,7 @@
     (is (= 0 (counter ["hungry" "users"])))
     (is (= 0 (counter ["satisfied" "users"])))
 
-    (create-jobs!-wrapper conn {::api/jobs [job3]})
+    (testutil/create-jobs! conn {::api/jobs [job3]})
     (with-redefs [share/get-share (constantly {:cpus 0 :mem 0})]
       (monitor/set-stats-counters! (db conn) stats-atom))
     (is (= 0 (counter ["running" "all" "jobs"])))

--- a/scheduler/test/cook/test/mesos/monitor.clj
+++ b/scheduler/test/cook/test/mesos/monitor.clj
@@ -20,7 +20,7 @@
             [cook.mesos.api :as api]
             [cook.mesos.monitor :as monitor]
             [cook.mesos.share :as share]
-            [cook.test.testutil :refer [restore-fresh-database! setup]]
+            [cook.test.testutil :refer [restore-fresh-database! setup create-jobs!-wrapper]]
             [datomic.api :as d :refer [db]]
             [metrics.counters :as counters])
   (:import (java.util UUID)
@@ -50,7 +50,8 @@
     (is (= 0 (counter ["hungry" "users"])))
     (is (= 0 (counter ["satisfied" "users"])))
 
-    (api/create-jobs! conn {::api/jobs [job1 job2]})
+    (create-jobs!-wrapper conn {::api/jobs [job1 job2]})
+
     (monitor/set-stats-counters! (db conn) stats-atom)
     (is (= 0 (counter ["running" "all" "jobs"])))
     (is (= 0 (counter ["running" "all" "cpus"])))
@@ -196,7 +197,7 @@
     (is (= 0 (counter ["hungry" "users"])))
     (is (= 0 (counter ["satisfied" "users"])))
 
-    (api/create-jobs! conn {::api/jobs [job3]})
+    (create-jobs!-wrapper conn {::api/jobs [job3]})
     (with-redefs [share/get-share (constantly {:cpus 0 :mem 0})]
       (monitor/set-stats-counters! (db conn) stats-atom))
     (is (= 0 (counter ["running" "all" "jobs"])))

--- a/scheduler/test/cook/test/rate_limit/generic.clj
+++ b/scheduler/test/cook/test/rate_limit/generic.clj
@@ -1,0 +1,115 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.test.rate-limit.generic
+  (:use clojure.test)
+  (:require [cook.rate-limit.generic :as rt]))
+
+(deftest independent-keys-1
+  (let [ratelimit (rt/make-token-bucket-filter 60000 60 10 true)]
+    (rt/time-until-out-of-debt-millis! ratelimit "Foo2")
+    (rt/spend-tokens! ratelimit "Foo4" 100)
+    (is (= 2 (.size (.asMap (:cache ratelimit)))))))
+
+(deftest independent-keys-2
+  (let [ratelimit (rt/make-token-bucket-filter 60000 60 10 true)]
+    (rt/earn-tokens! ratelimit "Foo4")
+    (rt/earn-tokens! ratelimit "Foo1")
+    (rt/time-until-out-of-debt-millis! ratelimit "Foo1")
+    (rt/time-until-out-of-debt-millis! ratelimit "Foo2")
+    (rt/spend-tokens! ratelimit "Foo3" 100)
+    (rt/spend-tokens! ratelimit "Foo4" 100)
+    (is (= 4 (.size (.asMap (:cache ratelimit)))))))
+
+(deftest earning-tokens-explicit
+  (let [ratelimit (rt/make-token-bucket-filter 20 60000 10 true)]
+    ;; take away the full bucket it starts with... (20 tokens)
+    (with-redefs [rt/current-time-in-millis (fn [] 1000000)]
+      (rt/spend-tokens! ratelimit "Foo1" 20)
+      (rt/spend-tokens! ratelimit "Foo2" 20)
+      (rt/spend-tokens! ratelimit "Foo3" 20)
+      (rt/spend-tokens! ratelimit "Foo4" 20)
+
+      ;; Should be able to do this first request almost instantly.
+      (is (= 0 (rt/time-until-out-of-debt-millis! ratelimit "Foo1")))
+      (is (= 0 (rt/time-until-out-of-debt-millis! ratelimit "Foo2")))
+      (is (= 0 (rt/time-until-out-of-debt-millis! ratelimit "Foo3")))
+
+      (rt/spend-tokens! ratelimit "Foo1" 0)
+      (rt/spend-tokens! ratelimit "Foo2" 10)
+      (rt/spend-tokens! ratelimit "Foo3" 10000)
+
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo1") {:current-tokens 0
+                                                            :last-update 1000000
+                                                            :max-tokens 20
+                                                            :token-rate 1.0}))
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo2") {:current-tokens -10
+                                                            :last-update 1000000
+                                                            :max-tokens 20
+                                                            :token-rate 1.0}))
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo3") {:current-tokens -10000
+                                                            :last-update 1000000
+                                                            :max-tokens 20
+                                                            :token-rate 1.0})))
+
+    (with-redefs [rt/current-time-in-millis (fn [] 1000001)]
+      ;; We've earned tokens.
+      (is (= 0 (rt/time-until-out-of-debt-millis! ratelimit "Foo1")))
+      (is (= 9 (rt/time-until-out-of-debt-millis! ratelimit "Foo2")))
+      (is (= 9999 (rt/time-until-out-of-debt-millis! ratelimit "Foo3")))
+
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo1") {:current-tokens 1
+                                                            :last-update 1000001
+                                                            :max-tokens 20
+                                                            :token-rate 1.0}))
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo2") {:current-tokens -9
+                                                            :last-update 1000001
+                                                            :max-tokens 20
+                                                            :token-rate 1.0}))
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo3") {:current-tokens -9999
+                                                            :last-update 1000001
+                                                            :max-tokens 20
+                                                            :token-rate 1.0})))
+
+    (with-redefs [rt/current-time-in-millis (fn [] 1000025)]
+      ;; We've earned tokens. First two are out of debt.. Foo3 is in debt.
+      (is (= 0 (rt/time-until-out-of-debt-millis! ratelimit "Foo1")))
+      (is (= 0 (rt/time-until-out-of-debt-millis! ratelimit "Foo2")))
+      (is (= 9975 (rt/time-until-out-of-debt-millis! ratelimit "Foo3")))
+
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo1") {:current-tokens 20
+                                                            :last-update 1000025
+                                                            :max-tokens 20
+                                                            :token-rate 1.0}))
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo2") {:current-tokens 15
+                                                            :last-update 1000025
+                                                            :max-tokens 20
+                                                            :token-rate 1.0}))
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo3") {:current-tokens -9975
+                                                            :last-update 1000025
+                                                            :max-tokens 20
+                                                            :token-rate 1.0}))
+
+      ; Make sure Foo4 is stale.
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo4") {:current-tokens 0
+                                                            :last-update 1000000
+                                                            :max-tokens 20
+                                                            :token-rate 1.0}))
+      (is (= 0 (rt/time-until-out-of-debt-millis! ratelimit "Foo4")))
+      ; And not stale
+      (is (= (.getIfPresent (:cache ratelimit nil) "Foo4") {:current-tokens 20
+                                                            :last-update 1000025
+                                                            :max-tokens 20
+                                                            :token-rate 1.0})))))

--- a/scheduler/test/cook/test/rate_limit/token_bucket_filter.clj
+++ b/scheduler/test/cook/test/rate_limit/token_bucket_filter.clj
@@ -1,0 +1,181 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.test.rate-limit.token-bucket-filter
+  (:use clojure.test)
+  (:require [cook.rate-limit.token-bucket-filter :as tbf]))
+
+(defn approx=
+  "Approximately equal"
+  ([^Double a ^Double b ^Double err]
+   (or (= a b) (< (/ (Math/abs (- b a)) (+ (Math/abs a) (Math/abs b))) err)))
+  ([^Double a ^Double b]
+   (approx= a b 0.01)))
+
+(deftest approx
+  (is (approx= 0 0))
+  (is (approx= 1 1))
+  (is (approx= -1 -1))
+  (is (approx= 1.001 1.002))
+  (is (approx= 1000.001 1000.002))
+  (is (approx= -1.001 -1.002))
+  (is (approx= -1000.001 -1000.002))
+  (is (not (approx= 1.1 1.2)))
+  (is (not (approx= 1.001 -1.002)))
+  (is (not (approx= -1.001 1.002))))
+
+
+(deftest test-earn-tokens
+  (let [tbf (tbf/create-tbf 10.0 100 0)] ; 10/time unit, 100 max total, and the current time is 0
+    (testing "Initial state not in debt"
+      (let [tbf (tbf/earn-tokens tbf 0)]
+        (is (not (tbf/in-debt? tbf)))))
+    (testing "We earn tokens with time."
+      (let [tbf (tbf/earn-tokens tbf 5)]
+        (is (approx= (:current-tokens tbf) 50.0))))
+    (testing "We earn the max number of tokens"
+      (let [tbf (tbf/earn-tokens tbf 20)]
+        (is (approx= (:current-tokens tbf) 100.0))))))
+
+(deftest test-negative-tokens.
+  (let [tbf (tbf/create-tbf 10.0 100 0)
+        tbf (tbf/spend-tokens tbf 0 130)] ; 10/time unit, 100 max total, and the current time is 0, and we have -130 tokens.
+    (testing "In debt as we earn tokens"
+      (let [tbf (tbf/earn-tokens tbf 0)]
+        (is (tbf/in-debt? tbf))
+        (let [tbf (tbf/earn-tokens tbf 12)]
+          (is (= 12 (:last-update tbf)))
+          (is (tbf/in-debt? tbf)))
+        (let [tbf (tbf/earn-tokens tbf 14)]
+          (is (= 14 (:last-update tbf)))
+          (is (not (tbf/in-debt? tbf))))))
+    (testing "In debt as we incrementally earn tokens"
+      (let [tbf0 (tbf/earn-tokens tbf 0)
+            tbf1 (tbf/earn-tokens tbf0 5)
+            tbf2 (tbf/earn-tokens tbf1 10)
+            tbf3 (tbf/earn-tokens tbf2 12)
+            tbf4 (tbf/earn-tokens tbf3 14)
+            tbf5 (tbf/earn-tokens tbf4 15)]
+        (is (= 15 (:last-update tbf5)))
+        (is (tbf/in-debt? tbf0))
+        (is (tbf/in-debt? tbf1))
+        (is (tbf/in-debt? tbf2))
+        (is (tbf/in-debt? tbf3))
+        (is (not (tbf/in-debt? tbf4)))
+        (is (not (tbf/in-debt? tbf5)))))
+    (testing "In debt as we incrementally earn tokens"
+      (let [tbf0 (tbf/earn-tokens tbf 0)
+            tbf1 (tbf/earn-tokens tbf 5)
+            tbf2 (tbf/earn-tokens tbf1 15)
+            tbf3 (tbf/earn-tokens tbf2 12) ; Timestamps are out of order, so we don't actually earn here.
+            tbf4 (tbf/earn-tokens tbf3 10)
+            tbf5 (tbf/earn-tokens tbf4 20)
+            tbf6 (tbf/earn-tokens tbf5 30)
+            ]
+        (is (= 5 (:last-update tbf1)))
+        (is (= 15 (:last-update tbf2)))
+        (is (= 15 (:last-update tbf3)))
+        (is (= 15 (:last-update tbf4)))
+        (is (= 20 (:last-update tbf5)))
+
+        (is (approx= (:current-tokens tbf1) -80.0))
+        (is (approx= (:current-tokens tbf2) 20.0))
+        (is (approx= (:current-tokens tbf3) 20.0))
+        (is (approx= (:current-tokens tbf4) 20.0))
+        (is (approx= (:current-tokens tbf5) 70.0))
+        (is (approx= (:current-tokens tbf6) 100.0))
+
+        (is (tbf/in-debt? tbf0))
+        (is (tbf/in-debt? tbf1))
+        (is (not (tbf/in-debt? tbf2)))
+        (is (not (tbf/in-debt? tbf3)))
+        (is (not (tbf/in-debt? tbf4)))
+        (is (not (tbf/in-debt? tbf5)))))))
+
+(deftest test-time-until
+  (let [tbf (tbf/create-tbf 10.0 100 0)
+        tbf (tbf/spend-tokens tbf 0 130)] ; 10/time unit, 100 max total, and the current time is 0, and we have -130 tokens.
+
+    (let [tbf1 (tbf/earn-tokens tbf 0)
+          tbf2 (tbf/earn-tokens tbf1 10)
+          tbf3 (tbf/earn-tokens tbf2 5)
+          tbf4 (tbf/earn-tokens tbf3 15)]
+
+      (is (= (tbf/time-until tbf1) 13))
+      (is (= (tbf/time-until tbf2) 3))
+      (is (= (tbf/time-until tbf3) 3))
+      (is (= (tbf/time-until tbf4) 0)))))
+
+(deftest test-fractional-token
+  ;; If we earn tokens a fraction at a time, make sure we keep all of the fractions and don't lose them from roundoff.
+  (testing "Earn fractional token and maxing out bucket"
+    (let [tbf2
+          (loop [ii 1000
+                 tbf (tbf/create-tbf 0.01 4 0)]
+            (if (= 0 ii)
+              tbf
+              (recur (- ii 1) (tbf/earn-tokens tbf ii))))]
+      (is (approx= (:current-tokens tbf2) 4))))
+
+  (testing "Earn fractional token and not maxing bucket"
+    ;; Note: Count by 3 timeunits, so we earn 12 tokens.
+    (let [tbf2
+          (loop [ii 3000
+                 tbf (tbf/create-tbf 0.01 40 0)]
+            (if (= 0 ii)
+              tbf
+              (recur (- ii 3) (tbf/earn-tokens tbf ii))))]
+      (is (approx= (:current-tokens tbf2) 30)))))
+
+(deftest test-take-fraction
+  (let [tbf (tbf/create-tbf 0.1 100 0)
+        tbf1 (tbf/spend-tokens tbf 0 130)
+        tbf2 (tbf/spend-tokens tbf1 500 0)
+        tbf3 (tbf/spend-tokens tbf2 1000 3)
+        tbf4 (tbf/spend-tokens tbf3 500 3)
+        tbf5 (tbf/spend-tokens tbf4 1500 10)
+        tbf6 (tbf/spend-tokens tbf5 3000 5)]
+    ;; -130 tokens.
+    (is (approx= (:current-tokens tbf1) -130))
+    (is (approx= (:current-tokens tbf2) -80)) ; -130 + 50 - 0
+    (is (approx= (:current-tokens tbf3) -33)) ; -80 +50 - 3
+    (is (approx= (:current-tokens tbf4) -36)) ; -27 -3
+    (is (approx= (:current-tokens tbf5) 4)) ; -36 + 50 - 10
+    (is (approx= (:current-tokens tbf6) 95)))) ;4 + 150 - 5 -- We earn, hit the max, then spend!
+
+(deftest test-spend-tokens
+  (let [tbf (tbf/create-tbf 10.0 100 0)
+        tbf1 (tbf/spend-tokens tbf 0 130)
+        tbf2 (tbf/spend-tokens tbf1 5 0)
+        tbf3 (tbf/spend-tokens tbf2 10 3)
+        tbf4 (tbf/spend-tokens tbf3 5 3)
+        tbf5 (tbf/spend-tokens tbf4 15 10)
+        tbf6 (tbf/spend-tokens tbf5 30 5)]
+    ;; -130 tokens.
+    (testing "We have the expected tokens"
+      (is (approx= (:current-tokens tbf1) -130))
+      (is (approx= (:current-tokens tbf2) -80)) ; -130 + 50 - 0
+      (is (approx= (:current-tokens tbf3) -33)) ; -80 +50 - 3
+      (is (approx= (:current-tokens tbf4) -36)) ; -27 -3
+      (is (approx= (:current-tokens tbf5) 4)) ; -36 + 50 - 10
+      (is (approx= (:current-tokens tbf6) 95))) ;4 + 150 - 5
+
+    (testing "We report in-debt? correctly"
+      (is (tbf/in-debt? tbf1))
+      (is (tbf/in-debt? tbf2))
+      (is (tbf/in-debt? tbf3))
+      (is (tbf/in-debt? tbf4))
+      (is (not (tbf/in-debt? tbf5)))
+      (is (not (tbf/in-debt? tbf6))))))

--- a/scheduler/test/cook/test/rate_limit/token_bucket_filter.clj
+++ b/scheduler/test/cook/test/rate_limit/token_bucket_filter.clj
@@ -36,7 +36,6 @@
   (is (not (approx= 1.001 -1.002)))
   (is (not (approx= -1.001 1.002))))
 
-
 (deftest test-earn-tokens
   (let [tbf (tbf/create-tbf 10.0 100 0)] ; 10/time unit, 100 max total, and the current time is 0
     (testing "Initial state not in debt"
@@ -82,8 +81,8 @@
             tbf3 (tbf/earn-tokens tbf2 12) ; Timestamps are out of order, so we don't actually earn here.
             tbf4 (tbf/earn-tokens tbf3 10)
             tbf5 (tbf/earn-tokens tbf4 20)
-            tbf6 (tbf/earn-tokens tbf5 30)
-            ]
+            tbf6 (tbf/earn-tokens tbf5 30)]
+
         (is (= 5 (:last-update tbf1)))
         (is (= 15 (:last-update tbf2)))
         (is (= 15 (:last-update tbf3)))

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -24,8 +24,7 @@
             [cook.mesos.api :as api]
             [cook.mesos.schema :as schema]
             [cook.mesos.util :as util]
-            [cook.rate-limit :refer [job-submission-rate-limiter]]
-            [cook.rate-limit.generic :as rt]
+            [cook.rate-limit :as rate-limit]
             [datomic.api :as d :refer (q db)]
             [mount.core :as mount]
             [plumbing.core :refer [mapply]]
@@ -50,7 +49,7 @@
                                               (Object.)
                                               (atom true))]
                         (fn [request]
-                          (with-redefs [job-submission-rate-limiter rt/AllowAllRateLimiter]
+                          (with-redefs [rate-limit/job-submission-rate-limiter rate-limit/AllowAllRateLimiter]
                             (handler request)))))
         ; Add impersonation handler (current user is authorized to impersonate)
         api-handler-impersonation ((create-impersonation-middleware #{user}) api-handler)
@@ -322,10 +321,10 @@
                       :pool/state :pool.state/active
                       :pool/dru-mode dru-mode}]))
 
-(defn create-jobs!-wrapper
+(defn create-jobs!
   "Wrapper around create-jobs! That runs them with the ratelimiter preconfigured to use rate limiter that
   allows all requests through."
   [conn context]
   (with-redefs
-    [job-submission-rate-limiter rt/AllowAllRateLimiter]
+    [rate-limit/job-submission-rate-limiter rate-limit/AllowAllRateLimiter]
     (api/create-jobs! conn context)))


### PR DESCRIPTION
## Changes proposed in this PR

- Token Bucket Filter core --- the rate limit accounting code.
- This will be integrated into the job submission path in a future PR.

## Why are we making these changes?
- We have existing rate limits, but those only rate limit HTTP request rate. 
- We want context-aware rate limits that look based on the costs of processing a request. E.g., 100 HTTP requests each inserting one job versus each inserting 300 jobs. 
- More importantly, we want to allow bursting to a higher limit -- production can have 10k jobs inserted in 30 seconds. Ergo the use of a TBF.
- This gives us the foundation for implementing those controls.
