### PR TITLE
Adds run-description to test metrics collection

### DIFF
--- a/integration/tests/conftest.py
+++ b/integration/tests/conftest.py
@@ -60,6 +60,7 @@ if 'TEST_METRICS_URL' in os.environ:
                 'host': socket.gethostname(),
                 'user': getpass.getuser(),
                 'run-id': os.getenv('TEST_METRICS_RUN_ID', None),
+                'run-description': os.getenv('TEST_METRICS_RUN_DESCRIPTION', 'open source integration tests'),
                 'build-id': os.getenv('TEST_METRICS_BUILD_ID', None),
                 'result': result,
                 'runtime-milliseconds': (end - start)*1000,


### PR DESCRIPTION
## Changes proposed in this PR

- adding the `run-description` field

## Why are we making these changes?

To allow for a description of what the run is doing/testing.