### PR TITLE
JobClient with custom HttpClient

### DIFF
--- a/jobclient/pom.xml
+++ b/jobclient/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.5</version>
+      <version>4.3.2</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
@@ -199,7 +199,7 @@ public class JobClient implements Closeable, JobClientInterface {
             return setKerberosAuth(null);
         }
 
-        public Builder setKerberosAuth(GSSCredentialProvider gssCrendentialProvider) {
+        public Builder setKerberosAuth(GSSCredentialProvider gssCredentialProvider) {
             Credentials creds = new Credentials() {
                 @Override
                 public String getPassword() {
@@ -216,8 +216,7 @@ public class JobClient implements Closeable, JobClientInterface {
                     AuthScope.ANY_REALM, AuthSchemes.SPNEGO), creds);
             _httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
 
-            AuthSchemeProvider authSchemaProvider = gssCrendentialProvider == null ?
-                    new SPNegoSchemeFactory(true) : new BasicSPNegoSchemeFactory(true, gssCrendentialProvider);
+            AuthSchemeProvider authSchemaProvider = BasicSPNegoSchemeFactory.build(true, gssCredentialProvider);
 
             _httpClientBuilder.setDefaultAuthSchemeRegistry(RegistryBuilder.<AuthSchemeProvider> create()
                     .register(AuthSchemes.SPNEGO, authSchemaProvider).build());

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
@@ -196,10 +196,10 @@ public class JobClient implements Closeable, JobClientInterface {
         }
 
         public Builder setKerberosAuth() {
-            return setKerberosAuth(null);
+            return setKerberosAuth((GSSCredentialProvider)null);
         }
 
-        public Builder setKerberosAuth(GSSCredentialProvider gssCredentialProvider) {
+        public Builder setKerberosAuth(AuthSchemeProvider authSchemaProvider) {
             Credentials creds = new Credentials() {
                 @Override
                 public String getPassword() {
@@ -216,11 +216,13 @@ public class JobClient implements Closeable, JobClientInterface {
                     AuthScope.ANY_REALM, AuthSchemes.SPNEGO), creds);
             _httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
 
-            AuthSchemeProvider authSchemaProvider = BasicSPNegoSchemeFactory.build(true, gssCredentialProvider);
-
             _httpClientBuilder.setDefaultAuthSchemeRegistry(RegistryBuilder.<AuthSchemeProvider> create()
                     .register(AuthSchemes.SPNEGO, authSchemaProvider).build());
             return this;
+        }
+
+        public Builder setKerberosAuth(GSSCredentialProvider gssCredentialProvider) {
+            return setKerberosAuth(BasicSPNegoSchemeFactory.build(true, gssCredentialProvider));
         }
 
         /**

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/auth/spnego/BasicSPNegoSchemeFactory.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/auth/spnego/BasicSPNegoSchemeFactory.java
@@ -40,6 +40,19 @@ import org.ietf.jgss.Oid;
 public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
 
     /**
+     * The canonical name lookup done by the HttpClient does not always give the value
+     * expected by the underlying Kerberos library, leading to hostname mismatch errors.
+     * We disable canonicalization here and allow Kerberos to do its own resolution.
+     */
+    public static final boolean USE_CANONICAL_HOSTNAME = false;
+
+    public static SPNegoSchemeFactory build(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
+        return credentialProvider == null
+            ? new SPNegoSchemeFactory(true, USE_CANONICAL_HOSTNAME)
+            : new BasicSPNegoSchemeFactory(true, credentialProvider);
+    }
+
+    /**
      * In the apache.httpclient 4.3.x version, {@code SPNEGO_OID = "1.3.6.1.5.5.2"}. However, we are
      * using {@code SPNEGO_OID = "1.2.840.113554.1.2.2"} here.
      *
@@ -72,7 +85,7 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
         }
 
         BasicSPNegoScheme(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
-            super(stripPort);
+            super(stripPort, USE_CANONICAL_HOSTNAME);
             _credentialProvider = credentialProvider;
         }
 
@@ -109,8 +122,8 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
 
     private final GSSCredentialProvider _credentialProvider;
 
-    public BasicSPNegoSchemeFactory(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
-        super(stripPort);
+    protected BasicSPNegoSchemeFactory(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
+        super(stripPort, USE_CANONICAL_HOSTNAME);
         _credentialProvider = credentialProvider;
     }
 

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/auth/spnego/BasicSPNegoSchemeFactory.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/auth/spnego/BasicSPNegoSchemeFactory.java
@@ -48,7 +48,8 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
 
     public static SPNegoSchemeFactory build(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
         return credentialProvider == null
-            ? new SPNegoSchemeFactory(true, USE_CANONICAL_HOSTNAME)
+            // USE_CANONICAL_HOSTNAME should be enabled below for HttpClient v4.4 or above
+            ? new SPNegoSchemeFactory(true /*, USE_CANONICAL_HOSTNAME */)
             : new BasicSPNegoSchemeFactory(true, credentialProvider);
     }
 
@@ -85,7 +86,8 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
         }
 
         BasicSPNegoScheme(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
-            super(stripPort, USE_CANONICAL_HOSTNAME);
+            // USE_CANONICAL_HOSTNAME should be enabled below for HttpClient v4.4 or above
+            super(stripPort /*, USE_CANONICAL_HOSTNAME */);
             _credentialProvider = credentialProvider;
         }
 
@@ -123,7 +125,8 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
     private final GSSCredentialProvider _credentialProvider;
 
     protected BasicSPNegoSchemeFactory(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
-        super(stripPort, USE_CANONICAL_HOSTNAME);
+        // USE_CANONICAL_HOSTNAME should be enabled below for HttpClient v4.4 or above
+        super(stripPort /*, USE_CANONICAL_HOSTNAME */);
         _credentialProvider = credentialProvider;
     }
 


### PR DESCRIPTION
## Changes proposed in this PR

- Allow users to set a custom `AuthSchemeProvider` when building a new `JobClient`.
- Add a static `build` method to `BasicSPNegoSchemeFactory`, which lets us handle all of the `SPNegoSchemeFactory` construction logic for the JobClient in one place.
- Define and document a new static constant flag `USE_CANONICAL_HOSTNAME`.
- Add commented-out `USE_CANONICAL_HOSTNAME` parameter in all `SPNegoScheme`-related constructor invocations as todo items for the future upgrade.

## Why are we making these changes?

Allowing users to set a custom `AuthSchemeProvider` when building a new `JobClient` lets users manually configure their SPNego auth correctly when they use newer versions of the Apache HttpClient. This is a workaround until we can reasonably assume all JobClient users are able to upgrade to the newer Apache HttpClient version.

The other refactorings are included from #1008. When we're ready to upgrade our HttpClient dependency, we can simply roll back the changes in the following commit: *Revert Apache HttpClient dependency to v4.3.2*