### PR TITLE
Fixes quota bug when not using pools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
       services: docker
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh
-      script: ./travis/run_integration.sh --pools=off
+      script: ./travis/run_integration.sh --pools=off --auth=http-basic
 
     - env: NAME='Cook Scheduler Simulator tests'
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       before_script: cd integration && ./travis/prepare_integration.sh
       script: ./travis/run_integration.sh --executor=cook
 
-    - env: NAME='Cook Scheduler integration tests with no pools'
+    - env: NAME='Cook Scheduler integration tests with no pools and with HTTP Basic Auth'
       services: docker
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -890,7 +890,7 @@
                                                             (cache/hit c slave-id)
                                                             (cache/miss c slave-id attrs)))))
                       _ (log/debug "In" pool "pool, passing following offers to handle-resource-offers!" offers)
-                      using-pools? (config/default-pool)
+                      using-pools? (not (nil? (config/default-pool)))
                       user->quota (quota/create-user->quota-fn (d/db conn) (if using-pools? pool nil))
                       matched-head? (handle-resource-offers! conn @driver-atom fenzo framework-id pending-jobs-atom
                                                              mesos-run-as-user @user->usage-future user->quota

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -890,7 +890,8 @@
                                                             (cache/hit c slave-id)
                                                             (cache/miss c slave-id attrs)))))
                       _ (log/debug "In" pool "pool, passing following offers to handle-resource-offers!" offers)
-                      user->quota (quota/create-user->quota-fn (d/db conn) (name pool))
+                      using-pools? (config/default-pool)
+                      user->quota (quota/create-user->quota-fn (d/db conn) (if using-pools? pool nil))
                       matched-head? (handle-resource-offers! conn @driver-atom fenzo framework-id pending-jobs-atom
                                                              mesos-run-as-user @user->usage-future user->quota
                                                              num-considerable offers-chan offers
@@ -1491,26 +1492,26 @@
                                          (->> o :attributes (filter #(= "cook-pool" (:name %))) first :text)
                                          "no-pool"))
                                      offers)
-              using-pools? (config/default-pool)
-              offer-count (count offers)]
+              using-pools? (config/default-pool)]
           (log/info "Offers by pool:" (pc/map-vals count pool->offers))
           (run!
             (fn [[pool-name offers]]
-              (if using-pools?
-                (if-let [offers-chan (get pool->offers-chan pool-name)]
-                  (do
-                    (log/info "Processing" offer-count "offer(s) for known pool" pool-name)
-                    (receive-offers offers-chan match-trigger-chan driver offers))
-                  (do
-                    (log/warn "Declining" offer-count "offer(s) for non-existent pool" pool-name)
-                    (decline-offers-safe driver offers)))
-                (if-let [offers-chan (get pool->offers-chan "no-pool")]
-                  (do
-                    (log/info "Processing" offer-count "offer(s) for pool" pool-name "(not using pools)")
-                    (receive-offers offers-chan match-trigger-chan driver offers))
-                  (do
-                    (log/error "Declining" offer-count "offer(s) for pool" pool-name "(missing no-pool offer chan)")
-                    (decline-offers-safe driver offers)))))
+              (let [offer-count (count offers)]
+                (if using-pools?
+                  (if-let [offers-chan (get pool->offers-chan pool-name)]
+                    (do
+                      (log/info "Processing" offer-count "offer(s) for known pool" pool-name)
+                      (receive-offers offers-chan match-trigger-chan driver offers))
+                    (do
+                      (log/warn "Declining" offer-count "offer(s) for non-existent pool" pool-name)
+                      (decline-offers-safe driver offers)))
+                  (if-let [offers-chan (get pool->offers-chan "no-pool")]
+                    (do
+                      (log/info "Processing" offer-count "offer(s) for pool" pool-name "(not using pools)")
+                      (receive-offers offers-chan match-trigger-chan driver offers))
+                    (do
+                      (log/error "Declining" offer-count "offer(s) for pool" pool-name "(missing no-pool offer chan)")
+                      (decline-offers-safe driver offers))))))
             pool->offers)
           (log/debug "Finished receiving offers for all pools")))
       (status-update


### PR DESCRIPTION
## Changes proposed in this PR

- turning on `--auth=http-basic` for the travis run without pools
- fixing a bug in quota-checking when running without pools

## Why are we making these changes?

The travis change allows multi-user tests (e.g. `test_preemption`) to run in the no-pools build. The bug went unnoticed because these tests were previously not running on that build.