### PR TITLE
Make the auto clean uncommitted be a jodatime to match clojure.

### DIFF
--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -701,16 +701,15 @@
                                 batch))))
     uncommitted-before))
 
-(defn clear-old-uncommitted-jobs-fn
+(defn clear-old-uncommitted-jobs
   "Returns a function that will, when invoked, clear any uncommitted jobs older than a week if the leadership atom is true."
   [conn mesos-leadership-atom]
-  (fn [_]
     (try
       (when @mesos-leadership-atom
         (let [age (-> -7 t/days t/from-now tc/to-date-time)]
           (clear-uncommitted-jobs conn age false)))
       (catch Exception e
-        (log/error e "Failed to kill the offensive job!")))))
+        (log/error e "Failed to kill the offensive job!"))))
 
 (defn clear-uncommitted-jobs-on-schedule
   "Runs the clear-uncommitted-jobs on a schedule; 12 hours after starting up and every 24 hours thereafter.
@@ -727,7 +726,8 @@
         frequency (-> 1 t/days)
         schedule (tp/periodic-seq start-time frequency)]
     (log/info "Launching clear-uncommitted-jobs-on-schedule")
-    (chime/chime-at schedule (clear-old-uncommitted-jobs-fn conn mesos-leadership-atom))))
+    (chime/chime-at schedule
+                    (fn [_] (clear-old-uncommitted-jobs conn mesos-leadership-atom)))))
 
 (defn instance-running?
   [instance]

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -701,6 +701,17 @@
                                 batch))))
     uncommitted-before))
 
+(defn clear-old-uncommitted-jobs-fn
+  "Returns a function that will, when invoked, clear any uncommitted jobs older than a week if the leadership atom is true."
+  [conn mesos-leadership-atom]
+  (fn [_]
+    (try
+      (when @mesos-leadership-atom
+        (let [age (-> -7 t/days t/from-now tc/to-date-time)]
+          (clear-uncommitted-jobs conn age false)))
+      (catch Exception e
+        (log/error e "Failed to kill the offensive job!")))))
+
 (defn clear-uncommitted-jobs-on-schedule
   "Runs the clear-uncommitted-jobs on a schedule; 12 hours after starting up and every 24 hours thereafter.
 
@@ -714,13 +725,9 @@
   [conn mesos-leadership-atom]
   (let [start-time (-> 12 t/hours t/from-now)
         frequency (-> 1 t/days)
-        schedule (tp/periodic-seq start-time frequency)
-        chime-fn (fn [_]
-                   (when @mesos-leadership-atom
-                     (let [age (-> -7 t/days t/from-now tc/to-date-time)]
-                       (clear-uncommitted-jobs conn age false))))]
+        schedule (tp/periodic-seq start-time frequency)]
     (log/info "Launching clear-uncommitted-jobs-on-schedule")
-    (chime/chime-at schedule chime-fn)))
+    (chime/chime-at schedule (clear-old-uncommitted-jobs-fn conn mesos-leadership-atom))))
 
 (defn instance-running?
   [instance]

--- a/scheduler/src/cook/mesos/util.clj
+++ b/scheduler/src/cook/mesos/util.clj
@@ -717,7 +717,7 @@
         schedule (tp/periodic-seq start-time frequency)
         chime-fn (fn [_]
                    (when @mesos-leadership-atom
-                     (let [age (-> -7 t/days t/from-now tc/to-date)]
+                     (let [age (-> -7 t/days t/from-now tc/to-date-time)]
                        (clear-uncommitted-jobs conn age false))))]
     (log/info "Launching clear-uncommitted-jobs-on-schedule")
     (chime/chime-at schedule chime-fn)))

--- a/scheduler/test/cook/test/mesos/util.clj
+++ b/scheduler/test/cook/test/mesos/util.clj
@@ -364,9 +364,8 @@
               (create-dummy-job conn
                                 :committed? false
                                 :submit-time (tc/to-date (-> 9 t/days t/ago))))]
