### PR TITLE
Make Cook not fail silently on startup on some startup errors.

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -76,7 +76,7 @@
                :level default}
               overrides))
      (catch Throwable t
-       (.println System/err "Failed to initialize logging!")
+       (.println System/err (str "Failed to initialize logging! Error: " (.toString t)))
        (stacktrace/print-cause-trace t)
        (throw t)))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Under some circumstances, Cook can fail to launch without logging anything. At least in this case, make it not fail silently.
- 
- 

## Why are we making these changes?
- Failing silently with no error shown is irritating to debug.

