### PR TITLE
Don't follow redirects on /queue admin self-impersonation test

### DIFF
--- a/integration/tests/cook/test_impersonation.py
+++ b/integration/tests/cook/test_impersonation.py
@@ -127,8 +127,10 @@ class ImpersonationCookTest(util.CookTest):
             # admin can self-impersonate for admin endpoints
             # i.e., self-impersonation is treated as a non-impersonated request
             with self.admin.impersonating(self.admin):
-                resp = util.query_queue(self.cook_url)
-                self.assertEqual(resp.status_code, 200, resp.text)
+                # The /queue endpoint redirects to the master, but we don't need to follow that.
+                # As long as we don't get an auth error, we're good.
+                resp = util.query_queue(self.cook_url, allow_redirects=False)
+                self.assertIn(resp.status_code, [200, 307], resp.text)
         finally:
             with self.admin:
                 util.kill_jobs(self.cook_url, [j for j in job_uuids if j])

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1000,9 +1000,9 @@ def user_current_usage(cook_url, **kwargs):
     return session.get('%s/usage' % cook_url, params=kwargs)
 
 
-def query_queue(cook_url):
+def query_queue(cook_url, **kwargs):
     """Get current jobs via the queue endpoint (admin-only)"""
-    return session.get(f'{cook_url}/queue')
+    return session.get(f'{cook_url}/queue', **kwargs)
 
 
 def get_limit(cook_url, limit_type, user, pool=None):


### PR DESCRIPTION
## Changes proposed in this PR

Don't follow the redirect on the `/queue` endpoint in the `test_self_impersonate` integration test.

## Why are we making these changes?

The redirect was causing problems with Kerberose clients.