### PR TITLE
Add Kubernetes Compute Cluster

### DIFF
--- a/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
+++ b/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
@@ -1,0 +1,29 @@
+package com.twosigma.cook.kubernetes;
+
+import com.google.common.reflect.TypeToken;
+import io.kubernetes.client.ApiClient;
+import io.kubernetes.client.ApiException;
+import io.kubernetes.client.apis.CoreV1Api;
+import io.kubernetes.client.models.V1Node;
+import io.kubernetes.client.models.V1Pod;
+import io.kubernetes.client.util.Watch;
+
+public class WatchHelper {
+
+    public static Watch<V1Pod> createPodWatch(ApiClient apiClient, String resourceVersion) throws ApiException {
+        CoreV1Api api = new CoreV1Api(apiClient);
+        return Watch.createWatch(apiClient,
+                api.listPodForAllNamespacesCall(null, null, null, null, null, null,
+                        resourceVersion, null, true, null, null),
+                new TypeToken<Watch.Response<V1Pod>>() {}.getType());
+    }
+
+    public static Watch<V1Node> createNodeWatch(ApiClient apiClient, String resourceVersion) throws ApiException {
+        CoreV1Api api = new CoreV1Api(apiClient);
+        return Watch.createWatch(apiClient,
+                api.listNodeCall(null, null, null, null, null,
+                        null, resourceVersion, null, true, null,
+                        null),
+                new TypeToken<Watch.Response<V1Node>>() {}.getType());
+    }
+}

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -113,7 +113,9 @@
                  [org.apache.curator/curator-test "2.7.1"]
 
                  ;; Dependency management
