### PR TITLE
Add a SIGUSR1 handler to print thread stack traces

### DIFF
--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -4,6 +4,7 @@
 This module configures logging and starts the executor's driver thread.
 """
 
+import faulthandler
 import logging
 import signal
 import sys
@@ -65,6 +66,11 @@ def main(args=None):
 
     signal.signal(signal.SIGINT, handle_interrupt)
     signal.signal(signal.SIGTERM, handle_interrupt)
+
+    def dump_traceback(signal, frame):
+        faulthandler.dump_traceback()
+
+    signal.signal(signal.SIGUSR1, dump_traceback)
 
     try:
         executor = ce.CookExecutor(stop_signal, config)

--- a/executor/cook/_version.py
+++ b/executor/cook/_version.py
@@ -1,4 +1,4 @@
 # This file is read by setup.py to obtain the version.
 # Be aware that changing the format may break the parsing logic.
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"


### PR DESCRIPTION
## Changes proposed in this PR
- Has the executor listen for `SIGUSR1` to print stack traces to stderr

## Why are we making these changes?
Allows debugging executors while running.

Example output:
```Thread 0x0000700007ac7000 (most recent call first):
  File "threading.py", line 295 in wait
  File "threading.py", line 551 in wait
  File "cook/executor.py", line 175 in process_stop_signal
  File "threading.py", line 864 in run
  File "threading.py", line 916 in _bootstrap_inner
  File "threading.py", line 884 in _bootstrap

Thread 0x00007000075c4000 (most recent call first):
  File "cook/progress.py", line 211 in tail
  File "cook/progress.py", line 279 in retrieve_progress_states
  File "cook/progress.py", line 349 in track_progress
  File "threading.py", line 864 in run
  File "threading.py", line 916 in _bootstrap_inner
  File "threading.py", line 884 in _bootstrap

Thread 0x00007000070c1000 (most recent call first):
  File "cook/progress.py", line 211 in tail
  File "cook/progress.py", line 279 in retrieve_progress_states
  File "cook/progress.py", line 349 in track_progress
  File "threading.py", line 864 in run
  File "threading.py", line 916 in _bootstrap_inner
  File "threading.py", line 884 in _bootstrap

Thread 0x0000700006bbe000 (most recent call first):
  File "subprocess.py", line 1404 in _try_wait
  File "subprocess.py", line 1457 in wait
  File "cook/executor.py", line 185 in await_process_completion
  File "cook/executor.py", line 367 in manage_task
  File "threading.py", line 864 in run
  File "threading.py", line 916 in _bootstrap_inner
  File "threading.py", line 884 in _bootstrap

Thread 0x00007000066bb000 (most recent call first):
  File "site-packages/pymesos/process.py", line 312 in _run
  File "threading.py", line 864 in run
  File "threading.py", line 916 in _bootstrap_inner
  File "threading.py", line 884 in _bootstrap

Thread 0x00007000061b8000 (most recent call first):
  File "threading.py", line 299 in wait
  File "threading.py", line 551 in wait
  File "threading.py", line 1180 in run
  File "threading.py", line 916 in _bootstrap_inner
  File "threading.py", line 884 in _bootstrap