### PR TITLE
Add http response code to JobClientException

### DIFF
--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
@@ -710,10 +710,16 @@ public class JobClient implements Closeable, JobClientInterface {
             } catch (IOException e) {
             }
         }
-        if (null != cause) {
-            return new JobClientException(newMsg.toString(), cause, httpResponse.getStatusLine().getStatusCode());
+        final Integer responseStatusCode;
+        if (httpResponse != null && httpResponse.getStatusLine() != null) {
+            responseStatusCode = httpResponse.getStatusLine().getStatusCode();
         } else {
-            return new JobClientException(newMsg.toString(), httpResponse.getStatusLine().getStatusCode());
+            responseStatusCode = null;
+        }
+        if (null != cause) {
+            return new JobClientException(newMsg.toString(), cause, responseStatusCode);
+        } else {
+            return new JobClientException(newMsg.toString(), responseStatusCode);
         }
     }
 

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClient.java
@@ -711,9 +711,9 @@ public class JobClient implements Closeable, JobClientInterface {
             }
         }
         if (null != cause) {
-            return new JobClientException(newMsg.toString(), cause);
+            return new JobClientException(newMsg.toString(), cause, httpResponse.getStatusLine().getStatusCode());
         } else {
-            return new JobClientException(newMsg.toString());
+            return new JobClientException(newMsg.toString(), httpResponse.getStatusLine().getStatusCode());
         }
     }
 
@@ -873,7 +873,8 @@ public class JobClient implements Closeable, JobClientInterface {
         } else {
             _log.error("Failed to submit jobs " + json.toString());
             throw new JobClientException("The response of POST request " + json + " via uri " + _jobURI + ": "
-                    + statusLine.getReasonPhrase() + ", " + statusLine.getStatusCode() + ", response is: " + response);
+                    + statusLine.getReasonPhrase() + ", " + statusLine.getStatusCode() + ", response is: " + response,
+                    statusLine.getStatusCode());
         }
     }
 

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClientException.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClientException.java
@@ -37,13 +37,13 @@ public class JobClientException extends Exception {
         this(msg, cause, null);
     }
 
-    JobClientException(final String msg, Integer httpResponseCode) {
+    JobClientException(final String msg, final Integer httpResponseCode) {
         super(msg);
         this.httpResponseCode = httpResponseCode;
     }
 
 
-    JobClientException(final String msg, final Throwable cause, Integer httpResponseCode) {
+    JobClientException(final String msg, final Throwable cause, final Integer httpResponseCode) {
         super(msg, cause);
         this.httpResponseCode = httpResponseCode;
     }

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClientException.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/JobClientException.java
@@ -27,15 +27,28 @@ package com.twosigma.cook.jobclient;
 public class JobClientException extends Exception {
     private static final long serialVersionUID = 1L;
 
-    JobClientException() {
-        super();
-    }
+    private final Integer httpResponseCode;
 
     JobClientException(final String msg) {
-        super(msg);
+        this(msg, (Integer) null);
     }
 
     JobClientException(final String msg, final Throwable cause) {
+        this(msg, cause, null);
+    }
+
+    JobClientException(final String msg, Integer httpResponseCode) {
+        super(msg);
+        this.httpResponseCode = httpResponseCode;
+    }
+
+
+    JobClientException(final String msg, final Throwable cause, Integer httpResponseCode) {
         super(msg, cause);
+        this.httpResponseCode = httpResponseCode;
+    }
+
+    public Integer getHttpResponseCode() {
+        return httpResponseCode;
     }
 }

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -187,7 +187,7 @@
    {:dependencies [[criterium "0.4.4"]
                    [org.clojure/test.check "0.6.1"]
                    [org.mockito/mockito-core "1.10.19"]
-                   [twosigma/cook-jobclient "0.2.0-SNAPSHOT"]]}
+                   [twosigma/cook-jobclient "0.2.1-SNAPSHOT"]]}
 
    :test-console
    [:test {:jvm-opts ["-Dcook.test.logging.console"]}]


### PR DESCRIPTION
## Changes proposed in this PR
- Adds an HTTP response code field to JobClientException

## Why are we making these changes?
It can be useful for users to differentiate between different failures (for instance, rate limited vs invalid request)
