### PR TITLE
Improve Kubernetes fenzo integration

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -27,7 +27,7 @@
   (db-id [this]
     "Get a database entity-id for this compute cluster (used for putting it into a task structure).")
 
-  (initialize-cluster [this pool->fenzo pool->offers-chan]
+  (initialize-cluster [this pool->fenzo]
     "Initializes the cluster. Returns a channel that will be delivered on when the cluster loses leadership.
      We expect Cook to give up leadership when a compute cluster loses leadership, so leadership is not expected to be regained.
      The channel result will be an exception if an error occurred, or a status message if leadership was lost normally.")
@@ -38,8 +38,14 @@
   (kill-task [this task-id]
     "Kill the task with the given task id")
 
-  (decline-offer [this offer-id]
-    "Decline the given offer"))
+  (decline-offers [this offer-ids]
+    "Decline the given offer ids")
+
+  (pending-offers [this pool-name]
+    "Retrieve pending offers for the given pool")
+
+  (restore-offers [this pool-name offers]
+    "Called when offers are not processed to ensure they're still available."))
 
 ; Internal method
 (defn write-compute-cluster

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -157,7 +157,7 @@
                               ;; TODO: get the framework ID and try to reregister
                               (let [normal-exit (atom true)]
                                 (try
-                                  (let [{:keys [pool-name->fenzo pool->offers-chan view-incubating-offers]}
+                                  (let [{:keys [pool-name->fenzo view-incubating-offers]}
                                         (sched/create-datomic-scheduler
                                          {:conn mesos-datomic-conn
                                           :compute-cluster compute-cluster
@@ -176,8 +176,7 @@
                                           :task-constraints task-constraints
                                           :trigger-chans trigger-chans})
                                         cluster-leadership-chan (cc/initialize-cluster compute-cluster
-                                                                                          pool-name->fenzo
-                                                                                          pool->offers-chan)]
+                                                                                          pool-name->fenzo)]
                                     (cook.monitor/start-collecting-stats)
                                     ; Many of these should look at the compute-cluster of the underlying jobs, and not use driver at all.
                                     (cook.scheduler.scheduler/lingering-task-killer mesos-datomic-conn compute-cluster

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -274,7 +274,7 @@
             (reset! driver-atom nil))))))
 
   (pending-offers [this pool-name]
-    (->> (util/read-chan (pool->offers-chan pool-name) offer-chan-size)
+    (->> (tools/read-chan (pool->offers-chan pool-name) offer-chan-size)
          ((fn decrement-offer-chan-depth [offer-lists]
             (counters/dec! offer-chan-depth (count offer-lists))
             offer-lists))

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -39,7 +39,7 @@
 (meters/defmeter [cook-mesos scheduler handle-status-update-rate])
 (counters/defcounter [cook-mesos scheduler offer-chan-depth])
 
-(def offer-chan-depth 100)
+(def offer-chan-size 100)
 
 (defn conditionally-sync-sandbox
   "For non cook executor tasks, call sync-agent-sandboxes-fn"
@@ -274,7 +274,7 @@
             (reset! driver-atom nil))))))
 
   (pending-offers [this pool-name]
-    (->> (util/read-chan (pool->offers-chan pool-name) offer-chan-depth)
+    (->> (util/read-chan (pool->offers-chan pool-name) offer-chan-size)
          ((fn decrement-offer-chan-depth [offer-lists]
             (counters/dec! offer-chan-depth (count offer-lists))
             offer-lists))
@@ -358,7 +358,7 @@
                               db-pools
                               [{:pool/name "no-pool"}])
           pool->offer-chan (pc/map-from-keys (fn [_]
-                                               (async/chan offer-chan-depth))
+                                               (async/chan offer-chan-size))
                                              (map :pool/name synthesized-pools))
           mesos-compute-cluster (->MesosComputeCluster compute-cluster-name
                                                        framework-id

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -24,18 +24,22 @@
             [cook.mesos.task :as task]
             [cook.plugins.definitions :as plugins]
             [cook.plugins.pool :as pool-plugin]
+            [cook.pool :as pool]
             [cook.progress :as progress]
             [cook.scheduler.scheduler :as sched]
             [cook.tools :as tools]
             [datomic.api :as d]
             [mesomatic.scheduler :as mesos]
             [metrics.meters :as meters]
-            [plumbing.core :as pc]))
+            [plumbing.core :as pc]
+            [metrics.counters :as counters]))
 
 (meters/defmeter [cook-mesos scheduler mesos-error])
 (meters/defmeter [cook-mesos scheduler handle-framework-message-rate])
 (meters/defmeter [cook-mesos scheduler handle-status-update-rate])
