### PR TITLE
Makes group_submit_kill_retry more reliable

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -636,7 +636,7 @@ def group_some_job_started(group_response):
     """
     group = group_response.json()[0]
     running_count = group['running']
-    logger.info(f"Currently {running_count} jobs running in group {group['uuid']}")
+    logger.info(f"Currently {running_count} jobs running in group {group}")
     return running_count > 0
 
 
@@ -913,7 +913,7 @@ def group_submit_kill_retry(cook_url, retry_failed_jobs_only):
     """
     group_spec = minimal_group()
     group_uuid = group_spec['uuid']
-    job_spec = {'group': group_uuid, 'command': f'sleep 1'}
+    job_spec = {'group': group_uuid, 'command': f'sleep 600'}
     try:
         jobs, resp = submit_jobs(cook_url, job_spec, 10, groups=[group_spec])
         assert resp.status_code == 201, resp


### PR DESCRIPTION
## Changes proposed in this PR

- logging the entire group json in `group_some_job_started`
- changing the command to `sleep 600` in `group_submit_kill_retry`

## Why are we making these changes?

There is a race in `group_submit_kill_retry` between the retry and checking if any of the jobs is running. If in between those two, all of the jobs in the group start and complete, then the test fails. The `sleep 600` should avoid this race.