### PR TITLE
Outgoing/global launch limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,12 @@ matrix:
       before_script: cd integration && ./travis/prepare_integration.sh
       script: ./travis/run_integration.sh --pools=off --auth=http-basic --job-launch-rate-limit=on
 
+    - name: 'Cook Scheduler integration tests with global job launch rate limit'
+      services: docker
+      install: sudo ./travis/install_mesos.sh
+      before_script: cd integration && ./travis/prepare_integration.sh
+      script: ./travis/run_integration.sh --pools=off --auth=http-basic --global-job-launch-rate-limit=on
+
     - name: 'Cook Scheduler Simulator tests'
       services: docker
       install: sudo ./travis/install_mesos.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,13 +60,7 @@ matrix:
       services: docker
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh
-      script: ./travis/run_integration_ratelimit.sh --job-launch-rate-limit=on
-
-    - name: 'Cook Scheduler integration tests with global job launch rate limit'
-      services: docker
-      install: sudo ./travis/install_mesos.sh
-      before_script: cd integration && ./travis/prepare_integration.sh
-      script: ./travis/run_integration_ratelimit.sh --global-job-launch-rate-limit=on
+      script: ./travis/run_integration_ratelimit.sh
 
     - name: 'Cook Scheduler Simulator tests'
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,13 +60,13 @@ matrix:
       services: docker
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh
-      script: ./travis/run_integration.sh --pools=off --auth=http-basic --job-launch-rate-limit=on
+      script: ./travis/run_integration_ratelimit.sh --job-launch-rate-limit=on
 
     - name: 'Cook Scheduler integration tests with global job launch rate limit'
       services: docker
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh
-      script: ./travis/run_integration.sh --pools=off --auth=http-basic --global-job-launch-rate-limit=on
+      script: ./travis/run_integration_ratelimit.sh --global-job-launch-rate-limit=on
 
     - name: 'Cook Scheduler Simulator tests'
       services: docker

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -315,7 +315,7 @@ class MultiUserCookTest(util.CookTest):
     # passed; the subsequent run will have used up the rate limit quota and it will need time to recharge.
     def test_global_rate_limit_launching_jobs(self):
         settings = util.settings(self.cook_url)
-        if settings['rate-limit']['job-launch-global'] is None:
+        if settings['rate-limit']['global-job-launch'] is None:
             pytest.skip("Can't test job launch rate limit without launch rate limit set.")
 
         # Allow an environmental variable override.
@@ -325,7 +325,7 @@ class MultiUserCookTest(util.CookTest):
         else:
             user = self.user_factory.new_user()
 
-        if not settings['rate-limit']['job-launch-global']['enforce?']:
+        if not settings['rate-limit']['global-job-launch']['enforce?']:
             pytest.skip("Enforcing must be on for test to run")
         bucket_size = settings['rate-limit']['global-job-launch']['bucket-size']
         token_rate = settings['rate-limit']['global-job-launch']['tokens-replenished-per-minute']

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -311,6 +311,63 @@ class MultiUserCookTest(util.CookTest):
             finally:
                 util.kill_jobs(self.cook_url, job_uuids)
 
