### PR TITLE
Limit ranked jobs

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -286,6 +286,9 @@
                                    (:offer-cache scheduler))))
      :mea-culpa-failure-limit (fnk [[:config {scheduler nil}]]
                                 (:mea-culpa-failure-limit scheduler))
+     :max-over-quota-jobs (fnk [[:config {scheduler nil}]]
+                             (when scheduler
+                               (or (:max-over-quota-jobs scheduler) 100)))
      :fenzo-max-jobs-considered (fnk [[:config {scheduler nil}]]
                                   (when scheduler
                                     (or (:fenzo-max-jobs-considered scheduler) 1000)))
@@ -530,3 +533,7 @@
   "Used to get the fremework-id"
   []
   (get-in config [:settings :mesos-framework-id]))
+
+(defn max-over-quota-jobs
+  []
+  (get-in config [:settings :max-over-quota-jobs]))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -287,8 +287,9 @@
      :mea-culpa-failure-limit (fnk [[:config {scheduler nil}]]
                                 (:mea-culpa-failure-limit scheduler))
      :max-over-quota-jobs (fnk [[:config {scheduler nil}]]
-                             (when scheduler
-                               (or (:max-over-quota-jobs scheduler) 100)))
+                               (or (when scheduler
+                                     (:max-over-quota-jobs scheduler))
+                                   100))
      :fenzo-max-jobs-considered (fnk [[:config {scheduler nil}]]
                                   (when scheduler
                                     (or (:fenzo-max-jobs-considered scheduler) 1000)))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1156,9 +1156,25 @@
              ;; Return all 0's for a user who does NOT have any running job.
              (zipmap (util/get-all-resource-types db) (repeat 0.0)))})))
 
+(defn limit-over-quota-jobs
+  "Filters task-ents, preserving at most (config/max-over-quota-jobs) that would exceed the user's quota"
+  [task-ents quota]
+  (let [over-quota-job-limit (config/max-over-quota-jobs)]
+    (->> task-ents
+         (map (fn [task-ent] [task-ent (util/job->usage (:job/_instance task-ent))]))
+         (reductions (fn [[prev-task total-usage] [task-ent usage]] [task-ent (merge-with + usage total-usage)]))
+         (reductions (fn [[prev-task-ent over-quota-jobs] [task-ent usage]]
+                       (if (util/below-quota? quota usage)
+                         [task-ent over-quota-jobs]
+                         [task-ent (inc over-quota-jobs)]))
+                     [nil 0])
+         (take-while (fn [[task-ent over-quota-jobs]] (<= over-quota-jobs over-quota-job-limit)))
+         (map (fn [[task-ent over-quota-jobs]] task-ent))
+         (filter (fn [task-ent] (not (nil? task-ent)))))))
+
 (defn sort-jobs-by-dru-helper
   "Return a list of job entities ordered by the provided sort function"
-  [pending-task-ents running-task-ents user->dru-divisors sort-task-scored-task-pairs sort-jobs-duration pool-name]
+  [pending-task-ents running-task-ents user->dru-divisors sort-task-scored-task-pairs sort-jobs-duration pool-name user->quota]
   (let [tasks (into (vec running-task-ents) pending-task-ents)
         task-comparator (util/same-user-task-comparator tasks)
         pending-task-ents-set (into #{} pending-task-ents)
@@ -1166,7 +1182,9 @@
                sort-jobs-duration
                (->> tasks
                     (group-by util/task-ent->user)
-                    (pc/map-vals (fn [task-ents] (sort task-comparator task-ents)))
+                    (map (fn [[user task-ents]] (let [sorted-tasks (sort task-comparator task-ents)]
+                                                  [user (limit-over-quota-jobs sorted-tasks (user->quota user))])))
+                    (into (hash-map))
                     (sort-task-scored-task-pairs user->dru-divisors pool-name)
                     (filter (fn [[task _]] (contains? pending-task-ents-set task)))
                     (map (fn [[task _]] (:job/_instance task)))))]
@@ -1174,15 +1192,15 @@
 
 (defn- sort-normal-jobs-by-dru
   "Return a list of normal job entities ordered by dru"
-  [pending-task-ents running-task-ents user->dru-divisors timer pool-name]
+  [pending-task-ents running-task-ents user->dru-divisors timer pool-name user->quota]
   (sort-jobs-by-dru-helper pending-task-ents running-task-ents user->dru-divisors
-                           dru/sorted-task-scored-task-pairs timer pool-name))
+                           dru/sorted-task-scored-task-pairs timer pool-name user->quota))
 
 (defn- sort-gpu-jobs-by-dru
   "Return a list of gpu job entities ordered by dru"
-  [pending-task-ents running-task-ents user->dru-divisors timer pool-name]
+  [pending-task-ents running-task-ents user->dru-divisors timer pool-name user->quota]
   (sort-jobs-by-dru-helper pending-task-ents running-task-ents user->dru-divisors
-                           dru/sorted-task-cumulative-gpu-score-pairs timer pool-name))
+                           dru/sorted-task-cumulative-gpu-score-pairs timer pool-name user->quota))
 
 (defn- pool-map
   "Given a collection of pools, and a function val-fn that takes a pool,
@@ -1220,8 +1238,10 @@
               (let [pending-tasks (pool-name->pending-task-ents pool-name)
                     running-tasks (pool-name->running-task-ents pool-name)
                     user->dru-divisors (pool-name->user->dru-divisors pool-name)
+                    user->quota (quota/create-user->quota-fn unfiltered-db
+                                                             (when using-pools? pool-name))
                     timer (timers/timer (metric-title "sort-jobs-hierarchy-duration" pool-name))]
-                [pool-name (sort-jobs-by-dru pending-tasks running-tasks user->dru-divisors timer pool-name)]))]
+                [pool-name (sort-jobs-by-dru pending-tasks running-tasks user->dru-divisors timer pool-name user->quota)]))]
       (into {} (map sort-jobs-by-dru-pool-helper) pool-name->sort-jobs-by-dru-fn))))
 
 (timers/deftimer [cook-mesos scheduler filter-offensive-jobs-duration])

