### PR TITLE
Skip data local constraint test when fitness calculator is disabled

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2544,6 +2544,9 @@ class CookTest(util.CookTest):
 
 
     def test_data_local_constraint(self):
+        settings = util.settings(self.cook_url)
+        if settings['fenzo-fitness-calculator'] != 'cook.mesos.data-locality/make-data-local-fitness-calculator':
+            return
         job_uuid, resp = util.submit_job(self.cook_url, datasets=[{'dataset': {'uuid': str(uuid.uuid4())}}])
         self.assertEqual(201, resp.status_code, resp.text)
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2543,10 +2543,8 @@ class CookTest(util.CookTest):
             self.assertEqual('Mesos task reconciliation', instances[0]['reason_string'])
 
 
+    @unittest.skipUnless(util.using_data_local_fitness_calculator(), "Requires the data local fitness calculator")
     def test_data_local_constraint(self):
-        settings = util.settings(self.cook_url)
-        if settings['fenzo-fitness-calculator'] != 'cook.mesos.data-locality/make-data-local-fitness-calculator':
-            return
         job_uuid, resp = util.submit_job(self.cook_url, datasets=[{'dataset': {'uuid': str(uuid.uuid4())}}])
         self.assertEqual(201, resp.status_code, resp.text)
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1252,3 +1252,16 @@ def should_expect_sandbox_directory_for_job(job):
   
 def data_local_service_is_set():
     return os.getenv('DATA_LOCAL_SERVICE', None) is not None
+
+@functools.lru_cache()
+def _fenzo_fitness_calculator():
+    """Get the cook executor config from the /settings endpoint"""
+    cook_url = retrieve_cook_url()
+    _wait_for_cook(cook_url)
+    init_cook_session(cook_url)
+    fitness_calculator = get_in(settings(cook_url), 'fenzo-fitness-calculator')
+    logger.info(f"Cook's fitness calculator is {fitness_calculator}")
+    return fitness_calculator
+
+def using_data_local_fitness_calculator():
+    return _fenzo_fitness_calculator() == 'cook.mesos.data-locality/make-data-local-fitness-calculator'


### PR DESCRIPTION
## Changes proposed in this PR
- Skips the data local constraint test when the fitness calculator is disabled

## Why are we making these changes?
The test will fail in an environment where the data local fitness calculator is not enabled, because the constraint is not enforced.
