### PR TITLE
Use x-cook-pool header when no pool param is provided

### DIFF
--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -5,7 +5,8 @@
                  :one-user #config/env "COOK_ONE_USER_AUTH"}
  :authorization-config {;; These users have admin privileges when using configfile-admins-auth;
                         ;; e.g., they can view and modify other users' jobs.
-                        :admins #{"admin" "root" #config/env "USER"}
+                        ;; Sets "admin" and the user defined in "COOK_ONE_USER_AUTH" to be admins for local development.
+                        :admins #{"admin" #config/env "COOK_ONE_USER_AUTH"}
                         ;; What function should be used to perform user authorization?
                         ;; See the docstring in cook.authorization for details.
                         :authorization-fn cook.authorization/configfile-admins-auth-open-gets

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -5,7 +5,7 @@
                  :one-user #config/env "COOK_ONE_USER_AUTH"}
  :authorization-config {;; These users have admin privileges when using configfile-admins-auth;
                         ;; e.g., they can view and modify other users' jobs.
-                        :admins #{"admin" "root"}
+                        :admins #{"admin" "root" #config/env "USER"}
                         ;; What function should be used to perform user authorization?
                         ;; See the docstring in cook.authorization for details.
                         :authorization-fn cook.authorization/configfile-admins-auth-open-gets


### PR DESCRIPTION
## Changes proposed in this PR
- Supports specifying the header `X-Cook-Pool` to provide the pool parameter on pool-specific requests.

## Why are we making these changes?
This will make it easier to migrate clusters onto the pool model, by replacing a cluster with a proxy which forwards requests to a different cluster with the `X-Cook-Pool` header set.
