### PR TITLE
Avoid sandbox checks if they shouldn't be expected

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1226,3 +1226,19 @@ def num_hosts_to_consider(cook_url, mesos_url):
     num_hosts = len(hosts_to_consider(cook_url, mesos_url))
     logging.info(f'There are {num_hosts} hosts to consider')
     return num_hosts
+
+
+def should_expect_sandbox_directory(instance=None, job=None):
+    """Returns true if we should expect the sandbox directory to get populated"""
+    if not instance and not job:
+        raise Exception('You must provide either an instance or job to know whether the sandbox directory is expected')
+
+    if not instance:
+        instance = job['instances'][0]
+
+    expect_sandbox = not has_ephemeral_hosts() or instance['executor'] == 'cook'
+    if expect_sandbox:
+        logging.info('The sandbox directory is expected to get populated')
+    else:
+        logging.info('The sandbox directory is not expected to get populated')
+    return expect_sandbox


### PR DESCRIPTION
## Changes proposed in this PR

- introducing `util.should_expect_sandbox_directory`, which tells you whether or not you should expect the sandbox directory to get populated
- calling the function in a couple of tests to determine whether or not assertions should be made

## Why are we making these changes?

In environments where Mesos agents can be garbage collected quickly, and where we're not using the Cook executor, we may never get the sandbox directory populated.
