### PR TITLE
Outgoing/rate limit unscheduled fix

### DIFF
--- a/integration/tests/cook/reasons.py
+++ b/integration/tests/cook/reasons.py
@@ -10,4 +10,4 @@ UNDER_INVESTIGATION = 'The job is now under investigation. Check back in a minut
 COULD_NOT_PLACE_JOB = 'The job couldn\'t be placed on any available hosts.'
 JOB_WOULD_EXCEED_QUOTA = 'The job would cause you to exceed resource quotas.'
 JOB_IS_RUNNING_NOW = 'The job is running now.'
-JOB_LAUNCH_RATE_LIMIT = 'You are currently limited by the maximum jobs per minute.'
+JOB_LAUNCH_RATE_LIMIT = 'You are currently rate limited on how many jobs you launch per minute.'

--- a/integration/tests/cook/reasons.py
+++ b/integration/tests/cook/reasons.py
@@ -10,4 +10,3 @@ UNDER_INVESTIGATION = 'The job is now under investigation. Check back in a minut
 COULD_NOT_PLACE_JOB = 'The job couldn\'t be placed on any available hosts.'
 JOB_WOULD_EXCEED_QUOTA = 'The job would cause you to exceed resource quotas.'
 JOB_IS_RUNNING_NOW = 'The job is running now.'
-JOB_LAUNCH_RATE_LIMIT = 'You have exceeded the limit of jobs launched per minute.'

--- a/integration/tests/cook/reasons.py
+++ b/integration/tests/cook/reasons.py
@@ -10,4 +10,4 @@ UNDER_INVESTIGATION = 'The job is now under investigation. Check back in a minut
 COULD_NOT_PLACE_JOB = 'The job couldn\'t be placed on any available hosts.'
 JOB_WOULD_EXCEED_QUOTA = 'The job would cause you to exceed resource quotas.'
 JOB_IS_RUNNING_NOW = 'The job is running now.'
-JOB_LAUNCH_RATE_LIMIT = 'You have exceeded the limit of jobs launched per minute.'
+JOB_LAUNCH_RATE_LIMIT = 'You are currently limited by the maximum jobs per minute.'

--- a/integration/tests/cook/reasons.py
+++ b/integration/tests/cook/reasons.py
@@ -10,3 +10,4 @@ UNDER_INVESTIGATION = 'The job is now under investigation. Check back in a minut
 COULD_NOT_PLACE_JOB = 'The job couldn\'t be placed on any available hosts.'
 JOB_WOULD_EXCEED_QUOTA = 'The job would cause you to exceed resource quotas.'
 JOB_IS_RUNNING_NOW = 'The job is running now.'
+JOB_LAUNCH_RATE_LIMIT = 'You have exceeded the limit of jobs launched per minute.'

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -6,7 +6,7 @@ import unittest
 
 import pytest
 
-from tests.cook import mesos, util
+from tests.cook import mesos, util, reasons
 
 
 @pytest.mark.multi_user

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -307,7 +307,8 @@ class MultiUserCookTest(util.CookTest):
                 jobs2 = util.query_jobs(self.cook_url, True, uuid=job_uuids).json()
                 running_jobs = [j for j in jobs2 if j['status'] == 'running']
                 waiting_jobs = [j for j in jobs2 if j['status'] == 'waiting']
-                self.assertEqual(len(running_jobs), bucket_size)
+                self.assertGreaterEqual(len(running_jobs), bucket_size)
+                self.assertLessEqual(len(running_jobs), bucket_size+3)
                 self.logger.debug(f'There are {len(waiting_jobs)} waiting jobs')
 
                 unscheduled, _ = util.unscheduled_jobs(self.cook_url, *[j['uuid'] for j in waiting_jobs])

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -300,14 +300,25 @@ class MultiUserCookTest(util.CookTest):
                     jobs1 = util.query_jobs(self.cook_url, True, uuid=job_uuids).json()
                     waiting_jobs = [j for j in jobs1 if j['status'] == 'waiting']
                     running_jobs = [j for j in jobs1 if j['status'] == 'running']
