### PR TITLE
Allow running cook executor in docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,12 @@ matrix:
       before_script: cd integration && ./travis/prepare_integration.sh
       script: ./travis/run_integration.sh --executor=cook
 
+    - name: 'Cook Scheduler integration tests with Cook Executor and Docker'
+      services: docker
+      install: sudo ./travis/install_mesos.sh
+      before_script: cd integration && ./travis/prepare_integration.sh
+      script: ./travis/run_integration.sh --executor=cook --image=python:3.5
+
     - name: 'Cook Scheduler integration tests with no pools and with HTTP Basic Auth'
       services: docker
       install: sudo ./travis/install_mesos.sh
@@ -67,10 +73,6 @@ matrix:
       install: sudo ./travis/install_mesos.sh
       before_script: cd simulator && ./travis/prepare_simulation.sh
       script: ./travis/run_simulation.sh
-
-    - name: 'Cook Scheduler benchmark tests'
-      before_script: cd scheduler && ./travis/setup.sh
-      script: lein with-profile +test test :benchmark
 
     - name: 'Cook Executor tests'
       before_script: cd executor && ./travis/setup.sh

--- a/executor/cook/executor.py
+++ b/executor/cook/executor.py
@@ -425,6 +425,10 @@ class CookExecutor(pm.Executor):
 
         env = os.environ
         if 'EXECUTOR_TEST_EXIT' in env:
+            # When running in docker, if the container exits too quickly it's logged in mesos as container launch failed
+            # instead of mesos executor terminated. This sleep ensures that we have the correct reason code for our
+            # integration tests.
+            time.sleep(5)
             exit_code = int(env['EXECUTOR_TEST_EXIT'])
             logging.warn('Exiting with code {} from EXECUTOR_TEST_EXIT environment variable'.
                          format(exit_code))

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -2184,7 +2184,7 @@ def dummy_cat_text(_, __, ___):
     def test_submit_docker(self):
         docker_image = util.docker_image()
         self.assertIsNotNone(docker_image)
-        cp, uuids = cli.submit('sleep 600', self.cook_url, submit_flags=f'--docker-image {docker_image}')
+        cp, uuids = cli.submit('sleep 600', self.cook_url, submit_flags=f'--docker-image {docker_image} --executor mesos')
         self.assertEqual(0, cp.returncode, cp.stderr)
         try:
             job = util.load_job(self.cook_url, uuids[0])

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -13,6 +13,7 @@ COOK_AUTH=one-user
 COOK_EXECUTOR=mesos
 COOK_POOLS=on
 CONFIG_FILE=scheduler_travis_config.edn
+COOK_TEST_DOCKER_IMAGE=""
 
 while (( $# > 0 )); do
   case "$1" in
@@ -26,6 +27,10 @@ while (( $# > 0 )); do
       ;;
     --pools=*)
       COOK_POOLS="${1#--pools=}"
+      shift
+      ;;
+    --image=*)
+      COOK_TEST_DOCKER_IMAGE="${1#--image=}"
       shift
       ;;
     *)
@@ -52,6 +57,7 @@ case "$COOK_EXECUTOR" in
     COOK_EXECUTOR_COMMAND="${TRAVIS_BUILD_DIR}/travis/cook-executor-local/cook-executor-local"
     # Build cook-executor
     ${TRAVIS_BUILD_DIR}/travis/build_cook_executor.sh
+    # Run with docker
     ;;
   mesos)
     COOK_EXECUTOR_COMMAND=""
@@ -124,6 +130,9 @@ lein exec -p datomic/data/seed_running_jobs.clj ${COOK_DATOMIC_URI_1}
 ## on travis, ports on 172.17.0.1 are bindable from the host OS, and are also
 ## available for processes inside minimesos containers to connect to
 export COOK_EXECUTOR_COMMAND=${COOK_EXECUTOR_COMMAND}
+if [[ ! -z "${COOK_TEST_DOCKER_IMAGE}" ]]; then
+    export COOK_TEST_DOCKER_IMAGE=${COOK_TEST_DOCKER_IMAGE}
+fi
 # Start one cook listening on port 12321, this will be the master of the "cook-framework-1" framework
 LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12321 COOK_SSL_PORT=12322 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12321.log" COOK_DEFAULT_POOL=${DEFAULT_POOL} lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
 # Start a second cook listening on port 22321, this will be the master of the "cook-framework-2" framework

--- a/scheduler/bin/submit-docker.sh
+++ b/scheduler/bin/submit-docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+UUID=$(uuidgen)
+
+curl -XPOST -H"Content-Type: application/json" http://localhost:12321/rawscheduler -d"{\"jobs\": [{\"uuid\": \"$UUID\", \"env\": {\"EXECUTOR_TEST_EXIT\": \"1\"}, \"executor\": \"cook\", \"mem\": 128, \"cpus\": 1, \"command\": \"echo progress: 50 test_progress && exit 0\", \"max_retries\": 1, \"container\": {\"type\": \"DOCKER\", \"docker\": {\"image\": \"python:3.5\", \"network\": \"HOST\", \"force-pull-image\": false}, \"volumes\": [{\"container-path\": \"/Users/paul/src/Cook/executor/dist\", \"host-path\": \"/Users/paul/src/Cook/executor/dist\"}]}}]}"

--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -381,8 +381,8 @@
 
             (= executor-key :container-cook-executor)
             (assoc :executor (assoc executor :name cook-executor-name
-                                    :source cook-executor-source
-                                    :container container))
+                                             :source cook-executor-source
+                                             :container container))
 
             (= executor-key :custom-executor)
             (assoc :executor (assoc executor :name custom-executor-name)))))

--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -84,8 +84,7 @@
         ;; If the custom-executor attr isn't set, we default to using a custom
         ;; executor in order to support jobs submitted before we added this field
         custom-executor? (use-custom-executor? job-ent)
-        cook-executor? (and (not container) ;;TODO support cook-executor in containers
-                            (use-cook-executor? job-ent))
+        cook-executor? (use-cook-executor? job-ent)
         group-uuid (util/job-ent->group-uuid job-ent)
         environment (cond-> (assoc (util/job-ent->env job-ent)
                               "COOK_INSTANCE_UUID" task-id
@@ -104,6 +103,7 @@
                  :value (if cook-executor? (:command (config/executor-config)) (:job/command job-ent))}
         ;; executor-key configure whether this is a command or custom executor
         executor-key (cond
+                       (and container cook-executor?) :container-cook-executor
                        (and container (not custom-executor?)) :container-command-executor
                        (and container custom-executor?) :container-executor
                        custom-executor? :custom-executor
@@ -113,6 +113,7 @@
         executor (case executor-key
                    :command-executor :executor/mesos
                    :container-command-executor :executor/mesos
+                   :container-cook-executor :executor/cook
                    :cook-executor :executor/cook
                    :executor/custom)
         data (.getBytes
@@ -377,6 +378,11 @@
             (= executor-key :cook-executor)
             (assoc :executor (assoc executor :name cook-executor-name
                                              :source cook-executor-source))
+
+            (= executor-key :container-cook-executor)
+            (assoc :executor (assoc executor :name cook-executor-name
+                                    :source cook-executor-source
+                                    :container container))
 
             (= executor-key :custom-executor)
             (assoc :executor (assoc executor :name custom-executor-name)))))


### PR DESCRIPTION
## Changes proposed in this PR
- Allow jobs to run in a docker container using Cook Executor

## Why are we making these changes?
This will allow jobs using containers to utilize executor-specific features like exit code and progress.

