### PR TITLE
Remove get-mesos-driver-hack

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -35,9 +35,11 @@
   (current-leader? [this]
     "Returns true if this cook instance is currently the leader for the compute cluster")
 
-  ; TODO - remove
-  (get-mesos-driver-hack [this]
-    "Get the mesos driver. Hack; any function invoking this should be put within the compute-cluster implementation"))
+  (kill-task [this task-id]
+    "Kill the task with the given task id")
+
+  (decline-offer [this offer-id]
+    "Decline the given offer"))
 
 ; Internal method
 (defn write-compute-cluster

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -180,11 +180,11 @@
                                                                                           pool->offers-chan)]
                                     (cook.monitor/start-collecting-stats)
                                     ; Many of these should look at the compute-cluster of the underlying jobs, and not use driver at all.
-                                    (cook.scheduler.scheduler/lingering-task-killer mesos-datomic-conn (cc/get-mesos-driver-hack compute-cluster)
+                                    (cook.scheduler.scheduler/lingering-task-killer mesos-datomic-conn compute-cluster
                                                                                     task-constraints lingering-task-trigger-chan)
-                                    (cook.scheduler.scheduler/straggler-handler mesos-datomic-conn (cc/get-mesos-driver-hack compute-cluster)
+                                    (cook.scheduler.scheduler/straggler-handler mesos-datomic-conn compute-cluster
                                                                                 straggler-trigger-chan)
-                                    (cook.scheduler.scheduler/cancelled-task-killer mesos-datomic-conn (cc/get-mesos-driver-hack compute-cluster)
+                                    (cook.scheduler.scheduler/cancelled-task-killer mesos-datomic-conn compute-cluster
                                                                                     cancelled-task-trigger-chan)
                                     (cook.mesos.heartbeat/start-heartbeat-watcher! mesos-datomic-conn mesos-heartbeat-chan)
                                     (cook.rebalancer/start-rebalancer! {:compute-cluster compute-cluster

--- a/scheduler/src/cook/rebalancer.clj
+++ b/scheduler/src/cook/rebalancer.clj
@@ -486,7 +486,7 @@
             (catch Throwable e
               (log/warn e "Failed to transact preemption")))
           (when-let [task-id (:instance/task-id task-ent)]
-            (mesos/kill-task! (cc/get-mesos-driver-hack compute-cluster) {:value task-id})))))))
+            (cc/kill-task compute-cluster task-id)))))))
 
 
 


### PR DESCRIPTION
## Changes proposed in this PR
- Remove `cc/get-mesos-driver-hack` and replace with `cc/kill-task` and `cc/decline-offer`

## Why are we making these changes?
Last remaining refactor for compute cluster API