-                 [mount "0.1.12"]]
+                 [mount "0.1.12"]
+
+                 [io.kubernetes/client-java "4.0.0"]]
 
   :repositories {"maven2" {:url "https://files.couchbase.com/maven2/"}
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -1,0 +1,225 @@
+(ns cook.kubernetes.compute-cluster
+  (:require [clj-time.periodic :as tp]
+            [cook.compute-cluster :as cc]
+            [cook.datomic]
+            [cook.scheduler.scheduler :as scheduler]
+            [datomic.api :as d]
+            [clojure.core.async :as async]
+            [plumbing.core :as pc]
+            [clojure.tools.logging :as log]
+            [clj-time.core :as t])
+  (:import (io.kubernetes.client ApiClient)
+           (io.kubernetes.client.util Config Watch)
+           (io.kubernetes.client.apis CoreV1Api)
+           (io.kubernetes.client.models V1Pod V1Node V1Container)
+           (com.twosigma.cook.kubernetes WatchHelper)
+           (java.util.concurrent Executors ExecutorService)
+           (io.kubernetes.client.custom Quantity)
+           (java.util UUID)))
+
+(def ^ExecutorService kubernetes-executor (Executors/newFixedThreadPool 2))
+
+(defn handle-watch-updates
+  [state-atom ^Watch watch key-fn]
+  (while (.hasNext watch)
+    (let [update (.next watch)
+          item (.-object update)]
+      (case (.-type update)
+        "ADDED" (swap! state-atom (fn [m] (assoc m (key-fn item) item)))
+        "MODIFIED" (swap! state-atom (fn [m] (assoc m (key-fn item) item)))
+        "DELETED" (swap! state-atom (fn [m] (dissoc m (key-fn item))))))))
+
+(let [current-pods-atom (atom {})]
+  (defn initialize-pod-watch
+    [^ApiClient api-client]
+    (let [api (CoreV1Api. api-client)
+          current-pods (.listPodForAllNamespaces api
+                                                 nil ; continue
+                                                 nil ; fieldSelector
+                                                 nil ; includeUninitialized
+                                                 nil ; labelSelector
+                                                 nil ; limit
+                                                 nil ; pretty
+                                                 nil ; resourceVersion
+                                                 nil ; timeoutSeconds
+                                                 nil ; watch
+                                                 )
+          pod-name->pod (pc/map-from-vals (fn [^V1Pod pod]
+                                            (-> pod
+                                                .getMetadata
+                                                .getName))
+                                          (.getItems current-pods))]
+      (log/info "Updating current-pods-atom with pods" (keys pod-name->pod))
+      (reset! current-pods-atom pod-name->pod)
+      (let [watch (WatchHelper/createPodWatch api-client (-> current-pods
+                                                             .getMetadata
+                                                             .getResourceVersion))]
+        (.submit kubernetes-executor ^Callable
+        (fn []
+          (try
+            (handle-watch-updates current-pods-atom watch (fn [p] (-> p .getMetadata .getName)))
+            (catch Exception e
+              (log/error e "Error during watch")
+              (.close watch)
+              (initialize-pod-watch api-client))))))))
+  (defn get-pods
+    []
+    @current-pods-atom))
+
+
+(let [current-nodes-atom (atom {})]
+  (defn initialize-node-watch [^ApiClient api-client]
+    (let [api (CoreV1Api. api-client)
+          current-nodes (.listNode api
+                                   nil ; includeUninitialized
+                                   nil ; pretty
+                                   nil ; continue
+                                   nil ; fieldSelector
+                                   nil ; labelSelector
+                                   nil ; limit
+                                   nil ; resourceVersion
+                                   nil ; timeoutSeconds
+                                   nil ; watch
+                                   )
+          node-name->node (pc/map-from-vals (fn [^V1Node node]
+                                              (-> node .getMetadata .getName))
+                                            (.getItems current-nodes))]
+      (reset! current-nodes-atom node-name->node)
+      (let [watch (WatchHelper/createNodeWatch api-client (-> current-nodes .getMetadata .getResourceVersion))]
+        (.submit kubernetes-executor ^Callable
+          (fn []
+            (try
+              (handle-watch-updates current-nodes-atom watch (fn [n] (-> n .getMetadata .getName)))
+              (catch Exception e
+                (log/warn e "Error during node watch")
+                (initialize-node-watch api-client))
+              (finally
+                (.close watch))))))))
+
+  (defn get-nodes
+    []
+    @current-nodes-atom))
+
+(defn to-double
+  [^Quantity q]
+  (-> q .getNumber .doubleValue))
+
+(defn convert-resource-map
+  [m]
+  {:mem (if (get m "memory")
+          (-> m (get "memory") to-double (/ (* 1024 1024)))
+          0.0)
+   :cpus (if (get m "cpu")
+           (-> m (get "cpu") to-double)
+           0.0)})
+
+(defn get-capacity
+  [node-name->node]
+  (pc/map-vals (fn [^V1Node node]
+                 (-> node .getStatus .getCapacity convert-resource-map))
+               node-name->node))
+
+(defn get-consumption
+  [pod-name->pod]
+  (let [node-name->pods (group-by (fn [^V1Pod p] (-> p .getSpec .getNodeName))
+                                  (vals pod-name->pod))
+        node-name->requests (pc/map-vals (fn [pods]
+                                           (->> pods
+                                                (map (fn [^V1Pod pod]
+                                                       (let [containers (-> pod .getSpec .getContainers)
+                                                             container-requests (map (fn [^V1Container c]
+                                                                                       (-> c
+                                                                                           .getResources
+                                                                                           .getRequests
+                                                                                           convert-resource-map))
+                                                                                     containers)]
+                                                         (apply merge-with + container-requests))))
+                                                (apply merge-with +)))
+                                         node-name->pods)]
+    node-name->requests))
+
+(defn generate-offers
+  [node-name->node pod-name->pod compute-cluster]
+  (let [node-name->capacity (get-capacity node-name->node)
+        node-name->consumed (get-consumption pod-name->pod)
+        ; TODO(pschorf): Should also include recently launched jobs
+        node-name->available (pc/map-from-keys (fn [node-name]
+                                                 (merge-with -
+                                                             (node-name->capacity node-name)
+                                                             (node-name->consumed node-name)))
+                                               (keys node-name->capacity))]
+    (log/info "Capacity: " node-name->capacity "Consumption:" node-name->consumed)
+    (map (fn [[node-name available]]
+           {:id {:value (str (UUID/randomUUID))}
+            :framework-id (cc/compute-cluster-name compute-cluster)
+            :slave-id {:value node-name}
+            :hostname node-name
+            :resources [{:name "mem" :type :value-scalar :scalar (max 0.0 (:mem available))}
+                        {:name "cpus" :type :value-scalar :scalar (max 0.0 (:cpus available))}
+                        {:name "disk" :type :value-scalar :scalar 0.0}]
+            :attributes []
+            :executor-ids []
+            :compute-cluster compute-cluster
+            :reject-after-match true})
+         node-name->available)))
+
+(defrecord KubernetesComputeCluster [^ApiClient api-client name entity-id match-trigger-chan]
+  cc/ComputeCluster
+  (launch-tasks [this offers task-metadata-seq]
+    (throw (UnsupportedOperationException. "Cannot launch tasks")))
+
+  (kill-task [this task-id]
+    (throw (UnsupportedOperationException. "Cannot kill tasks")))
+
+  (decline-offer [this offer-id])
+
+  (db-id [this]
+    entity-id)
+
+  (compute-cluster-name [this]
+    name)
+
+  (initialize-cluster [this pool->fenzo pool->offers-chan]
+    (initialize-pod-watch api-client)
+    (initialize-node-watch api-client)
+
+    ; TODO(pschorf): Figure out a better way to plumb these through
+    (chime/chime-at (tp/periodic-seq (t/now) (t/seconds 2))
+                    (fn [_]
+                      (try
+                        (let [nodes (get-nodes)
+                              pods (get-pods)
+                              offers (generate-offers nodes pods this)
+                              [pool chan] (first pool->offers-chan)] ; TODO(pschorf): Support pools
+                          (log/info "Processing offers:" offers)
+                          (scheduler/receive-offers chan match-trigger-chan this pool offers))
+                        (catch Exception e
+                          (log/error e "Exception while forwarding offers")))))
+    ; TODO(pschorf): Deliver when leadership lost
+    (async/chan 1))
+
+  (current-leader? [this]
+    true))
+
+(defn get-or-create-cluster-entity-id
+  [conn compute-cluster-name]
+  (let [query-result (d/q '[:find [?c]
+                            :in $ ?cluster-name
+                            :where
+                            [?c :compute-cluster/type :compute-cluster.type/kubernetes]
+                            [?c :compute-cluster/cluster-name ?cluster-name]]
+                          (d/db conn) compute-cluster-name)]
+    (if (seq query-result)
+      (first query-result)
+      (cc/write-compute-cluster conn {:compute-cluster/type :compute-cluster.type/kubernetes
+                                      :compute-cluster/cluster-name compute-cluster-name}))))
+
+(defn factory-fn
+  [{:keys [compute-cluster-name ^String config-file]} {:keys [trigger-chans]}]
+  (let [conn cook.datomic/conn
+        cluster-entity-id (get-or-create-cluster-entity-id conn compute-cluster-name)
+        api-client (Config/fromConfig config-file)
+        compute-cluster (->KubernetesComputeCluster api-client compute-cluster-name cluster-entity-id
+                                                    (:match-trigger-chan trigger-chans))]
+    (cc/register-compute-cluster! compute-cluster)
+    compute-cluster))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -11,14 +11,15 @@
             [cook.scheduler.scheduler :as scheduler]
             [datomic.api :as d]
             [plumbing.core :as pc])
