### PR TITLE
Add checkpointing support to Cook Executor

### DIFF
--- a/executor/cook/config.py
+++ b/executor/cook/config.py
@@ -91,7 +91,7 @@ def initialize_config(environment):
     progress_output_name = environment.get(progress_output_env_variable, default_progress_output_file)
     progress_regex_string = environment.get('PROGRESS_REGEX_STRING', 'progress: ([0-9]*\.?[0-9]+), (.*)')
     progress_sample_interval_ms = max(int(environment.get('PROGRESS_SAMPLE_INTERVAL_MS', 1000)), 100)
-    recovery_timeout = environment.get('MESOS_RECOVERY_TIMEOUT', '5mins')
+    recovery_timeout = environment.get('MESOS_RECOVERY_TIMEOUT', '15mins')
     sandbox_directory = environment.get('MESOS_SANDBOX', '')
     shutdown_grace_period = environment.get('MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD', '2secs')
 

--- a/executor/cook/config.py
+++ b/executor/cook/config.py
@@ -40,10 +40,10 @@ class ExecutorConfig(object):
                  progress_output_name='stdout',
                  progress_regex_string='',
                  progress_sample_interval_ms=100,
-                 recovery_timeout='5mins',
+                 recovery_timeout='15mins',
                  sandbox_directory='',
                  shutdown_grace_period='1secs'):
-        self.checkpoint = checkpoint
+        self.checkpoint = checkpoint != 0
         self.max_bytes_read_per_line = max_bytes_read_per_line
         self.max_message_length = max_message_length
         self.memory_usage_interval_secs = memory_usage_interval_secs

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -184,24 +184,24 @@ def await_process_completion(process, stop_signal, shutdown_grace_period_ms):
     # wait indefinitely for process to terminate (either normally or by being killed)
     process.wait()
 
-def await_reregister(reregister_signal, recovery_s, *disconnect_signals):
+def await_reregister(reregister_signal, recovery_secs, *disconnect_signals):
     """Awaits reregistration on rerigster_signal, and notifies on stop_signal and disconnect_signal if not set.
 
     Parameters
     ----------
     reregister_signal: Event
         Event that notifies on mesos agent reregistration
-    recovery_s: int
+    recovery_secs: int
         Number of seconds to wait for reregistration.
     disconnect_signals: [Event]
         Events to notify if reregistration does not occur
     """
     def await_reregister_thread():
-        reregister_signal.wait(recovery_s)
+        reregister_signal.wait(recovery_secs)
         if reregister_signal.isSet():
             logging.info("Reregistered with mesos agent. Not notifying on disconnect_signals")
         else:
-            logging.warn("Failed to reregister within {} seconds. Notifying disconnect_signals".format(recovery_s))
+            logging.warn("Failed to reregister within {} seconds. Notifying disconnect_signals".format(recovery_secs))
             for signal in disconnect_signals:
                 signal.set()
     await_thread = Thread(target=await_reregister_thread, args=())
@@ -417,14 +417,14 @@ class CookExecutor(pm.Executor):
 
     def reregistered(self, driver, agent_info):
         logging.info('Executor re-registered agent={}'.format(agent_info))
-        if self.config.checkpoint == 1:
+        if self.config.checkpoint:
             logging.info('Executor checkpointing is enabled. Notifying on reregister_signal')
             self.reregister_signal.set()
             self.reregister_signal = Event()
 
     def disconnected(self, driver):
         logging.info('Mesos requested executor to disconnect')
-        if self.config.checkpoint == 1:
+        if self.config.checkpoint:
             logging.info('Executor checkpointing is enabled. Waiting for agent recovery.')
             await_reregister(self.reregister_signal, self.config.recovery_timeout_ms / 1000, self.stop_signal, self.disconnect_signal)
         else:

--- a/executor/requirements.txt
+++ b/executor/requirements.txt
@@ -1,3 +1,3 @@
 psutil==5.4.1
 pyinstaller==3.3
-pymesos==0.2.15
+pymesos==0.3.9

