### PR TITLE
Change the data locality service port from 5000 to 35847

### DIFF
--- a/integration/bin/run-data-local-server.sh
+++ b/integration/bin/run-data-local-server.sh
@@ -10,12 +10,12 @@ NAME=data-local
 echo "Building docker images for ${NAME}"
 docker build -t ${NAME} ${SRC_DIR}
 
-# Expose port 5000 (default flask port)
+# Expose port 35847 (used for data-local service)
 docker create \
        -i \
        -t \
        --rm \
-       -p 5000:5000 \
+       -p 35847:35847 \
        --name=$NAME \
        ${NAME}:latest
 

--- a/integration/bin/run-integration.sh
+++ b/integration/bin/run-integration.sh
@@ -78,7 +78,7 @@ DATA_LOCAL_IP=$(docker inspect data-local | jq -r '.[].NetworkSettings.IPAddress
 DATA_LOCAL_ENV=""
 if [ ! "${DATA_LOCAL_IP}" = "null" ];
 then
-    DATA_LOCAL_ENV="-e DATA_LOCAL_SERVICE=http://${DATA_LOCAL_IP}:5000"
+    DATA_LOCAL_ENV="-e DATA_LOCAL_SERVICE=http://${DATA_LOCAL_IP}:35847"
 fi
 
 docker create \

--- a/integration/src/data_locality/Dockerfile
+++ b/integration/src/data_locality/Dockerfile
@@ -5,6 +5,6 @@ RUN pip install flask
 COPY . /opt/cook/integration
 ENV FLASK_APP /opt/cook/integration/service.py
 
-EXPOSE 5000
+EXPOSE 35847
 
-ENTRYPOINT ["flask", "run", "--host=0.0.0.0"]
+ENTRYPOINT ["flask", "run", "--host=0.0.0.0", "--port=35847"]

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -131,7 +131,7 @@ case "$JOB_LAUNCH_RATE_LIMIT" in
 esac
 
 pip install flask
-export DATA_LOCAL_SERVICE="http://localhost:5000"
+export DATA_LOCAL_SERVICE="http://localhost:35847"
 export DATA_LOCAL_ENDPOINT="${DATA_LOCAL_SERVICE}/retrieve-costs"
 mkdir ${SCHEDULER_DIR}/log
 FLASK_APP=${PROJECT_DIR}/src/data_locality/service.py flask run > ${SCHEDULER_DIR}/log/data-local.log 2>&1 &

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -131,10 +131,11 @@ case "$JOB_LAUNCH_RATE_LIMIT" in
 esac
 
 pip install flask
-export DATA_LOCAL_SERVICE="http://localhost:35847"
+export DATA_LOCAL_PORT=35847
+export DATA_LOCAL_SERVICE="http://localhost:${DATA_LOCAL_PORT}"
 export DATA_LOCAL_ENDPOINT="${DATA_LOCAL_SERVICE}/retrieve-costs"
 mkdir ${SCHEDULER_DIR}/log
-FLASK_APP=${PROJECT_DIR}/src/data_locality/service.py flask run > ${SCHEDULER_DIR}/log/data-local.log 2>&1 &
+FLASK_APP=${PROJECT_DIR}/src/data_locality/service.py flask run --port=${DATA_LOCAL_PORT} > ${SCHEDULER_DIR}/log/data-local.log 2>&1 &
 
 # Seed running jobs, which are used to test the task reconciler
 cd ${SCHEDULER_DIR}

--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -154,7 +154,7 @@ docker create \
     -e "COOK_ONE_USER_AUTH=root" \
     -e "COOK_EXECUTOR_PORTION=${COOK_EXECUTOR_PORTION:-0}" \
     -e "COOK_KEYSTORE_PATH=/opt/ssl/cook.p12" \
-    -e "DATA_LOCAL_ENDPOINT=http://${DATA_LOCAL_IP}:5000/retrieve-costs" \
+    -e "DATA_LOCAL_ENDPOINT=http://${DATA_LOCAL_IP}:35847/retrieve-costs" \
     -v ${DIR}/../log:/opt/cook/log \
     cook-scheduler:latest ${COOK_CONFIG:-}
 

--- a/scheduler/bin/run-local.sh
+++ b/scheduler/bin/run-local.sh
@@ -76,7 +76,7 @@ export MESOS_MASTER="${MASTER_IP}:5050"
 export MESOS_NATIVE_JAVA_LIBRARY="${MESOS_NATIVE_JAVA_LIBRARY}"
 export COOK_SSL_PORT="${COOK_SSL_PORT}"
 export COOK_KEYSTORE_PATH="${COOK_KEYSTORE_PATH}"
-export DATA_LOCAL_ENDPOINT="http://localhost:5000/retrieve-costs"
+export DATA_LOCAL_ENDPOINT="http://localhost:35847/retrieve-costs"
 
 echo "Starting cook..."
 lein run config.edn


### PR DESCRIPTION
## Changes proposed in this PR

- Change the data locality service port from 5000 to 35847

## Why are we making these changes?

5000 may be used by other services running locally. Use a different,
random port, e.g., 35847 instead to reduce the risk of conflicts.

(I had a conflict with a system program on my laptop that had to be uninstalled temporarily.)