### PR TITLE
Trigger Travis-CI on branches with "build/" prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: java
 jdk: oraclejdk8
 
 branches:
-  only: master
+  only:
+    - master
+    - /^build\/.*$/
 
 cache:
   directories:


### PR DESCRIPTION
## Changes proposed in this PR

- Trigger Travis-CI on branches with the `build/` prefix.

## Why are we making these changes?

This makes it easier for developers to trigger Travis-CI on branches in their personal GitHub forks of the Cook Scheduler project.