### PR TITLE
Allow setting cook executor retry-limit to 0 to disable fallback

### DIFF
--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -44,7 +44,7 @@
   (let [{:keys [portion retry-limit]} (config/executor-config)]
     (and (nil? (:job/executor job-ent))
          (number? retry-limit)
-         (> retry-limit (count (:job/instance job-ent)))
+         (or (= 0 retry-limit) (> retry-limit (count (:job/instance job-ent))))
          (number? portion)
          (> (* portion 100) (-> job-ent :job/uuid hash (mod 100))))))
 

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -690,7 +690,7 @@
         (with-redefs [cook.config/executor-config (constantly {:command "cook-executor"
                                                                :portion 0.25
                                                                :retry-limit 0})]
-          (is (not (task/use-cook-executor? job-ent))))
+          (is (task/use-cook-executor? job-ent)))
         (with-redefs [cook.config/executor-config (constantly {:command "cook-executor"
                                                                :portion 0.25
                                                                :retry-limit 1})]


### PR DESCRIPTION
## Changes proposed in this PR
- When cook executor's `retry-limit` is set to 0, don't fallback to the mesos executor

## Why are we making these changes?
Once Cook Executor is stable in production, it can be jarring for users to fall back. This allows disabling that behavior.
