### PR TITLE
Fix executor argument in some tests

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -170,7 +170,7 @@ class CookTest(util.CookTest):
         job_executor_type = util.get_job_executor_type(self.cook_url)
         self.assertEqual('cook', job_executor_type)
         uuid, resp = util.submit_job(self.cook_url, command='sleep 30', env={'EXECUTOR_TEST_EXIT': '1'},
-                                     disable_mea_culpa_retries=True)
+                                     disable_mea_culpa_retries=True, executor=job_executor_type)
         try:
             instance = util.wait_for_instance(self.cook_url, uuid)
             self.assertEqual('cook', instance['executor'])
@@ -190,7 +190,7 @@ class CookTest(util.CookTest):
     def test_mea_culpa_retries(self):
         job_executor_type = util.get_job_executor_type(self.cook_url)
         self.assertEqual('cook', job_executor_type)
-        uuid, resp = util.submit_job(self.cook_url, command='sleep 30', env={'EXECUTOR_TEST_EXIT': '1'})
+        uuid, resp = util.submit_job(self.cook_url, command='sleep 30', env={'EXECUTOR_TEST_EXIT': '1'}, executor=job_executor_type)
         try:
             instance = util.wait_for_instance(self.cook_url, uuid)
             self.assertEqual('cook', instance['executor'])

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -409,8 +409,8 @@ def minimal_job(**kwargs):
             }
         }
     job.update(kwargs)
-    map_container_volume=bool(os.getenv('COOK_MAP_CONTAINER_VOLUME', '1'))
-    if map_container_volume and is_cook_executor_in_use() and 'container' in job:
+    no_container_volume = os.getenv('COOK_NO_CONTAINER_VOLUME') is not None
+    if not no_container_volume and is_cook_executor_in_use() and 'container' in job:
         if 'volumes' not in job['container']:
             job['container']['volumes'] = []
         config = settings(retrieve_cook_url())


### PR DESCRIPTION
## Changes proposed in this PR
- Rename `COOK_MAP_CONTAINER_VOLUME` to `COOK_NO_CONTAINER_VOLUME` which is more clear
- Explicitly pass `executor` in two tests which were relying on portion

## Why are we making these changes?
Makes the tests more reliable in environments where the cook executor portion is low.
