### PR TITLE
Use pool selection attribute in slave_pool

### DIFF
--- a/integration/tests/cook/test_pools.py
+++ b/integration/tests/cook/test_pools.py
@@ -54,7 +54,7 @@ class PoolsCookTest(util.CookTest):
                                                           command='sleep 600', pool=pool_name)
                     all_job_uuids.append(filling_job_uuid)
                     instance = util.wait_for_running_instance(self.cook_url, filling_job_uuid)
-                    slave_pool = util.slave_pool(self.mesos_url, instance['hostname'])
+                    slave_pool = util.slave_pool(self.cook_url, self.mesos_url, instance['hostname'])
                     self.assertEqual(pool_name, slave_pool)
 
                     # Submit a job that should not get scheduled

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1162,12 +1162,14 @@ def slave_cpus(mesos_url, hostname):
     slave_cpus = next(s['unreserved_resources']['cpus'] for s in slaves if s['hostname'] == hostname)
     return slave_cpus
 
+def _pool_attribute_name(cook_url):
+    pool_selection_plugin_config = settings(cook_url).get('plugins', {}).get('pool-selection', {})
+    return pool_selection_plugin_config.get('attribute-name', None) or 'cook-pool'
 
 def slave_pool(cook_url, mesos_url, hostname):
     """Returns the pool of the specified Mesos agent, or None if the agent doesn't have the attribute"""
     slaves = get_mesos_state(mesos_url)['slaves']
-    pool_selection_plugin_config = settings(cook_url).get('plugins', {}).get('pool-selection', {})
-    attribute_name = pool_selection_plugin_config.get('attribute-name', None) or 'cook-pool'
+    attribute_name = _pool_attribute_name(cook_url)
     pool = next(s.get('attributes', {}).get(attribute_name, None) for s in slaves if s['hostname'] == hostname)
     return pool
 
@@ -1236,8 +1238,7 @@ def hosts_to_consider(cook_url, mesos_url):
     state = get_mesos_state(mesos_url)
     slaves = state['slaves']
     pool = default_pool(cook_url)
-    pool_selection_plugin_config = settings(cook_url).get('plugins', {}).get('pool-selection', {})
-    attribute_name = pool_selection_plugin_config.get('attribute-name', None) or 'cook-pool'
+    attribute_name = _pool_attribute_name(cook_url)
     slaves = [s for s in slaves if s['attributes'].get(attribute_name, None) == pool] if pool else slaves
     num_to_log = min(len(slaves), 10)
     logging.info(f'First {num_to_log} hosts to consider: {json.dumps(slaves[:num_to_log], indent=2)}')

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1163,10 +1163,12 @@ def slave_cpus(mesos_url, hostname):
     return slave_cpus
 
 
-def slave_pool(mesos_url, hostname):
+def slave_pool(cook_url, mesos_url, hostname):
     """Returns the pool of the specified Mesos agent, or None if the agent doesn't have the attribute"""
     slaves = get_mesos_state(mesos_url)['slaves']
-    pool = next(s.get('attributes', {}).get('cook-pool', None) for s in slaves if s['hostname'] == hostname)
+    pool_selection_plugin_config = settings(cook_url).get('plugins', {}).get('pool-selection', {})
+    attribute_name = pool_selection_plugin_config.get('attribute-name', None) or 'cook-pool'
+    pool = next(s.get('attributes', {}).get(attribute_name, None) for s in slaves if s['hostname'] == hostname)
     return pool
 
 


### PR DESCRIPTION
## Changes proposed in this PR
- Use pool selection attribute in `slave_pool`

## Why are we making these changes?
Fixes the `test_pool_scheduling` integration test in environments where the pool selection plugin is used.

