### PR TITLE
Clean up DockerFile

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /opt/cook/integration
 COPY requirements.txt /opt/cook/integration
 ADD cli.tar.gz /opt/cook/cli/
 RUN pip install -r requirements.txt
-COPY . /opt/cook/integration
 
-
+# Don't need to copy over the integration test files --- they're bind-mounted.
 ENTRYPOINT ["pytest"]

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -35,11 +35,12 @@ WORKDIR /opt/cook
 ## with fetched dependencies as long as project.clj isn't modified
 RUN lein deps
 
+# Datomic setup
+COPY datomic /opt/cook/datomic
+RUN unzip -uo /opt/cook/datomic/datomic-free-0.9.5394.zip
+
 # Copy the whole scheduler into the container
 COPY . /opt/cook/
-
-# Datomic setup
-RUN unzip -uo /opt/cook/datomic/datomic-free-0.9.5394.zip
 RUN lein uberjar
 RUN cp "target/cook-$(lein print :version | tr -d '"').jar" datomic-free-0.9.5394/lib/cook-$(lein print :version | tr -d '"').jar
 


### PR DESCRIPTION
We don't need to copy the integration test directory (and the virtualenv). We can also have docker cache the transactor untar.

## Changes proposed in this PR

- Some things to reduce docker generation overhead.
- 
- 

## Why are we making these changes?


