### PR TITLE
Don't launch multiple reconnect threads if disconnected is called many times

### DIFF
--- a/executor/cook/_version.py
+++ b/executor/cook/_version.py
@@ -1,4 +1,4 @@
 # This file is read by setup.py to obtain the version.
 # Be aware that changing the format may break the parsing logic.
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -880,6 +880,7 @@ class ExecutorTest(unittest.TestCase):
                         if 'Start' in content:
                             break
 
+            self.assertEqual(None, executor.reregister_signal)
             executor.disconnected(driver)
             self.assertFalse(executor.disconnect_signal.isSet())
             self.assertFalse(executor.stop_signal.isSet())
@@ -887,7 +888,7 @@ class ExecutorTest(unittest.TestCase):
             old_reregister_signal = executor.reregister_signal
             executor.reregistered(driver, agent_info)
             self.assertTrue(old_reregister_signal.isSet())
-            self.assertFalse(executor.reregister_signal.isSet())
+            self.assertEqual(None, executor.reregister_signal)
 
             executor.await_completion()
             logging.info('Task completed')


### PR DESCRIPTION
## Changes proposed in this PR
- Only launch one thread on disconnect until reregistered is called.

## Why are we making these changes?
It's wasteful to create the extra threads, and it pollutes the logs.
