### PR TITLE
Allows overriding the default test timeout with an environment variable

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -24,7 +24,7 @@ session.headers['User-Agent'] = f"Cook-Scheduler-Integration-Tests ({session.hea
 
 # default time limit for each individual integration test
 # if a test takes more than 10 minutes, it's probably broken
-DEFAULT_TEST_TIMEOUT_SECS = 600
+DEFAULT_TEST_TIMEOUT_SECS = int(os.getenv('COOK_TEST_DEFAULT_TEST_TIMEOUT_SECS', 600))
 
 # default time limit used by most wait_* utility functions
 # 2 minutes should be more than sufficient on most cases


### PR DESCRIPTION
## Changes proposed in this PR

- introducing `COOK_TEST_DEFAULT_TEST_TIMEOUT_SECS`, which lets you override the default test timeout

## Why are we making these changes?

In some environments, we need to allow some tests to run for longer than 10 minutes.
