### PR TITLE
Add additional logging to API operations

### DIFF
--- a/scheduler/test/cook/test/mesos/api.clj
+++ b/scheduler/test/cook/test/mesos/api.clj
@@ -112,6 +112,7 @@
     (json/read-str (.toString baos))))
 
 (deftest handler-db-roundtrip
+  (testutil/setup)
   (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
         uuid #uuid "386b374c-4c4a-444f-aca0-0c25384c6fa0"
         env {"MY_VAR" "one"


### PR DESCRIPTION
## Changes proposed in this PR
- Add additional logging to API operations which write or delete data

## Why are we making these changes?
Improve our ability to debug the results of the operations after the fact.