### PR TITLE
Remove stale datasets when not updating

### DIFF
--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -17,9 +17,9 @@
                         ;; users that are allowed to do things on behalf of others
                         :impersonators #{"poser" "travis"}}
  :cors-origins ["https?://cors.example.com"]
- :data-local {:fitness-calculator {:cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"
-                                   :update-interval-ms 1000
-                                   :cache-ttl-ms 20000}}
+ :data-local {:fitness-calculator {:cache-ttl-ms 20000
+                                   :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"
+                                   :update-interval-ms 1000}}
  :database {:datomic-uri #config/env "COOK_DATOMIC"}
  :zookeeper {:connection #config/env "COOK_ZOOKEEPER"
              :local? #config/env-bool "COOK_ZOOKEEPER_LOCAL"

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -18,7 +18,8 @@
                         :impersonators #{"poser" "travis"}}
  :cors-origins ["https?://cors.example.com"]
  :data-local {:fitness-calculator {:cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"
-                                   :update-interval-ms 1000}}
+                                   :update-interval-ms 1000
+                                   :cache-ttl-ms 20000}}
  :database {:datomic-uri #config/env "COOK_DATOMIC"}
  :zookeeper {:connection #config/env "COOK_ZOOKEEPER"
              :local? #config/env-bool "COOK_ZOOKEEPER_LOCAL"

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -13,7 +13,8 @@
                         :impersonators #{"poser" "other-impersonator"}}
  :cors-origins ["https?://cors.example.com"]
  :data-local {:fitness-calculator {:cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"
-                                   :update-interval-ms 1000}}
+                                   :update-interval-ms 1000
+                                   :cache-ttl-ms 60000}}
  :database {:datomic-uri #config/env "COOK_DATOMIC_URI"}
  :executor {:command #config/env "COOK_EXECUTOR_COMMAND"
             :environment {"EXECUTOR_DEFAULT_PROGRESS_OUTPUT_NAME" "stdout"}

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -12,9 +12,9 @@
                         ;; users that are allowed to do things on behalf of others
                         :impersonators #{"poser" "other-impersonator"}}
  :cors-origins ["https?://cors.example.com"]
- :data-local {:fitness-calculator {:cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"
-                                   :update-interval-ms 1000
-                                   :cache-ttl-ms 60000}}
+ :data-local {:fitness-calculator {:cache-ttl-ms 60000
+                                   :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"
+                                   :update-interval-ms 1000}}
  :database {:datomic-uri #config/env "COOK_DATOMIC_URI"}
  :executor {:command #config/env "COOK_EXECUTOR_COMMAND"
             :environment {"EXECUTOR_DEFAULT_PROGRESS_OUTPUT_NAME" "stdout"}


### PR DESCRIPTION
## Changes proposed in this PR
- Attempt to remove stale dataset costs even when there are no new updates

## Why are we making these changes?
This fixes a bug where the stale dataset costs would sit in the cache indefinitely after there were no more waiting jobs.
