### PR TITLE
Fixes pool bug in task reconciliation

### DIFF
--- a/scheduler/datomic/data/seed_pools.clj
+++ b/scheduler/datomic/data/seed_pools.clj
@@ -25,26 +25,8 @@
        (map (partial d/entity db))
        (map d/touch)))
 
-(defn retry
-  [tries f & args]
-  (let [res (try {:value (apply f args)}
-                 (catch Exception e
-                   (if (= 0 tries)
-                     (throw e)
-                     {:exception e})))]
-    (if (:exception res)
-      (do
-        (Thread/sleep 5000)
-        (recur (dec tries) f args))
-      (:value res))))
-
-(defn connect
-  []
-  (println "Attempting to connect to" uri)
-  (datomic/create-connection {:settings {:mesos-datomic-uri uri}}))
-
 (try
-  (let [conn (retry 10 connect)]
+  (let [conn (datomic/create-connection {:settings {:mesos-datomic-uri uri}})]
     (println "Connected to Datomic:" conn)
     (create-pool conn "alpha" :pool.state/active)
     (create-pool conn "beta" :pool.state/inactive)

--- a/scheduler/datomic/data/seed_running_jobs.clj
+++ b/scheduler/datomic/data/seed_running_jobs.clj
@@ -1,0 +1,66 @@
+(ns data.seed-running-jobs
+  (:require [cook.datomic :as datomic]
+            [cook.mesos.util :as util]
+            [datomic.api :as d])
+  (:import (java.util Date UUID)))
+
+(def uri (second *command-line-args*))
+(println "Datomic URI is" uri)
+
+(defn create-instance
+  [conn job]
+  @(d/transact conn [{:db/id (d/tempid :db.part/user)
+                      :instance/executor-id (str (UUID/randomUUID))
+                      :instance/hostname "localhost"
+                      :instance/preempted? false
+                      :instance/progress 0
+                      :instance/slave-id (str (UUID/randomUUID))
+                      :instance/start-time (Date.)
+                      :instance/status :instance.status/unknown
+                      :instance/task-id (str (UUID/randomUUID))
+                      :job/_instance job}]))
+
+(defn create-job
+  [conn name]
+  (let [id (d/tempid :db.part/user)
+        commit-latch-id (d/tempid :db.part/user)
+        commit-latch {:db/id commit-latch-id
+                      :commit-latch/committed? true}
+        job-info {:db/id id
+                  :job/command "echo hello"
+                  :job/commit-latch commit-latch-id
+                  :job/disable-mea-culpa-retries false
+                  :job/max-retries 5
+                  :job/max-runtime Long/MAX_VALUE
+                  :job/name name
+                  :job/priority 50
+                  :job/resource [{:resource/type :resource.type/cpus
+                                  :resource/amount (double 1.0)}
+                                 {:resource/type :resource.type/mem
+                                  :resource/amount (double 10.0)}]
+                  :job/state :job.state/running
+                  :job/submit-time (Date.)
+                  :job/data-local false
+                  :job/under-investigation false
+                  :job/user (System/getProperty "user.name")
+                  :job/uuid (d/squuid)}
+        tx-data [job-info commit-latch]]
+    (d/resolve-tempid (d/db conn) (:tempids @(d/transact conn tx-data)) id)))
+
+(defn create-running-job
+  [conn name]
+  (create-instance conn (create-job conn name)))
+
+(try
+  (let [conn (datomic/create-connection {:settings {:mesos-datomic-uri uri}})]
+    (println "Connected to Datomic:" conn)
+    (create-running-job conn "running_job_1")
+    (create-running-job conn "running_job_2")
+    (create-running-job conn "running_job_3")
+    (create-running-job conn "running_job_4")
+    (println "Running Jobs:")
+    (run! clojure.pprint/pprint (util/get-running-job-ents (d/db conn)))
+    (System/exit 0))
+  (catch Throwable t
+    (println "Failed to seed running jobs:" t)
+    (System/exit 1)))

--- a/scheduler/docker/run-cook.sh
+++ b/scheduler/docker/run-cook.sh
@@ -6,4 +6,5 @@ echo "alt-host=$(hostname -i | cut -d' ' -f2)" >> ${DATOMIC_PROPERTIES_FILE}
 /opt/cook/datomic-free-0.9.5394/bin/transactor ${DATOMIC_PROPERTIES_FILE} &
 echo "Seeding test data..."
 lein exec -p /opt/cook/datomic/data/seed_pools.clj ${COOK_DATOMIC_URI}
+lein exec -p /opt/cook/datomic/data/seed_running_jobs.clj ${COOK_DATOMIC_URI}
 lein with-profiles +docker run $1

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -2069,7 +2069,6 @@
 
 (deftest test-reconcile-tasks
   (let [conn (restore-fresh-database! "datomic:mem://test-reconcile-tasks")
-        framework-id #mesomatic.types.FrameworkID{:value "my-original-framework-id"}
         fenzo (make-dummy-scheduler)
         task-atom (atom [])
         mock-driver (reify msched/SchedulerDriver
@@ -2084,7 +2083,7 @@
         _ (create-dummy-job-with-instances conn
                                            :job-state :job.state/completed
                                            :instances [{:instance-status :instance.status/success}])]
-    (sched/reconcile-tasks (d/db conn) mock-driver framework-id fenzo)
+    (sched/reconcile-tasks (d/db conn) mock-driver (constantly fenzo))
     (let [reconciled-tasks (set @task-atom)
           running-instance (d/entity (d/db conn) running-instance-id)
           unknown-instance (d/entity (d/db conn) unknown-instance-id)]


### PR DESCRIPTION
## Changes proposed in this PR

- seeding running jobs in datomic before starting cook scheduler
- adding `test_reconciliation`, which tests that the seeded jobs get killed by the reconciler
- fixing the task reconciler to grab fenzo from the pool-to-fenzo map

## Why are we making these changes?

This bug was introduced when we added pool scheduling. The test should help prevent future task reconciliation bugs from going unnoticed.