--- a/scheduler/test/cook/test/benchmark.clj
+++ b/scheduler/test/cook/test/benchmark.clj
@@ -21,7 +21,7 @@
             [cook.scheduler.scheduler :as sched]
             [cook.scheduler.share :as share]
             [cook.tools :as util]
-            [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance poll-until)]
+            [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance poll-until setup)]
             [criterium.core :as cc]
             [datomic.api :as d]
             [metrics.timers :as timers]))
@@ -33,6 +33,7 @@
     [job inst]))
 
 (deftest ^:benchmark bench-rank-jobs
+  (setup)
   (let [uri "datomic:mem://bench-rank-jobs"
         conn (restore-fresh-database! uri)
         ;; Cheap way to have a non-uniform distribution of users


### PR DESCRIPTION
## Changes proposed in this PR
- Limit the number of over-quota jobs output by ranking

## Why are we making these changes?
This can cause performance issues downstream in a situation where there are relatively few runnable jobs, but many jobs that are over quota in the global queue.

After change:
```
lein test cook.test.benchmark
============ rank-jobs timing ============
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 842.769115 ms
    Execution time std-deviation : 32.152188 ms
   Execution time lower quantile : 819.166167 ms ( 2.5%)
   Execution time upper quantile : 892.687703 ms (97.5%)
                   Overhead used : 1.849735 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
============ rank-jobs minus offensive-job-filter timing ============
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 691.942744 ms
    Execution time std-deviation : 5.447180 ms
   Execution time lower quantile : 683.694154 ms ( 2.5%)
   Execution time upper quantile : 697.856670 ms (97.5%)
                   Overhead used : 1.849735 ns
============ sort-jobs-by-dru timing ============
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 282.943425 ms
    Execution time std-deviation : 5.670062 ms
   Execution time lower quantile : 275.517746 ms ( 2.5%)
   Execution time upper quantile : 289.528243 ms (97.5%)
                   Overhead used : 1.849735 ns
```

Before change:

```
============ rank-jobs timing ============
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 760.793033 ms
    Execution time std-deviation : 22.661330 ms
   Execution time lower quantile : 743.616719 ms ( 2.5%)
   Execution time upper quantile : 793.321066 ms (97.5%)
                   Overhead used : 1.519518 ns
============ rank-jobs minus offensive-job-filter timing ============
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 680.558862 ms
    Execution time std-deviation : 5.242206 ms
   Execution time lower quantile : 670.552910 ms ( 2.5%)
   Execution time upper quantile : 684.407241 ms (97.5%)
                   Overhead used : 1.519518 ns

Found 1 outliers in 6 samples (16.6667 %)
	low-severe	 1 (16.6667 %)
 Variance from outliers : 13.8889 % Variance is moderately inflated by outliers
============ sort-jobs-by-dru timing ============
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 370.130333 ms
    Execution time std-deviation : 13.754199 ms
   Execution time lower quantile : 353.049737 ms ( 2.5%)
   Execution time upper quantile : 384.385778 ms (97.5%)
                   Overhead used : 1.519518 ns
```