-  (:import (io.kubernetes.client ApiClient ApiException)
-           (io.kubernetes.client.util Config Watch)
+  (:import (com.twosigma.cook.kubernetes WatchHelper)
+           (io.kubernetes.client ApiClient ApiException)
            (io.kubernetes.client.apis CoreV1Api)
-           (io.kubernetes.client.models V1Pod V1Node V1Container V1ObjectMeta V1EnvVar V1ResourceRequirements V1PodSpec V1PodStatus V1ContainerState)
-           (com.twosigma.cook.kubernetes WatchHelper)
-           (java.util.concurrent Executors ExecutorService)
            (io.kubernetes.client.custom Quantity Quantity$Format)
-           (java.util UUID)))
+           (io.kubernetes.client.models V1Pod V1Node V1Container V1ObjectMeta V1EnvVar V1ResourceRequirements
+                                        V1PodSpec V1PodStatus V1ContainerState)
+           (io.kubernetes.client.util Config Watch)
+           (java.util UUID)
+           (java.util.concurrent Executors ExecutorService)))
 
 (def ^ExecutorService kubernetes-executor (Executors/newFixedThreadPool 2))
 
@@ -71,6 +72,7 @@
               (log/error e "Error during watch")
               (.close watch)
               (initialize-pod-watch api-client pod-callback))))))))
