### PR TITLE
Update JobClient dependency Apache HttpClient to v4.5.5

### DIFF
--- a/jobclient/pom.xml
+++ b/jobclient/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.2</version>
+      <version>4.5.5</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>


### PR DESCRIPTION
## Changes proposed in this PR

Update JobClient dependency Apache HttpClient to v4.5.5.

## Why are we making these changes?

A customer has a conflict with the old version, and asked us to upgrade.