### PR TITLE
Skips test_balanced_host_constraint_cannot_place when there are no agents to consider

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1719,8 +1719,9 @@ class CookTest(util.CookTest):
         num_hosts = util.num_hosts_to_consider(self.cook_url, self.mesos_url)
         if num_hosts > 10:
             # Skip this test on large clusters
-            self.logger.info(f"Skipping test due to cluster size of {num_hosts} greater than 10")
-            return
+            pytest.skip(f"Skipping test due to cluster size of {num_hosts} greater than 10")
+        if num_hosts == 0:
+            pytest.skip(f"Skipping test due to no Mesos agents to consider")
         minimum_hosts = num_hosts + 1
         group = {'uuid': str(uuid.uuid4()),
                  'host-placement': {'type': 'balanced',


### PR DESCRIPTION
## Changes proposed in this PR

- changing the existing early `return` to a `pytest.skip` call
- adding a skip when there are 0 hosts to consider

## Why are we making these changes?

In clusters that dynamically scale up agents in response to demand, this test can encounter the state where there are currently no running agents to consider. In this scenario, we'd rather simply skip the test.