### PR TITLE
Update .gitignore to ignore *.orig files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ scheduler/trace*.csv
 src/cfg/current.clj
 target
 test-log
+*.orig


### PR DESCRIPTION
## Changes proposed in this PR

- Have .gitignore ignore *.orig files
- 
- 

## Why are we making these changes?

Reduce clutter in git-gui.
