### PR TITLE
 Makes test_unique_host_constraint more reliable

### DIFF
--- a/integration/tests/cook/reasons.py
+++ b/integration/tests/cook/reasons.py
@@ -8,3 +8,4 @@ CMD_NON_ZERO_EXIT = 99003
 UNDER_INVESTIGATION = 'The job is now under investigation. Check back in a minute for more details!'
 COULD_NOT_PLACE_JOB = 'The job couldn\'t be placed on any available hosts.'
 JOB_WOULD_EXCEED_QUOTA = 'The job would cause you to exceed resource quotas.'
+JOB_IS_RUNNING_NOW = 'The job is running now.'

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1683,9 +1683,9 @@ class CookTest(util.CookTest):
                                      unique_reason['data']['reasons'][0]['reason'],
                                      unique_reason)
                 elif running_reasons:
-                    self.logger.info('Job is now running')
+                    self.logger.info(f'Job is now running: {job}')
                     self.assertEqual('running', job['status'])
-                    self.assertNotIn(job['hostname'], hosts)
+                    self.assertNotIn(job['instances'][0]['hostname'], hosts)
                 else:
                     self.fail(f'Expected job to either not be possible to place or to be running: {job}')
         finally:


### PR DESCRIPTION
## Changes proposed in this PR

- allowing for the "waiting job" to become running in `test_unique_host_constraint`

## Why are we making these changes?

In some environments, new Mesos agents can come online during the time that we wait for the unscheduled job reason to update. If this happens, our "waiting job" can switch to running, and we should allow for this in the test.
