### PR TITLE
Add support for EXECUTOR_RESET_VARS

### DIFF
--- a/executor/cook/config.py
+++ b/executor/cook/config.py
@@ -41,6 +41,7 @@ class ExecutorConfig(object):
                  progress_regex_string='',
                  progress_sample_interval_ms=100,
                  recovery_timeout='15mins',
+                 reset_vars=[],
                  sandbox_directory='',
                  shutdown_grace_period='1secs'):
         self.checkpoint = checkpoint != 0
@@ -52,6 +53,7 @@ class ExecutorConfig(object):
         self.progress_regex_string = progress_regex_string
         self.progress_sample_interval_ms = progress_sample_interval_ms
         self.recovery_timeout_ms = ExecutorConfig.parse_time_ms(recovery_timeout)
+        self.reset_vars=reset_vars
         self.sandbox_directory = sandbox_directory
         self.shutdown_grace_period_ms = ExecutorConfig.parse_time_ms(shutdown_grace_period)
 
@@ -92,6 +94,8 @@ def initialize_config(environment):
     progress_regex_string = environment.get('PROGRESS_REGEX_STRING', 'progress: ([0-9]*\.?[0-9]+), (.*)')
     progress_sample_interval_ms = max(int(environment.get('PROGRESS_SAMPLE_INTERVAL_MS', 1000)), 100)
     recovery_timeout = environment.get('MESOS_RECOVERY_TIMEOUT', '15mins')
+    reset_vars = [v for v in environment.get('EXECUTOR_RESET_VARS', '').split(',')
+                  if len(v) > 0]
     sandbox_directory = environment.get('MESOS_SANDBOX', '')
     shutdown_grace_period = environment.get('MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD', '2secs')
 
@@ -102,6 +106,7 @@ def initialize_config(environment):
     logging.info('Progress output file is {}'.format(progress_output_name))
     logging.info('Progress regex is {}'.format(progress_regex_string))
     logging.info('Progress sample interval is {}'.format(progress_sample_interval_ms))
+    logging.info('Reset vars are {}'.format(reset_vars))
     logging.info('Sandbox location is {}'.format(sandbox_directory))
     logging.info('Shutdown grace period is {}'.format(shutdown_grace_period))
 
@@ -114,5 +119,6 @@ def initialize_config(environment):
                           progress_regex_string=progress_regex_string,
                           progress_sample_interval_ms=progress_sample_interval_ms,
                           recovery_timeout=recovery_timeout,
+                          reset_vars=reset_vars,
                           sandbox_directory=sandbox_directory,
                           shutdown_grace_period=shutdown_grace_period)

--- a/executor/tests/test_config.py
+++ b/executor/tests/test_config.py
@@ -28,6 +28,7 @@ class ConfigTest(unittest.TestCase):
         progress_regex_string = 'some-regex-string'
         progress_sample_interval_ms = 100
         recovery_timeout = '5mins'
+        reset_vars = ['a', 'b']
         sandbox_directory = '/location/to/task/sandbox/task_id'
         shutdown_grace_period_secs = '5secs'
         config = cc.ExecutorConfig(checkpoint=checkpoint,
@@ -39,6 +40,7 @@ class ConfigTest(unittest.TestCase):
                                    progress_regex_string=progress_regex_string,
                                    progress_sample_interval_ms=progress_sample_interval_ms,
                                    recovery_timeout=recovery_timeout,
+                                   reset_vars=reset_vars,
                                    sandbox_directory=sandbox_directory,
                                    shutdown_grace_period=shutdown_grace_period_secs)
 
@@ -51,6 +53,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(progress_regex_string, config.progress_regex_string)
         self.assertEqual(progress_sample_interval_ms, config.progress_sample_interval_ms)
         self.assertEqual(5 * 60 * 1000, config.recovery_timeout_ms)
+        self.assertEqual(reset_vars, reset_vars)
         self.assertEqual(sandbox_directory, config.sandbox_directory)
         self.assertEqual(5000, config.shutdown_grace_period_ms)
         self.assertEqual(os.path.join(sandbox_directory, 'foo.bar'), config.sandbox_file('foo.bar'))
@@ -68,6 +71,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual('progress: ([0-9]*\\.?[0-9]+), (.*)', config.progress_regex_string)
         self.assertEqual(15 * 60 * 1000, config.recovery_timeout_ms)
         self.assertEqual(1000, config.progress_sample_interval_ms)
+        self.assertEqual([], config.reset_vars)
         self.assertEqual('', config.sandbox_directory)
         self.assertEqual(2000, config.shutdown_grace_period_ms)
 
@@ -76,6 +80,7 @@ class ConfigTest(unittest.TestCase):
                        'EXECUTOR_MAX_MESSAGE_LENGTH': '1024',
                        'EXECUTOR_MEMORY_USAGE_INTERVAL_SECS': '120',
                        'EXECUTOR_PROGRESS_OUTPUT_FILE': 'progress_file',
+                       'EXECUTOR_RESET_VARS': 'VAR_A,VAR_B',
                        'MESOS_CHECKPOINT': '1',
                        'MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD': '4secs',
                        'MESOS_RECOVERY_TIMEOUT': '5mins',
@@ -93,6 +98,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual('progress/regex', config.progress_regex_string)
         self.assertEqual(5 * 60 * 1000, config.recovery_timeout_ms)
         self.assertEqual(2500, config.progress_sample_interval_ms)
+        self.assertEqual(['VAR_A', 'VAR_B'], config.reset_vars)
         self.assertEqual('/sandbox/location', config.sandbox_directory)
         self.assertEqual(4000, config.shutdown_grace_period_ms)
 

