### PR TITLE
Uses pool-selection plugin config to determine pool attribute

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1791,6 +1791,7 @@ class CookTest(util.CookTest):
 
     def test_balanced_host_constraint_can_place(self):
         num_hosts = util.num_hosts_to_consider(self.cook_url, self.mesos_url)
+        self.assertLessEqual(2, num_hosts)
         minimum_hosts = min(int(os.getenv('COOK_TEST_BALANCED_CONSTRAINT_NUM_HOSTS', 10)), num_hosts)
         self.logger.info(f'Setting minimum hosts to {minimum_hosts}')
         group = {'uuid': str(uuid.uuid4()),


### PR DESCRIPTION
## Changes proposed in this PR

- using the attribute name configured in the pool-selection plugin if present

## Why are we making these changes?

Without this change, environments that use an attribute name other than `cook-pool` will see test failures.
