### PR TITLE
Initialize kubernetes expected state from datomic

### DIFF
--- a/scheduler/README-k8s.adoc
+++ b/scheduler/README-k8s.adoc
@@ -39,4 +39,4 @@ minikube dashboard
 
 - Submit a test job
 
-cs submit -i alpine:latest -c .01 "echo 200" 
+cs submit -i alpine:latest -c .01 -m 16 "echo 200" 

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -46,7 +46,6 @@
            :user-metrics-interval-seconds 60}
  :nrepl {:enabled? true
          :port #config/env-int "COOK_NREPL_PORT"}
- :pools {:default "gamma"}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -46,6 +46,7 @@
            :user-metrics-interval-seconds 60}
  :nrepl {:enabled? true
          :port #config/env-int "COOK_NREPL_PORT"}
+ :pools {:default "gamma"}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -27,7 +27,7 @@
   (db-id [this]
     "Get a database entity-id for this compute cluster (used for putting it into a task structure).")
 
-  (initialize-cluster [this pool->fenzo]
+  (initialize-cluster [this pool->fenzo running-task-ents]
     "Initializes the cluster. Returns a channel that will be delivered on when the cluster loses leadership.
      We expect Cook to give up leadership when a compute cluster loses leadership, so leadership is not expected to be regained.
      The channel result will be an exception if an error occurred, or a status message if leadership was lost normally.")

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -250,16 +250,6 @@
   [^V1Node node]
   :synthesized/TODO-node) ; TOOD
 
-(defn ^UUID pod-name->task-uuid
-  "Handles decoding the UUID from the name cook_uuid_43222432_......"
-  [pod-name]
-  (TODO)) ; TODO
-
-(defn ^UUID task-uuid->pod-name
-  "Handles encoding the UUID to the name cook_uuid_43222432_......"
-  [task-uuid]
-  "TODO: Implement task-uuid->pod-name") ; TODO
-
 (defn kill-task
   "Kill this kubernetes pod"
   [^ApiClient api-client ^V1Pod pod]

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -32,6 +32,8 @@
             (log/error e "Error while processing callback")))))))
 
 (defn initialize-pod-watch
+  "Initialize the pod watch. We require that this function set the current-pods-atom before it finishes so that
+  cook.kubernetes.compute-cluster/initialize-cluster works correctly."
   [^ApiClient api-client current-pods-atom pod-callback]
   (let [api (CoreV1Api. api-client)
         current-pods (.listPodForAllNamespaces api
@@ -51,6 +53,8 @@
                                               .getName))
                                         (.getItems current-pods))]
     (log/info "Updating current-pods-atom with pods" (keys pod-name->pod))
