### PR TITLE
Use twosigma clj-http

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -67,7 +67,7 @@
                  [jarohen/chime "0.1.6"]
 
                  ;;Networking
-                 [clj-http "2.0.0"]
+                 [twosigma/clj-http "2.0.0-ts1"]
                  [io.netty/netty "3.10.1.Final"]
                  [cc.qbits/jet "0.6.4" :exclusions [org.eclipse.jetty/jetty-io
                                                     org.eclipse.jetty/jetty-security


### PR DESCRIPTION
## Changes proposed in this PR
- Use the two sigma patched version of clj-http

## Why are we making these changes?
This adds support for SPNEGO authentication