### PR TITLE
Outgoing/auto clean uncommitted

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -312,6 +312,9 @@
                                ((util/lazy-load-var 'cook.mesos.sandbox/prepare-sandbox-publisher)
                                  framework-id datomic/conn publish-batch-size publish-interval-ms sync-interval-ms
                                  max-consecutive-sync-failure mesos-agent-query-cache)))
+     :clear-uncommitted-canceler (fnk [mesos-leadership-atom]
+                                   ((util/lazy-load-var 'cook.mesos.util/clear-uncommitted-jobs-on-schedule)
+                                     datomic/conn mesos-leadership-atom))
      :mesos-leadership-atom (fnk [] (atom false))
      :pool-name->pending-jobs-atom (fnk [] (atom {}))
      :mesos-agent-attributes-cache (fnk [[:settings {agent-attributes-cache nil}]]

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -691,7 +691,7 @@
                       {:count-committed (count committed-jobs)
                        :count-uncommitted (count uncommitted-jobs)})))
     (when-not dry-run?
-      (doseq [batch (partition-all 10 uncommitted-before)]
+      (doseq [batch (partition-all 100 uncommitted-before)]
         @(d/transact conn (mapv #(vector :db.fn/retractEntity (:db/id %))
                                 batch))))
     uncommitted-before))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -690,6 +690,9 @@
       (throw (ex-info "There is overlap between committed and uncommitted jobs, there is something wrong!"
                       {:count-committed (count committed-jobs)
                        :count-uncommitted (count uncommitted-jobs)})))
+    (if dry-run?
+      (log/info "clear-uncommitted-jobs would delete" (count uncommitted-before) "uncommitted jobs submitted before" submitted-before)
+      (log/info "clear-uncommitted-jobs is deleting" (count uncommitted-before) "uncommitted jobs submitted before" submitted-before))
     (when-not dry-run?
       (doseq [batch (partition-all 100 uncommitted-before)]
         @(d/transact conn (mapv #(vector :db.fn/retractEntity (:db/id %))

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -712,13 +712,13 @@
    This is a simple loop that nukes any uncommitted jobs older than a few days. It runs every 24 hours. There will be a minor
    performance hiccough lasting around 1 minute per 1000 jobs or so as this runs and flushes."
   [conn mesos-leadership-atom]
-  (let [age (tc/to-date (-> -3 t/days t/from-now))
-        start-time (-> 12 t/hours t/from-now)
+  (let [start-time (-> 12 t/hours t/from-now)
         frequency (-> 1 t/days)
         schedule (tp/periodic-seq start-time frequency)
-        chime-fn (fn [time]
+        chime-fn (fn [_]
                    (when @mesos-leadership-atom
-                     (clear-uncommitted-jobs conn age false)))]
+                     (let [age (-> -7 t/days t/from-now tc/to-date)]
+                       (clear-uncommitted-jobs conn age false))))]
     (log/info "Launching clear-uncommitted-jobs-on-schedule")
     (chime/chime-at schedule chime-fn)))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Runs the clear-uncommitted-jobs on a schedule; 12 hours after starting up and every 24 hours thereafter.
- 
- 

## Why are we making these changes?

If something goes wrong and a batch of jobs is submitted to Cook, but is never committed, they will slowly build up and clutter the database, causing the scheduler loop to slow down due to get-pending-jobs having to read and skip them.

The cost appears to be around one second every 50k jobs. This is a simple loop that nukes any uncommitted jobs older than a few days. 
