### PR TITLE
Cache refactor and add explicit expiration.

### DIFF
--- a/scheduler/src/cook/cache.clj
+++ b/scheduler/src/cook/cache.clj
@@ -1,0 +1,52 @@
+(ns cook.cache
+  (:require [clj-time.core :as t])
+  (:import (com.google.common.cache Cache)))
+
+
+(defn lookup-cache!
+  "Generic cache. Caches under a key (extracted from the item with extract-key-fn. Uses miss-fn to fill
+  any misses. Caches only positive hits where both functions return non-nil"
+  [^Cache cache extract-key-fn miss-fn item]
+  (if-let [key (extract-key-fn item)]
+    (if-let [result (.getIfPresent cache key)]
+      result ; we got a hit.
+      (let [new-result (miss-fn item)]
+        ; Only cache non-nil
+        (when new-result
+          (.put cache key new-result))
+        new-result))
+    (miss-fn item)))
+
+(defn expire-key!
+  "Generic cache. Caches under a key (extracted from the item with extract-key-fn. Uses miss-fn to fill
+  any misses. Caches only positive hits where both functions return non-nil. Also handles expiration if the value
+  is a map with the key :cache-expires-at."
+  [^Cache cache extract-key-fn item]
+  (if-let [key (extract-key-fn item)]
+    (locking cache ; TOOD: Consider lock striping based on hashcode of the key to allow concurrent loads.
+      ; If it has a timed expiration, expire it.
+      (when-let [result (.getIfPresent cache key)]
+        (let [{:keys [cache-expires-at]} result]
+          (when (and cache-expires-at (t/after? (t/now) cache-expires-at))  (.invalidate cache key)))))))
+
+
+(defn lookup-cache-with-expiration!
+  "Generic cache. Caches under a key (extracted from the item with extract-key-fn. Uses miss-fn to fill
+  any misses. Caches only positive hits where both functions return non-nil. Also handles expiration if the value
+  is a map with the key :cache-expires-at."
+  [^Cache cache extract-key-fn miss-fn item]
+  (if-let [key (extract-key-fn item)]
+    (locking cache ; TOOD: Consider lock striping based on hashcode of the key to allow concurrent loads.
+      ; If it has a timed expiration, expire it.
+      (when-let [result (.getIfPresent cache key)]
+        (let [{:keys [cache-expires-at]} result]
+          (when (and cache-expires-at (t/after? (t/now) cache-expires-at))  (.invalidate cache key))))
+      ; And then fetch it.
+      (if-let [result (.getIfPresent cache key)]
+        result ; we got a hit.
+        (let [new-result (miss-fn item)]
+          ; Only cache non-nil
+          (when new-result
+            (.put cache key new-result))
+          new-result)))
+    (miss-fn item)))

--- a/scheduler/src/cook/cache.clj
+++ b/scheduler/src/cook/cache.clj
@@ -17,18 +17,6 @@
         new-result))
     (miss-fn item)))
 
