### PR TITLE
Adds plugin mechanism to CLI

### DIFF
--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 from urllib.parse import urlparse
 
-from cook import util, http, metrics, version, configuration
+from cook import util, http, metrics, version, configuration, plugins
 from cook.subcommands import submit, show, wait, jobs, ssh, ls, tail, kill, config, cat, usage
 from cook.util import deep_merge
 
@@ -91,6 +91,7 @@ def run(args):
             metrics.inc('command.%s.runs' % action)
             clusters = load_target_clusters(config_map, url, cluster)
             http.configure(config_map)
+            plugins.configure(config_map)
             args = {k: v for k, v in args.items() if v is not None}
             defaults = config_map.get('defaults')
             action_defaults = (defaults.get(action) if defaults else None) or {}

--- a/cli/cook/plugins.py
+++ b/cli/cook/plugins.py
@@ -1,0 +1,34 @@
+import importlib
+import importlib.util
+import logging
+
+plugins = {}
+
+
+def configure(config):
+    """Configures the plugins map from the given config map"""
+    global plugins
+    if 'plugins' in config:
+        plugins = config['plugins']
+    else:
+        logging.debug('no plugins section found in config')
+
+    logging.debug(f'plugins: {plugins}')
+
+
+def get_fn(plugin_name, default_fn):
+    """Returns the plugin function corresponding to the given plugin name if found, otherwise, default_fn"""
+    if plugin_name in plugins:
+        try:
+            plugin = plugins[plugin_name]
+            plugin_path = plugin['path']
+            logging.debug(f'using plugin path {plugin_path}')
+            spec = importlib.util.spec_from_file_location(plugin['module-name'], plugin_path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            method_to_call = getattr(module, plugin['function-name'])
+            return method_to_call
+        except Exception as e:
+            logging.exception(e)
+
+    return default_fn

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -248,10 +248,10 @@ def tail(uuid, path, cook_url, tail_flags=None, wait_for_exit=True):
     return cp
 
 
-def ls(uuid, cook_url, path=None, parse_json=True):
+def ls(uuid, cook_url, path=None, parse_json=True, flags=None):
     """Invokes the ls subcommand"""
     args = f'ls --json {uuid} {path}' if path else f'ls --json {uuid}'
-    cp = cli(args, cook_url)
+    cp = cli(args, cook_url, flags=flags)
     out = stdout(cp)
     try:
         entries = json.loads(out) if parse_json else None

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1013,10 +1013,6 @@ class CookCliTest(util.CookTest):
         self.assertEqual(0, len(entries))
 
     def test_ls_with_plugin(self):
-
-        def entry(name):
-            return cli.ls_entry_by_name(entries, name)
-
         # Submit a job that clears the sandbox
         cp, uuids = cli.submit("'rm -r * && rm -r .*'", self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -1048,11 +1044,11 @@ def dummy_ls_entries(_, __, ___):
                 cp, entries = cli.ls(uuids[0], self.cook_url, flags=flags)
                 self.assertEqual(0, cp.returncode, cp.stderr)
                 self.assertEqual(2, len(entries))
-                entry1 = entry(path1)
+                entry1 = cli.ls_entry_by_name(entries, path1)
                 self.assertEqual('-rw-r--r--', entry1['mode'])
                 self.assertEqual(1, entry1['nlink'])
                 self.assertEqual(0, entry1['size'])
-                entry2 = entry(path2)
+                entry2 = cli.ls_entry_by_name(entries, path2)
                 self.assertEqual('drwxr-xr-x', entry2['mode'])
                 self.assertEqual(2, entry2['nlink'])
                 self.assertEqual(1, entry2['size'])


### PR DESCRIPTION
## Changes proposed in this PR

- adding `plugins` package, which supports config-based plugins
- adding a plugin hook in the `ls` subcommand for retrieving the entries
- adding an integration test for plugging in a dummy `ls` retrieval function

## Why are we making these changes?

We want to support runtime extensions to the base `cs` subcommands so that environment-specific plugins can be easily configured. For example, some environments may want to specify a different mechanism for browsing files in the sandbox.