### PR TITLE
Adds pool to several scheduler and monitor metrics

### DIFF
--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -2065,7 +2065,7 @@
                              (when (= :warn level)
                                (reset! logged-atom {:throwable throwable
                                                     :message message})))]
-      (is (thrown? ExceptionInfo (sched/launch-matched-tasks! matches conn nil nil nil nil nil)))
+      (is (thrown? ExceptionInfo (sched/launch-matched-tasks! matches conn nil nil nil nil nil nil)))
       (is (= timeout-exception (:throwable @logged-atom)))
       (is (str/includes? (:message @logged-atom) (str job-id))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- instead of statically defining the metrics, fetching them dynamically by title
- adding the pool name to the metric titles via `metric-title`

## Why are we making these changes?

This is another PR for the effort to "poolify" the necessary metrics.
