### PR TITLE
Enhance rate limit API to support fetching the number of tokens.

### DIFF
--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -22,6 +22,7 @@
 ; Import from cook.rate-limit.generic some relevant functions.
 (def spend! rtg/spend!)
 (def time-until-out-of-debt-millis! rtg/time-until-out-of-debt-millis!)
+(def get-token-count! rtg/get-token-count!)
 (def enforce? rtg/enforce?)
 (def AllowAllRateLimiter rtg/AllowAllRateLimiter)
 

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -23,6 +23,8 @@
 (defprotocol RateLimiter
   (spend! [this key resources]
     "Request this number of resources. Does not block (or otherwise indicate we're in debt)")
+  (get-token-count! [this key]
+    "Get the number of tokens in the token bucket filter under this name. Also earns any tokens first.")
   (time-until-out-of-debt-millis! [this key]
     "Time, in milliseconds, until this rate limiter is out of debt for this key. Earns resources first.")
   (enforce? [this]
@@ -78,6 +80,12 @@
       (earn-tokens! this key)
       (tbf/time-until (get-token-bucket-filter this key))))
 
+  (get-token-count!
+    [this key]
+    (let [key (get-key key)]
+      (earn-tokens! this key)
+      (tbf/get-token-count (get-token-bucket-filter this key))))
+
   (enforce?
     [_]
     enforce?))
@@ -105,4 +113,5 @@
     RateLimiter
     (spend! [_ _ _] 0)
     (time-until-out-of-debt-millis! [_ _] 0)
+    (get-token-count! [_ _] 100000000)
     (enforce? [_] false)))

--- a/scheduler/src/cook/rate_limit/token_bucket_filter.clj
+++ b/scheduler/src/cook/rate_limit/token_bucket_filter.clj
@@ -92,3 +92,8 @@
   "Reports if the tbf is currently in debt."
   [{:keys [current-tokens]}]
   (< current-tokens 0))
+
+(defn get-token-count
+  "Reports the number of tokens in the tbf."
+  [{:keys [current-tokens]}]
+  current-tokens)

--- a/scheduler/test/cook/test/rate_limit/generic.clj
+++ b/scheduler/test/cook/test/rate_limit/generic.clj
@@ -89,6 +89,10 @@
       (is (= 0 (rtg/time-until-out-of-debt-millis! ratelimit "Foo2")))
       (is (= 9975 (rtg/time-until-out-of-debt-millis! ratelimit "Foo3")))
 
+      (is (= (rtg/get-token-count! ratelimit "Foo1") 20))
+      (is (= (rtg/get-token-count! ratelimit "Foo2") 15))
+      (is (= (rtg/get-token-count! ratelimit "Foo3") -9975))
+
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo1") {:current-tokens 20
                                                             :last-update 1000025
                                                             :max-tokens 20


### PR DESCRIPTION
## Changes proposed in this PR

- Enhance rate limit API to support fetching the number of tokens.
- 
- 

## Why are we making these changes?

To prepare for the followup PR where we use the fetched token count to avoid 'going too far into debt'
