### PR TITLE
upgrade to clojure 1.10

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -16,7 +16,7 @@
 (defproject cook "1.29.1-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
 
                  ;;Data marshalling
                  [org.clojure/data.codec "0.1.0"]

--- a/scheduler/src/cook/mesos/fenzo_utils.clj
+++ b/scheduler/src/cook/mesos/fenzo_utils.clj
@@ -15,13 +15,7 @@
 ;;
 (ns cook.mesos.fenzo-utils
   (:require [clojure.tools.logging :as log]
-            [datomic.api :as d])
-  (import java.util.concurrent.TimeUnit
-          org.apache.mesos.Protos$Offer
-          com.netflix.fenzo.TaskAssignmentResult
-          com.netflix.fenzo.TaskScheduler
-          com.netflix.fenzo.VirtualMachineLease
-          com.netflix.fenzo.plugins.BinPackingFitnessCalculators))
+            [datomic.api :as d]))
 
 (defn extract-message
   "For some reason, Fenzo's AssignmentFailure doesn't have a getter for the

--- a/scheduler/src/cook/mesos/mesos_mock.clj
+++ b/scheduler/src/cook/mesos/mesos_mock.clj
@@ -23,8 +23,7 @@
             [mesomatic.scheduler :as mesos]
             [mesomatic.types :as mesos-type]
             [plumbing.core :refer (map-vals map-from-vals)])
-  (import org.apache.mesos.Protos$Status
-          org.apache.mesos.SchedulerDriver))
+  (:import (org.apache.mesos Protos$Status SchedulerDriver)))
 
 (def resource->type {:cpus :scalar
                      :mem :scalar

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -54,11 +54,10 @@
             [metrics.meters :as meters]
             [metrics.timers :as timers]
             [plumbing.core :as pc])
-  (import [com.netflix.fenzo ConstraintEvaluator ConstraintEvaluator$Result
-                             TaskAssignmentResult TaskRequest TaskScheduler TaskScheduler$Builder
-                             VirtualMachineLease VirtualMachineLease$Range
-                             VirtualMachineCurrentState]
-          [com.netflix.fenzo.functions Action1 Func1]))
+  (:import (com.netflix.fenzo TaskAssignmentResult TaskRequest TaskScheduler TaskScheduler$Builder
+                              VirtualMachineLease VirtualMachineLease$Range
+                              VirtualMachineCurrentState)
+           (com.netflix.fenzo.functions Action1 Func1)))
 
 (defn now
   []

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -15,12 +15,12 @@
 ;;
 
 (ns cook.test.testutil
-  (:use clojure.test)
   (:require [clj-logging-config.log4j :as log4j-conf]
             [clj-time.core :as t]
             [clojure.core.async :as async]
             [clojure.core.cache :as cache]
             [clojure.string :as str]
+            [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [cook.plugins.definitions :refer (JobSubmissionValidator JobLaunchFilter)]
             [cook.impersonation :refer (create-impersonation-middleware)]
@@ -292,7 +292,7 @@
                       :zookeeper {:local? true}}]
   (defn setup
     "Given an optional config map, initializes the config state"
-    [& {:keys [config], :or nil}]
+    [& {:keys [config]}]
     (mount/stop)
     (mount/start-with-args (merge minimal-config config)
                            #'cook.config/config

--- a/scheduler/src/metatransaction/core.clj
+++ b/scheduler/src/metatransaction/core.clj
@@ -15,7 +15,7 @@
 ;;
 (ns metatransaction.core
   (:require [datomic.api :as d])
-  (:import [datomic.Datom]))
+  (:import (datomic Datom)))
 
 (def metatransaction-schema
   [{:db/id (d/tempid :db.part/db)
@@ -127,7 +127,7 @@
    Transactions without a metatransaction will go unfiltered. "
   [db]
   (let [committed (d/entid db :metatransaction.status/committed)]
-    (fn [db ^datomic.Datom datom]
+    (fn [db ^Datom datom]
       (if-let [mt (-> (d/datoms db :vaet (.tx datom) :metatransaction/tx) first :e)]
         (= committed (-> (d/datoms db :eavt mt :metatransaction/status) first :v))
         true))))

--- a/scheduler/test/cook/test/mesos/fenzo_utils.clj
+++ b/scheduler/test/cook/test/mesos/fenzo_utils.clj
@@ -20,10 +20,7 @@
             [cook.mesos.util :as util]
             [cook.test.testutil :refer (restore-fresh-database! create-dummy-job)]
             [datomic.api :as d])
-  (import com.netflix.fenzo.SimpleAssignmentResult
-          com.netflix.fenzo.AssignmentFailure
-          com.netflix.fenzo.ConstraintFailure
-          com.netflix.fenzo.VMResource))
+  (:import (com.netflix.fenzo AssignmentFailure ConstraintFailure SimpleAssignmentResult VMResource)))
 
 ;; Fenzo is aware of other resources as well; just limiting it to ones
 ;; Cook will usually encounter
@@ -46,10 +43,10 @@
 (defn assignment-result
   [constraint-name resources-lacking]
   (SimpleAssignmentResult.
-   (map assignment-failure resources-lacking)
-   (when constraint-name
-     (ConstraintFailure. constraint-name (str constraint-name " was not satisfied")))
-   ))
+    (map assignment-failure resources-lacking)
+    (when constraint-name
+      (ConstraintFailure. constraint-name (str constraint-name " was not satisfied")))
+    ))
 
 (deftest test-summarize-placement-failures
   (testing "starting from empty accumulator"
@@ -57,18 +54,18 @@
            {}))
 
     (is (= (fenzo/summarize-placement-failure
-            {}
-            (assignment-result nil [:ports]))
+             {}
+             (assignment-result nil [:ports]))
            {:resources {"ports" 1}}))
 
     (is (= (fenzo/summarize-placement-failure
-            {}
-            (assignment-result "novel_host_constraint" []))
+             {}
+             (assignment-result "novel_host_constraint" []))
            {:constraints {"novel_host_constraint" 1}}))
 
     (is (= (fenzo/summarize-placement-failure
-            {}
-            (assignment-result "novel_host_constraint" [:cpus :mem]))
+             {}
+             (assignment-result "novel_host_constraint" [:cpus :mem]))
            {:constraints {"novel_host_constraint" 1}
             :resources {"cpus" 1
                         "mem" 1}})))

--- a/simulator/project.clj
+++ b/simulator/project.clj
@@ -1,6 +1,6 @@
 (defproject cook/sim "0.1.0-SNAPSHOT"
   :description "Simulation tests for Cook"
-  :dependencies   [[org.clojure/clojure "1.8.0"]
+  :dependencies   [[org.clojure/clojure "1.10.0"]
                    [clj-time "0.9.0"]
                    [cheshire "5.5.0"]
                    [com.datomic/datomic-free "0.9.5344"


### PR DESCRIPTION
## Changes proposed in this PR

- upgrade to clojure 1.10

## Why are we making these changes?

We would like for Cook to run on the latest version of Clojure.