+
   (defn get-pods
     []
     @current-pods-atom))
@@ -169,7 +171,7 @@
             :attributes []
             :executor-ids []
             :compute-cluster compute-cluster
-            :reject-after-match true})
+            :reject-after-match-attempt true})
          node-name->available)))
 
 (defn task-metadata->pod

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -984,7 +984,7 @@
         exit-code (:instance/exit-code instance)
         progress (:instance/progress instance)
         progress-message (:instance/progress-message instance)
-        file-url nil]
+        file-url (plugins/file-url file-plugin/plugin instance)]
     (cond-> {:backfilled false ;; Backfill has been deprecated
              :compute-cluster (fetch-compute-cluster-map db (:instance/compute-cluster instance))
              :executor_id (:instance/executor-id instance)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -953,7 +953,9 @@
   (cond-> {:name (:compute-cluster/cluster-name entity)}
     (= :compute-cluster.type/mesos (:compute-cluster/type entity))
     (-> (assoc :mesos {:framework-id (:compute-cluster/mesos-framework-id entity)})
-        (assoc :type :mesos))))
+        (assoc :type :mesos))
+    (= :compute-cluster.type/kubernetes (:compute-cluster/type entity))
+    (assoc :type :kubernetes)))
 
 (defn fetch-compute-cluster-map
   "Converts a compute cluster entity as a map representing the fields. For legacy instances
@@ -982,7 +984,7 @@
         exit-code (:instance/exit-code instance)
         progress (:instance/progress instance)
         progress-message (:instance/progress-message instance)
-        file-url (plugins/file-url file-plugin/plugin instance)]
+        file-url nil]
     (cond-> {:backfilled false ;; Backfill has been deprecated
              :compute-cluster (fetch-compute-cluster-map db (:instance/compute-cluster instance))
              :executor_id (:instance/executor-id instance)

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -533,6 +533,12 @@
                  (.scheduleOnce fenzo requests leases))
         failure-results (.. result getFailures values)
         assignments (.. result getResultMap values)]
+    (doall (map (fn [^VirtualMachineLease lease]
+                  (when (-> lease :offer :reject-after-match)
+                    (log/info "Retracting lease" (-> lease :offer :id))
+                    (locking fenzo
+                      (.expireLease fenzo (.getId lease)))))
+                leases))
 
     (log/debug "Found this assignment:" result)
 