-                    self.logger.debug(f'There are {len(waiting_jobs)} waiting jobs')
                     # We submitted just under two buckets. We should only see a bucket + some extra running. No more.
-                    return len(running_jobs) >= bucket_size and len(running_jobs) < (bucket_size + token_rate/2) and len(waiting_jobs) > 0
+                    return len(running_jobs) >= bucket_size and len(waiting_jobs) > 0
 
                 util.wait_until(submit_jobs, is_rate_limit_triggered)
                 jobs2 = util.query_jobs(self.cook_url, True, uuid=job_uuids).json()
                 running_jobs = [j for j in jobs2 if j['status'] == 'running']
+                waiting_jobs = [j for j in jobs2 if j['status'] == 'waiting']
                 self.assertEqual(len(running_jobs), bucket_size)
+                self.logger.debug(f'There are {len(waiting_jobs)} waiting jobs')
+
+                unscheduled, _ = util.unscheduled_jobs(self.cook_url, *[j['uuid'] for j in waiting_jobs])
+
+                is_job_launch_rate_limited = [
+                    any([reasons.JOB_LAUNCH_RATE_LIMIT == reason['reason'] for reason in ii['reasons']])
+                    for ii in unscheduled]
+                num_launch_rate_limited = len([ii for ii in is_job_launch_rate_limited if ii])
+                self.logger.debug(f'There are {num_launch_rate_limited} jobs being rate-limited')
+                self.assertGreaterEqual(num_launch_rate_limited,bucket_size/2)
+
             finally:
                 util.kill_jobs(self.cook_url, job_uuids)
 

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -6,7 +6,7 @@ import unittest
 
 import pytest
 
-from tests.cook import mesos, util, reasons
+from tests.cook import mesos, util
 
 
 @pytest.mark.multi_user

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -592,6 +592,10 @@
                              (map job->usage)
                              (reduce (partial merge-with +))))))))
 
+
+;Shared as we use this for unscheduled too.
+(defonce pool->user->number-jobs (atom {}))
+
 (defn pending-jobs->considerable-jobs
   "Limit the pending jobs to considerable jobs based on usage and quota.
    Further limit the considerable jobs to a maximum of num-considerable jobs."
@@ -619,6 +623,7 @@
                (take num-considerable)
                ; Force this to be taken eagerly so that the log line is accurate.
                (doall))]
+    (swap! pool->user->number-jobs update pool-name (constantly @user->number-jobs))
     (log/info "Users whose job launches are rate-limited " @user->rate-limit-count)
     considerable-jobs))
 

--- a/scheduler/src/cook/mesos/unscheduled.clj
+++ b/scheduler/src/cook/mesos/unscheduled.clj
@@ -158,7 +158,7 @@
         being-ratelimited? (not (zero? num-ratelimited))
         {:keys [tokens-replenished-per-minute]} ratelimit/job-launch-rate-limiter]
     (when (and enforcing-job-launch-rate-limit? being-ratelimited?)
-      ["You are currently limited by the maximum jobs per minute."
+      ["You are currently rate limited on how many jobs you launch per minute."
        {:max-jobs-per-minute tokens-replenished-per-minute}])))
 
 (defn reasons

--- a/scheduler/src/cook/mesos/unscheduled.clj
+++ b/scheduler/src/cook/mesos/unscheduled.clj
@@ -20,7 +20,6 @@
             [cook.mesos.quota :as quota]
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
-            [cook.rate-limit :as ratelimit]
             [clojure.edn :as edn]
             [datomic.api :as d :refer (q)]))
 
