### PR TITLE
Add file_url to job instances

### DIFF
--- a/scheduler/docs/scheduler-rest-api.adoc
+++ b/scheduler/docs/scheduler-rest-api.adoc
@@ -193,6 +193,7 @@ Where each instance contains a map with the following keys:
 |`executor_id` | Mesos executor_id
 |`status` | current status of the instance; could be `unknown`, `running`, `success`, or `failed`
 |`output_url` | See <<using_output_url>>, (will be absent if the agent the job was run on is unable to return the necessary data, e.g. it is offline)
+|`file_url`| See <<using_file_url>>. This is not a required field, and will only be returned if supported by the scheduler.
 |====
 
 [[using_output_url]]
@@ -211,6 +212,15 @@ Rather than always specifying `offset=0`, you can use whatever `offset` and `len
 Since the returned data always includes its length, a client can maintain a local offset and repeatedly poll for only the latest data.
 
 Don't forget that Mesos periodically garbage collects output directories--jobs should archive their results to a longer-term data store if longer-term access is neccessary.
+====
+
+[[using_file_url]]
+.Using the `file_url`
+[TIP]
+====
+The `file_url` is an optional alternative API for accessing the files stored in an instance's sandbox. If supported by Cook, each instance will have a `file_url` variable.
+To access a file, you should modify the url by appending the name of the file you want to access: `"$file_url/filename.txt"`
+The API will return the raw contents of that file.
 ====
 
 The response will include Job details listed below:

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -28,6 +28,8 @@
             [cook.plugins.completion]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.submission namespace.
             [cook.plugins.submission]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.file namespace.
+            [cook.plugins.file]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.launch namespace.
             [cook.plugins.launch]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.pool namespace.

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -50,3 +50,7 @@
 (defprotocol PoolSelector
   (select-pool [this offer]
     "Returns the pool name as a string for the offer"))
+
+(defprotocol FileUrlGenerator
+  (file-url [this instance]
+    "Returns the file URL endpoint for the instance"))

--- a/scheduler/src/cook/plugins/file.clj
+++ b/scheduler/src/cook/plugins/file.clj
@@ -1,0 +1,27 @@
+(ns cook.plugins.file
+  (:require [clojure.tools.logging :as log]
+            [cook.config :as config]
+            [cook.plugins.definitions :refer [FileUrlGenerator]]
+            [cook.plugins.util]
+            [mount.core :as mount]))
+
+(defrecord NilFileUrlPlugin []
+  FileUrlGenerator
+  (file-url [this instance]
+    nil))
+
+(defn create-plugin-object
+  "Returns the configured FileUrlPlugin, or a NilFileUrlPlugin if none is defined."
+  [config]
+  (let [pool-selection (get-in config [:settings :plugins :file-url])
+        factory-fn (:factory-fn pool-selection)]
+    (if factory-fn
+      (do
+        (log/info "Creating file url plugin with" factory-fn)
+        (if-let [resolved-fn (cook.plugins.util/resolve-symbol (symbol factory-fn))]
+          (resolved-fn config)
+          (throw (ex-info (str "Unable to resolve factory fn " factory-fn)))))
+      (NilFileUrlPlugin.))))
+
+(mount/defstate plugin
+  :start (create-plugin-object config/config))

--- a/scheduler/src/cook/plugins/file.clj
+++ b/scheduler/src/cook/plugins/file.clj
@@ -13,8 +13,8 @@
 (defn create-plugin-object
   "Returns the configured FileUrlPlugin, or a NilFileUrlPlugin if none is defined."
   [config]
-  (let [pool-selection (get-in config [:settings :plugins :file-url])
-        factory-fn (:factory-fn pool-selection)]
+  (let [file-url (get-in config [:settings :plugins :file-url])
+        factory-fn (:factory-fn file-url)]
     (if factory-fn
       (do
         (log/info "Creating file url plugin with" factory-fn)

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -54,6 +54,7 @@
                            #'cook.config/config
                            #'cook.rate-limit/job-launch-rate-limiter
                            #'cook.rate-limit/global-job-launch-rate-limiter
+                           #'cook.plugins.file/plugin
                            #'cook.plugins.launch/plugin-object
                            #'cook.plugins.pool/plugin
                            #'cook.plugins.submission/plugin-object)))


### PR DESCRIPTION
## Changes proposed in this PR
- Adds a new field, `file_url`, on job instances and a plugin definition to generate a file url for an instance.

## Why are we making these changes?
The Mesos file API can be cumbersome and is Mesos-specific. This allows us to migrate to a simpler API which could be implemented for another scheduler, like k8s.

