### PR TITLE
Fix options to Apache HttpClient SPNego lib to match old behavior

### DIFF
--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
@@ -199,7 +199,7 @@ public class JobClient implements Closeable, JobClientInterface {
             return setKerberosAuth(null);
         }
 
-        public Builder setKerberosAuth(GSSCredentialProvider gssCrendentialProvider) {
+        public Builder setKerberosAuth(GSSCredentialProvider gssCredentialProvider) {
             Credentials creds = new Credentials() {
                 @Override
                 public String getPassword() {
@@ -216,8 +216,7 @@ public class JobClient implements Closeable, JobClientInterface {
                     AuthScope.ANY_REALM, AuthSchemes.SPNEGO), creds);
             _httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
 
-            AuthSchemeProvider authSchemaProvider = gssCrendentialProvider == null ?
-                    new SPNegoSchemeFactory(true) : new BasicSPNegoSchemeFactory(true, gssCrendentialProvider);
+            AuthSchemeProvider authSchemaProvider = BasicSPNegoSchemeFactory.build(true, gssCredentialProvider);
 
             _httpClientBuilder.setDefaultAuthSchemeRegistry(RegistryBuilder.<AuthSchemeProvider> create()
                     .register(AuthSchemes.SPNEGO, authSchemaProvider).build());

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/auth/spnego/BasicSPNegoSchemeFactory.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/auth/spnego/BasicSPNegoSchemeFactory.java
@@ -40,6 +40,19 @@ import org.ietf.jgss.Oid;
 public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
 
     /**
+     * The canonical name lookup done by the HttpClient does not always give the value
+     * expected by the underlying Kerberos library, leading to hostname mismatch errors.
+     * We disable canonicalization here and allow Kerberos to do its own resolution.
+     */
+    public static final boolean USE_CANONICAL_HOSTNAME = false;
+
+    public static SPNegoSchemeFactory build(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
+        return credentialProvider == null
+            ? new SPNegoSchemeFactory(true, USE_CANONICAL_HOSTNAME)
+            : new BasicSPNegoSchemeFactory(true, credentialProvider);
+    }
+
+    /**
      * In the apache.httpclient 4.3.x version, {@code SPNEGO_OID = "1.3.6.1.5.5.2"}. However, we are
      * using {@code SPNEGO_OID = "1.2.840.113554.1.2.2"} here.
      *
@@ -72,7 +85,7 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
         }
 
         BasicSPNegoScheme(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
-            super(stripPort);
+            super(stripPort, USE_CANONICAL_HOSTNAME);
             _credentialProvider = credentialProvider;
         }
 
@@ -109,8 +122,8 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
 
     private final GSSCredentialProvider _credentialProvider;
 
-    public BasicSPNegoSchemeFactory(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
-        super(stripPort);
+    protected BasicSPNegoSchemeFactory(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
+        super(stripPort, USE_CANONICAL_HOSTNAME);
         _credentialProvider = credentialProvider;
     }
 


### PR DESCRIPTION
## Changes proposed in this PR

- Add a static `build` method to `BasicSPNegoSchemeFactory`, which lets us handle all of the `SPNegoSchemeFactory` construction logic for the JobClient in one place.
- Define and document a new static constant flag `USE_CANONICAL_HOSTNAME`.
- Pass the new `USE_CANONICAL_HOSTNAME` into all `SPNegoScheme`-related constructor invocations.

Also fixed a typo: Cre<del>n</del>dential

## Why are we making these changes?

The new default hostname canonicalization in the Apache HttpClient can cause problems with krb5, so we're disabling it and letting krb5 handle its own hostname conversions.

## Other resources

[Apache HttpClient `SPNegoSchemeFactory` JavaDoc](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/auth/SPNegoSchemeFactory.html)