### PR TITLE
Write Kubernetes state back to Datomic

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -46,7 +46,6 @@
            :user-metrics-interval-seconds 60}
  :nrepl {:enabled? true
          :port #config/env-int "COOK_NREPL_PORT"}
- :pools {:default "gamma"}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -176,7 +176,6 @@
     (.addContainersItem pod-spec container)
     (.setNodeName pod-spec hostname)
     (.setRestartPolicy pod-spec "Never")
-    (.setTerminationGracePeriodSeconds pod-spec 1) ; TODO(pschorf): make configurable/remove
 
     ; pod
     (.setMetadata pod metadata)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -176,6 +176,7 @@
     (.addContainersItem pod-spec container)
     (.setNodeName pod-spec hostname)
     (.setRestartPolicy pod-spec "Never")
+    (.setTerminationGracePeriodSeconds pod-spec 1)
 
     ; pod
     (.setMetadata pod metadata)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -176,7 +176,7 @@
     (.addContainersItem pod-spec container)
     (.setNodeName pod-spec hostname)
     (.setRestartPolicy pod-spec "Never")
-    (.setTerminationGracePeriodSeconds pod-spec 1)
+    (.setTerminationGracePeriodSeconds pod-spec 1) ; TODO(pschorf): make configurable/remove
 
     ; pod
     (.setMetadata pod metadata)

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -68,9 +68,9 @@
 (defn handle-status-update
   "Helper function for calling scheduler/handle-status-update"
   [kcc mesos-status]
-  (scheduler/handle-status-update datomic/conn
-                                  @(:pool->fenzo-atom kcc)
-                                  mesos-status))
+  (scheduler/write-status-to-datomic datomic/conn
+                                     @(:pool->fenzo-atom kcc)
+                                     mesos-status))
 
 (defn- get-job-container-status
   "Extract the constainer status for the api/cook-container-name-for-job container"

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -1,8 +1,10 @@
 (ns cook.kubernetes.controller
   (:require [clojure.tools.logging :as log]
-            [cook.kubernetes.api :as api])
+            [cook.datomic :as datomic]
+            [cook.kubernetes.api :as api]
+            [cook.scheduler.scheduler :as scheduler])
   (:import (clojure.lang IAtom)
-           (io.kubernetes.client.models V1Pod)))
+           (io.kubernetes.client.models V1Pod V1ContainerStatus V1PodStatus)))
 
 ;
 ;   Wire up a store with the results.
@@ -48,19 +50,42 @@
     (swap! map-atom dissoc key)
     (swap! map-atom assoc key value)))
 
-;; REVIEW: Review handle-status-update
+(defn container-status->failure-reason
+  [^V1PodStatus pod-status ^V1ContainerStatus status]
+  ; TODO map kubernetes failure reasons
+  (let [terminated (-> status .getState .getTerminated)]
+    (cond
+      (= "OutOfMemory" (.getReason pod-status)) :reason-container-limitation-memory
+      (= "Error" (.getReason terminated)) :reason-command-executor-failed
+      (= "OOMKilled" (.getReason terminated)) :reason-container-limitation-memory
+      :default :unknown)))
+
+(defn handle-status-update
+  [kcc mesos-status]
+  (scheduler/handle-status-update datomic/conn
+                                  @(:pool->fenzo-atom kcc)
+                                  mesos-status))
+
 (defn pod-has-just-completed
   "A pod has completed."
-  [{:keys [synthesized-state pod] :as existing-state-dictionary}]
-  (case (:state synthesized-state)
-    :pod/failed
-    (do
-      ; TODO: Extract failure reason, etc and store in datomic, via refactored handle-status-update.
-      {:expected-state :expected/completed})
-    :pod/succeeded
-    (do
-      ; TODO: Mark job as success in datomic, via refactored handle-status-update.
-      {:expected-state :expected/completed})))
+  [kcc {:keys [synthesized-state pod] :as existing-state-dictionary}]
+  (let [task-id (-> pod .getMetadata .getName)
+        ^V1ContainerStatus job-container-status (->> pod
+                                                     .getStatus
+                                                     .getContainerStatuses
+                                                     (filter (fn [container-status] (= api/cook-container-name-for-job
+                                                                                       (.getName container-status))))
+                                                     first)
+        mesos-state (case (:state synthesized-state)
+                      :pod/failed :task-failed
+                      :pod/succeeded :task-finished)
+        status {:task-id {:value task-id}
+                :state mesos-state
+                :reason (container-status->failure-reason (.getStatus pod) job-container-status)}
+        exit-code (-> job-container-status .getState .getTerminated .getExitCode)]
+    (handle-status-update kcc status)
+    (cook.mesos.sandbox/aggregate-exit-code (:exit-code-syncer-state kcc) task-id exit-code)
+    {:expected-state :expected/completed}))
 
 (defn prepare-expected-state-dict-for-logging
   [expected-state-dict]
@@ -69,12 +94,24 @@
     (assoc expected-state-dict :launch-pod [:elided-for-brevity])
     expected-state-dict))
 
