### PR TITLE
Optimize the job fetching code to not round-trip to UUID.

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1487,7 +1487,7 @@
 (histograms/defhistogram [cook-mesos api list-request-param-limit])
 (histograms/defhistogram [cook-mesos api list-response-job-count])
 
-(defn list-jobents
+(defn list-job-ents
   "Queries using the params from ctx and returns the jobs that were found as datomic entities."
   [db include-custom-executor? ctx]
   (timers/time!
@@ -1520,7 +1520,7 @@
 (defn list-jobs
   "Queries using the params from ctx and returns the job uuids that were found"
   [db include-custom-executor? ctx]
-  (map :job/uuid (list-jobents db include-custom-executor? ctx)))
+  (map :job/uuid (list-job-ents db include-custom-executor? ctx)))
 
 (defn jobs-list-exist?
   [conn ctx]
@@ -2585,7 +2585,7 @@
     :handle-ok (fn [ctx]
                  (timers/time!
                    (timers/timer ["cook-scheduler" "handler" "list-endpoint-duration"])
-                   (let [job-ents (list-jobents db false ctx)]
+                   (let [job-ents (list-job-ents db false ctx)]
                      (mapv (partial fetch-job-map-from-entity db) job-ents))))))
 
 ;;

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1045,12 +1045,11 @@
       (-> compute-clusters first :config :framework-id)
       "unsupported")))
 
-(defn fetch-job-map
-  [db job-uuid]
+(defn fetch-job-map-from-entity
+  [db job]
   (timers/time!
     (timers/timer ["cook-mesos" "internal" "fetch-job-map"])
-    (let [job (d/entity db [:job/uuid job-uuid])
-          resources (util/job-ent->resources job)
+    (let [resources (util/job-ent->resources job)
           groups (:group/_job job)
           application (:job/application job)
           expected-runtime (:job/expected-runtime job)
@@ -1104,6 +1103,10 @@
               pool (assoc :pool (:pool/name pool))
               container (assoc :container (container->response-map container))
               datasets (assoc :datasets datasets)))))
+
+(defn fetch-job-map
+  [db job-uuid]
+  (fetch-job-map-from-entity db (d/entity db [:job/uuid job-uuid])))
 
 (defn fetch-group-live-jobs
   "Get all jobs from a group that are currently running or waiting (not complete)"
@@ -1484,8 +1487,8 @@
 (histograms/defhistogram [cook-mesos api list-request-param-limit])
 (histograms/defhistogram [cook-mesos api list-response-job-count])
 
-(defn list-jobs
-  "Queries using the params from ctx and returns the job uuids that were found"
+(defn list-jobents
+  "Queries using the params from ctx and returns the jobs that were found as datomic entities."
   [db include-custom-executor? ctx]
   (timers/time!
     list-endpoint
@@ -1500,20 +1503,24 @@
           start-ms' (or start-ms (- end-ms (-> since-hours-ago t/hours t/in-millis)))
           start (Date. ^long start-ms')
           end (Date. ^long end-ms)
-          job-uuids (->> (timers/time!
+          job-ents (->> (timers/time!
                            fetch-jobs
                            (util/get-jobs-by-user-and-states db user states start end limit
                                                              name-filter-fn include-custom-executor? pool-name))
                          (sort-by :job/submit-time)
-                         reverse
-                         (map :job/uuid))
-          job-uuids (if (nil? limit)
-                      job-uuids
-                      (take limit job-uuids))]
+                         reverse)
+          job-ents (if (nil? limit)
+                      job-ents
+                      (take limit job-ents))]
       (histograms/update! list-request-param-time-range-ms (- end-ms start-ms'))
       (histograms/update! list-request-param-limit limit)
-      (histograms/update! list-response-job-count (count job-uuids))
-      job-uuids)))
+      (histograms/update! list-response-job-count (count job-ents))
+      job-ents)))
+
+(defn list-jobs
+  "Queries using the params from ctx and returns the job uuids that were found"
+  [db include-custom-executor? ctx]
+  (map :job/uuid (list-jobents db include-custom-executor? ctx)))
 
 (defn jobs-list-exist?
   [conn ctx]
@@ -2578,8 +2585,8 @@
     :handle-ok (fn [ctx]
                  (timers/time!
                    (timers/timer ["cook-scheduler" "handler" "list-endpoint-duration"])
-                   (let [job-uuids (list-jobs db false ctx)]
-                     (mapv (partial fetch-job-map db) job-uuids))))))
+                   (let [job-ents (list-jobents db false ctx)]
+                     (mapv (partial fetch-job-map-from-entity db) job-ents))))))
 
 ;;
 ;; /unscheduled_jobs


### PR DESCRIPTION
## Changes proposed in this PR

- Propagate job entities instead of job UUID's when assembling /list API responses. This avoids finding job entities, mapping them to job UUID's, then looking up jobs from their UUID in the /list path.
- 
- 

## Why are we making these changes?

This is a tech-debt/cleanup. Note that this isn't cleaning up the /jobs endpoint. That code would need more restructuring to fix (it propagates UUID's within the liberator context between the list and the explicit-uuid sub-endpoints).