+    # Note that subsequent runs of this test under the same user can fail if sufficient time has not
+    # passed; the subsequent run will have used up the rate limit quota and it will need time to recharge.
+    def test_global_rate_limit_launching_jobs(self):
+        settings = util.settings(self.cook_url)
+        if settings['rate-limit']['job-launch-global'] is None:
+            pytest.skip("Can't test job launch rate limit without launch rate limit set.")
+
+        # Allow an environmental variable override.
+        name = os.getenv('COOK_LAUNCH_RATE_LIMIT_NAME')
+        if name is not None:
+            user = self.user_factory.user_class(name)
+        else:
+            user = self.user_factory.new_user()
+
+        if not settings['rate-limit']['job-launch-global']['enforce?']:
+            pytest.skip("Enforcing must be on for test to run")
+        bucket_size = settings['rate-limit']['global-job-launch']['bucket-size']
+        token_rate = settings['rate-limit']['global-job-launch']['tokens-replenished-per-minute']
+        # In some environments, e.g., minimesos, we can only launch so many concurrent jobs.
+        if token_rate < 5 or token_rate > 20:
+            pytest.skip(
+                "Global job launch rate limit test is only validated to reliably work correctly with certain token rates.")
+        if bucket_size < 10 or bucket_size > 20:
+            pytest.skip(
+                "Global job launch rate limit test is only validated to reliably work correctly with certain token bucket sizes.")
+        with user:
+            job_uuids = []
+            try:
+                jobspec = {"command": "sleep 240", 'cpus': 0.03, 'mem': 32}
+
+                self.logger.info(f'Submitting initial batch of {bucket_size-1} jobs')
+                initial_uuids, initial_response = util.submit_jobs(self.cook_url, jobspec, bucket_size - 1)
+                job_uuids.extend(initial_uuids)
+                self.assertEqual(201, initial_response.status_code, msg=initial_response.content)
+
+                def submit_jobs():
+                    self.logger.info(f'Submitting subsequent batch of {bucket_size-1} jobs')
+                    subsequent_uuids, subsequent_response = util.submit_jobs(self.cook_url, jobspec, bucket_size - 1)
+                    job_uuids.extend(subsequent_uuids)
+                    self.assertEqual(201, subsequent_response.status_code, msg=subsequent_response.content)
+
+                def is_rate_limit_triggered(_):
+                    jobs1 = util.query_jobs(self.cook_url, True, uuid=job_uuids).json()
+                    running_jobs = [j for j in jobs1 if j['status'] == 'running']
+                    waiting_jobs = [j for j in jobs1 if j['status'] == 'waiting']
+                    self.logger.debug(f'There are {len(waiting_jobs)} waiting jobs')
+                    return len(waiting_jobs) > 0 and len(running_jobs) >= bucket_size
+
+                util.wait_until(submit_jobs, is_rate_limit_triggered,120000,5000)
+                jobs2 = util.query_jobs(self.cook_url, True, uuid=job_uuids).json()
+                running_jobs = [j for j in jobs2 if j['status'] == 'running']
+                self.assertGreaterEqual(len(running_jobs), bucket_size)
+                self.assertLessEqual(len(running_jobs), bucket_size+4)
+            finally:
+                util.kill_jobs(self.cook_url, job_uuids)
+
+
     def trigger_preemption(self, pool):
         """
         Triggers preemption on the provided pool (which can be None) by doing the following:

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -263,7 +263,7 @@ class MultiUserCookTest(util.CookTest):
             pytest.skip("Can't test job launch rate limit without launch rate limit set.")
 
         # Allow an environmental variable override.
-        name = os.getenv('COOK_LAUNCH_RATE_LIMIT_NAME')
+        name = os.getenv('COOK_LAUNCH_RATE_LIMIT_USER_NAME')
         if name is not None:
             user = self.user_factory.user_class(name)
         else:
@@ -319,7 +319,7 @@ class MultiUserCookTest(util.CookTest):
             pytest.skip("Can't test job launch rate limit without launch rate limit set.")
 
         # Allow an environmental variable override.
-        name = os.getenv('COOK_LAUNCH_RATE_LIMIT_NAME')
+        name = os.getenv('COOK_LAUNCH_RATE_LIMIT_USER_NAME')
         if name is not None:
             user = self.user_factory.user_class(name)
         else:

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -210,11 +210,14 @@ export COOK_SLAVE_URL=http://localhost:12323
 export COOK_MESOS_LEADER_URL=${MINIMESOS_MASTER}
 {
     echo "Using Mesos leader URL: ${COOK_MESOS_LEADER_URL}"
-    if [ "$JOB_LAUNCH_RATE_LIMIT" = off ]; then 
+    if [ "$JOB_LAUNCH_RATE_LIMIT" = on ]; then
+      pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_rate_limit_launching_jobs || test_failures=true
+    else if [ "$GLOBAL_JOB_LAUNCH_RATE_LIMIT" = on ]; then
+      pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_global_rate_limit_launching_jobs || test_failures=true
+    else
       pytest -n4 -v --color=no --timeout-method=thread --boxed -m "not serial" || test_failures=true
       pytest -n0 -v --color=no --timeout-method=thread --boxed -m "serial" || test_failures=true
-    else
-      pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_rate_limit_launching_jobs || test_failures=true
+    fi
     fi
 } &> >(tee ./log/pytest.log)
  

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -135,21 +135,21 @@ case "$JOB_LAUNCH_RATE_LIMIT" in
     exit 1
 esac
 
-case "$JOB_GLOBAL_LAUNCH_RATE_LIMIT" in
+case "$GLOBAL_JOB_LAUNCH_RATE_LIMIT" in
     on)
       # Note: Carefully chosen for test_global_rate_limit_launching_jobs unit test.
-      export JOB_GLOBAL_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
-      export JOB_GLOBAL_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
-      echo "Job global launch rate limit turned on"
+      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
+      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
+      echo "Global job launch rate limit turned on"
     ;;
     off)
       # Note: Wide enough that we're unlikely to hit these in testing.
-      export JOB_GLOBAL_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
-      export JOB_GLOBAL_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
-      echo "Job global launch rate limit turned off"
+      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
+      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
+      echo "Global job launch rate limit turned off"
     ;;
   *)
-    echo "Unrecognized job-global-launch-rate-limit toggle (should be on/off): $JOB_GLOBAL_LAUNCH_RATE_LIMIT"
+    echo "Unrecognized global-job-launch-rate-limit toggle (should be on/off): $GLOBAL_JOB_LAUNCH_RATE_LIMIT"
     exit 1
 esac
 

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -14,6 +14,7 @@ COOK_EXECUTOR=mesos
 COOK_POOLS=on
 CONFIG_FILE=scheduler_travis_config.edn
 JOB_LAUNCH_RATE_LIMIT=off
+GLOBAL_JOB_LAUNCH_RATE_LIMIT=off
 
 while (( $# > 0 )); do
   case "$1" in
@@ -31,6 +32,10 @@ while (( $# > 0 )); do
       ;;
     --job-launch-rate-limit=*)
       JOB_LAUNCH_RATE_LIMIT="${1#--job-launch-rate-limit=}"
+      shift
+      ;;
+    --global-job-launch-rate-limit=*)
+      GLOBAL_JOB_LAUNCH_RATE_LIMIT="${1#--global-job-launch-rate-limit=}"
       shift
       ;;
     *)
@@ -127,6 +132,24 @@ case "$JOB_LAUNCH_RATE_LIMIT" in
     ;;
   *)
     echo "Unrecognized job-launch-rate-limit toggle (should be on/off): $JOB_LAUNCH_RATE_LIMIT"
+    exit 1
+esac
+
+case "$JOB_GLOBAL_LAUNCH_RATE_LIMIT" in
+    on)
+      # Note: Carefully chosen for test_global_rate_limit_launching_jobs unit test.
+      export JOB_GLOBAL_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
+      export JOB_GLOBAL_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
+      echo "Job global launch rate limit turned on"
+    ;;
+    off)
+      # Note: Wide enough that we're unlikely to hit these in testing.
+      export JOB_GLOBAL_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
+      export JOB_GLOBAL_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
+      echo "Job global launch rate limit turned off"
+    ;;
+  *)
+    echo "Unrecognized job-global-launch-rate-limit toggle (should be on/off): $JOB_GLOBAL_LAUNCH_RATE_LIMIT"
     exit 1
 esac
 

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -13,8 +13,6 @@ COOK_AUTH=one-user
 COOK_EXECUTOR=mesos
 COOK_POOLS=on
 CONFIG_FILE=scheduler_travis_config.edn
-JOB_LAUNCH_RATE_LIMIT=off
-GLOBAL_JOB_LAUNCH_RATE_LIMIT=off
 
 while (( $# > 0 )); do
   case "$1" in
@@ -28,14 +26,6 @@ while (( $# > 0 )); do
       ;;
     --pools=*)
       COOK_POOLS="${1#--pools=}"
-      shift
-      ;;
-    --job-launch-rate-limit=*)
-      JOB_LAUNCH_RATE_LIMIT="${1#--job-launch-rate-limit=}"
-      shift
-      ;;
-    --global-job-launch-rate-limit=*)
-      GLOBAL_JOB_LAUNCH_RATE_LIMIT="${1#--global-job-launch-rate-limit=}"
       shift
       ;;
     *)
@@ -117,42 +107,6 @@ case "$COOK_POOLS" in
     exit 1
 esac
 
-case "$JOB_LAUNCH_RATE_LIMIT" in
-    on)
-      # Note: Carefully chosen for test_rate_limit_launching_jobs unit test.
-      export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
-      export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
-      echo "Job launch rate limit turned on"
-    ;;
-    off)
-      # Note: Wide enough that we're unlikely to hit these in testing.
-      export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
-      export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
-      echo "Job launch rate limit turned off"
-    ;;
-  *)
-    echo "Unrecognized job-launch-rate-limit toggle (should be on/off): $JOB_LAUNCH_RATE_LIMIT"
-    exit 1
-esac
-
-case "$GLOBAL_JOB_LAUNCH_RATE_LIMIT" in
-    on)
-      # Note: Carefully chosen for test_global_rate_limit_launching_jobs unit test.
-      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
-      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
-      echo "Global job launch rate limit turned on"
-    ;;
-    off)
-      # Note: Wide enough that we're unlikely to hit these in testing.
-      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
-      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
-      echo "Global job launch rate limit turned off"
-    ;;
-  *)
-    echo "Unrecognized global-job-launch-rate-limit toggle (should be on/off): $GLOBAL_JOB_LAUNCH_RATE_LIMIT"
-    exit 1
-esac
-
 pip install flask
 export DATA_LOCAL_PORT=35847
 export DATA_LOCAL_SERVICE="http://localhost:${DATA_LOCAL_PORT}"
@@ -210,15 +164,8 @@ export COOK_SLAVE_URL=http://localhost:12323
 export COOK_MESOS_LEADER_URL=${MINIMESOS_MASTER}
 {
     echo "Using Mesos leader URL: ${COOK_MESOS_LEADER_URL}"
-    if [ "$JOB_LAUNCH_RATE_LIMIT" = on ]; then
-      pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_rate_limit_launching_jobs || test_failures=true
-    else if [ "$GLOBAL_JOB_LAUNCH_RATE_LIMIT" = on ]; then
-      pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_global_rate_limit_launching_jobs || test_failures=true
-    else
-      pytest -n4 -v --color=no --timeout-method=thread --boxed -m "not serial" || test_failures=true
-      pytest -n0 -v --color=no --timeout-method=thread --boxed -m "serial" || test_failures=true
-    fi
-    fi
+    pytest -n4 -v --color=no --timeout-method=thread --boxed -m "not serial" || test_failures=true
+    pytest -n0 -v --color=no --timeout-method=thread --boxed -m "serial" || test_failures=true
 } &> >(tee ./log/pytest.log)
  
 

--- a/integration/travis/run_integration_ratelimit.sh
+++ b/integration/travis/run_integration_ratelimit.sh
@@ -7,24 +7,6 @@ set -ev
 export PROJECT_DIR=`pwd`
 
 CONFIG_FILE=scheduler_travis_config.edn
-JOB_LAUNCH_RATE_LIMIT=off
-GLOBAL_JOB_LAUNCH_RATE_LIMIT=off
-
-while (( $# > 0 )); do
-  case "$1" in
-    --job-launch-rate-limit=*)
-      JOB_LAUNCH_RATE_LIMIT="${1#--job-launch-rate-limit=}"
-      shift
-      ;;
-    --global-job-launch-rate-limit=*)
-      GLOBAL_JOB_LAUNCH_RATE_LIMIT="${1#--global-job-launch-rate-limit=}"
-      shift
-      ;;
-    *)
-      echo "Unrecognized option: $1"
-      exit 1
-  esac
-done
 
 function wait_for_cook {
     COOK_PORT=${1:-12321}
@@ -58,8 +40,6 @@ export COOK_KEYSTORE_PATH=${COOK_KEYSTORE_PATH}
 mkdir ${SCHEDULER_DIR}/log
 
 cd ${SCHEDULER_DIR}
-
-
 
 # Start two cook schedulers.
 export COOK_HTTP_BASIC_AUTH=true

--- a/integration/travis/run_integration_ratelimit.sh
+++ b/integration/travis/run_integration_ratelimit.sh
@@ -26,9 +26,6 @@ while (( $# > 0 )); do
   esac
 done
 
-export COOK_HTTP_BASIC_AUTH=true
-COOK_EXECUTOR_COMMAND=""
-
 function wait_for_cook {
     COOK_PORT=${1:-12321}
     while ! curl -s localhost:${COOK_PORT} >/dev/null;
@@ -62,14 +59,25 @@ mkdir ${SCHEDULER_DIR}/log
 
 cd ${SCHEDULER_DIR}
 
+
+
 # Start two cook schedulers.
-# The basic tests will run against cook-framework-1
+export COOK_HTTP_BASIC_AUTH=true
+export COOK_EXECUTOR_COMMAND=""
+## We launch two instances, with different configurations for the different unit tests.
 ## on travis, ports on 172.17.0.1 are bindable from the host OS, and are also
 ## available for processes inside minimesos containers to connect to
-export COOK_EXECUTOR_COMMAND=${COOK_EXECUTOR_COMMAND}
 # Start one cook listening on port 12321, this will be the master of the "cook-framework-1" framework
+export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
+export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
+export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
+export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
 LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12321 COOK_SSL_PORT=12322 COOK_COOKEEPER_LOCAL=true COOK_COOKEEPER_LOCAL_PORT=5291 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12321.log" COOK_DEFAULT_POOL=${DEFAULT_POOL} lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
 # Start a second cook listening on port 22321, this will be the master of the "cook-framework-2" framework
+export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
+export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
+export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
+export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
 LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=22321 COOK_SSL_PORT=22322 COOK_ZOOKEEPER_LOCAL=true COOK_ZOOKEEPER_LOCAL_PORT=4291 COOK_FRAMEWORK_ID=cook-framework-2 COOK_LOGFILE="log/cook-22321.log" lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
 
 # Wait for the cooks to be listening
@@ -93,28 +101,15 @@ command -v cs
 # Run the integration tests
 cd ${PROJECT_DIR}
 export COOK_MESOS_LEADER_URL=${MINIMESOS_MASTER}
-
-export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
-export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
-export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
-export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
-
-
 {
-    echo "Using Mesos leader URL: ${COOK_MESOS_LEADER_URL}"
-    if [ "$JOB_LAUNCH_RATE_LIMIT" = on ]; then
-      export COOK_SCHEDULER_URL=http://localhost:12321
-      export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
-      export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
-      pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_rate_limit_launching_jobs || test_failures=true
-    else if [ "$GLOBAL_JOB_LAUNCH_RATE_LIMIT" = on ]; then
-      export COOK_SCHEDULER_URL=http://localhost:22321
-      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
-      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
-      pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_global_rate_limit_launching_jobs || test_failures=true
-    fi
-    fi
-} &> >(tee ./log/pytest.log)
+  echo "Using Mesos leader URL: ${COOK_MESOS_LEADER_URL}"
+  export COOK_SCHEDULER_URL=http://localhost:12321
+  pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_rate_limit_launching_jobs || test_failures=true
+
+
+  export COOK_SCHEDULER_URL=http://localhost:22321
+  pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_global_rate_limit_launching_jobs || test_failures=true
+ } &> >(tee ./log/pytest.log)
  
 
 # If there were failures, then we should save the logs

--- a/integration/travis/run_integration_ratelimit.sh
+++ b/integration/travis/run_integration_ratelimit.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# Usage: ./run_integration [OPTIONS...]
+#   --auth={http-basic,one-user}    Use the specified authentication scheme. Default is one-user.
+#   --executor={cook,mesos}         Use the specified job executor. Default is mesos.
+#   --pools={on,off}                Use or don't use pools in the Cook under test. Default is on.
+
+set -ev
+
+export PROJECT_DIR=`pwd`
+
+COOK_AUTH=one-user
+COOK_EXECUTOR=mesos
+CONFIG_FILE=scheduler_travis_config.edn
+JOB_LAUNCH_RATE_LIMIT=off
+GLOBAL_JOB_LAUNCH_RATE_LIMIT=off
+
+while (( $# > 0 )); do
+  case "$1" in
+    --job-launch-rate-limit=*)
+      JOB_LAUNCH_RATE_LIMIT="${1#--job-launch-rate-limit=}"
+      shift
+      ;;
+    --global-job-launch-rate-limit=*)
+      GLOBAL_JOB_LAUNCH_RATE_LIMIT="${1#--global-job-launch-rate-limit=}"
+      shift
+      ;;
+    *)
+      echo "Unrecognized option: $1"
+      exit 1
+  esac
+done
+
+export COOK_HTTP_BASIC_AUTH=true
+COOK_EXECUTOR_COMMAND=""
+
+function wait_for_cook {
+    COOK_PORT=${1:-12321}
+    while ! curl -s localhost:${COOK_PORT} >/dev/null;
+    do
+        echo "$(date +%H:%M:%S) Cook is not listening on ${COOK_PORT} yet"
+        sleep 2.0
+    done
+    echo "$(date +%H:%M:%S) Connected to Cook on ${COOK_PORT}!"
+    curl -s localhost:${COOK_PORT}/info
+    echo
+}
+export -f wait_for_cook
+
+# Start minimesos
+cd ${TRAVIS_BUILD_DIR}/travis
+./minimesos up
+$(./minimesos info | grep MINIMESOS)
+export COOK_ZOOKEEPER="${MINIMESOS_ZOOKEEPER_IP}:2181"
+export MINIMESOS_ZOOKEEPER=${MINIMESOS_ZOOKEEPER%;}
+export MINIMESOS_MASTER=${MINIMESOS_MASTER%;}
+
+SCHEDULER_DIR=${TRAVIS_BUILD_DIR}/scheduler
+./datomic-free-0.9.5394/bin/transactor ${SCHEDULER_DIR}/datomic/datomic_transactor.properties &
+COOK_DATOMIC_URI_1=datomic:free://localhost:4334/cook-jobs
+COOK_DATOMIC_URI_2=datomic:mem://cook-jobs
+
+# Generate SSL certificate
+COOK_KEYSTORE_PATH=${SCHEDULER_DIR}/cook.p12
+keytool -genkeypair -keystore ${COOK_KEYSTORE_PATH} -storetype PKCS12 -storepass cookstore -dname "CN=cook, OU=Cook Developers, O=Two Sigma Investments, L=New York, ST=New York, C=US" -keyalg RSA -keysize 2048
+export COOK_KEYSTORE_PATH=${COOK_KEYSTORE_PATH}
+
+case "$JOB_LAUNCH_RATE_LIMIT" in
+    on)
+      # Note: Carefully chosen for test_rate_limit_launching_jobs unit test.
+      export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
+      export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
+      echo "Job launch rate limit turned on"
+    ;;
+    off)
+      # Note: Wide enough that we're unlikely to hit these in testing.
+      export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
+      export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
+      echo "Job launch rate limit turned off"
+    ;;
+  *)
+    echo "Unrecognized job-launch-rate-limit toggle (should be on/off): $JOB_LAUNCH_RATE_LIMIT"
+    exit 1
+esac
+
+case "$GLOBAL_JOB_LAUNCH_RATE_LIMIT" in
+    on)
+      # Note: Carefully chosen for test_global_rate_limit_launching_jobs unit test.
+      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
+      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
+      echo "Global job launch rate limit turned on"
+    ;;
+    off)
+      # Note: Wide enough that we're unlikely to hit these in testing.
+      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
+      export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
+      echo "Global job launch rate limit turned off"
+    ;;
+  *)
+    echo "Unrecognized global-job-launch-rate-limit toggle (should be on/off): $GLOBAL_JOB_LAUNCH_RATE_LIMIT"
+    exit 1
+esac
+
+pip install flask
+mkdir ${SCHEDULER_DIR}/log
+
+# Seed running jobs, which are used to test the task reconciler
+cd ${SCHEDULER_DIR}
+lein exec -p datomic/data/seed_running_jobs.clj ${COOK_DATOMIC_URI_1}
+
+# Start three cook schedulers.
+# We want one cluster with two cooks to run MasterSlaveTest, and a second cluster to run MultiClusterTest.
+# The basic tests will run against cook-framework-1
+## on travis, ports on 172.17.0.1 are bindable from the host OS, and are also
+## available for processes inside minimesos containers to connect to
+export COOK_EXECUTOR_COMMAND=${COOK_EXECUTOR_COMMAND}
+# Start one cook listening on port 12321, this will be the master of the "cook-framework-1" framework
+LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12321 COOK_SSL_PORT=12322 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12321.log" COOK_DEFAULT_POOL=${DEFAULT_POOL} lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
+# Start a second cook listening on port 22321, this will be the master of the "cook-framework-2" framework
+LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_2}" COOK_PORT=22321 COOK_SSL_PORT=22322 COOK_ZOOKEEPER_LOCAL=true COOK_ZOOKEEPER_LOCAL_PORT=4291 COOK_FRAMEWORK_ID=cook-framework-2 COOK_LOGFILE="log/cook-22321.log" lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
+
+# Wait for the cooks to be listening
+timeout 180s bash -c "wait_for_cook 12321" || curl_error=true
+if [ "$curl_error" = true ]; then
+  echo "$(date +%H:%M:%S) Timed out waiting for cook to start listening"
+  ${TRAVIS_BUILD_DIR}/travis/upload_logs.sh
+  exit 1
+fi
+
+# Start a third cook listening on port 12323, this will be a slave on the "cook-framework-1" framework
+LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12323 COOK_SSL_PORT=12324 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12323.log" COOK_DEFAULT_POOL=${DEFAULT_POOL} lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
+
+timeout 180s bash -c "wait_for_cook 12323" || curl_error=true
+if [ "$curl_error" = true ]; then
+  echo "$(date +%H:%M:%S) Timed out waiting for cook to start listening"
+  ${TRAVIS_BUILD_DIR}/travis/upload_logs.sh
+  exit 1
+fi
+timeout 180s bash -c "wait_for_cook 22321" || curl_error=true
+if [ "$curl_error" = true ]; then
+  echo "$(date +%H:%M:%S) Timed out waiting for cook to start listening"
+  ${TRAVIS_BUILD_DIR}/travis/upload_logs.sh
+  exit 1
+fi
+
+# Ensure the Cook Scheduler CLI is available
+command -v cs
+
+# Run the integration tests
+cd ${PROJECT_DIR}
+export COOK_MULTI_CLUSTER=
+export COOK_MASTER_SLAVE=
+export COOK_SLAVE_URL=http://localhost:12323
+export COOK_MESOS_LEADER_URL=${MINIMESOS_MASTER}
+{
+    echo "Using Mesos leader URL: ${COOK_MESOS_LEADER_URL}"
+    if [ "$JOB_LAUNCH_RATE_LIMIT" = on ]; then
+      pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_rate_limit_launching_jobs || test_failures=true
+    else if [ "$GLOBAL_JOB_LAUNCH_RATE_LIMIT" = on ]; then
+      pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_global_rate_limit_launching_jobs || test_failures=true
+    fi
+    fi
+} &> >(tee ./log/pytest.log)
+ 
+
+# If there were failures, then we should save the logs
+if [ "$test_failures" = true ]; then
+  echo "Uploading logs..."
+  ${TRAVIS_BUILD_DIR}/travis/upload_logs.sh
+  exit 1
+fi

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -34,6 +34,9 @@
  :rate-limit {:expire-minutes 120 ; Expire unused rate limit entries after 2 hours.
               ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
               ; spurious failures, and making them larger will cause the rate-limit integration test to skip itself.
+              :global-job-launch {:bucket-size #config/env-int-default ["GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE" 10000]
+                           :enforce? true
+                           :tokens-replenished-per-minute #config/env-int-default ["GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE" 10000]}
               :job-launch {:bucket-size #config/env-int-default ["JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE" 10000]
                            :enforce? true
                            :tokens-replenished-per-minute #config/env-int-default ["JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE" 10000]}

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -48,9 +48,12 @@
        :keystore-path #config/env "COOK_KEYSTORE_PATH"
        :keystore-type "pkcs12"
        :keystore-pass "cookstore"}
- :rate-limit {:expire-minutes 120 ; Expire unused rate limit entries after 2 hours.
+ :rate-limit {:expire-minutes 1200 ; Expire unused rate limit entries after 20 hours.
               ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
               ; spurious failures, and making them larger will cause test_rate_limit_launching_jobs to skip itself.
+              :global-job-launch {:bucket-size 10000
+                           :enforce? true
+                           :tokens-replenished-per-minute 5000}
               :job-launch {:bucket-size 10000
                            :enforce? true
                            :tokens-replenished-per-minute 5000}

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -204,10 +204,11 @@
                                      ((util/lazy-load-var 'cook.impersonation/create-impersonation-middleware) impersonators)
                                      {:json-value "config-impersonation"})))
      :rate-limit (fnk [[:config {rate-limit nil}]]
-                   (let [{:keys [expire-minutes user-limit-per-m job-submission job-launch]
+                   (let [{:keys [expire-minutes user-limit-per-m global-job-launch job-submission job-launch]
                           :or {expire-minutes 120
                                user-limit-per-m 600}} rate-limit]
                      {:expire-minutes expire-minutes
+                      :global-job-launch global-job-launch
                       :job-submission job-submission
                       :job-launch job-launch
                       :user-limit (->UserRateLimit :user-limit user-limit-per-m (t/minutes 1))}))

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -702,6 +702,7 @@
                     matches)
           (throw e))))
     (log/info "Launching" (count task-txns) "tasks")
+    (ratelimit/spend! ratelimit/global-job-launch-rate-limiter ratelimit/global-job-launch-rate-limiter-key (count task-txns))
     (log/debug "Matched tasks" task-txns)
     ;; This launch-tasks MUST happen after the above transaction in
     ;; order to allow a transaction failure (due to failed preconditions)

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -62,9 +62,9 @@
   [config]
   (let [{:keys [settings]} config
         {:keys [rate-limit]} settings
-        {:keys [expire-minutes job-launch-global]} rate-limit]
-    (if (seq job-launch-global)
-      (let [{:keys [bucket-size enforce? tokens-replenished-per-minute]} job-launch-global]
+        {:keys [expire-minutes global-job-launch]} rate-limit]
+    (if (seq global-job-launch)
+      (let [{:keys [bucket-size enforce? tokens-replenished-per-minute]} global-job-launch]
         (rtg/make-token-bucket-filter bucket-size tokens-replenished-per-minute expire-minutes enforce?))
       AllowAllRateLimiter)))
 

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -55,3 +55,20 @@
 
 (mount/defstate job-launch-rate-limiter
   :start (create-job-launch-rate-limiter config))
+
+(defn create-global-job-launch-rate-limiter
+  "From the configuration map, extract the keys that setup the job-launch rate limiter and return
+  the constructed object. If the configuration map is not found, the AllowAllRateLimiter is returned."
+  [config]
+  (let [{:keys [settings]} config
+        {:keys [rate-limit]} settings
+        {:keys [expire-minutes job-launch-global]} rate-limit]
+    (if (seq job-launch-global)
+      (let [{:keys [bucket-size enforce? tokens-replenished-per-minute]} job-launch-global]
+        (rtg/make-token-bucket-filter bucket-size tokens-replenished-per-minute expire-minutes enforce?))
+      AllowAllRateLimiter)))
+
+(mount/defstate global-job-launch-rate-limiter
+  :start (create-global-job-launch-rate-limiter config))
+
+(def global-job-launch-rate-limiter-key "*DEF*")

--- a/scheduler/test/cook/test/mesos/constraints.clj
+++ b/scheduler/test/cook/test/mesos/constraints.clj
@@ -54,6 +54,7 @@
 
 
 (deftest test-gpu-constraint
+  (cook.test.testutil/setup)
   (let [framework-id #mesomatic.types.FrameworkID{:value "my-framework-id"}
         gpu-offer #mesomatic.types.Offer{:id #mesomatic.types.OfferID {:value "my-offer-id"}
                                          :framework-id framework-id

--- a/scheduler/test/cook/test/mesos/fenzo_utils.clj
+++ b/scheduler/test/cook/test/mesos/fenzo_utils.clj
@@ -92,6 +92,7 @@
 
 
 (deftest test-record-placement-failures
+  (cook.test.testutil/setup)
   (let [uri "datomic:mem://test-record-placement-failures"
         conn (restore-fresh-database! uri)
         job-id (create-dummy-job conn :under-investigation true)

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -343,6 +343,7 @@
     (is (= 1000.0 (:mem resources)))))
 
 (deftest test-match-offer-to-schedule
+  (setup)
   (let [schedule (map #(d/entity (db c) %) [j1 j2 j3 j4]) ; all 1gb 1 cpu
         offer-maker (fn [cpus mem]
                       [{:resources [{:name "cpus" :type :value-scalar :scalar cpus}
@@ -766,6 +767,7 @@
                                   distinct))))))))
 
 (deftest test-attr-equals-host-placement-constraint
+  (setup)
   (let [uri "datomic:mem://test-attr-equals-host-placement-constraint"
         conn (restore-fresh-database! uri)
         framework-id #mesomatic.types.FrameworkID{:value "my-original-framework-id"}
@@ -1660,6 +1662,19 @@
             (is (= 1 (count @launched-job-ids-atom)))
             (is (= #{"job-1"} (set @launched-job-ids-atom))))))
 
+      (with-redefs [rate-limit/job-launch-rate-limiter
+                    (rate-limit/create-job-launch-rate-limiter job-launch-rate-limit-config-for-testing)
+                    rate-limit/get-token-count! (constantly 1)]
+        (testing "enough offers for all normal jobs, limited by num-considerable of 2, but only one token in global rate limit for one job"
+          ;; We filter so that fenzo only matches one job, so we should only launch the one job.
+          (let [num-considerable 2
+                offers [offer-1 offer-2 offer-3]]
+            (is (run-handle-resource-offers! num-considerable offers :normal))
+            (is (= :end-marker (async/<!! offers-chan)))
+            (is (= 1 (count @launched-offer-ids-atom)))
+            (is (= 1 (count @launched-job-ids-atom)))
+            (is (= #{"job-1"} (set @launched-job-ids-atom))))))
+
       (let [total-spent (atom 0)]
         (with-redefs [rate-limit/spend! (fn [_ _ tokens] (reset! total-spent (-> @total-spent (+ tokens))))]
           (testing "enough offers for all normal jobs, limited by num-considerable of 2. Make sure we spend the tokens."
@@ -1670,7 +1685,8 @@
               (is (= 2 (count @launched-offer-ids-atom)))
               (is (= 2 (count @launched-job-ids-atom)))
               (is (= #{"job-1" "job-2"} (set @launched-job-ids-atom)))
-              (is (= 2 @total-spent))))))
+              ; We launch two jobs, this involves spending two tokens on per-user rate limiter and 2 on the global launch rate limiter.
+              (is (= 4 @total-spent))))))
 
       (testing "enough offers for all normal jobs, limited by quota"
         (let [num-considerable 1

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -291,7 +291,7 @@
     "Given an optional config map, initializes the config state"
     [& {:keys [config], :or nil}]
     (mount/stop)
-    (mount/start-with-args (merge minimal-config config) #'cook.config/config #'cook.rate-limit/job-launch-rate-limiter)))
+    (mount/start-with-args (merge minimal-config config) #'cook.config/config #'cook.rate-limit/job-launch-rate-limiter #'cook.rate-limit/global-job-launch-rate-limiter)))
 
 (defn wait-for
   "Invoke predicate every interval (default 10) seconds until it returns true,


### PR DESCRIPTION
## Changes proposed in this PR

- New global rate limit. This lets us set a hard limit so that we only launch up to a given token-bucket-filter rate of jobs/second. 
- 
- 

## Why are we making these changes?

- Better control over cook's behavior.
