### PR TITLE
Improves memory limit tests

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -4,18 +4,14 @@ Our integration tests currently require Python 3.6.
 All dependencies are specified in [`requirements.txt`](./requirements.txt),
 and can be installed automatically via `pip`:
 
-Before running these tests, please make sure you've followed the instructions
-in the [Cook Readme](../README.md) Quickstart section. In particular, to run
-the integration tests in docker, you need to have minimesos running, and the
-cook scheduler running within docker. You also need to have 'jq' installed
-for json queries.
-
-
 ```bash
 $ pip install -r requirements.txt
 ```
 
-To run the tests on a local cook install, run
+Before running these tests, please make sure you've followed the instructions in the [Cook Readme](../README.md) Quickstart section.
+In particular, to run the integration tests in docker, you need to have minimesos running, and the Cook Scheduler running within docker. You also need to have `jq` installed.
+
+To run the tests on a local Cook install, run
 
 ```bash
 $ pytest
@@ -29,11 +25,20 @@ If you want to run a single test and see the log messages as they occur, you can
 $ ./bin/only-run test_basic_submit
 ```
 
-The `./bin/only-run` helper script invokes pytest internally.
+The `./bin/only-run` helper script invokes `pytest` internally.
 The above command is roughly equivalent to the following pytest invocation:
 
 ```bash
 $ pytest -v -n0 --capture=no tests/cook/test_basic.py::CookTest::test_basic_submit
+```
+
+## Memory limit tests
+
+There are a few tests marked as `memlimit` which test how Cook Scheduler behaves when a task exceeds its memory limit.
+Unfortunately, if you're running on macos and you're not using minimesos, these tests will fail, because the Mesos agent flags that dictate this behavior are not available. To avoid this, simply run:
+
+```bash
+$ pytest -m 'not memlimit'
 ```
 
 ## Multi-scheduler tests

--- a/integration/README.md
+++ b/integration/README.md
@@ -11,7 +11,7 @@ $ pip install -r requirements.txt
 Before running these tests, please make sure you've followed the instructions in the [Cook Readme](../README.md) Quickstart section.
 In particular, to run the integration tests in docker, you need to have minimesos running, and the Cook Scheduler running within docker. You also need to have `jq` installed.
 
-To run the tests on a local Cook install, run
+To run the tests on a local Cook install, run:
 
 ```bash
 $ pytest
@@ -35,7 +35,8 @@ $ pytest -v -n0 --capture=no tests/cook/test_basic.py::CookTest::test_basic_subm
 ## Memory limit tests
 
 There are a few tests marked as `memlimit` which test how Cook Scheduler behaves when a task exceeds its memory limit.
-Unfortunately, if you're running on macos and you're not using minimesos, these tests will fail, because the Mesos agent flags that dictate this behavior are not available. To avoid this, simply run:
+Unfortunately, if you're running on macos and you're not using minimesos, these tests will fail, because the Mesos agent flags that dictate this behavior are not available (specifically, `isolation` cannot be set to `cgroups/mem`).
+To skip these tests, simply run:
 
 ```bash
 $ pytest -m 'not memlimit'

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -509,7 +509,6 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, [job_uuid])
 
     @pytest.mark.memlimit
-    @unittest.skipUnless(util.continuous_integration(), "Doesn't work in our local test environments")
     @unittest.skipUnless(util.is_cook_executor_in_use(), 'Test assumes the Cook Executor is in use')
     def test_memory_limit_exceeded_cook_python(self):
         command = self.memory_limit_python_command()
@@ -527,7 +526,6 @@ class CookTest(util.CookTest):
         self.memory_limit_exceeded_helper(command, 'cook')
 
     @pytest.mark.memlimit
-    @unittest.skipUnless(util.continuous_integration(), "Doesn't work in our local test environments")
     def test_memory_limit_exceeded_mesos_script(self):
         command = self.memory_limit_script_command()
         self.memory_limit_exceeded_helper(command, 'mesos')

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -483,9 +483,10 @@ class CookTest(util.CookTest):
             job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
             job_details = f"Job details: {json.dumps(job, sort_keys=True)}"
             self.assertEqual('failed', job['state'], job_details)
-            self.assertEqual(1, len(job['instances']), job_details)
-            instance = job['instances'][0]
+            self.assertLessEqual(1, len(job['instances']), job_details)
+            instance = job['instances'][-1]
             instance_details = json.dumps(instance, sort_keys=True)
+            self.logger.debug('instance: %s' % instance)
             # did the job fail as expected?
             self.assertEqual(executor_type, instance['executor'], instance_details)
             self.assertEqual('failed', instance['status'], instance_details)
@@ -515,7 +516,6 @@ class CookTest(util.CookTest):
         self.memory_limit_exceeded_helper(command, 'cook')
 
     @pytest.mark.memlimit
-    @unittest.skipUnless(util.continuous_integration(), "Doesn't work in our local test environments")
     def test_memory_limit_exceeded_mesos_python(self):
         command = self.memory_limit_python_command()
         self.memory_limit_exceeded_helper(command, 'mesos')


### PR DESCRIPTION
## Changes proposed in this PR

- changing assumption of exactly 1 instance to at least 1 instance
- using the last instance instead of the first
- adding a log of the chosen instance
- removing `skipUnless(util.continuous_integration(), ...)` from 3 memory limit tests

## Why are we making these changes?

There can be more than 1 instance, for example, due to a mea-culpa failure like `Invalid Mesos offer`. We want to assert on the last of these instances. As for removing the `skipUnless`, these tests run reliably in my local environment, and I think it's good for devs to be running these.
