### PR TITLE
Adding plugins for cat and tail

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -132,6 +132,49 @@ The `usage` command allows you to list cluster share and usage for a particular 
 In addition to totals, it displays a breakdown of usage by application and job group.
 As with `show`, `usage` will list usage across all configured clusters.
 
+### Plugins
+
+You can also specify custom functionality for some subcommands with your own plugin functions.
+You will need to add a `plugins` map to your `.cs.json` file. An example plugin config is shown below.
+
+```json
+{
+  "plugins": {
+    "plugin-name": {
+      "module-name": "module_name",
+      "path": "path_to_plugin_module",
+      "function-name": "function_name"
+    }
+  }
+}
+```
+
+Plugins are available for the following subcommands:
+
+#### `ls`
+
+The `ls` command has the plugin name `retrieve-job-instance-files`.
+The plugin function must take in an instance, sandbox directory, and path,
+and must return an array of dicts containing the file metadata fields
+`path`, `mode`, `nlink`, `size`, `uid`, `gid`, and `mtime`.
+
+#### `cat`
+
+The `cat` command has the plugin name `download-job-instance-file`.
+The plugin function must take in an instance, sandbox directory, and path,
+and must return an object with an `iter_content` method which generates the file contents.
+
+#### `tail`
+
+The `tail` command has the plugin name `read-job-instance-file`.
+The plugin function must take in an instance, sandbox directory, path, offset, and length,
+and must return a dict containing two fields: `data` and `offset`.
+ - When the `offset` param is `None`, the returned `data` is empty and `offset` is the file size.
+ - When the `offset` param is not `None`, the returned `data` is the file contents starting at offset `offset` with length `length`,
+   and the returned `offset` is the `offset` param.
+
+See the integration tests for simple examples of the subcommand plugins.
+
 ### Examples
 
 Simple job creation:

--- a/cli/README.md
+++ b/cli/README.md
@@ -162,7 +162,7 @@ and must return an array of dicts containing the file metadata fields
 
 The `cat` command has the plugin name `download-job-instance-file`.
 The plugin function must take in an instance, sandbox directory, and path,
-and must return an object with an `iter_content` method which generates the file contents.
+and must return an iterator that takes in a chunk size, which generates the file contents.
 
 #### `tail`
 

--- a/cli/cook/http.py
+++ b/cli/cook/http.py
@@ -45,6 +45,12 @@ def configure(config):
             raise Exception(f'Encountered unsupported authentication type "{auth_type}".')
 
 
+def __head(url, params=None, **kwargs):
+    """Sends a HEAD with params to the given url"""
+    logging.info(f'HEAD {url} with {params}')
+    return session.head(url, params=params, timeout=timeouts, **kwargs)
+
+
 def __post(url, json_body):
     """Sends a POST with the json payload to the given url"""
     logging.info(f'POST {url} with body {json_body}')

--- a/cli/cook/mesos.py
+++ b/cli/cook/mesos.py
@@ -97,4 +97,4 @@ def download_file(instance, sandbox_dir, path):
         logging.error(f'mesos agent returned status code {resp.status_code} and body {resp.text}')
         raise Exception('Could not download the file.')
 
-    return resp
+    return resp.iter_content

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -11,7 +11,7 @@ from cook.util import guard_no_cluster
 
 def cat_for_instance(instance, sandbox_dir, path):
     """Outputs the contents of the Mesos sandbox path for the given instance."""
-    retrieve_fn = plugins.get_fn('cat-plugin', download_file)
+    retrieve_fn = plugins.get_fn('download-job-instance-file', download_file)
     resp = retrieve_fn(instance, sandbox_dir, path)
     try:
         for data in resp.iter_content(chunk_size=4096):

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -3,6 +3,7 @@ import logging
 import sys
 from functools import partial
 
+from cook import plugins
 from cook.mesos import download_file
 from cook.querying import parse_entity_refs, query_unique_and_run, parse_entity_ref
 from cook.util import guard_no_cluster
@@ -10,7 +11,8 @@ from cook.util import guard_no_cluster
 
 def cat_for_instance(instance, sandbox_dir, path):
     """Outputs the contents of the Mesos sandbox path for the given instance."""
-    resp = download_file(instance, sandbox_dir, path)
+    retrieve_fn = plugins.get_fn('cat-plugin', download_file)
+    resp = retrieve_fn(instance, sandbox_dir, path)
     try:
         for data in resp.iter_content(chunk_size=4096):
             if data:

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -12,9 +12,9 @@ from cook.util import guard_no_cluster
 def cat_for_instance(instance, sandbox_dir, path):
     """Outputs the contents of the Mesos sandbox path for the given instance."""
     retrieve_fn = plugins.get_fn('download-job-instance-file', download_file)
