### PR TITLE
Introduce a 'central' .cs.json for cs command.

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -17,8 +17,12 @@ Custom defaults may be provided for all commands.
 Multiple clusters are supported via configuration.
 
 In order to use the Cook CLI, you’ll need a configuration file. 
-`cs` looks first for a base `.cs.json` file in `${DIR}/.cs.json`, `${DIR}/../.cs.json`, and `${DIR}/../config/.cs.json`, where `${DIR}` is the location of the `cs` executable.
-It then looks for a `.cs.json` file in the current directory, and then for a `.cs.json` file in your home directory, and overwrites any properties in the base `.cs.json` file.
+`cs` uses a default `.cs.json` file located in either `${DIR}/.cs.json`, `${DIR}/../.cs.json`, or `${DIR}/../config/.cs.json`, where `${DIR}` is the location of the `cs` executable.
+This allows you to roll out configuration changes (such as adding a new cluster) without updating the configuration files of all end users.
+If a default `.cs.json` file is not found, an empty configuration is used.
+
+Users can also add and overwrite any properties in the default `.cs.json` file using a local `.cs.json` file.
+`cs` first looks for this `.cs.json` file in your current directory, and then for this `.cs.json` file in your home directory.
 The path to this file may also be provided manually via the command line with the `--config` option.
 
 There is a sample `.cs.json` file included in this directory, which looks something like this:

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,7 +17,8 @@ Custom defaults may be provided for all commands.
 Multiple clusters are supported via configuration.
 
 In order to use the Cook CLI, you’ll need a configuration file. 
-`cs` looks first for a `.cs.json` file in the current directory, and then for a `.cs.json` file in your home directory. 
+`cs` looks first for a base `.cs.json` file in `${DIR}/.cs.json`, `${DIR}/../.cs.json`, and `${DIR}/../config/.cs.json`, where `${DIR}` is the location of the `cs` executable.
+It then looks for a `.cs.json` file in the current directory, and then for a `.cs.json` file in your home directory, and overwrites any properties in the base `.cs.json` file.
 The path to this file may also be provided manually via the command line with the `--config` option.
 
 There is a sample `.cs.json` file included in this directory, which looks something like this:

--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -85,7 +85,7 @@ def run(args):
     if action is None:
         parser.print_help()
     else:
-        config_map = configuration.load_config_with_defaults(config_path)
+        _, config_map = configuration.load_config_with_defaults(config_path)
         try:
             metrics.initialize(config_map)
             metrics.inc('command.%s.runs' % action)

--- a/cli/cook/configuration.py
+++ b/cli/cook/configuration.py
@@ -59,7 +59,7 @@ def __load_base_config():
     return config
 
 
-def load_config(config_path):
+def __load_local_config(config_path):
     """
     Loads the configuration map, using the provided config_path if not None,
     otherwise, searching the additional config paths for a valid JSON config file
@@ -81,11 +81,11 @@ def load_config_with_defaults(config_path=None):
     base_config = __load_base_config()
     base_config = base_config or {}
     base_config = deep_merge(DEFAULT_CONFIG, base_config)
-    _, config = load_config(config_path)
+    config_path, config = __load_local_config(config_path)
     config = config or {}
     config = deep_merge(base_config, config)
     logging.debug(f'using configuration: {config}')
-    return config
+    return config_path, config
 
 
 def add_defaults(action, defaults):

--- a/cli/cook/subcommands/config.py
+++ b/cli/cook/subcommands/config.py
@@ -1,7 +1,7 @@
 from cook.util import print_info
 
 from cook import configuration, terminal
-from cook.configuration import load_config
+from cook.configuration import load_config_with_defaults
 
 
 def get_in(dct, keys):
@@ -98,14 +98,13 @@ def config(_, args, config_path):
         raise Exception(f'You can only provide a single key.')
 
     keys = key[0].split('.')
-    config_path, config_map = load_config(config_path)
-
-    if not config_path:
-        raise Exception(f'Unable to locate configuration file.')
+    config_path, config_map = load_config_with_defaults(config_path)
 
     if get:
         return get_config_value(config_map, keys)
     else:
+        if not config_path:
+            raise Exception(f'Unable to locate configuration file.')
         return set_config_value(config_map, keys, value, config_path)
 
 
@@ -117,3 +116,5 @@ def register(add_parser, _):
     parser.add_argument('key', nargs=1)
     parser.add_argument('value', nargs='?')
     return config
+
+

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -209,6 +209,28 @@ class temp_config_file:
         os.remove(self.path)
 
 
+class temp_base_config_file:
+    """
+    A context manager used to generate and subsequently delete a temporary
+    base config file for the CLI. Takes as input the config dictionary to use.
+    """
+
+    def __init__(self, config):
+        # Get the location of the cs executable so we can add a default `.cs.json` file
+        cp = subprocess.run(args=['which', command()], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        base_exec = cp.stdout.decode("utf-8").rstrip('\n')
+        base_dir = os.path.dirname(os.path.abspath(base_exec))
+        self.path = os.path.join(base_dir, '.cs.json')
+        self.config = config
+
+    def __enter__(self):
+        write_json(self.path, self.config)
+        return self.path
+
+    def __exit__(self, _, __, ___):
+        os.remove(self.path)
+
+
 def jobs(cook_url=None, jobs_flags=None, flags=None):
     """Invokes the jobs subcommand"""
     args = f'jobs {jobs_flags}' if jobs_flags else 'jobs'


### PR DESCRIPTION
## Changes proposed in this PR

- Introduces a central `.cs.json` file for the cs command

## Why are we making these changes?
We want to have a default `.cs.json` configuration file for all users. This allows users to roll out updates to their configurations (for instance, adding a new cluster) by only updating the default `.cs.json` file rather than the `.cs.json` file of all their end users.

