### PR TITLE
Adds more logging to test_unique_host_constraint

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1649,7 +1649,7 @@ class CookTest(util.CookTest):
                     # All of the jobs should be running
                     return num_running == num_jobs_total
 
-            jobs = util.wait_until(query, num_running_predicate, max_wait_ms=60000)
+            jobs = util.wait_until(query, num_running_predicate)
             hosts = [job['instances'][0]['hostname'] for job in jobs
                      if job['status'] == 'running']
             # Only one job should run on each host

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1628,8 +1628,8 @@ class CookTest(util.CookTest):
         group = {'uuid': str(uuid.uuid4()),
                  'host-placement': {'type': 'unique'}}
         job_spec = {'group': group['uuid'], 'command': 'sleep 600'}
-        # Don't submit too many jobs for the test. If the cluster is larger than 19 hosts, only submit 20 jobs.
-        num_jobs = min(num_hosts + 1, 20)
+        # Don't submit too many jobs for the test. If the cluster is larger than 9 hosts, only submit 10 jobs.
+        num_jobs = min(num_hosts + 1, 10)
         uuids, resp = util.submit_jobs(self.cook_url, job_spec, num_jobs, groups=[group])
         self.assertEqual(resp.status_code, 201, resp.content)
         try:

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1640,6 +1640,8 @@ class CookTest(util.CookTest):
                 num_jobs_total = len(response)
                 num_running = len([j for j in response if j['status'] == 'running'])
                 num_waiting = len([j for j in response if j['status'] == 'waiting'])
+                self.logger.info(f'There are {num_jobs_total} total jobs, {num_running} running jobs, '
+                                 f'and {num_waiting} waiting job(s)')
                 if num_jobs_total == num_hosts + 1:
                     # One job should not be scheduled
                     return (num_running == num_jobs_total - 1) and (num_waiting == 1)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1205,15 +1205,24 @@ def are_pools_enabled():
     return len(active_pools(cook_url)[0]) > 1
 
 
-def num_hosts_to_consider(cook_url, mesos_url):
+def hosts_to_consider(cook_url, mesos_url):
     """
-    Returns the number of hosts in the default pool, or the
-    total number of hosts if the cluster is not using pools
+    Returns the hosts in the default pool, or all hosts if the cluster is not using pools
     """
     state = get_mesos_state(mesos_url)
     slaves = state['slaves']
     pool = default_pool(cook_url)
     slaves = [s for s in slaves if s['attributes']['cook-pool'] == pool] if pool else slaves
-    num_hosts = len(slaves)
-    logging.info(f'There are {num_hosts} hosts in the default pool')
+    num_to_log = min(len(slaves), 10)
+    logging.info(f'First {num_to_log} hosts to consider: {json.dumps(slaves[:num_to_log], indent=2)}')
+    return slaves
+
+
+def num_hosts_to_consider(cook_url, mesos_url):
+    """
+    Returns the number of hosts in the default pool, or the
+    total number of hosts if the cluster is not using pools
+    """
+    num_hosts = len(hosts_to_consider(cook_url, mesos_url))
+    logging.info(f'There are {num_hosts} hosts to consider')
     return num_hosts


### PR DESCRIPTION
## Changes proposed in this PR

- adding a log with the number of total, running, and waiting jobs

## Why are we making these changes?

To make failures easier to track down.
