### PR TITLE
`periodic-seq` overflow bug

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -37,7 +37,7 @@
                  [org.clojure/tools.namespace "0.2.4"]
                  [org.clojure/core.cache "0.6.4"]
                  [org.clojure/core.memoize "0.5.8"]
-                 [clj-time "0.9.0"]
+                 [clj-time "0.12.0"]
                  [org.clojure/core.async "0.3.442" :exclusions [org.clojure/tools.reader]]
                  [org.clojure/tools.cli "0.3.5"]
                  [prismatic/schema "1.1.3"]

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -15,11 +15,8 @@
 ;;
 (ns cook.mesos
   (:require [chime :refer [chime-ch]]
-            [clj-http.client :as http]
             [clj-time.core :as time]
-            [clj-time.periodic :as periodic]
             [clojure.core.async :as async]
-            [clojure.data.json :as json]
             [clojure.tools.logging :as log]
             [cook.config :as config]
             [cook.datomic :refer (transact-with-retries)]
@@ -29,7 +26,7 @@
             [cook.mesos.optimizer]
             [cook.mesos.rebalancer]
             [cook.mesos.scheduler :as sched]
-            [cook.mesos.util]
+            [cook.mesos.util :as util]
             [cook.util]
             [datomic.api :as d :refer (q)]
             [mesomatic.scheduler]
@@ -131,7 +128,7 @@
   (let [{:keys [update-interval-ms]} (config/data-local-fitness-config)
         prepare-trigger-chan (fn prepare-trigger-chan [interval]
                                (let [ch (async/chan (async/sliding-buffer 1))]
-                                 (async/pipe (chime-ch (periodic/periodic-seq (time/now) interval))
+                                 (async/pipe (chime-ch (util/time-seq (time/now) interval))
                                              ch)
                                  ch))]
     (cond->

--- a/scheduler/src/cook/mesos/heartbeat.clj
+++ b/scheduler/src/cook/mesos/heartbeat.clj
@@ -17,9 +17,9 @@
   (:require [chime :refer [chime-at chime-ch]]
             [clj-time.coerce :as tc]
             [clj-time.core :as time]
-            [clj-time.periodic :as periodic]
             [clojure.core.async :as async :refer [alts! go-loop go >!]]
             [clojure.tools.logging :as log]
+            [cook.mesos.util :as util]
             [datomic.api :as d :refer (q)]
             [metatransaction.core :refer (db)]
             [metrics.meters :as meters]
@@ -126,7 +126,7 @@
   "Start heartbeat watcher. Return a fn to stop heartbeat watcher."
   [conn heartbeat-ch]
   (let [shutdown-ch (async/chan (async/dropping-buffer 1))
-        sync-datomic-ch (chime-ch (periodic/periodic-seq (time/now) (time/minutes 5)) (async/sliding-buffer 1))]
+        sync-datomic-ch (chime-ch (util/time-seq (time/now) (time/minutes 5)) (async/sliding-buffer 1))]
     (go-loop [[timeout-chs _ _ :as state] [#{} {} {}]]
              (let [;; Order is important here. We want to avoid the case where we timeout a task before having the chance to process its heartbeat.
                    [v ch] (async/alts! (into [shutdown-ch heartbeat-ch sync-datomic-ch] timeout-chs) :priority true)]

--- a/scheduler/src/cook/mesos/mesos_mock.clj
+++ b/scheduler/src/cook/mesos/mesos_mock.clj
@@ -16,7 +16,6 @@
 (ns cook.mesos.mesos-mock
   (:require [chime :refer [chime-at chime-ch]]
             [clj-time.core :as t]
-            [clj-time.periodic :as periodic]
             [clojure.core.async :as async]
             [clojure.tools.logging :as log]
             [cook.mesos.util :as util]
@@ -394,7 +393,7 @@
      :or {task->complete-status default-task->complete-status
           task->runtime-ms default-task->runtime-ms
           state-atom (atom nil)
-          complete-trigger-chan (chime-ch (periodic/periodic-seq (t/now) (t/millis 20)))}}]
+          complete-trigger-chan (chime-ch (util/time-seq (t/now) (t/millis 20)))}}]
    (let [action-chan (async/chan 10) ; This will block calls to the driver. This may be problematic..
          exit-chan (async/chan)
          start-chan (async/chan)

--- a/scheduler/src/cook/mesos/monitor.clj
+++ b/scheduler/src/cook/mesos/monitor.clj
@@ -16,7 +16,6 @@
 (ns cook.mesos.monitor
   (:require [chime :refer [chime-at]]
             [clj-time.core :as time]
-            [clj-time.periodic :as periodic]
             [clojure.set :refer (union difference)]
             [clojure.tools.logging :as log]
             [cook.config :refer (config)]
@@ -24,7 +23,6 @@
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
             [datomic.api :as d :refer (q)]
-            [metrics.core :as metrics]
             [metrics.counters :as counters]))
 
 (defn- get-job-stats
@@ -162,7 +160,7 @@
     (if interval-seconds
       (let [state->previous-stats-atom (atom {})]
         (log/info "Starting user stats collection at intervals of" interval-seconds "seconds")
-        (chime-at (periodic/periodic-seq (time/now) (time/seconds interval-seconds))
+        (chime-at (util/time-seq (time/now) (time/seconds interval-seconds))
                   (fn [_]
                     (let [mesos-db (d/db datomic/conn)]
                       (set-stats-counters! mesos-db state->previous-stats-atom)))

--- a/scheduler/src/cook/mesos/sandbox.clj
+++ b/scheduler/src/cook/mesos/sandbox.clj
@@ -17,11 +17,11 @@
   (:require [chime :as chime]
             [clj-http.client :as http]
             [clj-time.core :as time]
-            [clj-time.periodic :as periodic]
             [clojure.core.cache :as cache]
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [cook.mesos.util :as util]
             [datomic.api :as d]
             [metrics.counters :as counters]
             [metrics.histograms :as histograms]
@@ -263,7 +263,7 @@
   [task-id->sandbox-agent datomic-conn publish-batch-size publish-interval-ms]
   (log/info "Starting sandbox publisher at intervals of" publish-interval-ms "ms")
   (chime/chime-at
-    (periodic/periodic-seq (time/now) (time/millis publish-interval-ms))
+    (util/time-seq (time/now) (time/millis publish-interval-ms))
     (fn sandbox-publisher-task [_]
       (publish-instance-field-to-datomic!
         :instance/sandbox-directory datomic-conn publish-batch-size task-id->sandbox-agent))
@@ -275,7 +275,7 @@
   [{:keys [mesos-agent-query-cache pending-sync-agent] :as publisher-state} sync-interval-ms max-consecutive-sync-failure]
   (log/info "Starting sandbox syncer at intervals of" sync-interval-ms "ms")
   (chime/chime-at
-    (periodic/periodic-seq (time/now) (time/millis sync-interval-ms))
+    (util/time-seq (time/now) (time/millis sync-interval-ms))
     (fn host-sandbox-syncer-task [_]
       (let [{:keys [framework-id host->consecutive-failures pending-sync-hosts]} @pending-sync-agent
             num-pending-sync-hosts (count pending-sync-hosts)]
@@ -346,7 +346,7 @@
   [task-id->exit-code-agent datomic-conn publish-batch-size publish-interval-ms]
   (log/info "Starting exit-code publisher at intervals of" publish-interval-ms "ms")
   (chime/chime-at
-    (periodic/periodic-seq (time/now) (time/millis publish-interval-ms))
+    (util/time-seq (time/now) (time/millis publish-interval-ms))
     (fn exit-code-publisher-task [_]
       (publish-instance-field-to-datomic!
         :instance/exit-code datomic-conn publish-batch-size task-id->exit-code-agent))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -300,24 +300,6 @@
      get-pending-jobs-duration
      (get-pending-job-ents* unfiltered-db true))))
 
-(defn generate-intervals
-  "Generates a list of intervals between start and end as pairs
-   [interval-start interval-end]. The union of the intervals is
-   inclusive of both start and end
-
-   Parameters:
-   ----------
-   start : clj-time/datetime
-   end : clj-time/datetime
-   period-like : clj-time/period
-
-   Returns:
-   --------
-   list of pairs, [interval-start interval-end]"
-  ([start end period-like]
-   (->> (conj (vec (periodic-seq start end period-like)) end)
-        (partition 2 1))))
-
 (timers/deftimer [cook-mesos scheduler get-completed-jobs-by-user-duration])
 
 (defn job-ent->user

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -17,7 +17,6 @@
   (:require [clj-time.coerce :as tc]
             [clj-time.core :as t]
             [clj-time.format :as tf]
-            [clj-time.periodic :refer [periodic-seq]]
             [cook.config :as config]
             [cook.mesos.pool :as pool]
             [cook.mesos.schema :as schema]

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -31,7 +31,8 @@
   (:import
     [com.google.common.cache Cache CacheBuilder]
     [java.util.concurrent TimeUnit]
-    [java.util Date]))
+    [java.util Date]
+    [org.joda.time DateTime ReadablePeriod]))
 
 (defn new-cache []
   "Build a new cache"
@@ -824,3 +825,9 @@
   (if (nil? s)
     d
     (Integer/parseInt s)))
+
+(defn time-seq
+  "Returns a sequence of date-time values growing over specific period.
+   Takes as input the starting value and the growing value, returning a lazy infinite sequence."
+  [start ^ReadablePeriod period]
+  (iterate (fn [^DateTime t] (.plus t period)) start))

--- a/scheduler/test/cook/test/mesos/util.clj
+++ b/scheduler/test/cook/test/mesos/util.clj
@@ -398,19 +398,6 @@
       (async/<!! oc)
       (is (= (count (util/read-chan ch 10)) 10)))))
 
-(deftest test-generate-intervals
-  (let [start (tc/from-date #inst "2017-06-01")
-        end (tc/from-date #inst "2017-06-02")]
-    (is (= [[start end]] (util/generate-intervals start end (t/days 1))))
-    (is (= [[start (tc/from-date #inst "2017-06-01T07:00:00")]
-            [(tc/from-date #inst "2017-06-01T07:00:00")
-             (tc/from-date #inst "2017-06-01T14:00:00")]
-            [(tc/from-date #inst "2017-06-01T14:00:00")
-             (tc/from-date #inst "2017-06-01T21:00:00")]
-            [(tc/from-date #inst "2017-06-01T21:00:00")
-             end]]
-           (util/generate-intervals start end (t/hours 7))))))
-
 (deftest test-get-jobs-by-user-and-states
   (let [uri "datomic:mem://test-get-pending-job-ents"
         conn (restore-fresh-database! uri)]

--- a/scheduler/test/cook/test/mesos/util.clj
+++ b/scheduler/test/cook/test/mesos/util.clj
@@ -30,7 +30,8 @@
                      restore-fresh-database!]]
             [datomic.api :as d :refer (q db)])
   (:import [java.util Date]
-           [java.util.concurrent ExecutionException]))
+           [java.util.concurrent ExecutionException]
+           [org.joda.time DateTime]))
 
 (deftest test-total-resources-of-jobs
   (let [uri "datomic:mem://test-total-resources-of-jobs"
@@ -656,5 +657,25 @@
         (let [job-ent (d/entity (d/db conn) job)]
           (is (= 1 (:job/max-retries job-ent)))
           (is (= :job.state/waiting (:job/state job-ent))))))))
+
+(deftest test-time-seq
+  (testing "Generation of a sequence of times"
+
+    (testing "should work for small numbers of iterations"
+      (let [start (DateTime. 1000)
+            every-milli (util/time-seq start (t/millis 1))
+            every-ten-secs (util/time-seq start (t/seconds 10))]
+        (is (= (DateTime. 1000) (first every-milli)))
+        (is (= (DateTime. 1001) (second every-milli)))
+        (is (= (DateTime. 1002) (nth every-milli 2)))
+        (is (= (map #(DateTime. %) [1000 1001 1002 1003 1004 1005 1006 1007 1008 1009])
+               (take 10 every-milli)))
+        (is (= (map #(DateTime. %) [1000 11000 21000 31000 41000 51000 61000 71000 81000 91000])
+               (take 10 every-ten-secs)))))
+
+    (testing "should work for 52 weeks worth of ten-second intervals"
+      (let [now (t/now)
+            every-ten-secs (util/time-seq now (t/millis 10000))]
+        (is (true? (t/equal? (t/plus now (t/weeks 52)) (nth every-ten-secs 3144960))))))))
 
 (comment (run-tests))


### PR DESCRIPTION
## Changes proposed in this PR

- upgrades clj-time to `0.12.0`
- deletes unused generate-intervals function
- adds time-seq helper function to bypass overflow issues from `periodic-seq`
- replaces uses of `periodic/periodic-seq` with `util/time-seq`

## Why are we making these changes?

`periodic-seq` exhibits integer overflows when the scheduler runs for a long time.
