### PR TITLE
Precompile all sources in uberjar

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -158,7 +158,7 @@
                    [twosigma/mesomatic "1.0.1-2018.08.28-df2c2ca"]]}
 
    :uberjar
-   {:aot [cook.components]
+   {:aot :all
     :dependencies [[com.datomic/datomic-free "0.9.5206"
                     :exclusions [com.fasterxml.jackson.core/jackson-core
                                  joda-time


### PR DESCRIPTION
## Changes proposed in this PR

- Ahead-of-time compile *all* sources when building an uberjar, not just the sources explicitly references through the `cook.components` namespace.

## Why are we making these changes?

It makes sense to eagerly compile all of our code (including optional plugins), rather than mixing run-time and build-time compilation.

## Other notes

We have a similar PR in the Waiter project: https://github.com/twosigma/waiter/pull/518