### PR TITLE
Add distributionManagement section to jobclient pom

### DIFF
--- a/jobclient/pom.xml
+++ b/jobclient/pom.xml
@@ -98,4 +98,11 @@
       <version>2.4</version>
     </dependency>
   </dependencies>
+  <distributionManagement>
+   <repository>
+    <id>clojars</id>
+    <name>Clojars repository</name>
+    <url>https://clojars.org/repo</url>
+  </repository>
+ </distributionManagement>
 </project>


### PR DESCRIPTION
## Changes proposed in this PR
- Add `distributionManagement` section to jobclient pom

## Why are we making these changes?
Allows releasing on clojars with `mvn deploy`.
