### PR TITLE
clarifies contents of variable by renaming from pool to pool-name

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -66,11 +66,11 @@
                 "max-age=0"))))
 
 (def raw-scheduler-routes
-  {:scheduler (fnk [mesos mesos-leadership-atom pool->pending-jobs-atom framework-id settings]
+  {:scheduler (fnk [mesos mesos-leadership-atom pool-name->pending-jobs-atom framework-id settings]
                 ((util/lazy-load-var 'cook.mesos.api/main-handler)
                   datomic/conn
                   framework-id
-                  (fn [] @pool->pending-jobs-atom)
+                  (fn [] @pool-name->pending-jobs-atom)
                   settings
                   (get-in mesos [:mesos-scheduler :leader-selector])
                   mesos-leadership-atom))
@@ -91,7 +91,7 @@
                            mesos-role mesos-run-as-user offer-incubate-time-ms optimizer progress rebalancer server-port
                            task-constraints]
                           curator-framework exit-code-syncer-state framework-id mesos-datomic-mult mesos-leadership-atom
-                          mesos-agent-attributes-cache pool->pending-jobs-atom sandbox-syncer-state]
+                          mesos-agent-attributes-cache pool-name->pending-jobs-atom sandbox-syncer-state]
                       (if (cook.config/api-only-mode?)
                         (if curator-framework
                           (throw (ex-info "This node is configured for API-only mode, but also has a curator configured"
@@ -126,7 +126,7 @@
                                    :mesos-datomic-conn datomic/conn
                                    :mesos-datomic-mult mesos-datomic-mult
                                    :mesos-leadership-atom mesos-leadership-atom
-                                   :pool->pending-jobs-atom pool->pending-jobs-atom
+                                   :pool-name->pending-jobs-atom pool-name->pending-jobs-atom
                                    :mesos-run-as-user mesos-run-as-user
                                    :agent-attributes-cache mesos-agent-attributes-cache
                                    :offer-incubate-time-ms offer-incubate-time-ms
@@ -307,7 +307,7 @@
                                  framework-id datomic/conn publish-batch-size publish-interval-ms sync-interval-ms
                                  max-consecutive-sync-failure mesos-agent-query-cache)))
      :mesos-leadership-atom (fnk [] (atom false))
-     :pool->pending-jobs-atom (fnk [] (atom {}))
+     :pool-name->pending-jobs-atom (fnk [] (atom {}))
      :mesos-agent-attributes-cache (fnk [[:settings {agent-attributes-cache nil}]]
                                      (when agent-attributes-cache
                                        (log/info "Agent attributes cache max size =" (:max-size agent-attributes-cache))

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -158,7 +158,7 @@
    mea-culpa-failure-limit       -- long, max failures of mea culpa reason before it is considered a 'real' failure
                                     see scheduler/docs/configuration.adoc for more details
    task-constraints              -- map, constraints on task. See scheduler/docs/configuration.adoc for more details
-   pool->pending-jobs-atom       -- atom, Populate (and update) map from pool name to list of pending jobs into atom
+   pool-name->pending-jobs-atom  -- atom, Populate (and update) map from pool name to list of pending jobs into atom
    agent-attributes-cache        -- atom, map from agent id to most recent agent attributes
    gpu-enabled?                  -- boolean, whether cook will schedule gpus
    rebalancer-config             -- map, config for rebalancer. See scheduler/docs/rebalancer-config.adoc for details
@@ -167,7 +167,7 @@
    fenzo-config                  -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details
    sandbox-syncer-state          -- map, representing the sandbox syncer object"
   [{:keys [curator-framework exit-code-syncer-state fenzo-config framework-id gpu-enabled? make-mesos-driver-fn
-           mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom pool->pending-jobs-atom
+           mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom pool-name->pending-jobs-atom
            mesos-run-as-user agent-attributes-cache offer-incubate-time-ms optimizer-config progress-config rebalancer-config
            sandbox-syncer-state server-config task-constraints trigger-chans zk-prefix]}]
   (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
@@ -209,7 +209,7 @@
                                           :mesos-run-as-user mesos-run-as-user
                                           :agent-attributes-cache agent-attributes-cache
                                           :offer-incubate-time-ms offer-incubate-time-ms
-                                          :pool->pending-jobs-atom pool->pending-jobs-atom
+                                          :pool-name->pending-jobs-atom pool-name->pending-jobs-atom
                                           :progress-config progress-config
                                           :rebalancer-reservation-atom rebalancer-reservation-atom
                                           :sandbox-syncer-state sandbox-syncer-state
@@ -228,7 +228,7 @@
                                                                               :conn mesos-datomic-conn
                                                                               :driver driver
                                                                               :agent-attributes-cache agent-attributes-cache
-                                                                              :pool->pending-jobs-atom pool->pending-jobs-atom
+                                                                              :pool-name->pending-jobs-atom pool-name->pending-jobs-atom
                                                                               :rebalancer-reservation-atom rebalancer-reservation-atom
                                                                               :trigger-chan rebalancer-trigger-chan
                                                                               :view-incubating-offers view-incubating-offers})
@@ -237,7 +237,7 @@
                                                                                       ;; TODO Use filter of queue that scheduler uses to filter to considerable.
                                                                                       ;;      Specifically, think about filtering to jobs that are waiting and 
                                                                                       ;;      think about how to handle quota 
-                                                                                      @pool->pending-jobs-atom)
+                                                                                      @pool-name->pending-jobs-atom)
                                                                                     (fn get-running []
                                                                                       (cook.mesos.util/get-running-task-ents (d/db mesos-datomic-conn)))
                                                                                     view-incubating-offers

--- a/scheduler/src/cook/mesos/monitor.clj
+++ b/scheduler/src/cook/mesos/monitor.clj
@@ -34,7 +34,7 @@
    types to amounts."
   [job-ents pool-name]
   (->> job-ents
-       (filter #(= pool-name (util/job->pool %)))
+       (filter #(= pool-name (util/job->pool-name %)))
        ;; Produce a list of maps from user's name to his stats.
        (mapv (fn [job-ent]
                (let [user (:job/user job-ent)

--- a/scheduler/src/cook/mesos/rebalancer.clj
+++ b/scheduler/src/cook/mesos/rebalancer.clj
@@ -213,7 +213,7 @@
          running-task-ents (filter (fn [task]
                                      (-> task
                                          :job/_instance
-                                         util/job->pool
+                                         util/job->pool-name
                                          (= pool-name)))
                                    running-task-ents)
          using-pools? (not (nil? (config/default-pool)))
@@ -514,7 +514,7 @@
               recognized-params))]))))
 
 (defn start-rebalancer!
-  [{:keys [config conn driver agent-attributes-cache pool->pending-jobs-atom
+  [{:keys [config conn driver agent-attributes-cache pool-name->pending-jobs-atom
            rebalancer-reservation-atom trigger-chan view-incubating-offers]}]
   (binding [metrics-dru-scale (:dru-scale config)]
     (update-datomic-params-from-config! conn config)
@@ -546,7 +546,7 @@
                     (log/info "Rebalancing for pool" pool)
                     (rebalance! db conn driver agent-attributes-cache rebalancer-reservation-atom
                                 params init-state jobs-to-make-room-for (:pool/name pool-ent))))
-                @pool->pending-jobs-atom)
+                @pool-name->pending-jobs-atom)
               (log/info "Rebalance cycle ended"))
             (log/info "Skipping rebalancing because it's not cofigured"))))
       {:error-handler (fn [ex] (log/error ex "Rebalance failed"))})

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -81,8 +81,8 @@
 (let [default-pool (config/default-pool)
       miss-fn (fn [{:keys [job/pool]}]
                 (or (:pool/name pool) default-pool "no-pool"))]
-  (defn job->pool
-    "Return the pool of the job."
+  (defn job->pool-name
+    "Return the pool name of the job."
     [job]
     (lookup-cache-datomic-entity! job-ent->pool-cache miss-fn job)))
 

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1580,12 +1580,12 @@
                                                           (util/job-ent->map entity (d/db conn)))
                                             pool->pending-jobs (->> {:normal [job-1 job-2 job-3 job-4] :gpu [job-5 job-6]}
                                                                     (pc/map-vals (partial map entity->map)))
