### PR TITLE
Use metatransaction for loading unscheduled_jobs

### DIFF
--- a/scheduler/src/cook/mesos/unscheduled.clj
+++ b/scheduler/src/cook/mesos/unscheduled.clj
@@ -19,7 +19,8 @@
             [cook.mesos.quota :as quota]
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
-            [clojure.edn :as edn]))
+            [clojure.edn :as edn]
+            [metatransaction.core :as mt]))
 
 (defn check-exhausted-retries
   [db job]
@@ -107,7 +108,7 @@
   "IFF the job is not first in the user's queue, returns
   [\"You have x other jobs ahead in the queue\", {:jobs [other job uuids]]}]"
   [conn job]
-  (let [db (d/db conn)
+  (let [db (mt/db conn)
         user (:job/user job)
         job-uuid (:job/uuid job)
         pool-name (-> job :job/pool :pool/name)

--- a/scheduler/test/cook/test/mesos/unscheduled.clj
+++ b/scheduler/test/cook/test/mesos/unscheduled.clj
@@ -79,6 +79,9 @@
         running-job-id2 (-> (create-dummy-job conn :user "mforsyth"
                                               :ncpus 1.0 :memory 3.1
                                               :job-state :job.state/running))
+        uncommitted-job-id (create-dummy-job conn :user "mforsyth"
+                                             :job-state :job.state/waiting
+                                             :committed? false)
         waiting-job-id (-> (create-dummy-job conn :user "mforsyth"
                                              :ncpus 1.0 :memory 3.0
                                              :job-state :job.state/waiting


### PR DESCRIPTION
## Changes proposed in this PR
- Use metatransaction for loading jobs in a user's queue for unscheduled_jobs

## Why are we making these changes?
Fixes a bug where users would see enqueued, uncommitted jobs in unscheduled_jobs.