--- a/executor/setup.py
+++ b/executor/setup.py
@@ -22,7 +22,7 @@ setup(
     test_suite='tests',
     tests_require=test_deps,
     extras_require=extras,
-    install_requires=['psutil==5.4.1', 'pymesos==0.2.15'],
+    install_requires=['psutil==5.4.1', 'pymesos==0.3.9'],
     entry_points={
         'console_scripts': [
             'cook-executor = cook.__main__:main'

--- a/executor/tests/test_config.py
+++ b/executor/tests/test_config.py
@@ -42,7 +42,7 @@ class ConfigTest(unittest.TestCase):
                                    sandbox_directory=sandbox_directory,
                                    shutdown_grace_period=shutdown_grace_period_secs)
 
-        self.assertEqual(checkpoint, config.checkpoint)
+        self.assertEqual(checkpoint, True)
         self.assertEqual(max_bytes_read_per_line, config.max_bytes_read_per_line)
         self.assertEqual(max_message_length, config.max_message_length)
         self.assertEqual(memory_usage_interval_secs, config.memory_usage_interval_secs)
@@ -61,12 +61,12 @@ class ConfigTest(unittest.TestCase):
         environment = {}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(0, config.checkpoint)
+        self.assertEqual(False, config.checkpoint)
         self.assertEqual(4 * 1024, config.max_bytes_read_per_line)
         self.assertEqual(512, config.max_message_length)
         self.assertEqual('executor.progress', config.progress_output_name)
         self.assertEqual('progress: ([0-9]*\\.?[0-9]+), (.*)', config.progress_regex_string)
-        self.assertEqual(5 * 60 * 1000, config.recovery_timeout_ms)
+        self.assertEqual(15 * 60 * 1000, config.recovery_timeout_ms)
         self.assertEqual(1000, config.progress_sample_interval_ms)
         self.assertEqual('', config.sandbox_directory)
         self.assertEqual(2000, config.shutdown_grace_period_ms)
@@ -78,20 +78,20 @@ class ConfigTest(unittest.TestCase):
                        'EXECUTOR_PROGRESS_OUTPUT_FILE': 'progress_file',
                        'MESOS_CHECKPOINT': '1',
                        'MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD': '4secs',
-                       'MESOS_RECOVERY_TIMEOUT': '15mins',
+                       'MESOS_RECOVERY_TIMEOUT': '5mins',
                        'MESOS_SANDBOX': '/sandbox/location',
                        'PROGRESS_REGEX_STRING': 'progress/regex',
                        'PROGRESS_SAMPLE_INTERVAL_MS': '2500'}
         config = cc.initialize_config(environment)
 
-        self.assertEqual(1, config.checkpoint)
+        self.assertEqual(True, config.checkpoint)
         self.assertEqual(1234, config.max_bytes_read_per_line)
         self.assertEqual(1024, config.max_message_length)
         self.assertEqual(120, config.memory_usage_interval_secs)
         self.assertEqual('EXECUTOR_PROGRESS_OUTPUT_FILE', config.progress_output_env_variable)
         self.assertEqual('progress_file', config.progress_output_name)
         self.assertEqual('progress/regex', config.progress_regex_string)
-        self.assertEqual(15 * 60 * 1000, config.recovery_timeout_ms)
+        self.assertEqual(5 * 60 * 1000, config.recovery_timeout_ms)
         self.assertEqual(2500, config.progress_sample_interval_ms)
         self.assertEqual('/sandbox/location', config.sandbox_directory)
         self.assertEqual(4000, config.shutdown_grace_period_ms)

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -947,13 +947,12 @@ class ExecutorTest(unittest.TestCase):
             self.assertFalse(executor.disconnect_signal.isSet())
             self.assertFalse(executor.stop_signal.isSet())
 
-            time.sleep(6)
+            executor.await_completion()
+            logging.info('Task completed')
+
             self.assertFalse(executor.reregister_signal.isSet())
             self.assertTrue(executor.disconnect_signal.isSet())
             self.assertTrue(executor.stop_signal.isSet())
-
-            executor.await_completion()
-            logging.info('Task completed')
 
             if os.path.isfile(output_name):
                 with open(output_name) as f:

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -790,7 +790,7 @@ class ExecutorTest(unittest.TestCase):
             tu.cleanup_output(stdout_name, stderr_name)
             tu.cleanup_file(output_name)
 
-    def test_executor_launch_task_and_disconnect(self):
+    def test_executor_launch_task_and_disconnect_no_checkpointing(self):
 
         task_id = tu.get_random_task_id()
         stdout_name = tu.ensure_directory('build/stdout.{}'.format(task_id))
@@ -833,6 +833,133 @@ class ExecutorTest(unittest.TestCase):
                     file_contents = f.read()
                     self.assertTrue('Start' in file_contents)
                     self.assertTrue('Done' not in file_contents)
+            else:
+                self.fail('{} does not exist.'.format(stderr_name))
+
+            expected_statuses = [{'task_id': {'value': task_id}, 'state': cook.TASK_STARTING},
+                                 {'task_id': {'value': task_id}, 'state': cook.TASK_RUNNING},
+                                 {'task_id': {'value': task_id}, 'state': cook.TASK_KILLED}]
+            tu.assert_statuses(self, expected_statuses, driver.statuses)
+
+            expected_message_0 = {'sandbox-directory': '', 'task-id': task_id, 'type': 'directory'}
+            expected_message_1 = {'exit-code': -15, 'task-id': task_id}
+            tu.assert_messages(self, [expected_message_0, expected_message_1], [], driver.messages)
+        finally:
+            tu.cleanup_output(stdout_name, stderr_name)
+            tu.cleanup_file(output_name)
+
+    def test_executor_reregistration(self):
+
+        task_id = tu.get_random_task_id()
+        stdout_name = tu.ensure_directory('build/stdout.{}'.format(task_id))
+        stderr_name = tu.ensure_directory('build/stderr.{}'.format(task_id))
+        output_name = tu.ensure_directory('build/output.' + str(task_id))
+
+        tu.redirect_stdout_to_file(stdout_name)
+        tu.redirect_stderr_to_file(stderr_name)
+
+        try:
+            config = cc.ExecutorConfig(checkpoint=1, recovery_timeout='5mins')
+            stop_signal = Event()
+            executor = ce.CookExecutor(stop_signal, config)
+
+            driver = tu.FakeMesosExecutorDriver()
+            agent_info = {'id': {'value': 'agent'}}
+            command = 'echo "Start" >> {}; sleep 30; echo "Done." >> {}; '.format(output_name, output_name)
+            task = {'task_id': {'value': task_id},
+                    'data': pm.encode_data(json.dumps({'command': command}).encode('utf8'))}
+
+            executor.launchTask(driver, task)
+
+            # let the process run for up to 10 seconds
+            for _ in range(1000):
+                time.sleep(0.01)
+                if os.path.isfile(output_name):
+                    with open(output_name) as f:
+                        content = f.read()
+                        if 'Start' in content:
+                            break
+
+            executor.disconnected(driver)
+            self.assertFalse(executor.disconnect_signal.isSet())
+            self.assertFalse(executor.stop_signal.isSet())
+
+            old_reregister_signal = executor.reregister_signal
+            executor.reregistered(driver, agent_info)
+            self.assertTrue(old_reregister_signal.isSet())
+            self.assertFalse(executor.reregister_signal.isSet())
+
+            executor.await_completion()
+            logging.info('Task completed')
+
+            if os.path.isfile(output_name):
+                with open(output_name) as f:
+                    file_contents = f.read()
+                    self.assertTrue('Start' in file_contents)
+                    self.assertTrue('Done' in file_contents)
+            else:
+                self.fail('{} does not exist.'.format(stderr_name))
+
+            expected_statuses = [{'task_id': {'value': task_id}, 'state': cook.TASK_STARTING},
+                                 {'task_id': {'value': task_id}, 'state': cook.TASK_RUNNING},
+                                 {'task_id': {'value': task_id}, 'state': cook.TASK_FINISHED}]
+            tu.assert_statuses(self, expected_statuses, driver.statuses)
+
+            expected_message_0 = {'sandbox-directory': '', 'task-id': task_id, 'type': 'directory'}
+            expected_message_1 = {'exit-code': 0, 'task-id': task_id}
+            tu.assert_messages(self, [expected_message_0, expected_message_1], [], driver.messages)
+        finally:
+            tu.cleanup_output(stdout_name, stderr_name)
+            tu.cleanup_file(output_name)
+
+    def test_executor_reregistration_timeout(self):
+        task_id = tu.get_random_task_id()
+        stdout_name = tu.ensure_directory('build/stdout.{}'.format(task_id))
+        stderr_name = tu.ensure_directory('build/stderr.{}'.format(task_id))
+        output_name = tu.ensure_directory('build/output.' + str(task_id))
+
+        tu.redirect_stdout_to_file(stdout_name)
+        tu.redirect_stderr_to_file(stderr_name)
+
+        try:
+            config = cc.ExecutorConfig(checkpoint=1, recovery_timeout='5secs')
+            stop_signal = Event()
+            executor = ce.CookExecutor(stop_signal, config)
+
+            driver = tu.FakeMesosExecutorDriver()
+            agent_info = {'id': {'value': 'agent'}}
+            command = 'echo "Start" >> {}; sleep 30; echo "Done." >> {}; '.format(output_name, output_name)
+            task = {'task_id': {'value': task_id},
+                    'data': pm.encode_data(json.dumps({'command': command}).encode('utf8'))}
+
+            executor.launchTask(driver, task)
+
+            # let the process run for up to 10 seconds
+            for _ in range(1000):
+                time.sleep(0.01)
+                if os.path.isfile(output_name):
+                    with open(output_name) as f:
+                        content = f.read()
+                        if 'Start' in content:
+                            break
+
+            executor.disconnected(driver)
+            self.assertFalse(executor.disconnect_signal.isSet())
+            self.assertFalse(executor.stop_signal.isSet())
+
+            time.sleep(6)
+            self.assertFalse(executor.reregister_signal.isSet())
+            self.assertTrue(executor.disconnect_signal.isSet())
+            self.assertTrue(executor.stop_signal.isSet())
+
+            executor.await_completion()
+            logging.info('Task completed')
+
+            if os.path.isfile(output_name):
+                with open(output_name) as f:
+                    file_contents = f.read()
+                    self.assertTrue('Start' in file_contents)
+                    self.assertFalse('Done' in file_contents)
             else:
                 self.fail('{} does not exist.'.format(stderr_name))
 


### PR DESCRIPTION
## Changes proposed in this PR
- Add support for mesos executor checkpointing to Cook Executor

## Why are we making these changes?
When supported by the agent, this allows the executor to reregister after an agent restarts.