-;; REVIEW: Review handle-status-update
 (defn pod-has-started
   "A pod has started."
-  [{:keys [synthesized-state pod] :as existing-state-dictionary}]
-  ;(api/TODO); TODO Update datomic state to instance.state/running.
-  {:expected-state :expected/running})
+  [kcc {:keys [pod] :as existing-state-dictionary}]
+  (let [task-id (-> pod .getMetadata .getName)
+        status {:task-id {:value task-id}
+                :state :task-running}]
+    (handle-status-update kcc status)
+    {:expected-state :expected/running}))
+
+(defn pod-was-killed
+  [kcc {:keys [pod] :as existing-state-dictionary}]
+  (let [task-id (-> pod .getMetadata .getName)
+        status {:task-id {:value task-id}
+                :state :task-failed
+                :reason :reason-command-executor-failed}]
+    (handle-status-update kcc status)
+    (cook.mesos.sandbox/aggregate-exit-code (:exit-code-syncer-state kcc) task-id 143)
+    {:expected-state :expected/completed}))
 
 (defn process
   "Visit this pod-name, processing the new level-state. Returns the new expected state. Returns
@@ -90,24 +127,28 @@
     (let
       [new-expected-state-dict (case (vector (or expected-state :missing) (or (:state synthesized-state) :missing))
                                  [:expected/starting :missing] (launch-task api-client expected-state-dict)
-                                 [:expected/starting :pod/running] (pod-has-started existing-state-dict)
+                                 [:expected/starting :pod/running] (pod-has-started kcc existing-state-dict)
                                  ; TODO We need to add cases for the other [:expected/starting *] states in.
                                  [:expected/starting :pod/waiting] expected-state-dict
-                                 [:expected/starting :pod/succeeded] (pod-has-just-completed existing-state-dict)
-                                 [:expected/starting :pod/failed] (pod-has-just-completed existing-state-dict)
+                                 [:expected/starting :pod/succeeded] (pod-has-just-completed kcc existing-state-dict)
+                                 [:expected/starting :pod/failed] (pod-has-just-completed kcc existing-state-dict)
                                  [:expected/running :pod/running] expected-state-dict
-                                 [:expected/running :pod/succeeded] (pod-has-just-completed existing-state-dict)
+                                 [:expected/running :pod/succeeded] (pod-has-just-completed kcc existing-state-dict)
                                  [:expected/completed :pod/succeeded] (remove-finalization-if-set-and-delete api-client expected-state-dict pod)
-                                 [:expected/running :pod/failed] (pod-has-just-completed existing-state-dict)
+                                 [:expected/running :pod/failed] (pod-has-just-completed kcc existing-state-dict)
                                  [:expected/completed :pod/failed] (remove-finalization-if-set-and-delete api-client expected-state-dict pod)
                                  [:expected/completed :missing] nil ; Cause it to be deleted.
+                                 [:expected/killed :pod/waiting] (kill-task api-client expected-state-dict pod)
                                  [:expected/killed :pod/running] (kill-task api-client expected-state-dict pod) ; TODO: Where does the datomic update occur? Do we do it when we do [expected/killed :pod/failed], to be similar to mesos, we update it only when the backend says its dead?
 
-                                 [:expected/killed :pod/succeeded] (remove-finalization-if-set-and-delete api-client expected-state-dict pod)
+                                 [:expected/killed :pod/succeeded] (do
+                                                                     (pod-has-just-completed kcc existing-state-dict)
+                                                                     (remove-finalization-if-set-and-delete api-client expected-state-dict pod))
                                  [:expected/killed :pod/failed]
-                                 (do ; TODO: Invoke handle-status-update.
+                                 (do
+                                   (pod-has-just-completed kcc existing-state-dict)
                                    (remove-finalization-if-set-and-delete api-client expected-state-dict pod))
-                                 [:expected/killed :missing] nil
+                                 [:expected/killed :missing] (pod-was-killed kcc existing-state-dict)
                                  ; TODO: Implement :pod/unknown cases.
                                  ; TODO: Implement :pod/pending cases.
                                  ; TODO: Implement :pod/need-to-fail cases.
@@ -115,7 +156,13 @@
                                  [:missing :pod/pending] (kill-task api-client expected-state-dict pod)
                                  [:missing :pod/need-to-fail] (kill-task api-client expected-state-dict pod)
                                  [:missing :pod/succeeded] (remove-finalization-if-set-and-delete api-client expected-state-dict pod)
-                                 [:missing :pod/failed] (remove-finalization-if-set-and-delete api-client expected-state-dict pod))]
+                                 [:missing :pod/failed] (remove-finalization-if-set-and-delete api-client expected-state-dict pod)
+                                 [:missing :missing] nil
+                                 (do
+                                   (log/error "Unexpected state: "
+                                              (vector (or expected-state :missing) (or (:state synthesized-state) :missing))
+                                              "for pod" pod-name)
+                                   expected-state-dict))]
       (when-not (expected-state-equivalent? expected-state-dict new-expected-state-dict)
         (update-or-delete! expected-state-map pod-name new-expected-state-dict)
         (log/info "Processing: WANT TO RECUR" new-expected-state-dict " ---- " existing-state-dict)

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -2,6 +2,7 @@
   (:require [clojure.tools.logging :as log]
             [cook.datomic :as datomic]
             [cook.kubernetes.api :as api]
+            [cook.mesos.sandbox :as sandbox]
             [cook.scheduler.scheduler :as scheduler])
   (:import (clojure.lang IAtom)
            (io.kubernetes.client.models V1Pod V1ContainerStatus V1PodStatus)))
@@ -84,7 +85,7 @@
                 :reason (container-status->failure-reason (.getStatus pod) job-container-status)}
         exit-code (-> job-container-status .getState .getTerminated .getExitCode)]
     (handle-status-update kcc status)
