### PR TITLE
Limit the number of outstanding lookup-key! requests.

### DIFF
--- a/scheduler/src/cook/cache.clj
+++ b/scheduler/src/cook/cache.clj
@@ -43,11 +43,12 @@
   (if-let [key (extract-key-fn item)]
     (if-let [result (.getIfPresent cache key)]
       result ; we got a hit.
-      (let [new-result (miss-fn item)]
-        ; Only cache non-nil
-        (when new-result
-          (.put cache key new-result))
-        new-result))
+      (locking cache ; TODO: Consider lock striping based on hashcode of the key to allow concurrent loads.
+        (let [new-result (miss-fn item)]
+          ; Only cache non-nil
+          (when new-result
+            (.put cache key new-result))
+          new-result)))
     (miss-fn item)))
 
 (defn- expire-key-helper


### PR DESCRIPTION
## Changes proposed in this PR

- Do the cache lookup inside of a lock
- 
- 

## Why are we making these changes?

Without this, we can have multiple outstanding requests for the same
key, possibly hitting a backend multiple times.

lookup-cache-with-expiration! has the fix already.