-                                            pool->pending-jobs-atom (atom pool->pending-jobs)
+                                            pool-name->pending-jobs-atom (atom pool->pending-jobs)
                                             user->usage (or user->usage {test-user {:count 1, :cpus 2, :mem 1024, :gpus 0}})
                                             user->quota (or user-quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}})
                                             mesos-run-as-user nil
                                             result (sched/handle-resource-offers!
-                                                     conn driver fenzo framework-id pool->pending-jobs-atom mesos-run-as-user
+                                                     conn driver fenzo framework-id pool-name->pending-jobs-atom mesos-run-as-user
                                                      user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom pool)]
                                         (async/>!! offers-chan :end-marker)
                                         result))]
@@ -1794,12 +1794,12 @@
                                                             (util/job-ent->map entity (d/db conn)))
                                               pool->pending-jobs (->> {:normal [job-1 job-2]}
                                                                       (pc/map-vals (partial map entity->map)))
-                                              pool->pending-jobs-atom (atom pool->pending-jobs)
+                                              pool-name->pending-jobs-atom (atom pool->pending-jobs)
                                               user->usage (or user->usage {test-user {:count 1, :cpus 2, :mem 1024, :gpus 0}})
                                               user->quota (or user-quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}})
                                               mesos-run-as-user nil
                                               result (sched/handle-resource-offers!
-                                                      conn driver fenzo framework-id pool->pending-jobs-atom mesos-run-as-user
+                                                      conn driver fenzo framework-id pool-name->pending-jobs-atom mesos-run-as-user
                                                       user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom :normal)]
                                           result))]
       (testing "enough offers for all normal jobs"

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -82,8 +82,8 @@
   `(let [[zookeeper-server# curator-framework#] (setup-test-curator-framework)
          mesos-mult# (or (:mesos-datomic-mult ~scheduler-config)
                          (async/mult (async/chan)))
-         pending-jobs-atom# (or (:mesos-pending-jobs-atom ~scheduler-config)
-                                (atom []))
+         pool-name->pending-jobs-atom# (or (:pool-name->pending-jobs-atom ~scheduler-config)
+                                           (atom {}))
          agent-attributes-cache# (or (:mesos-agent-attributes-cache ~scheduler-config)
                                      (-> {}
                                          (cache/fifo-cache-factory :threshold 100)
@@ -134,7 +134,7 @@
             :mesos-datomic-conn ~conn
             :mesos-datomic-mult mesos-mult#
             :mesos-leadership-atom mesos-leadership-atom#
-            :pool->pending-jobs-atom pending-jobs-atom#
+            :pool-name->pending-jobs-atom pool-name->pending-jobs-atom#
             :mesos-run-as-user nil
             :agent-attributes-cache agent-attributes-cache#
             :offer-incubate-time-ms offer-incubate-time-ms#


### PR DESCRIPTION
## Changes proposed in this PR

- clarifies contents of variable by renaming from pool to pool-name

## Why are we making these changes?

Variable names should clarify their contents (e.g. pool vs the name of the pool) when possible to do so. This improves readability and can also avoid bugs.