-    (cook.mesos.sandbox/aggregate-exit-code (:exit-code-syncer-state kcc) task-id exit-code)
+    (sandbox/aggregate-exit-code (:exit-code-syncer-state kcc) task-id exit-code)
     {:expected-state :expected/completed}))
 
 (defn prepare-expected-state-dict-for-logging
@@ -110,7 +111,7 @@
                 :state :task-failed
                 :reason :reason-command-executor-failed}]
     (handle-status-update kcc status)
-    (cook.mesos.sandbox/aggregate-exit-code (:exit-code-syncer-state kcc) task-id 143)
+    (sandbox/aggregate-exit-code (:exit-code-syncer-state kcc) task-id 143)
     {:expected-state :expected/completed}))
 
 (defn process

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -26,7 +26,7 @@
             [cook.plugins.pool :as pool-plugin]
             [cook.progress :as progress]
             [cook.scheduler.scheduler :as sched]
-            [cook.tools :as util]
+            [cook.tools :as tools]
             [datomic.api :as d]
             [mesomatic.scheduler :as mesos]
             [metrics.meters :as meters]
@@ -38,6 +38,7 @@
 
 
 (defn conditionally-sync-sandbox
+  "For non cook executor tasks, call sync-agent-sandboxes-fn"
   [conn task-id task-state sync-agent-sandboxes-fn]
   (let [instance-ent (d/entity (d/db conn) [:instance/task-id task-id])]
     (when (and (#{:task-starting :task-running} task-state)
@@ -51,7 +52,7 @@
         instance (d/entity (d/db conn) [:instance/task-id task-id])
         prior-job-state (:job/state (:job/_instance instance))
         prior-instance-status (:instance/status instance)
-        pool-name (util/job->pool-name (:job/_instance instance))]
+        pool-name (tools/job->pool-name (:job/_instance instance))]
     (if (and
             (or (nil? instance) ; We could know nothing about the task, meaning a DB error happened and it's a waste to finish
                 (= prior-job-state :job.state/completed) ; The task is attached to a failed job, possibly due to instances running on multiple hosts

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -26,12 +26,11 @@
             [cook.plugins.pool :as pool-plugin]
             [cook.progress :as progress]
             [cook.scheduler.scheduler :as sched]
+            [cook.tools :as util]
             [datomic.api :as d]
             [mesomatic.scheduler :as mesos]
             [metrics.meters :as meters]
-            [plumbing.core :as pc]
-            [cook.tools :as util]
-            [cook.scheduler.scheduler :as scheduler]))
+            [plumbing.core :as pc]))
 
 (meters/defmeter [cook-mesos scheduler mesos-error])
 (meters/defmeter [cook-mesos scheduler handle-framework-message-rate])
@@ -66,7 +65,7 @@
         (log/warn "Attempting to kill task" task-id
                   "as instance" instance "with" prior-job-state "and" prior-instance-status
                   "should've been put down already")
-        (meters/mark! (meters/meter (scheduler/metric-title "tasks-killed-in-status-update" pool-name)))
+        (meters/mark! (meters/meter (sched/metric-title "tasks-killed-in-status-update" pool-name)))
         (cc/kill-task compute-cluster task-id))
       (sched/handle-status-update conn pool->fenzo status))
     (conditionally-sync-sandbox conn task-id (:state status) sync-agent-sandboxes-fn)))

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -47,7 +47,7 @@
       (sync-agent-sandboxes-fn (:instance/hostname instance-ent) task-id))))
 
 (defn handle-status-update
-  [conn {:keys [state] :as status} compute-cluster sync-agent-sandboxes-fn pool->fenzo]
+  [conn compute-cluster sync-agent-sandboxes-fn pool->fenzo {:keys [state] :as status}]
   (let [task-id (-> status :task-id :value)
         instance (d/entity (d/db conn) [:instance/task-id task-id])
         prior-job-state (:job/state (:job/_instance instance))
@@ -170,7 +170,7 @@
         (meters/mark! handle-status-update-rate)
         (let [task-id (-> status :task-id :value)]
           (sched/async-in-order-processing
-            task-id (fn [] (handle-status-update conn status compute-cluster sync-agent-sandboxes-fn pool->fenzo))))))))
+            task-id (fn [] (handle-status-update conn compute-cluster sync-agent-sandboxes-fn pool->fenzo status))))))))
 
 
 (defn make-mesos-driver

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -68,7 +68,7 @@
                   "should've been put down already")
         (meters/mark! (meters/meter (sched/metric-title "tasks-killed-in-status-update" pool-name)))
         (cc/kill-task compute-cluster task-id))
