### PR TITLE
Change cook executor to be more container-friendly

### DIFF
--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -35,9 +35,10 @@ def main(args=None):
     environment = os.environ
     executor_id = environment.get('MESOS_EXECUTOR_ID', '1')
     log_level = environment.get('EXECUTOR_LOG_LEVEL', 'INFO')
+    sandbox_directory = environment.get('MESOS_SANDBOX', '.')
 
     logging.basicConfig(level = log_level,
-                        filename = 'executor.log',
+                        filename = os.path.join(sandbox_directory, 'executor.log'),
                         format='%(asctime)s %(levelname)s %(message)s')
     logging.info('Starting Cook Executor {} for executor-id={}'.format(__version__, executor_id))
     logging.info('Log level is {}'.format(log_level))

--- a/executor/cook/config.py
+++ b/executor/cook/config.py
@@ -36,6 +36,7 @@ class ExecutorConfig(object):
                  max_bytes_read_per_line=1024,
                  max_message_length=512,
                  memory_usage_interval_secs=15,
+                 mesos_directory='',
                  progress_output_env_variable=DEFAULT_PROGRESS_FILE_ENV_VARIABLE,
                  progress_output_name='stdout',
                  progress_regex_string='',
@@ -47,6 +48,7 @@ class ExecutorConfig(object):
         self.max_bytes_read_per_line = max_bytes_read_per_line
         self.max_message_length = max_message_length
         self.memory_usage_interval_secs = memory_usage_interval_secs
+        self.mesos_directory = mesos_directory
         self.progress_output_env_variable = progress_output_env_variable
         self.progress_output_name = progress_output_name
         self.progress_regex_string = progress_regex_string
@@ -72,6 +74,7 @@ def initialize_config(environment):
     checkpoint = int(environment.get('MESOS_CHECKPOINT', '0'))
     executor_id = environment.get('MESOS_EXECUTOR_ID', 'executor')
     sandbox_directory = environment.get('MESOS_SANDBOX', '')
+    mesos_directory = environment.get('MESOS_DIRECTORY', '')
     default_progress_output_key = 'EXECUTOR_DEFAULT_PROGRESS_OUTPUT_NAME'
     default_progress_output_name = environment.get(default_progress_output_key, '{}.progress'.format(executor_id))
     if sandbox_directory:
@@ -103,12 +106,14 @@ def initialize_config(environment):
     logging.info('Progress regex is {}'.format(progress_regex_string))
     logging.info('Progress sample interval is {}'.format(progress_sample_interval_ms))
     logging.info('Sandbox location is {}'.format(sandbox_directory))
+    logging.info('Mesos directory is {}'.format(mesos_directory))
     logging.info('Shutdown grace period is {}'.format(shutdown_grace_period))
 
     return ExecutorConfig(checkpoint=checkpoint,
                           max_bytes_read_per_line=max_bytes_read_per_line,
                           max_message_length=max_message_length,
                           memory_usage_interval_secs=memory_usage_interval_secs,
+                          mesos_directory=mesos_directory,
                           progress_output_env_variable=progress_output_env_variable,
                           progress_output_name=progress_output_name,
                           progress_regex_string=progress_regex_string,

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -311,7 +311,8 @@ def manage_task(driver, task, stop_signal, completed_signal, config):
         # not yet started to run the task
         status_updater.update_status(cook.TASK_STARTING)
 
-        sandbox_message = {'sandbox-directory': config.sandbox_directory, 'task-id': task_id, 'type': 'directory'}
+        # Use MESOS_DIRECTORY instead of MESOS_SANDBOX, to report the sandbox location outside of the container
+        sandbox_message = {'sandbox-directory': config.mesos_directory, 'task-id': task_id, 'type': 'directory'}
         send_message(driver, inner_os_error_handler, sandbox_message)
 
         environment = retrieve_process_environment(config, os.environ)

--- a/executor/tests/test_config.py
+++ b/executor/tests/test_config.py
@@ -23,6 +23,7 @@ class ConfigTest(unittest.TestCase):
         max_bytes_read_per_line = 16 * 1024
         max_message_length = 300
         memory_usage_interval_secs = 150
+        mesos_directory = '/mesos/directory'
         progress_output_env_variable = 'PROGRESS_OUTPUT_ENV_VARIABLE'
         progress_output_name = 'stdout_name'
         progress_regex_string = 'some-regex-string'
@@ -34,6 +35,7 @@ class ConfigTest(unittest.TestCase):
                                    max_bytes_read_per_line=max_bytes_read_per_line,
                                    max_message_length=max_message_length,
                                    memory_usage_interval_secs=memory_usage_interval_secs,
+                                   mesos_directory=mesos_directory,
                                    progress_output_env_variable=progress_output_env_variable,
                                    progress_output_name=progress_output_name,
                                    progress_regex_string=progress_regex_string,
@@ -46,6 +48,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(max_bytes_read_per_line, config.max_bytes_read_per_line)
         self.assertEqual(max_message_length, config.max_message_length)
         self.assertEqual(memory_usage_interval_secs, config.memory_usage_interval_secs)
+        self.assertEqual(mesos_directory, config.mesos_directory)
         self.assertEqual(progress_output_env_variable, config.progress_output_env_variable)
         self.assertEqual(progress_output_name, config.progress_output_name)
         self.assertEqual(progress_regex_string, config.progress_regex_string)
@@ -64,6 +67,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(False, config.checkpoint)
         self.assertEqual(4 * 1024, config.max_bytes_read_per_line)
         self.assertEqual(512, config.max_message_length)
+        self.assertEqual('', config.mesos_directory)
         self.assertEqual('executor.progress', config.progress_output_name)
         self.assertEqual('progress: ([0-9]*\\.?[0-9]+), (.*)', config.progress_regex_string)
         self.assertEqual(15 * 60 * 1000, config.recovery_timeout_ms)
@@ -77,6 +81,7 @@ class ConfigTest(unittest.TestCase):
                        'EXECUTOR_MEMORY_USAGE_INTERVAL_SECS': '120',
                        'EXECUTOR_PROGRESS_OUTPUT_FILE': 'progress_file',
                        'MESOS_CHECKPOINT': '1',
+                       'MESOS_DIRECTORY': '/mesos/directory',
                        'MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD': '4secs',
                        'MESOS_RECOVERY_TIMEOUT': '5mins',
                        'MESOS_SANDBOX': '/sandbox/location',
@@ -88,6 +93,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(1234, config.max_bytes_read_per_line)
         self.assertEqual(1024, config.max_message_length)
         self.assertEqual(120, config.memory_usage_interval_secs)
+        self.assertEqual('/mesos/directory', config.mesos_directory)
         self.assertEqual('EXECUTOR_PROGRESS_OUTPUT_FILE', config.progress_output_env_variable)
         self.assertEqual('progress_file', config.progress_output_name)
         self.assertEqual('progress/regex', config.progress_regex_string)


### PR DESCRIPTION
## Changes proposed in this PR
- Report MESOS_DIRECTORY to cook as the sandbox location instead of MESOS_SANDBOX. This is the root filesystem path instead of the path in the container
- Explicitly write executor.log in the MESOS_SANDBOX, not the current working directory

## Why are we making these changes?
These make cook executor behave better when in a container.

