### PR TITLE
fixes typo in `cluser`

### DIFF
--- a/cli/cook/http.py
+++ b/cli/cook/http.py
@@ -105,7 +105,7 @@ def make_data_request(cluster, make_request_fn):
             print_error(f'Authentication failed on {cluster["name"]} ({cluster["url"]}).')
             return []
         elif resp.status_code == 500:
-            print_error(f'Encountered server error while querying {cluser["name"]}.')
+            print_error(f'Encountered server error while querying {cluster["name"]}.')
             # fall through to logging call below
 
         logging.warn(f'Unexpected response code {resp.status_code} for data request. Response body: {resp.text}')


### PR DESCRIPTION
## Changes proposed in this PR

- fixes typo in `cluser`

## Why are we making these changes?

Fixes typo in code and error.

```
Traceback (most recent call last):
  File "cook/__main__.py", line 18, in main
  File "cook/cli.py", line 97, in run
  File "cook/subcommands/jobs.py", line 170, in jobs
  File "cook/subcommands/jobs.py", line 62, in query
  File "cook/querying.py", line 160, in query_across_clusters
  File "concurrent/futures/_base.py", line 425, in result
  File "concurrent/futures/_base.py", line 384, in __get_result
  File "concurrent/futures/thread.py", line 57, in run
  File "cook/subcommands/jobs.py", line 42, in list_jobs_on_cluster
  File "cook/http.py", line 108, in make_data_request
```
