### PR TITLE
Run travis builds on kubernetes_integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
   only:
     - master
     - /^build\/.*$/
+    - kubernetes_integration
 
 cache:
   directories:


### PR DESCRIPTION
## Changes proposed in this PR
- Runs integration tests on kubernetes_integration PRs

## Why are we making these changes?
This is a production-ish branch, so let's run tests while we're working on the Kubernetes integration.