-      (sched/handle-status-update conn pool->fenzo status))
+      (sched/write-status-to-datomic conn pool->fenzo status))
     (conditionally-sync-sandbox conn task-id (:state status) sync-agent-sandboxes-fn)))
 
 (defn create-mesos-scheduler

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -565,11 +565,6 @@
 ;Shared as we use this for unscheduled too.
 (defonce pool->user->number-jobs (atom {}))
 
-(defn log-and-return
-  [msg obj]
-  (log/debug msg (count obj))
-  obj)
-
 (defn pending-jobs->considerable-jobs
   "Limit the pending jobs to considerable jobs based on usage and quota.
    Further limit the considerable jobs to a maximum of num-considerable jobs."
@@ -592,15 +587,10 @@
         considerable-jobs
         (->> pending-jobs
              (util/filter-based-on-quota user->quota user->usage)
-             (log-and-return "after quota filtering")
              (filter (fn [job] (util/job-allowed-to-start? db job)))
-             (log-and-return "after allowed to start")
              (filter user-within-launch-rate-limit?-fn)
-             (log-and-return "after rate limit")
              (filter launch-plugin/filter-job-launches)
-             (log-and-return "after plugin")
              (take num-considerable)
-             (log-and-return "after take")
              ; Force this to be taken eagerly so that the log line is accurate.
              (doall))]
     (swap! pool->user->number-jobs update pool-name (constantly @user->number-jobs))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -203,7 +203,7 @@
     (update-metrics! "cpu-times" (* instance-runtime-seconds cpus))
     (update-metrics! "mem-times" (* instance-runtime-seconds mem-gb))))
 
