### PR TITLE
Docker file build changes for integration tests.

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,8 +1,11 @@
 FROM python:3.6
 
+WORKDIR /opt/cook/integration
+COPY requirements.txt /opt/cook/integration
 ADD cli.tar.gz /opt/cook/cli/
+RUN pip install -r requirements.txt
 COPY . /opt/cook/integration
 WORKDIR /opt/cook/integration
-RUN pip install -r requirements.txt
+
 
 ENTRYPOINT ["pytest"]

--- a/integration/bin/build-docker-image.sh
+++ b/integration/bin/build-docker-image.sh
@@ -6,9 +6,9 @@
 INTEGRATION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 NAME=cook-integration
 
-echo "Building docker images for ${NAME}"
+echo "Building docker images for ${NAME} IN $(dirname ${INTEGRATION_DIR})/cli"
 cd $(dirname ${INTEGRATION_DIR})/cli
-tar -czf ${INTEGRATION_DIR}/cli.tar.gz .
+tar -c . | gzip -n >${INTEGRATION_DIR}/cli.tar.gz
 cd ${INTEGRATION_DIR}
 docker build -t ${NAME} ${INTEGRATION_DIR}
 rm cli.tar.gz


### PR DESCRIPTION
## Changes proposed in this PR

- Slight refactor in how we build docker images. 
- Avoids the pip install + requisite CPU time. 

## Why are we making these changes?

Avoids 200mb of downloads + 200 seconds to generate docker images for
the docker-based integration test workflow.

A docker image build and integration test run in it goes from
350 to 150 seconds.
