### PR TITLE
Explicitly uninstall CLI to fix caching issues

### DIFF
--- a/integration/travis/prepare_integration.sh
+++ b/integration/travis/prepare_integration.sh
@@ -4,4 +4,11 @@ set -ev
 
 PROJECT_DIR=`pwd` ../travis/prepare.sh
 python --version
+
+# Explicitly uninstall cli
+if [[ $(pip list --format=columns | grep cook-client) ]];
+then
+    pip uninstall -y cook-client
+fi
+
 pip install --user -r requirements.txt


### PR DESCRIPTION
## Changes proposed in this PR
- Uninstall the CLI before installing the integration test requirements.

## Why are we making these changes?
Occasionally, we'll have issues that appear to be related to caching the CLI source between runs of the travis build. Hopefully, this will prevent that from happening.