### PR TITLE
Marks test_group_failed_only_change_retries_all_active as xfail

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1449,6 +1449,7 @@ class CookTest(util.CookTest):
             # ensure that we don't leave a bunch of jobs running/waiting
             util.kill_groups(self.cook_url, [group_uuid])
 
+    @pytest.mark.xfail(reason="Test can fail if one of the 5 jobs fails, e.g. due to 'Invalid task'")
     def test_group_failed_only_change_retries_all_active(self):
         statuses = ['running', 'waiting']
         jobs = util.group_submit_retry(self.cook_url, command='sleep 120', predicate_statuses=statuses)


### PR DESCRIPTION
## Changes proposed in this PR

- marking `test_group_failed_only_change_retries_all_active` as `xfail`

## Why are we making these changes?

We've seen this test fail because one of the 5 jobs fails with `Invalid task`. Here's an example:

https://travis-ci.org/twosigma/Cook/jobs/467034340#L1465