### PR TITLE
Makes test_group_kill_simple more reliable

### DIFF
--- a/integration/tests/cook/reasons.py
+++ b/integration/tests/cook/reasons.py
@@ -2,6 +2,7 @@
 # See scheduler/src/cook/mesos/schema.clj for the reason code names.
 MAX_RUNTIME_EXCEEDED = 2003
 EXECUTOR_UNREGISTERED = 6002
+UNKNOWN_MESOS_REASON = 99001
 CMD_NON_ZERO_EXIT = 99003
 
 # Named constants for unscheduled job reason strings from cook or fenzo.

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1339,7 +1339,10 @@ class CookTest(util.CookTest):
                 # cook killed the job, so it exits non-zero
                 reasons.CMD_NON_ZERO_EXIT,
                 # cook killed the job during setup, so the executor had an error
-                reasons.EXECUTOR_UNREGISTERED]
+                reasons.EXECUTOR_UNREGISTERED,
+                # we've seen this happen in the wild
+                reasons.UNKNOWN_MESOS_REASON
+            ]
             self.assertIn(jobs[1]['instances'][0]['reason_code'], valid_reasons, slow_job_details)
         finally:
             # Now try to kill the group again


### PR DESCRIPTION
## Changes proposed in this PR

- allowing reason 99001 on the killed job's instance

## Why are we making these changes?

We've seen this happen in the wild.