--- a/executor/tests/test_executor.py
+++ b/executor/tests/test_executor.py
@@ -25,6 +25,12 @@ def sleep_and_set_stop_signal_task(stop_signal, wait_seconds):
     timer.daemon = True
     timer.start()
 
+def make_task_env(env_dict):
+    environment = []
+    for (key, value) in env_dict.items():
+        environment.append({'type': 'VALUE', 'name': key, 'value': str(value)})
+    return {'executor': {'command': {'environment': {'variables': environment}}}}
+
 
 class ExecutorTest(unittest.TestCase):
     def test_get_task_id(self):
@@ -315,13 +321,14 @@ class ExecutorTest(unittest.TestCase):
 
     def test_retrieve_process_environment(self):
         self.assertEqual({'EXECUTOR_PROGRESS_OUTPUT_FILE': 'stdout'},
-                         ce.retrieve_process_environment(cc.ExecutorConfig(), {}))
+                         ce.retrieve_process_environment(cc.ExecutorConfig(), make_task_env({}), {}))
         self.assertEqual({'CUSTOM_PROGRESS_OUTPUT_FILE': 'stdout',
                           'FOO': 'BAR',
                           'MESOS_SANDBOX': '/path/to/sandbox',
                           'PROGRESS_OUTPUT_FILE': 'executor.progress'},
                          ce.retrieve_process_environment(
                              cc.ExecutorConfig(progress_output_env_variable='CUSTOM_PROGRESS_OUTPUT_FILE'),
+                             make_task_env({}),
                              {'FOO': 'BAR',
                               'MESOS_SANDBOX': '/path/to/sandbox',
                               'PROGRESS_OUTPUT_FILE': 'executor.progress'}))
@@ -330,6 +337,7 @@ class ExecutorTest(unittest.TestCase):
                          ce.retrieve_process_environment(
                              cc.ExecutorConfig(progress_output_env_variable='CUSTOM_PROGRESS_OUTPUT_FILE',
                                                progress_output_name='custom.progress'),
+                             make_task_env({}),
                              {'CUSTOM_PROGRESS_OUTPUT_FILE': 'executor.progress',
                               'EXECUTOR_PROGRESS_OUTPUT_FILE_ENV': 'CUSTOM_PROGRESS_OUTPUT_FILE'}))
         self.assertEqual({'CUSTOM_PROGRESS_OUTPUT_FILE': 'custom.progress',
@@ -338,9 +346,19 @@ class ExecutorTest(unittest.TestCase):
                          ce.retrieve_process_environment(
                              cc.ExecutorConfig(progress_output_env_variable='CUSTOM_PROGRESS_OUTPUT_FILE',
                                                progress_output_name='custom.progress'),
+                             make_task_env({}),
                              {'CUSTOM_PROGRESS_OUTPUT_FILE': 'executor.progress',
                               'EXECUTOR_PROGRESS_OUTPUT_FILE_ENV': 'CUSTOM_PROGRESS_OUTPUT_FILE',
                               'PROGRESS_OUTPUT_FILE': 'stdout'}))
+        self.assertEqual({'EXECUTOR_PROGRESS_OUTPUT_FILE': 'stdout',
+                          'MY_RESET_VAR': 'myval',
+                          'ANOTHER_VAR': 'another'},
+                         ce.retrieve_process_environment(
+                             cc.ExecutorConfig(reset_vars=['MY_RESET_VAR', 'ANOTHER_RESET_VAR', 'A_MISSING_VAR']),
+                             make_task_env({'MY_RESET_VAR': 'myval'}),
+                             {'MY_RESET_VAR': 'badval',
+                              'ANOTHER_VAR': 'another',
+                              'ANOTHER_RESET_VAR': 'get rid of me'}))
 
     def manage_task_runner(self, command, assertions_fn, stop_signal=None, task_id=None, config=None, driver=None):
 
@@ -723,6 +741,7 @@ class ExecutorTest(unittest.TestCase):
                                         'progress_output_name': progress_name,
                                         'progress_regex_string': '\^\^\^\^JOB-PROGRESS:\s+([0-9]*\.?[0-9]+)($|\s+.*)',
                                         'progress_sample_interval_ms': 10,
+                                        'reset_vars': [],
                                         'sandbox_directory': '/sandbox/directory/for/{}'.format(task_id),
                                         'shutdown_grace_period_ms': 60000,
                                         'stderr_file': stderr_name,

--- a/executor/tests/utils.py
+++ b/executor/tests/utils.py
@@ -85,7 +85,8 @@ def assert_messages(test_case, expected_process_messages, expected_progress_mess
 
 def assert_statuses(test_case, expected_statuses, driver_statuses):
     logging.info('Statuses: {}'.format(driver_statuses))
-    test_case.assertEqual(len(expected_statuses), len(driver_statuses))
+    test_case.assertEqual(len(expected_statuses), len(driver_statuses),
+                          'Expected: {} but got {}'.format(expected_statuses, driver_statuses))
     for i in range(1, len(expected_statuses)):
         expected_status = expected_statuses[i]
         actual_status = driver_statuses[i]


### PR DESCRIPTION
## Changes proposed in this PR
- Add support for specifying a list of environment variables to clear in cook executor with `EXECUTOR_RESET_VARS`

## Why are we making these changes?
Some environment variables may be set as part of starting the cook executor itself, which we would prefer not to propagate to the child process. This environment variable allows setting a list of environment variables to clear.

