### PR TITLE
Mark tail large file tests xfail

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -762,6 +762,7 @@ class CookCliTest(util.CookTest):
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(' '.join([str(i) for i in range(1, 101)]) + ' ', cli.decode(cp.stdout))
 
+    @pytest.mark.xfail
     def test_tail_large_file(self):
         iterations = 20
         cp, uuids = cli.submit('bash -c \'printf "hello\\nworld\\n" > file.txt; '
@@ -777,6 +778,7 @@ class CookCliTest(util.CookTest):
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual('hello\nworld\n' * int(lines_to_tail / 2), cli.decode(cp.stdout))
 
+    @pytest.mark.xfail
     def test_tail_large_file_no_newlines(self):
         iterations = 18
         cp, uuids = cli.submit('bash -c \'printf "helloworld" > file.txt; '


### PR DESCRIPTION
## Changes proposed in this PR
- Mark the "tail large file" tests xfail

## Why are we making these changes?
Several flaky builds on our internal Jenkins.