+(counters/defcounter [cook-mesos scheduler offer-chan-depth])
 
+(def offer-chan-depth 100)
 
 (defn conditionally-sync-sandbox
   "For non cook executor tasks, call sync-agent-sandboxes-fn"
@@ -209,7 +213,7 @@
 
 (defrecord MesosComputeCluster [compute-cluster-name framework-id db-id driver-atom
                                 sandbox-syncer-state exit-code-syncer-state mesos-heartbeat-chan
-                                trigger-chans mesos-config]
+                                trigger-chans mesos-config pool->offers-chan]
   cc/ComputeCluster
   (compute-cluster-name [this]
     compute-cluster-name)
@@ -222,8 +226,9 @@
   (kill-task [this task-id]
     (mesos/kill-task! @driver-atom {:value task-id}))
 
-  (decline-offer [this offer-id]
-    (mesos/decline-offer @driver-atom offer-id))
+  (decline-offers [this offer-ids]
+    (doseq [id offer-ids]
+      (mesos/decline-offer @driver-atom id)))
 
   (db-id [this]
     db-id)
@@ -231,7 +236,7 @@
   (current-leader? [this]
     (not (nil? @driver-atom)))
 
-  (initialize-cluster [this pool->fenzo pool->offers-chan]
+  (initialize-cluster [this pool->fenzo]
     (let [settings (:settings config/config)
           progress-config (:progress settings)
           conn cook.datomic/conn
@@ -266,7 +271,18 @@
           (catch Exception e
             e)
           (finally
-            (reset! driver-atom nil)))))))
+            (reset! driver-atom nil))))))
+
+  (pending-offers [this pool-name]
+    (->> (util/read-chan (pool->offers-chan pool-name) offer-chan-depth)
+         ((fn decrement-offer-chan-depth [offer-lists]
+            (counters/dec! offer-chan-depth (count offer-lists))
+            offer-lists))
+         (reduce into [])))
+
+  (restore-offers [this pool-name offers]
+    (async/go
+      (async/>! (pool->offers-chan pool-name) offers))))
 
 ; Internal method
 (defn- mesos-cluster->compute-cluster-map-for-datomic
@@ -337,6 +353,13 @@
                         :mesos-role (or role "*")
                         :mesos-framework-name (or framework-name "Cook")
                         :gpu-enabled? gpu-enabled?}
+          db-pools (pool/all-pools (d/db conn))
+          synthesized-pools (if (-> db-pools count pos?)
+                              db-pools
+                              [{:pool/name "no-pool"}])
+          pool->offer-chan (pc/map-from-keys (fn [_]
+                                               (async/chan offer-chan-depth))
+                                             (map :pool/name synthesized-pools))
           mesos-compute-cluster (->MesosComputeCluster compute-cluster-name
                                                        framework-id
                                                        cluster-entity-id
@@ -345,7 +368,8 @@
                                                        exit-code-syncer-state
                                                        mesos-heartbeat-chan
                                                        trigger-chans
-                                                       mesos-config)]
+                                                       mesos-config
+                                                       pool->offer-chan)]
       (log/info "Registering compute cluster" mesos-compute-cluster)
       (cc/register-compute-cluster! mesos-compute-cluster)
       mesos-compute-cluster)

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -54,7 +54,8 @@
                                exit-code-syncer-state
                                mesos-heartbeat-chan
                                trigger-chans
-                               {})))
+                               {}
+                               {"no-pool" (async/chan 100)})))
 
 (defn fake-test-compute-cluster-with-driver
   "Create a test compute cluster with associated driver attached to it. Returns the compute cluster."

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -138,7 +138,8 @@
                                                               exit-code-syncer-state#
                                                               mesos-heartbeat-chan#
                                                               trigger-chans#
-                                                              {}))]
+                                                              {}
+                                                              {"no-pool" (async/chan 100)}))]
      (try
        (with-redefs [executor-config (constantly executor-config#)
                      completion/plugin completion/no-op


### PR DESCRIPTION
## Changes proposed in this PR
- Refactor scheduler/compute cluster offer interface

## Why are we making these changes?
This allows a more natural integration for Kubernetes than the channel-based approach.

