### PR TITLE
Feature/jobclient httpclient 4.5.5

### DIFF
--- a/jobclient/pom.xml
+++ b/jobclient/pom.xml
@@ -3,7 +3,7 @@
   <groupId>twosigma</groupId>
   <artifactId>cook-jobclient</artifactId>
   <packaging>jar</packaging>
-  <version>0.4.2-SNAPSHOT</version>
+  <version>0.4.2</version>
   <name>cook-jobclient</name>
   <description>A Java API for connecting to the Cook scheduler, submitting, and monitoring jobs.</description>
   <licenses>

--- a/jobclient/pom.xml
+++ b/jobclient/pom.xml
@@ -3,7 +3,7 @@
   <groupId>twosigma</groupId>
   <artifactId>cook-jobclient</artifactId>
   <packaging>jar</packaging>
-  <version>0.4.2</version>
+  <version>0.4.3-SNAPSHOT</version>
   <name>cook-jobclient</name>
   <description>A Java API for connecting to the Cook scheduler, submitting, and monitoring jobs.</description>
   <licenses>

--- a/jobclient/pom.xml
+++ b/jobclient/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.6</version>
+      <version>4.5.5</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/jobclient/src/main/java/com/twosigma/cook/jobclient/auth/spnego/BasicSPNegoSchemeFactory.java
+++ b/jobclient/src/main/java/com/twosigma/cook/jobclient/auth/spnego/BasicSPNegoSchemeFactory.java
@@ -48,8 +48,7 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
 
     public static SPNegoSchemeFactory build(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
         return credentialProvider == null
-            // USE_CANONICAL_HOSTNAME should be enabled below for HttpClient v4.4 or above
-            ? new SPNegoSchemeFactory(true /*, USE_CANONICAL_HOSTNAME */)
+            ? new SPNegoSchemeFactory(true, USE_CANONICAL_HOSTNAME)
             : new BasicSPNegoSchemeFactory(true, credentialProvider);
     }
 
@@ -86,8 +85,7 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
         }
 
         BasicSPNegoScheme(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
-            // USE_CANONICAL_HOSTNAME should be enabled below for HttpClient v4.4 or above
-            super(stripPort /*, USE_CANONICAL_HOSTNAME */);
+            super(stripPort, USE_CANONICAL_HOSTNAME);
             _credentialProvider = credentialProvider;
         }
 
@@ -125,8 +123,7 @@ public class BasicSPNegoSchemeFactory extends SPNegoSchemeFactory {
     private final GSSCredentialProvider _credentialProvider;
 
     protected BasicSPNegoSchemeFactory(final boolean stripPort, final GSSCredentialProvider credentialProvider) {
-        // USE_CANONICAL_HOSTNAME should be enabled below for HttpClient v4.4 or above
-        super(stripPort /*, USE_CANONICAL_HOSTNAME */);
+        super(stripPort, USE_CANONICAL_HOSTNAME);
         _credentialProvider = credentialProvider;
     }
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -188,7 +188,7 @@
    {:dependencies [[criterium "0.4.4"]
                    [org.clojure/test.check "0.6.1"]
                    [org.mockito/mockito-core "1.10.19"]
-                   [twosigma/cook-jobclient "0.4.2-SNAPSHOT"]]}
+                   [twosigma/cook-jobclient "0.4.3-SNAPSHOT"]]}
 
    :test-console
    [:test {:jvm-opts ["-Dcook.test.logging.console"]}]


### PR DESCRIPTION
## Changes proposed in this PR

- Upgrades JobClient dependence of Apache HttpClient to v4.5.5
- Release JobClient v0.4.2

## Why are we making these changes?

We want this newer version of the Apache HttpClient.

The changes to constructor calls using `USE_CANONICAL_HOSTNAME` are for better Kerberos compatibility, and were previously explained in #1013.

## Other notes

Please **rebase and merge** when resolving this PR, since we want to preserve the separate release commit.