### PR TITLE
Add COOK_MAP_CONTAINER_VOLUME

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -409,7 +409,8 @@ def minimal_job(**kwargs):
             }
         }
     job.update(kwargs)
-    if is_cook_executor_in_use() and 'container' in job:
+    map_container_volume=bool(os.getenv('COOK_MAP_CONTAINER_VOLUME', '1'))
+    if map_container_volume and is_cook_executor_in_use() and 'container' in job:
         if 'volumes' not in job['container']:
             job['container']['volumes'] = []
         config = settings(retrieve_cook_url())


### PR DESCRIPTION
## Changes proposed in this PR
- Add a new environment variable, `COOK_MAP_CONTAINER_VOLUME` to disable the integration test volume created for the cook executor

## Why are we making these changes?
If the executor is built into the docker image, you don't want to create the volume mapping.