-(defn handle-status-update
+(defn write-status-to-datomic
   "Takes a status update from mesos."
   [conn pool->fenzo status]
   (log/info "Mesos status is:" status)

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -1,10 +1,8 @@
 (ns cook.test.kubernetes.compute-cluster
   (:require [clojure.test :refer :all]
-            [cook.kubernetes.api :as api]
             [cook.kubernetes.compute-cluster :as kcc]
             [cook.test.testutil :as tu]
-            [datomic.api :as d])
-  (:import (io.kubernetes.client.models V1Pod V1PodStatus V1ContainerStatus V1ContainerState V1ContainerStateWaiting)))
+            [datomic.api :as d]))
 
 (deftest test-get-or-create-cluster-entity-id
   (let [conn (tu/restore-fresh-database! "datomic:mem://test-get-or-create-cluster-entity-id")]
@@ -21,7 +19,8 @@
         (is (= eid eid2))))))
 
 (deftest test-generate-offers
-  (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil (atom {}) (atom {}) (atom {}) (atom {}))
+  (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
+                                                        (atom {}) (atom {}) (atom {}) (atom {}) (atom nil))
         node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0)
                          "nodeB" (tu/node-helper "nodeB" 1.0 1000.0)
                          "nodeC" (tu/node-helper "nodeC" 1.0 1000.0)}

--- a/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
+++ b/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
@@ -1,5 +1,6 @@
 (ns cook.test.mesos.mesos-compute-cluster
   (:require [clojure.core.async :as async]
+            [clojure.core.cache :as cache]
             [clojure.data.json :as json]
             [clojure.test :refer :all]
             [cook.mesos.heartbeat :as heartbeat]
@@ -10,8 +11,7 @@
             [datomic.api :as d]
             [mesomatic.types :as mtypes]
             [mesomatic.scheduler :as msched]
-            [plumbing.core :as pc]
-            [clojure.core.cache :as cache])
+            [plumbing.core :as pc])
   (:import (java.util.concurrent CountDownLatch TimeUnit)))
 
 (deftest test-in-order-status-update-processing

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1455,9 +1455,8 @@
                                            :data (ByteString/copyFrom (.getBytes (pr-str {:percent progress}) "UTF-8"))}]
                                  task))
           job-id (create-dummy-job conn :user "user" :job-state :job.state/running)
-          sync-agent-sandboxes-fn (constantly true)
           send-status-update #(->> (make-status-update "task1" :unknown :task-running %)
-                                   (sched/handle-status-update conn driver {} sync-agent-sandboxes-fn)
+                                   (sched/handle-status-update conn {})
                                    async/<!!)
           instance-id (create-dummy-instance conn job-id
                                              :instance-status :instance.status/running

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1456,7 +1456,7 @@
                                  task))
           job-id (create-dummy-job conn :user "user" :job-state :job.state/running)
           send-status-update #(->> (make-status-update "task1" :unknown :task-running %)