@@ -684,6 +690,7 @@
   [matches conn db fenzo mesos-run-as-user pool-name]
   (let [matches (map #(update-match-with-task-metadata-seq % db mesos-run-as-user) matches)
         task-txns (matches->task-txns matches)]
+    (log/info "Writing tasks" task-txns)
     ;; Note that this transaction can fail if a job was scheduled
     ;; during a race. If that happens, then other jobs that should
     ;; be scheduled will not be eligible for rescheduling until

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -534,7 +534,7 @@
         failure-results (.. result getFailures values)
         assignments (.. result getResultMap values)]
     (doall (map (fn [^VirtualMachineLease lease]
-                  (when (-> lease :offer :reject-after-match)
+                  (when (-> lease :offer :reject-after-match-attempt)
                     (log/info "Retracting lease" (-> lease :offer :id))
                     (locking fenzo
                       (.expireLease fenzo (.getId lease)))))

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -1070,7 +1070,8 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
                    :requires [[metatransaction.core :as mt]]
                    :code
                    (let [db (mt/filter-committed db)
-                         state-transitions {:instance.status/unknown #{:instance.status/running :instance.status/failed}
+                         state-transitions {:instance.status/unknown #{:instance.status/running :instance.status/failed
+                                                                       :instance.status/success}
                                             :instance.status/running #{:instance.status/failed :instance.status/success}
                                             ;; terminal states
                                             :instance.status/success #{}

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -126,7 +126,7 @@
               {:name "cpus" :type :value-scalar :scalar 0.4}
               {:name "disk" :type :value-scalar :scalar 0.0}]
              (:resources offer)))
-      (is (:reject-after-match offer)))
+      (is (:reject-after-match-attempt offer)))
 
     (let [offer (first (filter #(= "nodeB" (:hostname %))
                                      offers))]

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -1,0 +1,137 @@
+(ns cook.test.kubernetes.compute-cluster
+  (:require [clojure.test :refer :all]
+            [cook.kubernetes.compute-cluster :as kcc]
+            [cook.test.testutil :as tu]
+            [datomic.api :as d])
+  (:import (io.kubernetes.client.models V1Pod V1ObjectMeta V1PodSpec V1Container V1ResourceRequirements V1Node V1NodeStatus)
+           (io.kubernetes.client.custom Quantity Quantity$Format)
+           (java.math BigDecimal)))
+
+(defn pod-helper [pod-name node-name & requests]
+  (let [pod (V1Pod.)
+        metadata (V1ObjectMeta.)
+        spec (V1PodSpec.)]
+    (doall (for [{:keys [mem cpus]} requests]
+             (let [container (V1Container.)
+                   resources (V1ResourceRequirements.)]
+               (when mem
+                 (.putRequestsItem resources
+                                   "memory"
+                                   (Quantity. (BigDecimal. ^double (* 1024 1024 mem))
+                                              Quantity$Format/DECIMAL_SI)))
+               (when cpus
+                 (.putRequestsItem resources
+                                   "cpu"
+                                   (Quantity. (BigDecimal. cpus)
+                                              Quantity$Format/DECIMAL_SI)))
+               (.setResources container resources)
+               (.addContainersItem spec container))))
+    (.setNodeName spec node-name)
+    (.setName metadata pod-name)
+    (.setMetadata pod metadata)
+    (.setSpec pod spec)
+    pod))
+
+(defn node-helper [node-name cpus mem]
+  (let [node (V1Node.)
+        status (V1NodeStatus.)
+        metadata (V1ObjectMeta.)]
+    (when cpus
+      (.putCapacityItem status "cpu" (Quantity. (BigDecimal. cpus)
+                                                Quantity$Format/DECIMAL_SI)))
+    (when mem
+      (.putCapacityItem status "memory" (Quantity. (BigDecimal. (* 1024 1024 mem))
+                                                   Quantity$Format/DECIMAL_SI)))
+    (.setStatus node status)
+    (.setName metadata node-name)
+    (.setMetadata node metadata)
+    node))
+
+(deftest test-get-or-create-cluster-entity-id
+  (let [conn (tu/restore-fresh-database! "datomic:mem://test-get-or-create-cluster-entity-id")]
+    (testing "successfully creates clusters"
+      (let [eid (kcc/get-or-create-cluster-entity-id conn "test-a")
+            entity (d/entity (d/db conn) eid)]
+        (is (= "test-a" (:compute-cluster/cluster-name entity)))
+        (is (= :compute-cluster.type/kubernetes (:compute-cluster/type entity)))))
+    (testing "does not create duplicate clusters"
+      (let [eid (kcc/get-or-create-cluster-entity-id conn "test-b")
+            eid2 (kcc/get-or-create-cluster-entity-id conn "test-b")]
+        (is eid)
+        (is eid2)
+        (is (= eid eid2))))))
+
+(deftest test-get-consumption
+  (testing "correctly computes consumption for a single pod"
+    (let [pod-name->pod {"podA" (pod-helper "podA" "hostA" {:cpus 1.0 :mem 100.0})}]
+      (is (= {"hostA" {:cpus 1.0
+                       :mem 100.0}}
+             (kcc/get-consumption pod-name->pod)))))
+
+  (testing "correctly computes consumption for a pod with multiple containers"
+    (let [pod-name->pod {"podA" (pod-helper "podA" "hostA"
+                                            {:cpus 1.0 :mem 100.0}
+                                            {:cpus 1.0 :mem 0.0}
+                                            {:mem 100.0})}]
+      (is (= {"hostA" {:cpus 2.0
+                       :mem 200.0}}
+             (kcc/get-consumption pod-name->pod)))))
+
+  (testing "correctly aggregates pods by node name"
+    (let [pod-name->pod {"podA" (pod-helper "podA" "hostA"
+                                            {:cpus 1.0 :mem 100.0})
+                         "podB" (pod-helper "podB" "hostA"
+                                            {:cpus 1.0})
+                         "podC" (pod-helper "podC" "hostB"
+                                            {:cpus 1.0}
+                                            {:mem 100.0})
+                         "podD" (pod-helper "podD" "hostC"
+                                            {:cpus 1.0})}]
+      (is (= {"hostA" {:cpus 2.0 :mem 100.0}
+              "hostB" {:cpus 1.0 :mem 100.0}
+              "hostC" {:cpus 1.0 :mem 0.0}}
+             (kcc/get-consumption pod-name->pod))))))
+
+(deftest test-get-capacity
+  (let [node-name->node {"nodeA" (node-helper "nodeA" 1.0 100.0)
+                         "nodeB" (node-helper "nodeB" 1.0 nil)
+                         "nodeC" (node-helper "nodeC" nil 100.0)
+                         "nodeD" (node-helper "nodeD" nil nil)}]
+    (is (= {"nodeA" {:cpus 1.0 :mem 100.0}
+            "nodeB" {:cpus 1.0 :mem 0.0}
+            "nodeC" {:cpus 0.0 :mem 100.0}
+            "nodeD" {:cpus 0.0 :mem 0.0}}
+           (kcc/get-capacity node-name->node)))))
+
+(deftest test-generate-offers
+  (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil)
+        node-name->node {"nodeA" (node-helper "nodeA" 1.0 1000.0)
+                         "nodeB" (node-helper "nodeB" 1.0 1000.0)
+                         "nodeC" (node-helper "nodeC" 1.0 1000.0)}
+        pod-name->pod {"podA" (pod-helper "podA" "nodeA"
+                                          {:cpus 0.25 :mem 250.0}
+                                          {:cpus 0.1 :mem 100.0})
+                       "podB" (pod-helper "podB" "nodeA"
+                                          {:cpus 0.25 :mem 250.0})
+                       "podC" (pod-helper "podC" "nodeB"
+                                          {:cpus 1.0 :mem 1100.0})}
+        offers (kcc/generate-offers node-name->node pod-name->pod compute-cluster)]
+    (is (= 3 (count offers)))
+    (let [offer (first (filter #(= "nodeA" (:hostname %))
+                                     offers))]
+      (is (not (nil? offer)))
+      (is (= "kubecompute" (:framework-id offer)))
+      (is (= {:value "nodeA"} (:slave-id offer)))
+      (is (= [{:name "mem" :type :value-scalar :scalar 400.0}
+              {:name "cpus" :type :value-scalar :scalar 0.4}
+              {:name "disk" :type :value-scalar :scalar 0.0}]
+             (:resources offer)))
+      (is (:reject-after-match offer)))
+
+    (let [offer (first (filter #(= "nodeB" (:hostname %))
+                                     offers))]
+      (is (= {:value "nodeB"} (:slave-id offer)))
+      (is (= [{:name "mem" :type :value-scalar :scalar 0.0}
+              {:name "cpus" :type :value-scalar :scalar 0.0}
+              {:name "disk" :type :value-scalar :scalar 0.0}]
+             (:resources offer))))))

--- a/scheduler/test/cook/test/schema.clj
+++ b/scheduler/test/cook/test/schema.clj
@@ -41,7 +41,7 @@
     (testing "URU"
         (verify-state-transition :instance.status/unknown :instance.status/running :instance.status/running))
     (testing "USU"
-        (verify-state-transition :instance.status/unknown :instance.status/success :instance.status/unknown))
+        (verify-state-transition :instance.status/unknown :instance.status/success :instance.status/success))
     (testing "UFF"
         (verify-state-transition :instance.status/unknown :instance.status/failed :instance.status/failed))
 