@@ -146,18 +145,6 @@
        {:jobs (->> tasks-ahead
                    (mapv #(-> % :job/_instance :job/uuid str)))}])))
 
-(defn- check-launch-rate-limit
-  "Return the appropriate error message if a user's job is unscheduled because they're over the job launch rate limit threshold"
-  [{:keys [job/user]}]
-  (let [enforcing-job-launch-rate-limit? (ratelimit/enforce? ratelimit/job-launch-rate-limiter)
-        time-until-out-of-debt (ratelimit/time-until-out-of-debt-millis! ratelimit/job-launch-rate-limiter user)
-        in-debt? (not (zero? time-until-out-of-debt))
-        {:keys [tokens-replenished-per-minute]} ratelimit/job-launch-rate-limiter]
-    (when (and enforcing-job-launch-rate-limit? in-debt?)
-      ["You have exceeded the limit of jobs launched per minute."
-       {:max-jobs-per-minute tokens-replenished-per-minute
-        :seconds-until-can-launch (-> time-until-out-of-debt (/ 1000.0) Math/ceil int)}])))
-
 (defn reasons
   "Top level function which assembles a data structure representing the list
   of possible responses to the question \"Why isn't this job being scheduled?\".
@@ -186,3 +173,4 @@
                  (check-launch-rate-limit job)
                  (check-queue-position conn job running-jobs waiting-jobs)
                  (check-fenzo-placement conn job)])))))