-(defn expire-key!
-  "Generic cache. Caches under a key (extracted from the item with extract-key-fn. Uses miss-fn to fill
-  any misses. Caches only positive hits where both functions return non-nil. Also handles expiration if the value
-  is a map with the key :cache-expires-at."
-  [^Cache cache extract-key-fn item]
-  (if-let [key (extract-key-fn item)]
-    (locking cache ; TOOD: Consider lock striping based on hashcode of the key to allow concurrent loads.
-      ; If it has a timed expiration, expire it.
-      (when-let [result (.getIfPresent cache key)]
-        (let [{:keys [cache-expires-at]} result]
-          (when (and cache-expires-at (t/after? (t/now) cache-expires-at))  (.invalidate cache key)))))))
-
 
 (defn lookup-cache-with-expiration!
   "Generic cache. Caches under a key (extracted from the item with extract-key-fn. Uses miss-fn to fill

--- a/scheduler/src/cook/mesos/data_locality.clj
+++ b/scheduler/src/cook/mesos/data_locality.clj
@@ -6,6 +6,7 @@
             [clj-time.format :as tf]
             [clojure.set :as set]
             [clojure.tools.logging :as log]
+            [cook.cache :as ccache]
             [cook.config :as config]
             [cook.mesos.util :as util]
             [datomic.api :as d]
@@ -49,7 +50,7 @@
 (defn get-dataset-maps
   "Returns the (possibly cached) datasets for the given job"
   [job]
-  (util/lookup-cache! job-uuid->dataset-maps-cache
+  (ccache/lookup-cache! job-uuid->dataset-maps-cache
                       :job/uuid
                       make-dataset-maps
                       job))

--- a/scheduler/test/cook/test/cache.clj
+++ b/scheduler/test/cook/test/cache.clj
@@ -1,0 +1,140 @@
+(ns cook.test.cache
+  (:use clojure.test)
+  (:require [clj-time.core :as t]
+            [cook.cache :as ccache])
+  (:import (com.google.common.cache Cache CacheBuilder)
+           (java.util.concurrent TimeUnit)))
+
+(defn new-cache []
+  "Build a new cache"
+  (-> (CacheBuilder/newBuilder)
+      (.maximumSize 100)
+      (.expireAfterAccess 2 TimeUnit/HOURS)
+      (.build)))
+
+(deftest test-cache
+  (let [^Cache cache (new-cache)
+        extract-fn #(if (odd? %) nil %)
+        miss-fn #(if (> % 100) nil %)]
+    ;; u1 has 2 jobs running
+    (is (= 1 (ccache/lookup-cache! cache extract-fn miss-fn 1))) ; Should not be cached. Nil from extractor.
+    (is (= 2 (ccache/lookup-cache! cache extract-fn miss-fn 2))) ; Should be cached.
+    (is (= nil (.getIfPresent cache 1)))
+    (is (= 2 (.getIfPresent cache 2)))
+    (is (= nil (ccache/lookup-cache! cache extract-fn miss-fn 101))) ; Should not be cached. Nil from miss function
+    (is (= nil (ccache/lookup-cache! cache extract-fn miss-fn 102))) ; Should not be cached. Nil from miss function
+    (is (= nil (.getIfPresent cache 101)))
+    (is (= nil (.getIfPresent cache 102)))
+    (is (= 4 (ccache/lookup-cache! cache extract-fn miss-fn 4))) ; Should be cached.
+    (is (= 2 (.getIfPresent cache 2)))
+    (is (= 4 (.getIfPresent cache 4)))))
+
+(deftest test-cache-expire-explicit
+  (let [^Cache cache (new-cache)
+        epoch (t/epoch)
+        extract-fn identity
+        make-fn (fn [key offset]
+                  {:val (* key 2) :cache-expires-at (->> offset t/millis (t/plus epoch))})
+        miss-fn (fn [key] (make-fn key (-> key (* 1000))))
+        miss-fn2 (fn [key] (make-fn key (-> key (* 1000) (+ 10000))))]
+    ;; Should expire at 1000, 2000, and 3000
+    (with-redefs [t/now (fn [] epoch)]
+      (ccache/lookup-cache-with-expiration! cache identity miss-fn 1)
+      (ccache/lookup-cache-with-expiration! cache identity miss-fn 2)
+      (ccache/lookup-cache-with-expiration! cache identity miss-fn 3))
+
+    ;; None of these should be expired.
+    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 999)))]
+      (is (= (make-fn 1 1000) (ccache/lookup-cache-with-expiration! cache identity miss-fn 1)))
+      (is (= (make-fn 2 2000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn 2)))
+      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn 3))))
+
+    ;; This should not expire
+    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 999)))]
+      (ccache/expire-key! cache identity 1)
+      (ccache/expire-key! cache identity 2)
+      (ccache/expire-key! cache identity 3)
+
+      (is (= (make-fn 1 1000) (.getIfPresent cache 1)))
+      (is (= (make-fn 2 2000) (.getIfPresent cache 2)))
+      (is (= (make-fn 3 3000) (.getIfPresent cache 3))))
+
+    ;; This should expire
+    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 1001)))]
+      (ccache/expire-key! cache identity 1)
+      (ccache/expire-key! cache identity 2)
+      (ccache/expire-key! cache identity 3)
+
+      (is (= nil (.getIfPresent cache 1)))
+      (is (= (make-fn 2 2000) (.getIfPresent cache 2)))
+      (is (= (make-fn 3 3000) (.getIfPresent cache 3))))
+
+    ;; This should expire
+    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 2001)))]
+      (ccache/expire-key! cache identity 1)
+      (ccache/expire-key! cache identity 2)
+      (ccache/expire-key! cache identity 3)
+
+      (is (= nil (.getIfPresent cache 1)))
+      (is (= nil (.getIfPresent cache 2)))
+      (is (= (make-fn 3 3000) (.getIfPresent cache 3))))))
+
+(deftest test-cache-expiration
+  (let [^Cache cache (new-cache)
+        epoch (t/epoch)
+        extract-fn identity
+        make-fn (fn [key offset]
+                  {:val (* key 2) :cache-expires-at (->> offset t/millis (t/plus epoch))})
+        miss-fn (fn [key] (make-fn key (-> key (* 1000))))
+        miss-fn2 (fn [key] (make-fn key (-> key (* 1000) (+ 10000))))]
+    ;; Should expire at 1000, 2000, and 3000
+    (with-redefs [t/now (fn [] epoch)]
+      (ccache/lookup-cache-with-expiration! cache identity miss-fn 1)
+      (ccache/lookup-cache-with-expiration! cache identity miss-fn 2)
+      (ccache/lookup-cache-with-expiration! cache identity miss-fn 3))
+
+    ;; None of these should be expired.
+    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 999)))]
+      (is (= (make-fn 1 1000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
+      (is (= (make-fn 2 2000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))
+
+    ;; This should expire and be replaced
+    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 1001)))]
+      (is (= (make-fn 1 11000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
+      (is (= (make-fn 2 2000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))
+
+    ;; This should expire and be replaced
+    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 2001)))]
+      (is (= (make-fn 1 11000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
+      (is (= (make-fn 2 12000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))))
+
+
+(deftest test-cache-not-expiring
+  (let [^Cache cache (new-cache)
+        epoch (t/epoch)
+        extract-fn identity
+        make-fn (fn [key offset]
+                  {:val (* key 2)})
+        miss-fn (fn [key] (make-fn key (-> key (* 1000))))
+        miss-fn2 (fn [key] (make-fn key (-> key (* 1000) (+ 10000))))]
+    ;; These do not have the :cache-expires-at and should not expire.
+    (with-redefs [t/now (fn [] epoch)]
+      (ccache/lookup-cache-with-expiration! cache identity miss-fn 1)
+      (ccache/lookup-cache-with-expiration! cache identity miss-fn 2)
+      (ccache/lookup-cache-with-expiration! cache identity miss-fn 3))
+
+    ;; None of these should be expired.
+    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 999)))]
+      (is (= (make-fn 1 1000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
+      (is (= (make-fn 2 2000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))
+
+    ;; None of these should be expired.
+    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 2000001)))]
+      (is (= (make-fn 1 11000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
+      (is (= (make-fn 2 12000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))))
+

--- a/scheduler/test/cook/test/cache.clj
+++ b/scheduler/test/cook/test/cache.clj
@@ -29,56 +29,6 @@
     (is (= 2 (.getIfPresent cache 2)))
     (is (= 4 (.getIfPresent cache 4)))))
 
