### PR TITLE
Allows for overriding wait interval with environment variable

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -30,6 +30,9 @@ DEFAULT_TEST_TIMEOUT_SECS = 600
 # 2 minutes should be more than sufficient on most cases
 DEFAULT_TIMEOUT_MS = int(os.getenv('COOK_TEST_DEFAULT_TIMEOUT_MS', 120000))
 
+# default wait interval (i.e. time between attempts) used by most wait_* utility functions
+DEFAULT_WAIT_INTERVAL_MS = int(os.getenv('COOK_TEST_DEFAULT_WAIT_INTERVAL_MS', 1000))
+
 # Name of our custom HTTP header for user impersonation
 IMPERSONATION_HEADER = 'X-Cook-Impersonate'
 
@@ -567,7 +570,7 @@ def load_instance(cook_url, instance_uuid, assert_response=True):
     return load_resource(cook_url, 'instances', instance_uuid, assert_response)
 
 
-def wait_until(query, predicate, max_wait_ms=DEFAULT_TIMEOUT_MS, wait_interval_ms=1000):
+def wait_until(query, predicate, max_wait_ms=DEFAULT_TIMEOUT_MS, wait_interval_ms=DEFAULT_WAIT_INTERVAL_MS):
     """
     Block until the predicate is true for the result of the provided query.
     `query` is a thunk (nullary callable) that may be called multiple times.

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -670,7 +670,7 @@ def wait_for_jobs(cook_url, job_ids, status, max_wait_ms=DEFAULT_TIMEOUT_MS):
             logger.info(f"Job {job['uuid']} has status {job['status']}, expecting {status}.")
         return all([job['status'] == status for job in jobs])
 
-    response = wait_until(query, predicate, max_wait_ms=max_wait_ms, wait_interval_ms=2000)
+    response = wait_until(query, predicate, max_wait_ms=max_wait_ms, wait_interval_ms=DEFAULT_WAIT_INTERVAL_MS * 2)
     return response.json()
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- introducing `COOK_TEST_DEFAULT_WAIT_INTERVAL_MS`, which allows for overriding the default wait interval (i.e. time between attempts) used by most of the `wait_*` functions

## Why are we making these changes?

In some environments, it's useful to allow the total timeout to be quite high (e.g. 8 minutes), in which case checking the condition once per second can cause the test logs to get way too huge. In these cases, it's also nice to allow for a longer wait between checks.
