### PR TITLE
Add python 3 classifier

### DIFF
--- a/executor/setup.py
+++ b/executor/setup.py
@@ -27,5 +27,8 @@ setup(
         'console_scripts': [
             'cook-executor = cook.__main__:main'
         ]
-    }
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3"
+    ]
 )

--- a/executor/setup.py
+++ b/executor/setup.py
@@ -29,6 +29,6 @@ setup(
         ]
     },
     classifiers=[
-        "Programming Language :: Python :: 3"
+        "Programming Language :: Python :: 3.5"
     ]
 )


### PR DESCRIPTION
## Changes proposed in this PR
- Add a python 3 classifier to the executor setup.py

## Why are we making these changes?
The executor requires python3, so make this clear to potential users.

https://test.pypi.org/project/cook-executor/