-(deftest test-cache-expire-explicit
-  (let [^Cache cache (new-cache)
-        epoch (t/epoch)
-        extract-fn identity
-        make-fn (fn [key offset]
-                  {:val (* key 2) :cache-expires-at (->> offset t/millis (t/plus epoch))})
-        miss-fn (fn [key] (make-fn key (-> key (* 1000))))
-        miss-fn2 (fn [key] (make-fn key (-> key (* 1000) (+ 10000))))]
-    ;; Should expire at 1000, 2000, and 3000
-    (with-redefs [t/now (fn [] epoch)]
-      (ccache/lookup-cache-with-expiration! cache identity miss-fn 1)
-      (ccache/lookup-cache-with-expiration! cache identity miss-fn 2)
-      (ccache/lookup-cache-with-expiration! cache identity miss-fn 3))
-
-    ;; None of these should be expired.
-    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 999)))]
-      (is (= (make-fn 1 1000) (ccache/lookup-cache-with-expiration! cache identity miss-fn 1)))
-      (is (= (make-fn 2 2000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn 2)))
-      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn 3))))
-
-    ;; This should not expire
-    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 999)))]
-      (ccache/expire-key! cache identity 1)
-      (ccache/expire-key! cache identity 2)
-      (ccache/expire-key! cache identity 3)
-
-      (is (= (make-fn 1 1000) (.getIfPresent cache 1)))
-      (is (= (make-fn 2 2000) (.getIfPresent cache 2)))
-      (is (= (make-fn 3 3000) (.getIfPresent cache 3))))
-
-    ;; This should expire
-    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 1001)))]
-      (ccache/expire-key! cache identity 1)
-      (ccache/expire-key! cache identity 2)
-      (ccache/expire-key! cache identity 3)
-
-      (is (= nil (.getIfPresent cache 1)))
-      (is (= (make-fn 2 2000) (.getIfPresent cache 2)))
-      (is (= (make-fn 3 3000) (.getIfPresent cache 3))))
-
-    ;; This should expire
-    (with-redefs [t/now (fn [] (t/plus epoch (t/millis 2001)))]
-      (ccache/expire-key! cache identity 1)
-      (ccache/expire-key! cache identity 2)
-      (ccache/expire-key! cache identity 3)
-
-      (is (= nil (.getIfPresent cache 1)))
-      (is (= nil (.getIfPresent cache 2)))
-      (is (= (make-fn 3 3000) (.getIfPresent cache 3))))))
-
 (deftest test-cache-expiration
   (let [^Cache cache (new-cache)
         epoch (t/epoch)
@@ -96,20 +46,20 @@
     ;; None of these should be expired.
     (with-redefs [t/now (fn [] (t/plus epoch (t/millis 999)))]
       (is (= (make-fn 1 1000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
-      (is (= (make-fn 2 2000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
-      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))
+      (is (= (make-fn 2 2000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))
 
     ;; This should expire and be replaced
     (with-redefs [t/now (fn [] (t/plus epoch (t/millis 1001)))]
       (is (= (make-fn 1 11000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
-      (is (= (make-fn 2 2000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
-      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))
+      (is (= (make-fn 2 2000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))
 
     ;; This should expire and be replaced
     (with-redefs [t/now (fn [] (t/plus epoch (t/millis 2001)))]
       (is (= (make-fn 1 11000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
-      (is (= (make-fn 2 12000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
-      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))))
+      (is (= (make-fn 2 12000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))))
 
 
 (deftest test-cache-not-expiring
@@ -129,12 +79,11 @@
     ;; None of these should be expired.
     (with-redefs [t/now (fn [] (t/plus epoch (t/millis 999)))]
       (is (= (make-fn 1 1000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
-      (is (= (make-fn 2 2000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
-      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))
+      (is (= (make-fn 2 2000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))
 
     ;; None of these should be expired.
     (with-redefs [t/now (fn [] (t/plus epoch (t/millis 2000001)))]
       (is (= (make-fn 1 11000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 1)))
-      (is (= (make-fn 2 12000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
-      (is (= (make-fn 3 3000)  (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))))
-
+      (is (= (make-fn 2 12000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 2)))
+      (is (= (make-fn 3 3000) (ccache/lookup-cache-with-expiration! cache identity miss-fn2 3))))))

--- a/scheduler/test/cook/test/mesos/util.clj
+++ b/scheduler/test/cook/test/mesos/util.clj
@@ -123,24 +123,6 @@
       (is (= 2 (count (util/get-user-running-job-ents-in-pool (db conn) "u2" nil))))
       (is (= 0 (count (util/get-user-running-job-ents-in-pool (db conn) "u3" nil)))))))
 
-(deftest test-cache
-  (let [cache (util/new-cache)
-        extract-fn #(if (odd? %) nil %)
-        miss-fn #(if (> % 100) nil %)]
-    ;; u1 has 2 jobs running
-    (is (= 1 (util/lookup-cache! cache extract-fn miss-fn 1))) ; Should not be cached. Nil from extractor.
-    (is (= 2 (util/lookup-cache! cache extract-fn miss-fn 2))) ; Should be cached.
-    (is (= nil (.getIfPresent cache 1)))
-    (is (= 2 (.getIfPresent cache 2)))
-    (is (= nil (util/lookup-cache! cache extract-fn miss-fn 101))) ; Should not be cached. Nil from miss function
-    (is (= nil (util/lookup-cache! cache extract-fn miss-fn 102))) ; Should not be cached. Nil from miss function
-    (is (= nil (.getIfPresent cache 101)))
-    (is (= nil (.getIfPresent cache 102)))
-    (is (= 4 (util/lookup-cache! cache extract-fn miss-fn 4))) ; Should be cached.
-    (is (= 2 (.getIfPresent cache 2)))
-    (is (= 4 (.getIfPresent cache 4)))))
-
-
 (deftest test-get-pending-job-ents
   (let [uri "datomic:mem://test-get-pending-job-ents"
         conn (restore-fresh-database! uri)]


### PR DESCRIPTION
## Changes proposed in this PR

- Refactor the guava cache code into its own toplevel namespace
- Add an explicit :cache-expires-at value to the value dictionary for explicit expiration semantics
- 

## Why are we making these changes?
- This refactor makes sense.
- The new :cache-expires-at will be used in the future plugin PR. 

