### PR TITLE
Capture output from pytest when running integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,45 +22,45 @@ before_install:
 
 matrix:
   allow_failures:
-    - env: NAME='Cook Scheduler benchmark tests'
+    - name: 'Cook Scheduler benchmark tests'
 
   fast_finish: true
 
   include:
-    - env: NAME='Cook Scheduler and JobClient unit tests'
+    - name: 'Cook Scheduler and JobClient unit tests'
       before_script: cd scheduler && ./travis/setup.sh
       script:
         - pushd ../jobclient && mvn test
         - popd && lein with-profile +test test :all-but-benchmark
 
-    - env: NAME='Cook Scheduler integration tests with HTTP Basic Auth'
+    - name: 'Cook Scheduler integration tests with HTTP Basic Auth'
       services: docker
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh
       script: ./travis/run_integration.sh --auth=http-basic
 
-    - env: NAME='Cook Scheduler integration tests with Cook Executor'
+    - name: 'Cook Scheduler integration tests with Cook Executor'
       services: docker
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh
       script: ./travis/run_integration.sh --executor=cook
 
-    - env: NAME='Cook Scheduler integration tests with no pools and with HTTP Basic Auth'
+    - name: 'Cook Scheduler integration tests with no pools and with HTTP Basic Auth'
       services: docker
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh
       script: ./travis/run_integration.sh --pools=off --auth=http-basic
 
-    - env: NAME='Cook Scheduler Simulator tests'
+    - name: 'Cook Scheduler Simulator tests'
       services: docker
       install: sudo ./travis/install_mesos.sh
       before_script: cd simulator && ./travis/prepare_simulation.sh
       script: ./travis/run_simulation.sh
 
-    - env: NAME='Cook Scheduler benchmark tests'
+    - name: 'Cook Scheduler benchmark tests'
       before_script: cd scheduler && ./travis/setup.sh
       script: lein with-profile +test test :benchmark
 
-    - env: NAME='Cook Executor tests'
+    - name: 'Cook Executor tests'
       before_script: cd executor && ./travis/setup.sh
       script: ./travis/run_tests.sh

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -160,9 +160,11 @@ export COOK_MULTI_CLUSTER=
 export COOK_MASTER_SLAVE=
 export COOK_SLAVE_URL=http://localhost:12323
 export COOK_MESOS_LEADER_URL=${MINIMESOS_MASTER}
-echo "Using Mesos leader URL: ${COOK_MESOS_LEADER_URL}"
-pytest -n4 -v --color=no --timeout-method=thread --boxed -m "not serial" || test_failures=true
-pytest -n0 -v --color=no --timeout-method=thread --boxed -m "serial" || test_failures=true
+{
+    echo "Using Mesos leader URL: ${COOK_MESOS_LEADER_URL}"
+    pytest -n4 -v --color=no --timeout-method=thread --boxed -m "not serial" || test_failures=true
+    pytest -n0 -v --color=no --timeout-method=thread --boxed -m "serial" || test_failures=true
+} &> >(tee ./log/pytest.log)
 
 # If there were failures, then we should save the logs
 if [ "$test_failures" = true ]; then


### PR DESCRIPTION
## Changes proposed in this PR

- Use `name: ...` instead of `env: NAME=...` to name our Travis jobs.
- Capture integration tests' stdout/stderr in a log file when running in Travis.

## Why are we making these changes?

The main motivation of this change is that we don't currently get the console output in our Travis log dumps. If we restart a failed job, we still have the rest of the dump, but we lose console, which makes debugging more difficult. Having the console output for the integration test runner improves the log dumps by making them more stand-alone.

And the `name` thing just looks nicer.