### PR TITLE
Don't use docker in start-datomic.sh

### DIFF
--- a/scheduler/bin/run-local.sh
+++ b/scheduler/bin/run-local.sh
@@ -48,23 +48,6 @@ then
     keytool -genkeypair -keystore ${COOK_KEYSTORE_PATH} -storetype PKCS12 -storepass cookstore -dname "CN=cook, OU=Cook Developers, O=Two Sigma Investments, L=New York, ST=New York, C=US" -keyalg RSA -keysize 2048
 fi
 
-set +e
-lsof -Pi :5000 -sTCP:LISTEN
-LSOF_EXIT=$?
-set -e
-if [ ${LSOF_EXIT} -ne 0 ];
-then
-    # Nothing listening on port 5000
-    if ! [ -x "$(command -v flask)" ]; then
-        echo "Please install flask"
-        exit 1
-    fi
-
-    INTEGRATION_DIR="$(dirname ${SCHEDULER_DIR})/integration"
-
-    FLASK_APP=${INTEGRATION_DIR}/src/data_locality_service.py flask run &
-fi
-
 echo "Mesos Master IP is ${MASTER_IP}"
 
 echo "Creating environment variables..."

--- a/scheduler/bin/run-local.sh
+++ b/scheduler/bin/run-local.sh
@@ -48,6 +48,23 @@ then
     keytool -genkeypair -keystore ${COOK_KEYSTORE_PATH} -storetype PKCS12 -storepass cookstore -dname "CN=cook, OU=Cook Developers, O=Two Sigma Investments, L=New York, ST=New York, C=US" -keyalg RSA -keysize 2048
 fi
 
+set +e
+lsof -Pi :5000 -sTCP:LISTEN
+LSOF_EXIT=$?
+set -e
+if [ ${LSOF_EXIT} -ne 0 ];
+then
+    # Nothing listening on port 5000
+    if ! [ -x "$(command -v flask)" ]; then
+        echo "Please install flask"
+        exit 1
+    fi
+
+    INTEGRATION_DIR="$(dirname ${SCHEDULER_DIR})/integration"
+
+    FLASK_APP=${INTEGRATION_DIR}/src/data_locality_service.py flask run &
+fi
+
 echo "Mesos Master IP is ${MASTER_IP}"
 
 echo "Creating environment variables..."


### PR DESCRIPTION
## Changes proposed in this PR
- Don't use docker in start-datomic.sh

## Why are we making these changes?
Docker isn't required for datomic, so make it easier for people who prefer not to use it.