-    resp = retrieve_fn(instance, sandbox_dir, path)
+    download = retrieve_fn(instance, sandbox_dir, path)
     try:
-        for data in resp.iter_content(chunk_size=4096):
+        for data in download(chunk_size=4096):
             if data:
                 sys.stdout.buffer.write(data)
     except BrokenPipeError as bpe:

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -91,7 +91,7 @@ def retrieve_entries_from_mesos(instance, sandbox_dir, path):
 
 def ls_for_instance(instance, sandbox_dir, path, long_format, as_json):
     """Lists contents of the Mesos sandbox path for the given instance"""
-    retrieve_fn = plugins.get_fn('retrieve-ls-entries', retrieve_entries_from_mesos)
+    retrieve_fn = plugins.get_fn('ls-plugin', retrieve_entries_from_mesos)
     entries = retrieve_fn(instance, sandbox_dir, path)
     if as_json:
         print(json.dumps(entries))

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -91,7 +91,7 @@ def retrieve_entries_from_mesos(instance, sandbox_dir, path):
 
 def ls_for_instance(instance, sandbox_dir, path, long_format, as_json):
     """Lists contents of the Mesos sandbox path for the given instance"""
-    retrieve_fn = plugins.get_fn('ls-plugin', retrieve_entries_from_mesos)
+    retrieve_fn = plugins.get_fn('retrieve-job-instance-files', retrieve_entries_from_mesos)
     entries = retrieve_fn(instance, sandbox_dir, path)
     if as_json:
         print(json.dumps(entries))

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -110,7 +110,7 @@ def tail_for_instance(instance, sandbox_dir, path, num_lines_to_print, follow, f
     Tails the contents of the Mesos sandbox path for the given instance. If follow is truthy, it will
     try and read more data from the file until the user terminates. This assumes files will not shrink.
     """
-    retrieve_fn = plugins.get_fn('tail-plugin', read_file)
+    retrieve_fn = plugins.get_fn('read-job-instance-file', read_file)
     read = partial(retrieve_fn, instance=instance, sandbox_dir=sandbox_dir, path=path)
     file_size = read()['offset']
     tail_backwards(file_size, read, num_lines_to_print)

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -1,6 +1,7 @@
 import time
 from functools import partial
 
+from cook import plugins
 from cook.mesos import read_file
 from cook.querying import query_unique_and_run, parse_entity_refs
 from cook.util import check_positive, guard_no_cluster
@@ -109,7 +110,8 @@ def tail_for_instance(instance, sandbox_dir, path, num_lines_to_print, follow, f
     Tails the contents of the Mesos sandbox path for the given instance. If follow is truthy, it will
     try and read more data from the file until the user terminates. This assumes files will not shrink.
     """
-    read = partial(read_file, instance=instance, sandbox_dir=sandbox_dir, path=path)
+    retrieve_fn = plugins.get_fn('tail-plugin', read_file)
+    read = partial(retrieve_fn, instance=instance, sandbox_dir=sandbox_dir, path=path)
     file_size = read()['offset']
     tail_backwards(file_size, read, num_lines_to_print)
     if follow:

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -263,10 +263,10 @@ def ssh(uuid, cook_url=None, env=None, flags=None):
     return cp
 
 
-def tail(uuid, path, cook_url, tail_flags=None, wait_for_exit=True):
+def tail(uuid, path, cook_url, tail_flags=None, wait_for_exit=True, flags=None):
     """Invokes the tail subcommand"""
     args = f'tail {tail_flags} {uuid} {path}' if tail_flags else f'tail {uuid} {path}'
-    cp = cli(args, cook_url, wait_for_exit=wait_for_exit)
+    cp = cli(args, cook_url, flags=flags, wait_for_exit=wait_for_exit)
     return cp
 
 
@@ -344,10 +344,10 @@ def command_prefix():
     return decode(cp.stdout).rstrip('\n') if cp.returncode == 0 else ''
 
 
-def cat(uuid, path, cook_url):
+def cat(uuid, path, cook_url, flags=None):
     """Invokes the cat subcommand"""
     args = f'cat {uuid} {path}'
-    cp = cli(args, cook_url)
+    cp = cli(args, cook_url, flags=flags)
     return cp
 
 

--- a/integration/tests/cook/mesos.py
+++ b/integration/tests/cook/mesos.py
@@ -96,14 +96,14 @@ def download_file(session, instance, sandbox_dir, path):
         logging.error(f'mesos agent returned status code {resp.status_code} and body {resp.text}')
         raise Exception('Could not download the file.')
 
-    return resp
+    return resp.iter_content
 
 
 def cat_for_instance(session, instance, sandbox_dir, path):
     """Outputs the contents of the Mesos sandbox path for the given instance."""
-    resp = download_file(session, instance, sandbox_dir, path)
+    download = download_file(session, instance, sandbox_dir, path)
     try:
-        for data in resp.iter_content(chunk_size=4096):
+        for data in download(chunk_size=4096):
             if data:
                 logging.info(data.decode())
     except BrokenPipeError as bpe:

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1033,7 +1033,7 @@ def dummy_ls_entries(_, __, ___):
             temp.flush()
             config = {
                 'plugins': {
-                    "retrieve-ls-entries": {
+                    "ls-plugin": {
                         "module-name": "does_not_matter",
                         "path": temp.name,
                         "function-name": "dummy_ls_entries"

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1343,30 +1343,30 @@ def dummy_ls_entries(_, __, ___):
             self.assertEqual('success', jobs[0]['state'])
 
     def test_base_config_file(self):
-        base_config = {'defaults': {'submit': {'command-prefix': 'export FOO=0; '}}, 'other': 'bar'}
+        base_config = {'overwrite': 'foo', 'constant': 'bar'}
 
         with cli.temp_base_config_file(base_config) as base_config:
             # Get entries in base config file
-            cp = cli.config_get('defaults.submit.command-prefix')
+            cp = cli.config_get('overwrite')
             self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertEqual('export FOO=0; \n', cli.decode(cp.stdout))
+            self.assertEqual('foo\n', cli.decode(cp.stdout))
 
-            cp = cli.config_get('other')
+            cp = cli.config_get('constant')
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertEquals('bar\n', cli.decode(cp.stdout))
 
             # Overwrite defaults with specified config file
-            config = {'defaults': {'submit': {'command-prefix': 'export FOO=1; '}}}
+            config = {'overwrite': 'baz'}
             with cli.temp_config_file(config) as path:
                 flags = '--config %s' % path
 
                 # Verify default config is overwritten
-                cp = cli.config_get('defaults.submit.command-prefix', flags=flags)
+                cp = cli.config_get('overwrite', flags=flags)
                 self.assertEqual(0, cp.returncode, cp.stderr)
-                self.assertEqual('export FOO=1; \n', cli.decode(cp.stdout))
+                self.assertEqual('baz\n', cli.decode(cp.stdout))
 
                 # Verify other config is still loaded
-                cp = cli.config_get('other', flags=flags)
+                cp = cli.config_get('constant', flags=flags)
                 self.assertEqual(0, cp.returncode, cp.stderr)
                 self.assertEqual('bar\n', cli.decode(cp.stdout))
 

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -871,8 +871,8 @@ def dummy_tail_text(instance, sandbox_dir, path, offset=None, length=None):
             temp.write(plugin_code.encode())
             temp.flush()
             config = {
-                'plugins': {
-                    "tail-plugin": {
+                "plugins": {
+                    "read-job-instance-file": {
                         "module-name": "does_not_matter",
                         "path": temp.name,
                         "function-name": "dummy_tail_text"
@@ -1067,8 +1067,8 @@ def dummy_ls_entries(_, __, ___):
             temp.write(plugin_code.encode())
             temp.flush()
             config = {
-                'plugins': {
-                    "ls-plugin": {
+                "plugins": {
+                    "retrieve-job-instance-files": {
                         "module-name": "does_not_matter",
                         "path": temp.name,
                         "function-name": "dummy_ls_entries"
@@ -1834,8 +1834,8 @@ def dummy_cat_text(_, __, ___):
             temp.write(plugin_code.encode())
             temp.flush()
             config = {
-                'plugins': {
-                    "cat-plugin": {
+                "plugins": {
+                    "download-job-instance-file": {
                         "module-name": "does_not_matter",
                         "path": temp.name,
                         "function-name": "dummy_cat_text"


### PR DESCRIPTION
## Changes proposed in this PR

- Adding a HEAD request to the http requests.
- Adding a plugin hook in the `cat` and `tail` subcommands for printing out files
- Adding integration tests for plugging in dummy `cat` and `tail` plugin functions

## Why are we making these changes?

We want to add runtime support extensions to the `cat` and `tail` subcommands to complement the plugins provided by the `ls` subcommand already. The added HEAD request may be used by plugins to quickly verify they can run successfully, defaulting otherwise to the base command.
