### PR TITLE
Add maximum command length configuration parameter

### DIFF
--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -40,7 +40,7 @@
                                 :memory-gb 48
                                 :retry-limit 200
                                 :cpus 10
-                                :command-length-limit 1024}}
+                                :command-length-limit 5000}}
  :rate-limit {:expire-minutes 120 ; Expire unused rate limit entries after 2 hours.
               ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
               ; spurious failures, and making them larger will cause the rate-limit integration test to skip itself.

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -39,7 +39,8 @@
                                 :timeout-interval-minutes 1
                                 :memory-gb 48
                                 :retry-limit 200
-                                :cpus 10}}
+                                :cpus 10
+                                :command-length-limit 1024}}
  :rate-limit {:expire-minutes 120 ; Expire unused rate limit entries after 2 hours.
               ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
               ; spurious failures, and making them larger will cause the rate-limit integration test to skip itself.

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -80,7 +80,8 @@
  :sandbox-syncer {:sync-interval-ms 1000}
  :scheduler {:fenzo-fitness-calculator "cook.scheduler.data-locality/make-data-local-fitness-calculator"
              :offer-incubate-ms 15000
-             :task-constraints {:cpus 10
+             :task-constraints {:command-length-limit 1024
+                                :cpus 10
                                 :memory-gb 48
                                 :retry-limit 15
                                 :timeout-hours 1

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -80,7 +80,7 @@
  :sandbox-syncer {:sync-interval-ms 1000}
  :scheduler {:fenzo-fitness-calculator "cook.scheduler.data-locality/make-data-local-fitness-calculator"
              :offer-incubate-ms 15000
-             :task-constraints {:command-length-limit 1024
+             :task-constraints {:command-length-limit 5000
                                 :cpus 10
                                 :memory-gb 48
                                 :retry-limit 15

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -908,6 +908,12 @@
       (throw (ex-info (str "Requested " max-retries " exceeds the maximum retry limit")
                       {:constraints task-constraints
                        :job job})))
+    (when (and (:command-length-limit task-constraints)
+               (> (.length command) (:command-length-limit task-constraints)))
+      (throw (ex-info (str "Job command length of " (.length command) " is greater than the maximum command length ("
+                           (:command-length-limit task-constraints) ")")
+                      {:command-length-limit (:command-length-limit task-constraints)
+                       :job job})))
     (doseq [{:keys [executable? extract?] :as uri} (:uris munged)
             :when (and (not (nil? executable?)) (not (nil? extract?)))]
       (throw (ex-info "Uri cannot set executable and extract" uri)))


### PR DESCRIPTION
## Changes proposed in this PR
- Adds a new configuration parameter to configure maximum command length

## Why are we making these changes?
Prevents users from submitting arbitrarily long commands.
