### PR TITLE
Add additional logging on exceptions

### DIFF
--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -2711,9 +2711,22 @@
           (update :body body-matchers)
           (update :response resp-matchers)))))
 
-(defn- logging-exception-handler [base-handler]
+(defn- truncate
+  "Truncates `in-str` to a maximum length of `max-len` and adds an ellipsis if truncated."
+  [in-str max-len]
+  (let [ellipsis "..."
+        ellipsis-len (count ellipsis)]
+    (if (and (string? in-str) (> (count in-str) max-len) (> max-len ellipsis-len))
+      (str (subs in-str 0 (- max-len ellipsis-len)) ellipsis)
+      in-str)))
+
+(defn- logging-exception-handler
+  "Wraps `base-handler` with an additional `log/error` call which logs the request and exception"
+  [base-handler]
   (fn logging-exception-handler [ex data req]
-    (log/error ex "Error when processing request" (dissoc req ::c-mw/options))
+    (log/error ex "Error when processing request"
+               (-> (dissoc req ::c-mw/options :body :ctrl :request-time :servlet-request :ssl-client-cert)
+                   (update-in [:headers] (fn [headers] (pc/map-vals (fn [value] (truncate value 80)) headers)))))
     (base-handler ex data req)))
 
 ;;


### PR DESCRIPTION
## Changes proposed in this PR
- Wrap all of the default exception handlers with additional logging

## Why are we making these changes?
Several of the exception types don't log at all, and the default logger doesn't log the request so it's hard to associate the log with the request that caused it.
