### PR TITLE
Updates requests and numpy versions for tests

### DIFF
--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -2,12 +2,12 @@ beakerx==0.16.1
 jupyter_client==5.2.3
 nbconvert==5.3.1
 nbformat==4.4.0
-numpy==1.14.0
+numpy==1.15.3
 pip==9.0.1; python_version >= '3.6'
 pytest==3.3.1
 pytest-timeout==1.2.1
 pytest-xdist==1.20.1
 python-dateutil==2.6.1
-requests==2.18.4
+requests==2.20.0
 retrying==1.3.3
 file:../cli#egg=cook_client


### PR DESCRIPTION
## Changes proposed in this PR

- updating `numpy` to `1.15.3`
- updating `requests` to `2.20.0`

## Why are we making these changes?

The `numpy` change is to correct issues we've seen when running `pip install` in Conda environments. 

The `requests` change is to address a security vulnerability: 

https://github.com/twosigma/Cook/network/alert/integration/requirements.txt/requests/open