### PR TITLE
Asserts that there is at least 1 active pool

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -290,6 +290,7 @@ class MultiUserCookTest(util.CookTest):
     @pytest.mark.serial
     def test_preemption_for_pools(self):
         pools, _ = util.active_pools(self.cook_url)
+        self.assertLess(0, len(pools))
         for pool in pools:
             self.logger.info(f'Triggering preemption for {pool}')
             self.trigger_preemption(pool=pool['name'])


### PR DESCRIPTION
## Changes proposed in this PR

- asserting that there is at least 1 active pool in `test_preemption_for_pools`

## Why are we making these changes?

To ensure that the `for` loop below is not a no-op.