-                                   (sched/handle-status-update conn {})
+                                   (sched/write-status-to-datomic conn {})
                                    async/<!!)
           instance-id (create-dummy-instance conn job-id
                                              :instance-status :instance.status/running

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -865,7 +865,7 @@
         ;        group-id (create-dummy-group conn)
         jobs (doall (take 200 (repeatedly (fn [] (create-dummy-job conn :group group-id)))))
         group (d/entity (d/db conn) group-id)]
-    (println  "============ match offers with group constraints timing ============")
+    (println "============ match offers with group constraints timing ============")
     (crit/bench (schedule-and-run-jobs conn scheduler (make-offers) jobs))))
 
 (deftest test-gpu-share-prioritization
@@ -946,7 +946,7 @@
                                                  :task-id task-id)]
                                         ; Wait for async database transaction inside handle-status-update
           (->> (make-dummy-status-update task-id :reason-gc-error :task-killed)
-               (sched/handle-status-update conn compute-cluster (constantly fenzo) sync-agent-sandboxes-fn)
+               (sched/handle-status-update conn (constantly fenzo))
                async/<!!)
 
           (is (= :instance.status/failed
@@ -971,7 +971,7 @@
                 original-end-time (get-end-time)]
             (Thread/sleep 100)
             (->> (make-dummy-status-update task-id :reason-gc-error :task-killed)
-                 (sched/handle-status-update conn compute-cluster (constantly fenzo) sync-agent-sandboxes-fn)
+                 (sched/handle-status-update conn (constantly fenzo))
                  async/<!!)
             (is (= original-end-time (get-end-time))))))
 
@@ -996,7 +996,7 @@
                                                  :reason :max-runtime-exceeded)] ; Previous reason is not mea-culpa
                                         ; Status update says slave got restarted (mea-culpa)
           (->> (make-dummy-status-update task-id :mesos-slave-restarted :task-killed)
-               (sched/handle-status-update conn compute-cluster (constantly fenzo) sync-agent-sandboxes-fn)
+               (sched/handle-status-update conn (constantly fenzo))
                async/<!!)
                                         ; Assert old reason persists
           (is (= :max-runtime-exceeded
@@ -1015,29 +1015,6 @@
                               [?s :db/ident ?state]]
                             (db conn) job-id))))))
 
-      (testing "Tasks of completed jobs are killed"
-        (let [job-id (create-dummy-job conn
-                                       :user "tsram"
-                                       :job-state :job.state/completed
-                                       :retry-count 3)
-              task-id-a "taska"
-              task-id-b "taskb"]
-          (create-dummy-instance conn job-id
-                                 :hostname "www.test-host.com"
-                                 :instance-status :instance.status/running
-                                 :task-id task-id-a
-                                 :reason :unknown)
-          (create-dummy-instance conn job-id
-                                 :instance-status :instance.status/success
-                                 :task-id task-id-b
-                                 :reason :unknown)
-          (reset! synced-agents-atom [])
-          (->> (make-dummy-status-update task-id-a :mesos-slave-restarted :task-running)
-               (sched/handle-status-update conn compute-cluster (constantly fenzo) sync-agent-sandboxes-fn)
-               async/<!!)
-          (is (true? (contains? @tasks-killed task-id-a)))
-          (is (= ["www.test-host.com"] @synced-agents-atom))))
-
       (testing "instance persists mesos-start-time when task is first known to be starting or running"
         (let [job-id (create-dummy-job conn
                                        :user "mforsyth"
@@ -1055,19 +1032,18 @@
                                  :task-id task-id)
           (is (nil? (mesos-start-time)))
           (->> (make-dummy-status-update task-id :unknown :task-staging)
-               (sched/handle-status-update conn compute-cluster (constantly fenzo) sync-agent-sandboxes-fn)
+               (sched/handle-status-update conn (constantly fenzo))
                async/<!!)
           (is (nil? (mesos-start-time)))
           (reset! synced-agents-atom [])
           (->> (make-dummy-status-update task-id :unknown :task-running)
-               (sched/handle-status-update conn driver (constantly fenzo) sync-agent-sandboxes-fn)
+               (sched/handle-status-update conn (constantly fenzo))
                async/<!!)
-          (is (= ["www.test-host.com"] @synced-agents-atom))
           (is (not (nil? (mesos-start-time))))
           (let [first-observed-start-time (.getTime (mesos-start-time))]
             (is (not (nil? first-observed-start-time)))
             (->> (make-dummy-status-update task-id :unknown :task-running)
-                 (sched/handle-status-update conn compute-cluster (constantly fenzo) sync-agent-sandboxes-fn)
+                 (sched/handle-status-update conn (constantly fenzo))
                  async/<!!)
             (is (= first-observed-start-time (.getTime (mesos-start-time))))))))))
 
