### PR TITLE
Fix rebalancer

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -432,7 +432,8 @@ class MultiUserCookTest(util.CookTest):
                 def job_was_preempted(job):
                     for instance in job['instances']:
                         self.logger.debug(f'Checking if instance was preempted: {instance}')
-                        if instance.get('reason_string') == 'Preempted by rebalancer':
+                        # Rebalancing marks the instance failed eagerly, so also wait for end_time to ensure it was actually killed
+                        if instance.get('reason_string') == 'Preempted by rebalancer' and instance.get('end_time') is not None:
                             return True
                     self.logger.info(f'Job has not been preempted: {job}')
                     return False

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -187,14 +187,14 @@
                                     (cook.scheduler.scheduler/cancelled-task-killer mesos-datomic-conn (cc/get-mesos-driver-hack compute-cluster)
                                                                                     cancelled-task-trigger-chan)
                                     (cook.mesos.heartbeat/start-heartbeat-watcher! mesos-datomic-conn mesos-heartbeat-chan)
-                                    (cook.rebalancer/start-rebalancer! {:config rebalancer-config
-                                                                              :conn mesos-datomic-conn
-                                                                              :driver (cc/get-mesos-driver-hack compute-cluster)
-                                                                              :agent-attributes-cache agent-attributes-cache
-                                                                              :pool-name->pending-jobs-atom pool-name->pending-jobs-atom
-                                                                              :rebalancer-reservation-atom rebalancer-reservation-atom
-                                                                              :trigger-chan rebalancer-trigger-chan
-                                                                              :view-incubating-offers view-incubating-offers})
+                                    (cook.rebalancer/start-rebalancer! {:compute-cluster compute-cluster
+                                                                        :config rebalancer-config
+                                                                        :conn mesos-datomic-conn
+                                                                        :agent-attributes-cache agent-attributes-cache
+                                                                        :pool-name->pending-jobs-atom pool-name->pending-jobs-atom
+                                                                        :rebalancer-reservation-atom rebalancer-reservation-atom
+                                                                        :trigger-chan rebalancer-trigger-chan
+                                                                        :view-incubating-offers view-incubating-offers})
                                     (when (seq optimizer-config)
                                       (cook.scheduler.optimizer/start-optimizer-cycles! (fn get-queue []
                                                                                       ;; TODO Use filter of queue that scheduler uses to filter to considerable.


### PR DESCRIPTION
## Changes proposed in this PR
- Pass `compute-cluster` instead of `driver` to rebalancer
- Fix integration test to detect issue

## Why are we making these changes?
Currently, the rebalancer thinks it killed things but doesn't actually terminate them. Fix the bug, and fix the test to detect this in the future.