### PR TITLE
Remove -XX:MaxPermSize, obsolete in JDK8 and above.

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -208,7 +208,6 @@
 
   :main cook.components
   :jvm-opts ["-Dpython.cachedir.skip=true"
-             "-XX:MaxPermSize=500M"
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"


### PR DESCRIPTION
## Changes proposed in this PR

- Remove this option
- 
- 

## Why are we making these changes?

- This option is obsolete in JDK8 and above. It suppresses an error message that occurs on many lein commands.