@@ -1092,13 +1068,13 @@
                                                  :instance-status :instance.status/unknown
                                                  :task-id task-id)]
           (->> (make-dummy-status-update task-id :reason-command-executor-failed :task-running)
-               (sched/handle-status-update conn driver (constantly fenzo) (constantly nil))
+               (sched/handle-status-update conn (constantly fenzo))
                async/<!!)
           ; instance not complete, plugin should not have been invoked
           (is (= {} @plugin-invocation-atom))
 
           (->> (make-dummy-status-update task-id :reason-command-executor-failed :task-killed)
-               (sched/handle-status-update conn driver (constantly fenzo) (constantly nil))
+               (sched/handle-status-update conn (constantly fenzo))
                async/<!!)
           ; instance complete, plugin should have been invoked with resulting job/instance
           (let [job (:job @plugin-invocation-atom)
@@ -1885,107 +1861,6 @@
             (is (= (:slave-id offer-1) (:slave-id task-1)))
             (is (= (:slave-id offer-2) (:slave-id task-2)))))))))
 
-(defn- task-id->instance-entity
-  [db-conn task-id]
-  (let [datomic-db (d/db db-conn)]
-    (->> task-id
-         (d/q '[:find ?i
-                :in $ ?task-id
-                :where [?i :instance/task-id ?task-id]]
-              datomic-db)
-         ffirst
-         (d/entity (d/db db-conn))
-         d/touch)))
-
-(deftest test-sandbox-directory-population-for-mesos-executor-tasks
-  (let [db-conn (restore-fresh-database! "datomic:mem://test-sandbox-directory-population")
-        executing-tasks-atom (atom #{})
-        num-jobs 25
-        cache-timeout-ms 65
-        get-task-id #(str "task-test-sandbox-directory-population-" %)]
-    (dotimes [n num-jobs]
-      (let [task-id (get-task-id n)
-            job (create-dummy-job db-conn :task-id task-id)]
-        (create-dummy-instance db-conn job :executor :executor/mesos :executor-id task-id :task-id task-id)))
-
-    (with-redefs [sandbox/retrieve-sandbox-directories-on-agent
-                  (fn [_ _]
-                    (pc/map-from-keys #(str "/sandbox/for/" %) @executing-tasks-atom))]
-      (let [framework-id "test-framework-id"
-            publish-batch-size 10
-            publish-interval-ms 20
-            sync-interval-ms 20
-            max-consecutive-sync-failure 5
-            agent-query-cache (-> {} (cache/ttl-cache-factory :ttl cache-timeout-ms) atom)
-            {:keys [pending-sync-agent publisher-cancel-fn syncer-cancel-fn task-id->sandbox-agent] :as sandbox-syncer-state}
-            (sandbox/prepare-sandbox-publisher
-              framework-id db-conn publish-batch-size publish-interval-ms sync-interval-ms max-consecutive-sync-failure
-              agent-query-cache)
-            sync-agent-sandboxes-fn
-            (fn [hostname task-id]
-              (sandbox/sync-agent-sandboxes sandbox-syncer-state framework-id hostname task-id))]
-        (try
-          (-> (dotimes [n num-jobs]
-                (let [task-id (get-task-id n)]
-                  (swap! executing-tasks-atom conj task-id)
-                  (->> {:task-id {:value task-id}, :state :task-running}
-                       (sched/handle-status-update db-conn nil {} sync-agent-sandboxes-fn)))
-                (Thread/sleep 5))
-              async/thread
-              async/<!!)
-
-          (dotimes [n num-jobs]
-            (let [task-id (get-task-id n)
-                  instance-ent (task-id->instance-entity db-conn task-id)]
-              (is (= "localhost" (:instance/hostname instance-ent)))
-              (is (= :instance.status/running (:instance/status instance-ent)))
-              (is (= :executor/mesos (:instance/executor instance-ent)))))
-
-          (Thread/sleep (+ cache-timeout-ms sync-interval-ms))
-          (await pending-sync-agent)
-          (Thread/sleep (* 2 publish-interval-ms))
-          (await task-id->sandbox-agent)
-
-          ;; verify the sandbox-directory stored into the db
-          (dotimes [n num-jobs]
-            (let [task-id (get-task-id n)
-                  instance-ent (task-id->instance-entity db-conn task-id)]
-              (is (= (str "/sandbox/for/" task-id) (:instance/sandbox-directory instance-ent)))))
-
-          (finally
-            (publisher-cancel-fn)
-            (syncer-cancel-fn)))))))
-
-(deftest test-no-sandbox-directory-population-for-cook-executor-tasks
-  (let [db-conn (restore-fresh-database! "datomic:mem://test-sandbox-directory-population")
-        executing-tasks-atom (atom #{})
-        num-jobs 25
-        get-task-id #(str "task-test-sandbox-directory-population-" %)
-        sync-agent-sandboxes-fn (fn [_] (throw (Exception. "Unexpected call for cook executor task")))]
-    (dotimes [n num-jobs]
-      (let [task-id (get-task-id n)
-            job (create-dummy-job db-conn :task-id task-id)]
-        (create-dummy-instance db-conn job :executor :executor/cook :executor-id task-id :task-id task-id)))
-
-    (try
-      (-> (dotimes [n num-jobs]
-            (let [task-id (get-task-id n)]
-              (swap! executing-tasks-atom conj task-id)
-              (->> {:task-id {:value task-id}, :state :task-running}
-                   (sched/handle-status-update db-conn nil (constantly nil) sync-agent-sandboxes-fn)))
-            (Thread/sleep 5))
-          async/thread
-          async/<!!)
-
-      ;; verify the instance state
-      (dotimes [n num-jobs]
-        (let [task-id (get-task-id n)
-              instance-ent (task-id->instance-entity db-conn task-id)]
-          (is (= "localhost" (:instance/hostname instance-ent)))
-          (is (= :instance.status/running (:instance/status instance-ent)))
-          (is (= :executor/cook (:instance/executor instance-ent)))
-          (is (nil? (:instance/sandbox-directory instance-ent))))))))
-
 (deftest test-monitor-tx-report-queue
   (let [uri "datomic:mem://test-monitor-tx-report-queue"
         conn (restore-fresh-database! uri)
@@ -2006,7 +1881,7 @@
     (let [[report-mult close-fn] (cook.datomic/create-tx-report-mult conn)
           transaction-chan (async/chan (async/sliding-buffer 4096))
           _ (async/tap report-mult transaction-chan)
-          kill-fn (cook.scheduler.scheduler/monitor-tx-report-queue transaction-chan conn)]
+          _ (cook.scheduler.scheduler/monitor-tx-report-queue transaction-chan conn)]
       (cook.mesos/kill-job conn [(:job/uuid (d/entity (d/db conn) job-id-2))])
       (let [expected-tasks-killed [{:value (:instance/task-id (d/entity (d/db conn) instance-id-1))}
                                    {:value (:instance/task-id (d/entity (d/db conn) instance-id-2))}]


### PR DESCRIPTION
## Changes proposed in this PR
- Refactor `handle-status-update` to remove sandbox syncing and lingering task killer
- Invoke handle status update from Kubernetes controller

## Why are we making these changes?
We need to write Kubernetes state back to Datomic.
