### PR TITLE
Makes test_balanced_host_constraint_cannot_place more reliable

### DIFF
--- a/integration/tests/cook/reasons.py
+++ b/integration/tests/cook/reasons.py
@@ -8,3 +8,4 @@ CMD_NON_ZERO_EXIT = 99003
 UNDER_INVESTIGATION = 'The job is now under investigation. Check back in a minute for more details!'
 COULD_NOT_PLACE_JOB = 'The job couldn\'t be placed on any available hosts.'
 JOB_WOULD_EXCEED_QUOTA = 'The job would cause you to exceed resource quotas.'
+JOB_IS_RUNNING_NOW = 'The job is running now.'

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1701,8 +1701,11 @@ class CookTest(util.CookTest):
                 return util.query_jobs(self.cook_url, uuid=uuids).json()
 
             def num_running_predicate(response):
+                num_jobs_total = len(response)
                 num_running = len([j for j in response if j['status'] == 'running'])
                 num_waiting = len([j for j in response if j['status'] == 'waiting'])
+                self.logger.info(f'There are {num_jobs_total} total jobs, {num_running} running jobs, '
+                                 f'and {num_waiting} waiting job(s)')
                 return num_running == num_hosts and num_waiting == 1
 
             jobs = util.wait_until(query_list, num_running_predicate)


### PR DESCRIPTION
## Changes proposed in this PR

- allowing for the case where the "waiting job" becomes running while we wait for the unscheduled jobs reason

## Why are we making these changes?

In some environments, new Mesos agents can become available during the time we're waiting for the unscheduled jobs reason. When this happens, we want to allow for the "waiting job" to become running.
