### PR TITLE
Makes memory_limit_exceeded_helper more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -496,6 +496,7 @@ class CookTest(util.CookTest):
                 # If the command was killed, it will have exited with 137 (Fatal error signal of 128 + SIGKILL)
                 self.assertEqual('Command exited non-zero', instance['reason_string'], instance_details)
                 if executor_type == 'cook':
+                    instance = util.wait_for_exit_code(self.cook_url, job_uuid)
                     self.assertEqual(137, instance['exit_code'], instance_details)
             else:
                 self.fail('Unknown reason code {}, details {}'.format(instance['reason_code'], instance_details))


### PR DESCRIPTION
## Changes proposed in this PR

- adding a call to `util.wait_for_exit_code` before assuming the exit code is populated

## Why are we making these changes?

This function can fail if the exit code is not yet populated on the instance.