+    (log/error "TODO: We should have two atoms, one for cook pods (that feeds into the controller) and one for
+    all pods (that feeds into machine utilization then into offer generation)")
     (reset! current-pods-atom pod-name->pod)
     (let [watch (WatchHelper/createPodWatch api-client (-> current-pods
                                                            .getMetadata
@@ -297,15 +301,25 @@
   "Given a pod-name use lookup the associated task, extract the parts needed to syntehsize the kubenretes object and go"
   [api-client {:keys [launch-pod] :as expected-state-dict}]
   ;; TODO: IF there's an error, log it and move on. We'll try again later.
-  (let [api (CoreV1Api. api-client)]
-    (log/info "Launching pod" api launch-pod)
-    (try
-      (-> api
-          (.createNamespacedPod "cook" launch-pod nil nil nil))
-      (catch ApiException e
-        (log/error e "Error submitting pod:" (.getResponseBody e))))))
-
-;; TODO: Need the 'stuck pod scanner' to detect stuck states and move them into killed.
+  (if launch-pod
+    (let [api (CoreV1Api. api-client)]
+      (log/info "Launching pod" api launch-pod)
+      (try
+        (-> api
+            (.createNamespacedPod "cook" launch-pod nil nil nil))
+        (catch ApiException e
+          (log/error e "Error submitting pod:" (.getResponseBody e)))))
+    ; Because of the complicated nature of task-metadata-seq --- we can't easily run the V1Pod creation code for a
+    ; failed-to-start pod on a server restart. Thus, if we create a task, store into datomic, but then the cook scheduler
+    ; fails --- before kubernetes creates a pod (either the message isn't sent, or there's a kubernetes problem), we will
+    ; the inability to create a new V1Pod and we can't retry this at the kubernetes level.
+    ;
+    ; Eventually, the stuck pod detector will recognize the stuck pod, kill the task, and a cook-level retry will make
+    ; a new task.
+    ;
+    ; Because the issue is relatively rare and auto-recoverable, we're going to punt on the task-metadata-seq refactor.
+    (log/warn "Unimplemented Operation to launch a pod for becuause we do not reconstruct on startup.")))
+    ;; TODO: Need the 'stuck pod scanner' to detect stuck states and move them into killed.
 
 
 (defn rebuild-watch-pods

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -127,6 +127,8 @@
 
     ; Initialize the node watch path.
     (api/initialize-node-watch api-client current-nodes-atom)
+    ; TODO: Need to visit every state to refresh (i.e., do a single pass of state scanner)
+
     (reset! pool->fenzo-atom pool->fenzo)
 
     ; TODO(pschorf): Deliver when leadership lost

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -80,9 +80,8 @@
         running-tasks-in-cc-ents (filter
                                    #(-> % cook.task/task-entity->compute-cluster-name (= compute-cluster-name))
                                    running-tasks-ents)
-        _ (log/info "Running tasks in cc in datomic: " running-tasks-in-cc-ents)
+        _ (log/info "Running tasks in compute cluster in datomic: " running-tasks-in-cc-ents)
         cc-running-tasks-map (task-ents->map-by-task-id running-tasks-in-cc-ents)
-        _ (log/info "Running tasks map: " cc-running-tasks-map)
         cc-running-tasks-ids (->> cc-running-tasks-map keys (into #{}))
         extra-tasks-map (->> (set/difference all-tasks-ids-in-pods cc-running-tasks-ids)
                              (map (fn [task-id] [task-id (cook.tools/retrieve-instance db task-id)]))
@@ -90,7 +89,7 @@
                              (into {}))
         all-tasks-ents-map (set/union extra-tasks-map cc-running-tasks-map)]
     (doseq [[k v] all-tasks-ents-map]
-      (log/info "Doing processing for " k " ---> " (task-ent->expected-state v)))
+      (log/info "Setting expected state for " k " ---> " (task-ent->expected-state v)))
     (into {}
           (map (fn [[k v]] [k (task-ent->expected-state v)]) all-tasks-ents-map))))
 

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -115,6 +115,8 @@
     {:expected-state :expected/running}))
 
 (defn pod-was-killed
+  ; TODO: Bug here, this can be called in :expected/killed missing, and NPE's trying to get the pod-name
+  ; out. We should ship the pod-id through instead of extracting from the V1Pod.
   [kcc {:keys [pod] :as existing-state-dictionary}]
   (let [task-id (-> pod .getMetadata .getName)
         status {:task-id {:value task-id}

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -175,8 +175,10 @@
                                           :rebalancer-reservation-atom rebalancer-reservation-atom
                                           :task-constraints task-constraints
                                           :trigger-chans trigger-chans})
+                                        running-tasks-ents (cook.tools/get-running-task-ents (d/db mesos-datomic-conn))
                                         cluster-leadership-chan (cc/initialize-cluster compute-cluster
-                                                                                          pool-name->fenzo)]
+                                                                                       pool-name->fenzo
+                                                                                       running-tasks-ents)]
                                     (cook.monitor/start-collecting-stats)
                                     ; Many of these should look at the compute-cluster of the underlying jobs, and not use driver at all.
                                     (cook.scheduler.scheduler/lingering-task-killer mesos-datomic-conn compute-cluster

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -236,7 +236,7 @@
   (current-leader? [this]
     (not (nil? @driver-atom)))
 
-  (initialize-cluster [this pool->fenzo]
+  (initialize-cluster [this pool->fenzo _]
     (let [settings (:settings config/config)
           progress-config (:progress settings)
           conn cook.datomic/conn

--- a/scheduler/src/cook/task.clj
+++ b/scheduler/src/cook/task.clj
@@ -24,10 +24,16 @@
        (d/entity db)
        :instance/task-id))
 
+(defn task-entity->compute-cluster-name
+  "Get the compute-cluster name from a task-entity"
+  [task-ent]
+  (-> task-ent
+      :instance/compute-cluster
+      :compute-cluster/cluster-name))
+
 (defn task-entity-id->compute-cluster-name
   "Given a task entity, what is the compute cluser name associated with it?"
   [db task-entity-id]
   (->> task-entity-id
        (d/entity db)
-       :instance/compute-cluster
-       :compute-cluster/cluster-name))
+       task-entity->compute-cluster-name))

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -487,6 +487,11 @@
             db [:instance.status/running :instance.status/unknown])
          (map (partial d/entity db)))))
 
+(defn retrieve-instance
+  "Given an instance UUID, return the instance entity."
+  [db instance-uuid]
+  (d/entity db [:instance/task-id (str instance-uuid)]))
+
 (timers/deftimer [cook-mesos scheduler get-user-running-jobs-duration])
 
 (defn get-user-running-job-ents


### PR DESCRIPTION
## Changes proposed in this PR

- Initialize the kubernetes expected state from the datomic-stored instance state
- Its been minimally tested by launching a job, killing cook, and then resuming cook.
- Several todo's have been added.

## Why are we making these changes?
So that cook will reinitialize and resume from a shutdown.