+

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1314,6 +1314,7 @@
              (sched/filter-based-on-quota {test-user {:count 4, :cpus 20, :mem 6144}} user->usage queue))))))
 
 (deftest test-pending-jobs->considerable-jobs
+  (cook.test.testutil/setup)
   (let [uri "datomic:mem://test-pending-jobs-considerable-jobs"
         conn (restore-fresh-database! uri)
         test-db (d/db conn)

--- a/scheduler/test/cook/test/mesos/unscheduled.clj
+++ b/scheduler/test/cook/test/mesos/unscheduled.clj
@@ -154,7 +154,7 @@
                 {:count {:limit 2 :usage 3}}]))
 
         (is (= (nth reasons 2)
-               ["You are currently limited by the maximum jobs per minute." {:max-jobs-per-minute 100.0}]))
+               ["You are currently rate limited on how many jobs you launch per minute." {:max-jobs-per-minute 100.0}]))
 
         (is (= (nth reasons 3)
                ["You have 2 other jobs ahead in the queue."

--- a/scheduler/test/cook/test/mesos/unscheduled.clj
+++ b/scheduler/test/cook/test/mesos/unscheduled.clj
@@ -19,7 +19,6 @@
             [datomic.api :as d]
             [cook.mesos.scheduler :as scheduler]
             [cook.mesos.util :as util]
-            [cook.rate-limit :as rate-limit]
             [cook.test.testutil :refer (create-dummy-instance
                                         create-dummy-job
                                         restore-fresh-database!
@@ -118,79 +117,6 @@
         (is (= (nth reasons 1)
                ["The job would cause you to exceed resource quotas."
                 {:count {:limit 2 :usage 3}}]))
-
-        (is (= (nth reasons 2)
-               ["You have 2 other jobs ahead in the queue."
-                {:jobs running-job-uuids}]))
-
-        (is (= (nth reasons 3)
-               ["The job is now under investigation. Check back in a minute for more details!"
-                {}]))))
-
-    (testing "Waiting job returns multiple reasons, including an enforced launch rate limit."
-      @(d/transact conn [[:db/add waiting-job-id :job/state :job.state/waiting]])
-      (let [db (d/db conn)
-            running-job-ent1 (d/touch (d/entity db running-job-id1))
-            running-job-ent2 (d/touch (d/entity db running-job-id2))
-            waiting-job-ent (d/touch (d/entity db waiting-job-id))
-            running-job-uuids [(-> running-job-ent1 :job/uuid str)
-                               (-> running-job-ent2 :job/uuid str)]
-            reasons
-            (with-redefs [rate-limit/time-until-out-of-debt-millis! (constantly 1999)
-                          rate-limit/job-launch-rate-limiter
-                          (rate-limit/create-job-launch-rate-limiter
-                            {:settings {:rate-limit {:expire-minutes 180
-                                                     :job-launch {:bucket-size 500
-                                                                  :enforce? true
-                                                                  :tokens-replenished-per-minute 100}}}})]
-              (u/reasons conn waiting-job-ent))]
-
-        (is (= (nth reasons 0)
-               ["Job has exhausted its maximum number of retries."
-                {:max-retries 2, :instance-count 2}]))
-
-        (is (= (nth reasons 1)
-               ["The job would cause you to exceed resource quotas."
-                {:count {:limit 2 :usage 3}}]))
-
-        (is (= (nth reasons 2)
-               ["You have exceeded the limit of jobs launched per minute." {:max-jobs-per-minute 100.0, :seconds-until-can-launch 2}]))
-
-        (is (= (nth reasons 3)
-               ["You have 2 other jobs ahead in the queue."
-                {:jobs running-job-uuids}]))
-
-        (is (= (nth reasons 4)
-               ["The job is now under investigation. Check back in a minute for more details!"
-                {}]))))
-
-    (testing "Waiting job returns multiple reasons, including an unenforced rate launch rate limit."
-      @(d/transact conn [[:db/add waiting-job-id :job/state :job.state/waiting]])
-      (let [db (d/db conn)
-            running-job-ent1 (d/touch (d/entity db running-job-id1))
-            running-job-ent2 (d/touch (d/entity db running-job-id2))
-            waiting-job-ent (d/touch (d/entity db waiting-job-id))
-            running-job-uuids [(-> running-job-ent1 :job/uuid str)
-                               (-> running-job-ent2 :job/uuid str)]
-            reasons
-            (with-redefs [rate-limit/time-until-out-of-debt-millis! (constantly 1999)
-                          rate-limit/job-launch-rate-limiter
-                          (rate-limit/create-job-launch-rate-limiter
-                            {:settings {:rate-limit {:expire-minutes 180
-                                                     :job-launch {:bucket-size 500
-                                                                  :enforce? false
-                                                                  :tokens-replenished-per-minute 100}}}})]
-              (u/reasons conn waiting-job-ent))]
-
-        (is (= (nth reasons 0)
-               ["Job has exhausted its maximum number of retries."
-                {:max-retries 2, :instance-count 2}]))
-
-        (is (= (nth reasons 1)
-               ["The job would cause you to exceed resource quotas."
-                {:count {:limit 2 :usage 3}}]))
-
-        ; Note: No launch rate limit reason is returned here, because not enforcing.
 
         (is (= (nth reasons 2)
                ["You have 2 other jobs ahead in the queue."

--- a/scheduler/test/cook/test/mesos/unscheduled.clj
+++ b/scheduler/test/cook/test/mesos/unscheduled.clj
@@ -136,7 +136,7 @@
             running-job-uuids [(-> running-job-ent1 :job/uuid str)
                                (-> running-job-ent2 :job/uuid str)]
             reasons
-            (with-redefs [rate-limit/time-until-out-of-debt-millis! (constantly 1999)
+            (with-redefs [scheduler/pool->user->number-jobs (atom {:pool0 {"mforsyth" 3}})
                           rate-limit/job-launch-rate-limiter
                           (rate-limit/create-job-launch-rate-limiter
                             {:settings {:rate-limit {:expire-minutes 180
@@ -154,7 +154,7 @@
                 {:count {:limit 2 :usage 3}}]))
 
         (is (= (nth reasons 2)
-               ["You have exceeded the limit of jobs launched per minute." {:max-jobs-per-minute 100.0, :seconds-until-can-launch 2}]))
+               ["You are currently limited by the maximum jobs per minute." {:max-jobs-per-minute 100.0}]))
 
         (is (= (nth reasons 3)
                ["You have 2 other jobs ahead in the queue."

--- a/scheduler/test/cook/test/mesos/unscheduled.clj
+++ b/scheduler/test/cook/test/mesos/unscheduled.clj
@@ -19,6 +19,7 @@
             [datomic.api :as d]
             [cook.mesos.scheduler :as scheduler]
             [cook.mesos.util :as util]
+            [cook.rate-limit :as rate-limit]
             [cook.test.testutil :refer (create-dummy-instance
                                         create-dummy-job
                                         restore-fresh-database!
@@ -117,6 +118,79 @@
         (is (= (nth reasons 1)
                ["The job would cause you to exceed resource quotas."
                 {:count {:limit 2 :usage 3}}]))
+
+        (is (= (nth reasons 2)
+               ["You have 2 other jobs ahead in the queue."
+                {:jobs running-job-uuids}]))
+
+        (is (= (nth reasons 3)
+               ["The job is now under investigation. Check back in a minute for more details!"
+                {}]))))
+
+    (testing "Waiting job returns multiple reasons, including an enforced launch rate limit."
+      @(d/transact conn [[:db/add waiting-job-id :job/state :job.state/waiting]])
+      (let [db (d/db conn)
+            running-job-ent1 (d/touch (d/entity db running-job-id1))
+            running-job-ent2 (d/touch (d/entity db running-job-id2))
+            waiting-job-ent (d/touch (d/entity db waiting-job-id))
+            running-job-uuids [(-> running-job-ent1 :job/uuid str)
+                               (-> running-job-ent2 :job/uuid str)]
+            reasons
+            (with-redefs [rate-limit/time-until-out-of-debt-millis! (constantly 1999)
+                          rate-limit/job-launch-rate-limiter
+                          (rate-limit/create-job-launch-rate-limiter
+                            {:settings {:rate-limit {:expire-minutes 180
+                                                     :job-launch {:bucket-size 500
+                                                                  :enforce? true
+                                                                  :tokens-replenished-per-minute 100}}}})]
+              (u/reasons conn waiting-job-ent))]
+
+        (is (= (nth reasons 0)
+               ["Job has exhausted its maximum number of retries."
+                {:max-retries 2, :instance-count 2}]))
+
+        (is (= (nth reasons 1)
+               ["The job would cause you to exceed resource quotas."
+                {:count {:limit 2 :usage 3}}]))
+
+        (is (= (nth reasons 2)
+               ["You have exceeded the limit of jobs launched per minute." {:max-jobs-per-minute 100.0, :seconds-until-can-launch 2}]))
+
+        (is (= (nth reasons 3)
+               ["You have 2 other jobs ahead in the queue."
+                {:jobs running-job-uuids}]))
+
+        (is (= (nth reasons 4)
+               ["The job is now under investigation. Check back in a minute for more details!"
+                {}]))))
+
+    (testing "Waiting job returns multiple reasons, including an unenforced rate launch rate limit."
+      @(d/transact conn [[:db/add waiting-job-id :job/state :job.state/waiting]])
+      (let [db (d/db conn)
+            running-job-ent1 (d/touch (d/entity db running-job-id1))
+            running-job-ent2 (d/touch (d/entity db running-job-id2))
+            waiting-job-ent (d/touch (d/entity db waiting-job-id))
+            running-job-uuids [(-> running-job-ent1 :job/uuid str)
+                               (-> running-job-ent2 :job/uuid str)]
+            reasons
+            (with-redefs [rate-limit/time-until-out-of-debt-millis! (constantly 1999)
+                          rate-limit/job-launch-rate-limiter
+                          (rate-limit/create-job-launch-rate-limiter
+                            {:settings {:rate-limit {:expire-minutes 180
+                                                     :job-launch {:bucket-size 500
+                                                                  :enforce? false
+                                                                  :tokens-replenished-per-minute 100}}}})]
+              (u/reasons conn waiting-job-ent))]
+
+        (is (= (nth reasons 0)
+               ["Job has exhausted its maximum number of retries."
+                {:max-retries 2, :instance-count 2}]))
+
+        (is (= (nth reasons 1)
+               ["The job would cause you to exceed resource quotas."
+                {:count {:limit 2 :usage 3}}]))
+
+        ; Note: No launch rate limit reason is returned here, because not enforcing.
 
         (is (= (nth reasons 2)
                ["You have 2 other jobs ahead in the queue."


### PR DESCRIPTION
## Changes proposed in this PR

- The gradual rate limit means we're never in debt, so the unscheduled endpoint won't ever report anything anymore. Fix it with new logic. We export when we're hitting a rate limit from the scheduler and expose it to the unscheduled.
- 
- 

## Why are we making these changes?
The current rate limit unscheduled code is broken. Either remove or fix. This fixes it. :)


