### PR TITLE
Light refactor to move things into KubernetesComputeCluster

### DIFF
--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -104,7 +104,7 @@
            (kcc/get-capacity node-name->node)))))
 
 (deftest test-generate-offers
-  (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil)
+  (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil (atom {}) (atom {}))
         node-name->node {"nodeA" (node-helper "nodeA" 1.0 1000.0)
                          "nodeB" (node-helper "nodeB" 1.0 1000.0)
                          "nodeC" (node-helper "nodeC" 1.0 1000.0)}


### PR DESCRIPTION
## Changes proposed in this PR

- These state atoms are compute-cluster specific. Move them within the compute cluster.
- 
- 

## Why are we making these changes?
- These state atoms are compute-cluster specific, so can't be global.