### PR TITLE
Removes blessed

### DIFF
--- a/cli/cook/colors.py
+++ b/cli/cook/colors.py
@@ -1,14 +1,29 @@
 import os
-from blessed import Terminal
+import sys
 
-term = Terminal()
-failed = term.bold_red
-success = term.green
-running = term.cyan
-waiting = term.yellow
-reason = term.red
-bold = term.bold
-wrap = term.wrap
+import textwrap
+
+
+class Color:
+    PURPLE = '\033[95m'
+    CYAN = '\033[96m'
+    DARKCYAN = '\033[36m'
+    BLUE = '\033[94m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    RED = '\033[91m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+    END = '\033[0m'
+
+
+failed = lambda s: Color.BOLD + Color.RED + s + Color.END
+success = lambda s: Color.GREEN + s + Color.END
+running = lambda s: Color.CYAN + s + Color.END
+waiting = lambda s: Color.YELLOW + s + Color.END
+reason = lambda s: Color.RED + s + Color.END
+bold = lambda s: Color.BOLD + s + Color.END
+wrap = textwrap.fill
 
 
 def __ls_color(s, code, fallback_fn):
@@ -16,7 +31,7 @@ def __ls_color(s, code, fallback_fn):
     Parses the LS_COLORS environment variable to get consistent colors with the
     user's current setup, falling back to default formatting if the parsing fails
     """
-    if term.is_a_tty and 'LS_COLORS' in os.environ:
+    if sys.stdout.isatty() and 'LS_COLORS' in os.environ:
         split_pairs = [p.split('=') for p in os.environ['LS_COLORS'].split(':')]
         matched_pairs = [p for p in split_pairs if len(p) == 2 and p[0] == code]
         if len(matched_pairs) > 0:
@@ -27,9 +42,9 @@ def __ls_color(s, code, fallback_fn):
 
 def directory(s):
     """Attempts to use the "di" entry in LS_COLORS, falling back to cyan"""
-    return __ls_color(s, 'di', term.cyan)
+    return __ls_color(s, 'di', lambda t: Color.CYAN + t + Color.END)
 
 
 def executable(s):
     """Attempts to use the "ex" entry in LS_COLORS, falling back to green"""
-    return __ls_color(s, 'ex', term.green)
+    return __ls_color(s, 'ex', lambda t: Color.GREEN + t + Color.END)

--- a/cli/cook/colors.py
+++ b/cli/cook/colors.py
@@ -23,7 +23,7 @@ running = lambda s: Color.CYAN + s + Color.END
 waiting = lambda s: Color.YELLOW + s + Color.END
 reason = lambda s: Color.RED + s + Color.END
 bold = lambda s: Color.BOLD + s + Color.END
-wrap = textwrap.fill
+wrap = textwrap.wrap
 
 
 def __ls_color(s, code, fallback_fn):

--- a/cli/cook/format.py
+++ b/cli/cook/format.py
@@ -2,7 +2,7 @@ import time
 
 import humanfriendly
 
-from cook import colors
+from cook import terminal
 from cook.util import millis_to_timedelta, millis_to_date_string
 
 
@@ -20,13 +20,13 @@ def format_state(state):
     """Capitalizes and colorizes the given state"""
     state = state.capitalize()
     if state == 'Running':
-        text = colors.running(state)
+        text = terminal.running(state)
     elif state == 'Waiting':
-        text = colors.waiting(state)
+        text = terminal.waiting(state)
     elif state == 'Failed':
-        text = colors.failed(state)
+        text = terminal.failed(state)
     elif state == 'Success':
-        text = colors.success(state)
+        text = terminal.success(state)
     else:
         text = state
     return text
@@ -37,13 +37,13 @@ def format_instance_status(instance):
     status_text = format_state(instance['status'])
 
     if 'reason_string' in instance:
-        reason_text = f' ({colors.reason(instance["reason_string"])})'
+        reason_text = f' ({terminal.reason(instance["reason_string"])})'
     else:
         reason_text = ''
 
     if 'progress' in instance and instance['progress'] > 0:
         if 'progress_message' in instance:
-            progress_text = f' ({instance["progress"]}% {colors.bold(instance["progress_message"])})'
+            progress_text = f' ({instance["progress"]}% {terminal.bold(instance["progress_message"])})'
         else:
             progress_text = f' ({instance["progress"]}%)'
     else:

--- a/cli/cook/progress.py
+++ b/cli/cook/progress.py
@@ -1,10 +1,7 @@
 import threading
 
-from blessed import Terminal
-
 from cook.util import print_info
 
-term = Terminal()
 data = []
 lock = threading.Lock()
 
@@ -15,7 +12,7 @@ def __print_state(lines_to_move_up):
     lines_to_move_up lines and then printing the current state of the data
     list, which contains [item, status] pairs.
     """
-    print_info(term.move_up * lines_to_move_up, end='')
+    print_info('\033[F' * lines_to_move_up, end='')
     print_info('\n'.join([f'{item} ... {state}' for [item, state] in data]))
 
 

--- a/cli/cook/progress.py
+++ b/cli/cook/progress.py
@@ -1,5 +1,6 @@
 import threading
 
+from cook import terminal
 from cook.util import print_info
 
 data = []
@@ -12,7 +13,7 @@ def __print_state(lines_to_move_up):
     lines_to_move_up lines and then printing the current state of the data
     list, which contains [item, status] pairs.
     """
-    print_info('\033[F' * lines_to_move_up, end='')
+    print_info(terminal.MOVE_UP * lines_to_move_up, end='')
     print_info('\n'.join([f'{item} ... {state}' for [item, state] in data]))
 
 

--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -8,7 +8,7 @@ from functools import partial
 from operator import itemgetter
 from urllib.parse import urlparse, parse_qs
 
-from cook import http, colors, mesos, progress
+from cook import http, terminal, mesos, progress
 from cook.exceptions import CookRetriableException
 from cook.util import is_valid_uuid, wait_until, print_info, distinct, partition
 
@@ -37,7 +37,7 @@ def __query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, en
     num_entities = len(entities)
     if pred and num_entities > 0:
         s = 's' if num_entities > 1 else ''
-        num_string = colors.bold(str(num_entities))
+        num_string = terminal.bold(str(num_entities))
         if entity_type == Types.JOB:
             wait_text = f'Waiting for {num_string} job{s}'
         elif entity_type == Types.INSTANCE:
@@ -47,14 +47,14 @@ def __query_cluster(cluster, uuids, pred, timeout, interval, make_request_fn, en
         else:
             raise Exception(f'Invalid entity type {entity_type}.')
 
-        wait_text = f'{wait_text} on {colors.bold(cluster["name"])}'
+        wait_text = f'{wait_text} on {terminal.bold(cluster["name"])}'
         index = progress.add(wait_text)
         if pred(entities):
-            progress.update(index, colors.bold('Done'))
+            progress.update(index, terminal.bold('Done'))
         else:
             entities = wait_until(satisfy_pred, timeout, interval)
             if entities:
-                progress.update(index, colors.bold('Done'))
+                progress.update(index, terminal.bold('Done'))
             else:
                 raise TimeoutError('Timeout waiting for response.')
     return entities
@@ -184,7 +184,7 @@ def query(clusters, entity_refs, pred_jobs=None, pred_instances=None, pred_group
 def no_data_message(clusters):
     """Returns a message indicating that no data was found in the given clusters"""
     clusters_text = ' / '.join([c['name'] for c in clusters])
-    message = colors.failed(f'No matching data found in {clusters_text}.')
+    message = terminal.failed(f'No matching data found in {clusters_text}.')
     message = f'{message}\nDo you need to add another cluster to your configuration?'
     return message
 

--- a/cli/cook/subcommands/config.py
+++ b/cli/cook/subcommands/config.py
@@ -1,6 +1,6 @@
 from cook.util import print_info
 
-from cook import configuration, colors
+from cook import configuration, terminal
 from cook.configuration import load_config
 
 
@@ -74,7 +74,7 @@ def set_config_value(config_map, keys, value, config_path):
         value = False
 
     set_in(config_map, keys, value)
-    print_info(f'Updating configuration in {colors.bold(config_path)}.')
+    print_info(f'Updating configuration in {terminal.bold(config_path)}.')
     configuration.save_config(config_path, config_map)
     return 0
 

--- a/cli/cook/subcommands/jobs.py
+++ b/cli/cook/subcommands/jobs.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 from tabulate import tabulate
 
-from cook import colors, http
+from cook import terminal, http
 from cook.format import format_job_memory, format_job_attempts, format_job_status
 from cook.querying import query_across_clusters
 from cook.util import current_user, print_info, millis_to_date_string, check_positive, guard_no_cluster
@@ -26,7 +26,7 @@ def print_no_data(clusters, states, user):
         states.remove('success')
         states.append('successful')
     states_text = ' / '.join(states)
-    print(colors.failed(f'No matching {states_text} jobs for {user} found in {clusters_text}.'))
+    print(terminal.failed(f'No matching {states_text} jobs for {user} found in {clusters_text}.'))
 
 
 def list_jobs_on_cluster(cluster, state, user, start_ms, end_ms, name, limit, include_custom_executor, pool):

--- a/cli/cook/subcommands/kill.py
+++ b/cli/cook/subcommands/kill.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from cook import http, colors
+from cook import http, terminal
 from cook.querying import print_no_data, parse_entity_refs, query_with_stdin_support
 from cook.util import print_info, guard_no_cluster, partition
 
@@ -93,9 +93,9 @@ def kill_entities(query_result, clusters):
         __kill(cluster, group_uuids, kill_groups, 'job group')
 
     for item in succeeded:
-        print_info(f'Killed {item["type"]} {colors.bold(item["uuid"])} on {colors.bold(item["cluster"]["name"])}.')
+        print_info(f'Killed {item["type"]} {terminal.bold(item["uuid"])} on {terminal.bold(item["cluster"]["name"])}.')
     for item in failed:
-        print(colors.failed(f'Failed to kill {item["type"]} {item["uuid"]} on {item["cluster"]["name"]}.'))
+        print(terminal.failed(f'Failed to kill {item["type"]} {item["uuid"]} on {item["cluster"]["name"]}.'))
     num_succeeded = len(succeeded)
     num_failed = len(failed)
     print_info(f'Successful: {num_succeeded}, Failed: {num_failed}')

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -6,7 +6,7 @@ from functools import partial
 
 from tabulate import tabulate
 
-from cook import http, mesos, colors
+from cook import http, mesos, terminal
 from cook.querying import query_unique_and_run, parse_entity_refs
 from cook.util import guard_no_cluster
 
@@ -26,9 +26,9 @@ def format_path(entry):
     executable_by_user = 3
     name = basename(entry['path'])
     if is_directory(entry):
-        name = colors.directory(name)
+        name = terminal.directory(name)
     elif entry['mode'][executable_by_user] == 'x':
-        name = colors.executable(name)
+        name = terminal.executable(name)
     return name
 
 
@@ -95,7 +95,7 @@ def ls_for_instance(instance, sandbox_dir, path, long_format, as_json):
                 table = tabulate(rows, tablefmt='plain')
                 print(table)
             else:
-                print('\n'.join(colors.wrap('  '.join([format_path(e) for e in entries]))))
+                print('\n'.join(terminal.wrap('  '.join([format_path(e) for e in entries]))))
         else:
             logging.info('the directory is empty')
 
@@ -115,13 +115,13 @@ def ls(clusters, args, _):
 
     if path and not literal and any(c in path for c in '*?[]{}'):
         message = 'It looks like you are trying to glob, but ls does not support globbing. ' \
-                  f'You can use the {colors.bold("ssh")} command instead:\n' \
+                  f'You can use the {terminal.bold("ssh")} command instead:\n' \
                   '\n' \
                   f'  cs ssh {entity_refs[0]}\n' \
                   '\n' \
-                  f'Or, if you want the literal path {colors.bold(path)}, add {colors.bold("--literal")}:\n' \
+                  f'Or, if you want the literal path {terminal.bold(path)}, add {terminal.bold("--literal")}:\n' \
                   '\n' \
-                  f'  cs ls {colors.bold("--literal")} {entity_refs[0]} {path}'
+                  f'  cs ls {terminal.bold("--literal")} {entity_refs[0]} {path}'
         print(message)
         return 1
 

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -1,18 +1,18 @@
 import logging
 import os
 
-from cook import colors
+from cook import terminal
 from cook.querying import query_unique_and_run, parse_entity_refs
 from cook.util import print_info, guard_no_cluster
 
 
 def ssh_to_instance(instance, sandbox_dir):
     """Attempts to ssh (using os.execlp) to the Mesos agent corresponding to the given instance."""
-    print_info(f'Attempting ssh for job instance {colors.bold(instance["task_id"])}...')
+    print_info(f'Attempting ssh for job instance {terminal.bold(instance["task_id"])}...')
     command = os.environ.get('CS_SSH', 'ssh')
     logging.info(f'using ssh command: {command}')
     hostname = instance['hostname']
-    print_info(f'Executing ssh to {colors.bold(hostname)}.')
+    print_info(f'Executing ssh to {terminal.bold(hostname)}.')
     os.execlp(command, 'ssh', '-t', hostname, f'cd "{sandbox_dir}" ; bash')
 
 

--- a/cli/cook/subcommands/submit.py
+++ b/cli/cook/subcommands/submit.py
@@ -7,7 +7,7 @@ import uuid
 
 import requests
 
-from cook import colors, http, metrics, version
+from cook import terminal, http, metrics, version
 from cook.util import deep_merge, is_valid_uuid, read_lines, print_info, current_user, guard_no_cluster, check_positive
 
 
@@ -36,15 +36,15 @@ def submit_succeeded_message(cluster_name, uuids):
     """Generates a successful submission message with the given cluster and uuid(s)"""
     if len(uuids) == 1:
         return 'Job submission %s on %s. Your job UUID is:\n%s' % \
-               (colors.success('succeeded'), cluster_name, uuids[0])
+               (terminal.success('succeeded'), cluster_name, uuids[0])
     else:
         return 'Job submission %s on %s. Your job UUIDs are:\n%s' % \
-               (colors.success('succeeded'), cluster_name, '\n'.join(uuids))
+               (terminal.success('succeeded'), cluster_name, '\n'.join(uuids))
 
 
 def submit_failed_message(cluster_name, reason):
     """Generates a failed submission message with the given cluster name and reason"""
-    return 'Job submission %s on %s:\n%s' % (colors.failed('failed'), cluster_name, colors.reason(reason))
+    return 'Job submission %s on %s:\n%s' % (terminal.failed('failed'), cluster_name, terminal.reason(reason))
 
 
 def print_submit_result(cluster, response):
@@ -84,7 +84,7 @@ def submit_federated(clusters, jobs, group, pool):
         cluster_name = cluster['name']
         cluster_url = cluster['url']
         try:
-            print_info('Attempting to submit on %s cluster...' % colors.bold(cluster_name))
+            print_info('Attempting to submit on %s cluster...' % terminal.bold(cluster_name))
 
             json_body = {'jobs': jobs}
             if group:
@@ -99,7 +99,7 @@ def submit_federated(clusters, jobs, group, pool):
                 return 0
         except requests.exceptions.ReadTimeout as rt:
             logging.exception(rt)
-            print_info(colors.failed(
+            print_info(terminal.failed(
                 f'Encountered read timeout with {cluster_name} ({cluster_url}). Your submission may have completed.'))
             return 1
         except IOError as ioe:
@@ -107,7 +107,7 @@ def submit_federated(clusters, jobs, group, pool):
             reason = f'Cannot connect to {cluster_name} ({cluster_url})'
             message = submit_failed_message(cluster_name, reason)
             print_info(f'{message}\n')
-    raise Exception(colors.failed('Job submission failed on all of your configured clusters.'))
+    raise Exception(terminal.failed('Job submission failed on all of your configured clusters.'))
 
 
 def read_commands_from_stdin():

--- a/cli/cook/subcommands/usage.py
+++ b/cli/cook/subcommands/usage.py
@@ -3,7 +3,7 @@ import sys
 
 from tabulate import tabulate
 
-from cook import http, colors
+from cook import http, terminal
 from cook.format import format_job_memory, format_memory_amount
 from cook.querying import query_across_clusters, make_job_request
 from cook.util import guard_no_cluster, current_user, print_info, print_error
@@ -158,7 +158,7 @@ def print_formatted_cluster_or_pool_usage(cluster_or_pool, cluster_or_pool_usage
     usage_map = cluster_or_pool_usage['usage']
     share_map = cluster_or_pool_usage['share']
     quota_map = cluster_or_pool_usage['quota']
-    print_info(colors.bold(cluster_or_pool))
+    print_info(terminal.bold(cluster_or_pool))
 
     format_limit = lambda limit, formatter=(lambda x: x): \
         'Unlimited' if limit == sys.float_info.max else formatter(limit)
@@ -187,13 +187,13 @@ def print_formatted_cluster_or_pool_usage(cluster_or_pool, cluster_or_pool_usage
         print_info('Applications:')
     for application, application_usage in applications.items():
         usage_map = application_usage['usage']
-        print_info(f'- {colors.running(application if application else "[no application defined]")}')
+        print_info(f'- {terminal.running(application if application else "[no application defined]")}')
         print_info(f'  {format_usage(usage_map)}')
         print_info('  Job Groups:')
         for group, group_usage in application_usage['groups'].items():
             usage_map = group_usage['usage']
             jobs = group_usage['jobs']
-            print_info(f'\t- {colors.bold(group if group else "[ungrouped]")}')
+            print_info(f'\t- {terminal.bold(group if group else "[ungrouped]")}')
             print_info(f'\t  {format_usage(usage_map)}')
             print_info(f'\t  Jobs: {len(jobs)}')
             print_info('')

--- a/cli/cook/terminal.py
+++ b/cli/cook/terminal.py
@@ -4,6 +4,9 @@ import sys
 import textwrap
 
 
+MOVE_UP = '\033[F'
+
+
 class Color:
     PURPLE = '\033[95m'
     CYAN = '\033[96m'
@@ -17,13 +20,36 @@ class Color:
     END = '\033[0m'
 
 
-failed = lambda s: Color.BOLD + Color.RED + s + Color.END
-success = lambda s: Color.GREEN + s + Color.END
-running = lambda s: Color.CYAN + s + Color.END
-waiting = lambda s: Color.YELLOW + s + Color.END
-reason = lambda s: Color.RED + s + Color.END
-bold = lambda s: Color.BOLD + s + Color.END
+def failed(s):
+    return colorize(s, Color.BOLD + Color.RED)
+
+
+def success(s):
+    return colorize(s, Color.GREEN)
+
+
+def running(s):
+    return colorize(s, Color.CYAN)
+
+
+def waiting(s):
+    return colorize(s, Color.YELLOW)
+
+
+def reason(s):
+    return colorize(s, Color.RED)
+
+
+def bold(s):
+    return colorize(s, Color.BOLD)
+
+
 wrap = textwrap.wrap
+
+
+def colorize(s, color):
+    """Formats the given string with the given color"""
+    return color + s + Color.END if tty() else s
 
 
 def __ls_color(s, code, fallback_fn):
@@ -31,7 +57,7 @@ def __ls_color(s, code, fallback_fn):
     Parses the LS_COLORS environment variable to get consistent colors with the
     user's current setup, falling back to default formatting if the parsing fails
     """
-    if sys.stdout.isatty() and 'LS_COLORS' in os.environ:
+    if tty() and 'LS_COLORS' in os.environ:
         split_pairs = [p.split('=') for p in os.environ['LS_COLORS'].split(':')]
         matched_pairs = [p for p in split_pairs if len(p) == 2 and p[0] == code]
         if len(matched_pairs) > 0:
@@ -40,11 +66,16 @@ def __ls_color(s, code, fallback_fn):
     return fallback_fn(s)
 
 
+def tty():
+    """Returns true if running in a real terminal (as opposed to being piped or redirected)"""
+    return sys.stdout.isatty()
+
+
 def directory(s):
     """Attempts to use the "di" entry in LS_COLORS, falling back to cyan"""
-    return __ls_color(s, 'di', lambda t: Color.CYAN + t + Color.END)
+    return __ls_color(s, 'di', lambda t: colorize(t, Color.CYAN))
 
 
 def executable(s):
     """Attempts to use the "ex" entry in LS_COLORS, falling back to green"""
-    return __ls_color(s, 'ex', lambda t: Color.GREEN + t + Color.END)
+    return __ls_color(s, 'ex', lambda t: colorize(t, Color.GREEN))

--- a/cli/cook/util.py
+++ b/cli/cook/util.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 import arrow
 import humanfriendly
 
-from cook import colors
+from cook import terminal
 
 quit_running = False
 
@@ -97,7 +97,7 @@ def print_info(text, silent_mode_text=None, end='\n'):
 
 def print_error(text):
     """Prints text to stderr, colored as a failure"""
-    print(colors.failed(text), file=sys.stderr)
+    print(terminal.failed(text), file=sys.stderr)
 
 
 def seconds_to_timedelta(s):

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2614,6 +2614,7 @@ class CookTest(util.CookTest):
 
     @unittest.skipUnless(util.data_local_service_is_set(), "Requires a data local service")
     @pytest.mark.serial
+    @pytest.mark.xfail(condition=util.continuous_integration(), reason="Sometimes fails on Travis")
     def test_data_local_debug_endpoint(self):
         job_uuid, resp = util.submit_job(self.cook_url, datasets=[{'dataset': {'foo': str(uuid.uuid4())}}])
         try:

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -45,7 +45,7 @@ EPHEMERAL_HOSTS_SKIP_REASON = 'If the cluster under test has ephemeral hosts, th
 
 def continuous_integration():
     """Returns true if the CONTINUOUS_INTEGRATION environment variable is set, as done by Travis-CI."""
-    return os.getenv('CONTINUOUS_INTEGRATION')
+    return to_bool(os.getenv('CONTINUOUS_INTEGRATION'))
 
 
 def has_docker_service():


### PR DESCRIPTION
## Changes proposed in this PR

- switching from using the `blessed` library to simply rolling our own terminal colors, etc.

## Why are we making these changes?

We are running into issues with `blessed` when using `pyinstaller`. Also, we simply don't use much of the functionality provided by `blessed`, so it's nice to get rid of the dependency.