-      (is (= (count ((util/clear-old-uncommitted-jobs-fn conn (atom true)) nil))
-             uncommitted-count))
-      (is (= (count ((util/clear-old-uncommitted-jobs-fn conn (atom true)) nil)) 0))))
+      (is (= (count (util/clear-old-uncommitted-jobs conn (atom true))) uncommitted-count))
+      (is (= (count (util/clear-old-uncommitted-jobs conn (atom true))) 0))))
 
   (testing "Clear old uncommitted jobs does nothing when we're not the master."
     (let [uri "datomic:mem://test-clear-old-uncommitted"
@@ -382,8 +381,8 @@
               (create-dummy-job conn
                                 :committed? false
                                 :submit-time (tc/to-date (-> 9 t/days t/ago))))]
-      (is (= (count ((util/clear-old-uncommitted-jobs-fn conn (atom false)) nil)) 0))
-      (is (= (count ((util/clear-old-uncommitted-jobs-fn conn (atom false)) nil)) 0)))))
+      (is (= (count (util/clear-old-uncommitted-jobs conn (atom false))) 0))
+      (is (= (count (util/clear-old-uncommitted-jobs conn (atom false))) 0)))))
 
 (deftest test-make-guuid->juuids
   (let [jobs [{:job/uuid "1"

--- a/scheduler/test/cook/test/mesos/util.clj
+++ b/scheduler/test/cook/test/mesos/util.clj
@@ -349,6 +349,42 @@
              uncommitted-count))
       (is (= (count (util/clear-uncommitted-jobs conn (t/yesterday) false)) 0)))))
 
+(deftest test-clear-old-uncommitted-jobs
+  (testing "Clear old uncommitted jobs works when we're the master."
+    (let [uri "datomic:mem://test-clear-old-uncommitted"
+          conn (restore-fresh-database! uri)
+          _ (dotimes [_ 100]
+              (create-dummy-job conn))
+          _ (dotimes [_ 100]
+              (create-dummy-job conn
+                                :committed? false
+                                :submit-time (tc/to-date (-> 6 t/hours t/ago))))
+          uncommitted-count 26
+          _ (dotimes [_ uncommitted-count]
+              (create-dummy-job conn
+                                :committed? false
+                                :submit-time (tc/to-date (-> 9 t/days t/ago))))]
+      (is (= (count ((util/clear-old-uncommitted-jobs-fn conn (atom true)) nil))
+             uncommitted-count))
+      (is (= (count ((util/clear-old-uncommitted-jobs-fn conn (atom true)) nil)) 0))))
+
+  (testing "Clear old uncommitted jobs does nothing when we're not the master."
+    (let [uri "datomic:mem://test-clear-old-uncommitted"
+          conn (restore-fresh-database! uri)
+          _ (dotimes [_ 100]
+              (create-dummy-job conn))
+          _ (dotimes [_ 100]
+              (create-dummy-job conn
+                                :committed? false
+                                :submit-time (tc/to-date (-> 6 t/hours t/ago))))
+          uncommitted-count 27
+          _ (dotimes [_ uncommitted-count]
+              (create-dummy-job conn
+                                :committed? false
+                                :submit-time (tc/to-date (-> 9 t/days t/ago))))]
+      (is (= (count ((util/clear-old-uncommitted-jobs-fn conn (atom false)) nil)) 0))
+      (is (= (count ((util/clear-old-uncommitted-jobs-fn conn (atom false)) nil)) 0)))))
+
 (deftest test-make-guuid->juuids
   (let [jobs [{:job/uuid "1"
                :group/_job #{{:group/uuid "a"} {:group/uuid "b"} {:group/uuid "c"} {:group/uuid "d"} {:group/uuid "e"}}}


### PR DESCRIPTION
## Changes proposed in this PR

- A java.util.Date is the wrong type. Make it JodaTime so that the cleaner works correctly.
- 
- 

## Why are we making these changes?


