### PR TITLE
Add support for suitable flag to data local service

### DIFF
--- a/scheduler/bin/run-local.sh
+++ b/scheduler/bin/run-local.sh
@@ -54,7 +54,7 @@ if ! [ -x "$(command -v flask)" ]; then
 fi
 
 INTEGRATION_DIR="$(dirname ${SCHEDULER_DIR})/integration"
-FLASK_APP=${INTEGRATION_DIR}/src/data_locality/service.py flask run &
+FLASK_APP=${INTEGRATION_DIR}/src/data_locality/service.py flask run -p 35847 &
 
 echo "Mesos Master IP is ${MASTER_IP}"
 

--- a/scheduler/src/cook/mesos/api.clj
+++ b/scheduler/src/cook/mesos/api.clj
@@ -2645,7 +2645,8 @@
   {s/Uuid (s/maybe s/Str)})
 
 (def DataLocalCostResponse
-  {s/Str s/Num})
+  {s/Str {:cost s/Num
+          :suitable s/Bool}})
 
 (defn data-local-update-time-handler
   "Handler for return the last update time of data locality"

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -143,7 +143,7 @@
           launch-after-age (t/plus (tc/from-date submit-time) (t/seconds launch-wait-seconds))
           launch-without-data? (t/after? (t/now) launch-after-age)]
       (if (contains? data-locality-costs datasets)
-        (let [{:keys [suitable]} (get-in data-locality-costs [datasets (get vm-attributes "HOSTNAME")] {:suitable true})]
+        (let [{:keys [suitable] :or {suitable true}} (get-in data-locality-costs [datasets (get vm-attributes "HOSTNAME")])]
           (if suitable
             [true nil]
             [false "Host is not suitable for datasets"]))

--- a/scheduler/src/cook/mesos/constraints.clj
+++ b/scheduler/src/cook/mesos/constraints.clj
@@ -136,18 +136,22 @@
 (defrecord data-locality-constraint [job launch-wait-seconds]
   JobConstraint
   (job-constraint-name [this] (get-class-name this))
-  (job-constraint-evaluate [_ _ _]
+  (job-constraint-evaluate [this _ vm-attributes]
     (let [{:keys [job/submit-time]} job
           datasets (dl/get-dataset-maps job)
           data-locality-costs (dl/get-data-local-costs)
           launch-after-age (t/plus (tc/from-date submit-time) (t/seconds launch-wait-seconds))
           launch-without-data? (t/after? (t/now) launch-after-age)]
-      (if (or launch-without-data?
-              (contains? data-locality-costs datasets))
-        [true nil]
-        [false "No data locality costs available"])))
-  (job-constraint-evaluate [this _ _ _]
-    (job-constraint-evaluate this _ _)))
+      (if (contains? data-locality-costs datasets)
+        (let [{:keys [suitable]} (get-in data-locality-costs [datasets (get vm-attributes "HOSTNAME")] {:suitable true})]
+          (if suitable
+            [true nil]
+            [false "Host is not suitable for datasets"]))
+        (if launch-without-data?
+          [true nil]
+          [false "No data locality costs available"]))))
+  (job-constraint-evaluate [this _ vm-attributes _]
+    (job-constraint-evaluate this _ vm-attributes)))
 
 (defn build-data-locality-constraint
   "If the job supports data local and the data local fitness calculator is in use,

--- a/scheduler/src/cook/mesos/data_locality.clj
+++ b/scheduler/src/cook/mesos/data_locality.clj
@@ -200,8 +200,7 @@
           {:keys [job/uuid] :as job} (:job task-request)
           datasets (get-dataset-maps job)]
       (if-not (empty? (or datasets []))
-        (let [{:keys [cost suitable]}(get-in (get-data-local-costs) [datasets (.getHostname target-vm)] {:cost 1.0
-                                                                                                         :suitable true})
+        (let [{:keys [cost suitable] :or {cost 1.0 suitable true}} (get-in (get-data-local-costs) [datasets (.getHostname target-vm)])
               suitability-adjusted-cost (if suitable cost 1.0)
               normalized-fitness (- 1.0 suitability-adjusted-cost)
               data-local-fitness (* data-locality-weight normalized-fitness)

--- a/scheduler/test/cook/test/mesos/data_locality.clj
+++ b/scheduler/test/cook/test/mesos/data_locality.clj
@@ -22,15 +22,23 @@
       (let [job-1 (str (UUID/randomUUID))
             job-2 (str (UUID/randomUUID))]
         (dl/reset-data-local-costs!)
-        (dl/update-data-local-costs {job-1 {"hostA" 2.0
-                                            "hostB" 0.2
-                                            "hostC" -20}
-                                     job-2 {"hostB" 10.0}}
+        (dl/update-data-local-costs {job-1 {"hostA" {:cost 2.0
+                                                     :suitable true}
+                                            "hostB" {:cost 0.2
+                                                     :suitable true}
+                                            "hostC" {:cost -20
+                                                     :suitable false}}
+                                     job-2 {"hostB" {:cost 10.0
+                                                     :suitable false}}}
                                     [])
-        (is (= {job-1 {"hostA" 1.0
-                       "hostB" 0.2
-                       "hostC" 0}
-                job-2 {"hostB" 1.0}}
+        (is (= {job-1 {"hostA" {:cost 1.0
+                                :suitable true}
+                       "hostB" {:cost 0.2
+                                :suitable true}
+                       "hostC" {:cost 0
+                                :suitable false}}
+                job-2 {"hostB" {:cost 1.0
+                                :suitable false}}}
                (dl/get-data-local-costs)))))
 
     (testing "correctly updates existing values"
@@ -39,24 +47,34 @@
             job-3 (UUID/randomUUID)
             job-4 (UUID/randomUUID)]
         (dl/reset-data-local-costs!)
-        (dl/update-data-local-costs {job-1 {"hostA" 100}
-                                     job-2 {"hostB" 200}
-                                     job-4 {"hostC" 300}}
+        (dl/update-data-local-costs {job-1 {"hostA" {:cost 100
+                                                     :suitable true}}
+                                     job-2 {"hostB" {:cost 200
+                                                     :suitable true}}
+                                     job-4 {"hostC" {:cost 300
+                                                     :suitable true}}}
                                     [])
-        (dl/update-data-local-costs {job-3 {"hostB" 300}
-                                     job-4 {"hostA" 200}}
+        (dl/update-data-local-costs {job-3 {"hostB" {:cost 300
+                                                     :suitable true}}
+                                     job-4 {"hostA" {:cost 200
+                                                     :suitable true}}}
                                     [])
-        (is (= {job-1 {"hostA" 100}
-                job-2 {"hostB" 200}
-                job-3 {"hostB" 300}
-                job-4 {"hostA" 200}})
+        (is (= {job-1 {"hostA" {:cost 100
+                                :suitable true}}
+                job-2 {"hostB" {:cost 200
+                                :suitable true}}
+                job-3 {"hostB" {:cost 300
+                                :suitable true}}
+                job-4 {"hostA" {:cost 200
+                                :suitable true}}})
             (dl/get-data-local-costs))))
 
     (testing "waits until ttl expiry to remove elements"
       (dl/reset-data-local-costs!)
       (let [older-datasets #{{:dataset {"a" "a"}}}
             newer-datasets #{{:dataset {"b" "b"}}}
-            cost {"hostA" 1.0}]
+            cost {"hostA" {:cost 1.0
+                           :suitable true}}]
         (with-redefs [t/now (constantly (tc/from-long 0))]
           (dl/update-data-local-costs {older-datasets cost}
                                       []))
@@ -101,10 +119,16 @@
           j2 (create-dummy-job conn :job-state :job.state/waiting)
           job-1 (d/entity (d/db conn) j1)
           job-2 (d/entity (d/db conn) j2)]
-      (dl/update-data-local-costs {d1 {"hostA" 0
-                                       "hostB" 0.5}
-                                   d2 {"hostA" 0
-                                       "hostB" 0}}
+      (dl/update-data-local-costs {d1 {"hostA" {:cost 0
+                                                :suitable true}
+                                       "hostB" {:cost 0.5
+                                                :suitable true}
+                                       "unsuitable" {:cost 0.25
+                                                     :suitable false}}
+                                   d2 {"hostA" {:cost 0
+                                                :suitable true}
+                                       "hostB" {:cost 0
+                                                :suitable true}}}
                                   [])
       (testing "uses base fitness for jobs that do not support data locality"
         (is (= base-fitness (.calculateFitness calculator (FakeTaskRequest. job-2) (fake-vm-for-host "hostA") nil)))
@@ -116,7 +140,9 @@
         (is (= (+ (* 0.5 data-locality-weight) base-fitness-portion)
                (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostB") nil)))
         (is (= base-fitness-portion
-               (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostC") nil)))))))
+               (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "hostC") nil)))
+        (is (= base-fitness-portion
+               (.calculateFitness calculator (FakeTaskRequest. job-1) (fake-vm-for-host "unsuitable") nil)))))))
 
 
 (deftest test-jobs-to-update
@@ -157,7 +183,8 @@
                                  :submit-time (java.util.Date. 2)
                                  :datasets d4)
             db (d/db conn)
-            _ (dl/update-data-local-costs {d1 {"hostA" 100}} [])
+            _ (dl/update-data-local-costs {d1 {"hostA" {:cost 100
+                                                        :suitable true}}} [])
             {:keys [to-fetch to-remove]} (dl/jobs-to-update db)]
         (is (= (map :job/datasets to-fetch) [d2 d4 d3 d1]))
         (is (= #{} to-remove))))
@@ -174,9 +201,12 @@
             j3 (create-dummy-job conn :job-state :job.state/completed
                                  :datasets d3)
             db (d/db conn)
-            _ (dl/update-data-local-costs {d1 {"hostA" 100}
-                                           d2 {"hostA" 100}
-                                           d3 {"hostA" 100}}
+            _ (dl/update-data-local-costs {d1 {"hostA" {:cost 100
+                                                        :suitable true}}
+                                           d2 {"hostA" {:cost 100
+                                                        :suitable true}}
+                                           d3 {"hostA" {:cost 100
+                                                        :suitable true}}}
                                           [])
             {:keys [to-fetch to-remove]} (dl/jobs-to-update db)]
         (is (= (map :job/datasets to-fetch) [d1]))
@@ -184,9 +214,12 @@
 
 
 (deftest test-fetch-and-update-data-local-costs
-  (let [first-cost {"hostA" 1.0}
-        second-cost {"hostA" 0.5}
-        third-cost {"hostA" 0.2}
+  (let [first-cost {"hostA" {:cost 1.0
+                             :suitable true}}
+        second-cost {"hostA" {:cost 0.5
+                              :suitable true}}
+        third-cost {"hostA" {:cost 0.2
+                             :suitable true}}
         current-cost-atom (atom first-cost)]
     (with-redefs [config/data-local-fitness-config (constantly {:batch-size 2
                                                                 :cache-ttl-ms 30000})
@@ -254,11 +287,13 @@
           costs [[{"node" "hostA"
                    "cost" 0.0}
                   {"node" "hostB"
-                   "cost" 1.0}]
+                   "cost" 1.0
+                   "suitable" false}]
                  [{"node" "hostA"
                    "cost" 1.0}
                   {"node" "hostB"
-                   "cost" 0.0}]]
+                   "cost" 0.0
+                   "suitable" true}]]
           request-body-atom (atom {})
           cost-endpoint "http://test.example.com/cost"]
       (with-redefs [config/data-local-fitness-config (constantly {:cost-endpoint cost-endpoint})
@@ -270,10 +305,14 @@
                                             "costs" (first costs)}
                                            {"task_id" (-> jobs second :job/uuid str)
                                             "costs" (second costs)}]}})]
-        (is (= {#{{:dataset {"foo" "bar"}}} {"hostA" 0.0
-                                             "hostB" 1.0}
-                #{{:dataset {"bar" "baz"}}} {"hostA" 1.0
-                                             "hostB" 0.0}}
+        (is (= {#{{:dataset {"foo" "bar"}}} {"hostA" {:cost 0.0
+                                                      :suitable true}
+                                             "hostB" {:cost 1.0
+                                                      :suitable false}}
+                #{{:dataset {"bar" "baz"}}} {"hostA" {:cost 1.0
+                                                      :suitable true}
+                                             "hostB" {:cost 0.0
+                                                      :suitable true}}}
                (dl/fetch-data-local-costs jobs)))
 
         (let [{:strs [batch tasks]} (cheshire/parse-string @request-body-atom)]

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -1854,12 +1854,18 @@
                                                                                             :ncpus 13
                                                                                             :memory 1024
                                                                                             :datasets d2))
-                                              _ (dl/update-data-local-costs {d1 {(:hostname offer-1) 0.0
-                                                                                 (:hostname offer-2) 0.0
-                                                                                 (:hostname offer-3) 100.0}
-                                                                             d2 {(:hostname offer-1) 0.0
-                                                                                 (:hostname offer-2) 0.0
-                                                                                 (:hostname offer-3) 0.0}}
+                                              _ (dl/update-data-local-costs {d1 {(:hostname offer-1) {:cost 0.0
+                                                                                                      :suitable true}
+                                                                                 (:hostname offer-2) {:cost 0.0
+                                                                                                      :suitable true}
+                                                                                 (:hostname offer-3) {:cost 100.0
+                                                                                                      :suitable true}}
+                                                                             d2 {(:hostname offer-1) {:cost 0.0
+                                                                                                      :suitable true}
+                                                                                 (:hostname offer-2) {:cost 0.0
+                                                                                                      :suitable true}
+                                                                                 (:hostname offer-3) {:cost 0.0
+                                                                                                      :suitable true}}}
                                                                             [])
                                               entity->map (fn [entity]
                                                             (util/job-ent->map entity (d/db conn)))


### PR DESCRIPTION
## Changes proposed in this PR
- Adds support for a "suitable" flag on data local service responses

## Why are we making these changes?
This allows more granular control of the scheduling by the data local service.
