### PR TITLE
Add plugin for pool selection

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -30,6 +30,8 @@
             [cook.plugins.submission]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.launch namespace.
             [cook.plugins.launch]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.pool namespace.
+            [cook.plugins.pool]
             [cook.impersonation :refer (impersonation-authorized-wrapper)]
             [cook.mesos.pool :as pool]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.rate-limit namespace.

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -408,7 +408,8 @@
                                             :launch-wait-seconds (get fitness-calculator :launch-wait-seconds 60)
                                             :update-interval-ms (get fitness-calculator :update-interval-ms nil)}))
      :plugins (fnk [[:config {plugins {}}]]
-                (let [{:keys [job-launch-filter job-submission-validator]} plugins]
+                 (let [{:keys [job-launch-filter job-submission-validator
+                               pool-selection]} plugins]
                   (merge plugins
                          {:job-launch-filter
                           (merge
@@ -418,7 +419,11 @@
                             job-launch-filter)
                           :job-submission-validator
                           (merge {:batch-timeout-seconds 40}
-                                 job-submission-validator)})))}))
+                                 job-submission-validator)
+                          :pool-selection
+                          (merge {:attribute-name "cook-pool"
+                                  :default-pool "no-pool"}
+                                 pool-selection)})))}))
 
 (defn read-config
   "Given a config file path, reads the config and returns the map"

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -29,6 +29,7 @@
             [cook.plugins.completion :as completion]
             [cook.plugins.definitions :as plugins]
             [cook.plugins.launch :as launch-plugin]
+            [cook.plugins.pool :as pool-plugin]
             [cook.mesos.constraints :as constraints]
             [cook.mesos.data-locality :as dl]
             [cook.mesos.dru :as dru]
@@ -1485,11 +1486,7 @@
       (resource-offers
         [this driver offers]
         (log/debug "Got offers:" offers)
-        (let [pool->offers (group-by (fn [o]
-                                       (or
-                                         (->> o :attributes (filter #(= "cook-pool" (:name %))) first :text)
-                                         "no-pool"))
-                                     offers)
+        (let [pool->offers (group-by (fn [o] (plugins/select-pool pool-plugin/plugin o)) offers)
               using-pools? (config/default-pool)]
           (log/info "Offers by pool:" (pc/map-vals count pool->offers))
           (run!

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -46,3 +46,7 @@
   (on-instance-completion [this job instance]
     "Plugin for performing operations on a job after an instance of the job has completed.
      The return value of the plugin is ignored."))
+
+(defprotocol PoolSelector
+  (select-pool [this offer]
+    "Returns the pool name as a string for the offer"))

--- a/scheduler/src/cook/plugins/pool.clj
+++ b/scheduler/src/cook/plugins/pool.clj
@@ -11,14 +11,14 @@
     (or (->> offer :attributes (filter #(= attribute-name (:name %))) first :text)
         default-pool)))
 
-(defn create-default-plugin-object
+(defn create-plugin-object
   "Returns the configured PoolSelector, or a no-op if none is defined."
   [config]
   (let [pool-selection (get-in config [:settings :plugins :pool-selection])
         factory-fn (:factory-fn pool-selection)]
     (if factory-fn
       (do
-        (log/info "Creating instance completion plugin with" factory-fn)
+        (log/info "Creating pool selection plugin with" factory-fn)
         (if-let [resolved-fn (cook.plugins.util/resolve-symbol (symbol factory-fn))]
           (resolved-fn config)
           (throw (ex-info (str "Unable to resolve factory fn " factory-fn)))))
@@ -26,4 +26,4 @@
                               (:default-pool pool-selection)))))
 
 (mount/defstate plugin
-  :start (create-default-plugin-object config/config))
+  :start (create-plugin-object config/config))

--- a/scheduler/src/cook/plugins/pool.clj
+++ b/scheduler/src/cook/plugins/pool.clj
@@ -1,0 +1,29 @@
+(ns cook.plugins.pool
+  (:require [clojure.tools.logging :as log]
+            [cook.config :as config]
+            [cook.plugins.definitions :refer [PoolSelector]]
+            [cook.plugins.util]
+            [mount.core :as mount]))
+
+(defrecord AttributePoolSelector [attribute-name default-pool]
+  PoolSelector
+  (select-pool [this offer]
+    (or (->> offer :attributes (filter #(= attribute-name (:name %))) first :text)
+        default-pool)))
+
+(defn create-default-plugin-object
+  "Returns the configured PoolSelector, or a no-op if none is defined."
+  [config]
+  (let [pool-selection (get-in config [:settings :plugins :pool-selection])
+        factory-fn (:factory-fn pool-selection)]
+    (if factory-fn
+      (do
+        (log/info "Creating instance completion plugin with" factory-fn)
+        (if-let [resolved-fn (cook.plugins.util/resolve-symbol (symbol factory-fn))]
+          (resolved-fn config)
+          (throw (ex-info (str "Unable to resolve factory fn " factory-fn)))))
+      (AttributePoolSelector. (:attribute-name pool-selection)
+                              (:default-pool pool-selection)))))
+
+(mount/defstate plugin
+  :start (create-default-plugin-object config/config))

--- a/scheduler/src/cook/plugins/pool.clj
+++ b/scheduler/src/cook/plugins/pool.clj
@@ -12,7 +12,7 @@
         default-pool)))
 
 (defn create-plugin-object
-  "Returns the configured PoolSelector, or a no-op if none is defined."
+  "Returns the configured PoolSelector, or an AttributePoolSelector if none is defined."
   [config]
   (let [pool-selection (get-in config [:settings :plugins :pool-selection])
         factory-fn (:factory-fn pool-selection)]

--- a/scheduler/test/cook/test/mesos/mesos_mock.clj
+++ b/scheduler/test/cook/test/mesos/mesos_mock.clj
@@ -8,7 +8,7 @@
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
             [cook.test.simulator :refer (with-cook-scheduler pull-all-task-ents dump-jobs-to-csv)]
-            [cook.test.testutil :refer (restore-fresh-database! create-dummy-job poll-until)]
+            [cook.test.testutil :refer (restore-fresh-database! create-dummy-job poll-until setup)]
             [datomic.api :as d]
             [mesomatic.scheduler :as mesos]
             [mesomatic.types :as mesos-types])
@@ -654,6 +654,7 @@
           (throw (ex-info "Error while testing launch" atom-map t)))))))
 
 (deftest cook-scheduler-integration
+  (setup)
   ;; This tests the case where one user has all the resources in the cluster
   ;; and then another user shows up which causes the scheduler to preempt jobs
   ;; so both may run.

--- a/scheduler/test/cook/test/plugins/pool.clj
+++ b/scheduler/test/cook/test/plugins/pool.clj
@@ -1,0 +1,14 @@
+(ns cook.test.plugins.pool
+  (:use clojure.test)
+  (:require [cook.plugins.definitions :as plugins]
+            [cook.plugins.pool :as pool]))
+
+(deftest test-attribute-pool-selector
+  (let [selector (pool/->AttributePoolSelector "test-attribute" "my-pool")]
+    (is (= "my-pool" (plugins/select-pool selector {})))
+    (is (= "my-pool" (plugins/select-pool selector {:attributes [{:name "cook-pool"
+                                                                  :text "a-pool"}]})))
+    (is (= "a-pool" (plugins/select-pool selector {:attributes [{:name "test-attribute"
+                                                                 :text "a-pool"}]})))
+    (is (= "b-pool" (plugins/select-pool selector {:attributes [{:name "test-attribute"
+                                                                 :text "b-pool"}]})))))

--- a/scheduler/test/cook/test/testutil.clj
+++ b/scheduler/test/cook/test/testutil.clj
@@ -299,6 +299,7 @@
                            #'cook.rate-limit/job-launch-rate-limiter
                            #'cook.rate-limit/global-job-launch-rate-limiter
                            #'cook.plugins.launch/plugin-object
+                           #'cook.plugins.pool/plugin
                            #'cook.plugins.submission/plugin-object)))
 
 (defn wait-for


### PR DESCRIPTION
## Changes proposed in this PR
- Adds a plugin to support selecting the pool for an offer 

## Why are we making these changes?
Some environments may want to use different logic for selecting the appropriate pool for an offer.