@@ -216,7 +216,7 @@
     (testing "Instance initially unknown"
         (verify-job-state-transition [:instance.status/unknown] [:instance.status/unknown] :old-job-state :job.state/running :new-job-state :job.state/running)
         (verify-job-state-transition [:instance.status/unknown] [:instance.status/running] :old-job-state :job.state/running :new-job-state :job.state/running)
-        (verify-job-state-transition [:instance.status/unknown] [:instance.status/success] :old-job-state :job.state/running :new-job-state :job.state/running)
+        (verify-job-state-transition [:instance.status/unknown] [:instance.status/success] :old-job-state :job.state/running :new-job-state :job.state/completed)
         (verify-job-state-transition [:instance.status/unknown] [:instance.status/failed] :old-job-state :job.state/running :new-job-state :job.state/waiting))
 
     (testing "Instance intially running"
@@ -245,7 +245,7 @@
       (verify-job-state-transition [:instance.status/failed :instance.status/running] [nil :instance.status/running] :old-job-state :job.state/running :new-job-state :job.state/running))
 
     (testing "Instances initially failed and unknown"
-      (verify-job-state-transition [:instance.status/failed :instance.status/unknown] [nil :instance.status/success] :old-job-state :job.state/running :new-job-state :job.state/running)
+      (verify-job-state-transition [:instance.status/failed :instance.status/unknown] [nil :instance.status/success] :old-job-state :job.state/running :new-job-state :job.state/completed)
       (verify-job-state-transition [:instance.status/failed :instance.status/unknown] [nil :instance.status/failed] :old-job-state :job.state/running :new-job-state :job.state/waiting)
       (verify-job-state-transition [:instance.status/failed :instance.status/unknown] [nil :instance.status/unknown] :old-job-state :job.state/running :new-job-state :job.state/running)
       (verify-job-state-transition [:instance.status/failed :instance.status/unknown] [nil :instance.status/running] :old-job-state :job.state/running :new-job-state :job.state/running))


### PR DESCRIPTION
## Changes proposed in this PR
- Adds Kubernetes compute cluster
- Allows marking instances as succeeded without transitioning to running.

## Why are we making these changes?
Part of adding Kubernetes support.

The instance change is something that could happen in Mesos (for instance, if you missed the task running message and found the task had succeeded during reconciliation) but is more likely in Kubernetes. I think it's a reasonable change to make for both.
