### PR TITLE
Add support for configurable namespaces

### DIFF
--- a/scheduler/README-k8s.md
+++ b/scheduler/README-k8s.md
@@ -20,6 +20,19 @@ Example:
                              ;; Location of credential file
                              :google-credentials "/home/myuser/creds.json"}}]
 ```
+## Additional configuration options
+### `:namespace`
+Cook has two ways of configuring the namespace kubernetes pods are launched in:
+- Single static namespace: Cook can be configured to launch all kubernetes pods in a single static namespace. Example:
+```clojure
+:namespace {:kind :static
+            :namespace "cook"}
+```
+- Per-user namespaces: Cook can also be configured to launch each pod in a namespace corresponding to the username of 
+  the user who submitted the job. Example:
+```clojure
+:namespace {:kind :per-user}
+```
 
 # Running with kubernetes has several differences:
 - Use config-k8s.edn instead of config.edn

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -301,14 +301,14 @@
   "Given a V1Pod, launch it."
   [api-client {:keys [launch-pod] :as expected-state-dict}]
   ;; TODO: make namespace configurable
-  (let [namespace "cook"]
+  (let [{:keys [pod namespace]} launch-pod]
     ;; TODO: IF there's an error, log it and move on. We'll try again later.
     (if launch-pod
       (let [api (CoreV1Api. api-client)]
-        (log/info "Launching pod" api launch-pod)
+        (log/info "Launching pod in namespace" namespace pod)
         (try
           (-> api
-              (.createNamespacedPod namespace launch-pod nil nil nil))
+              (.createNamespacedPod namespace pod nil nil nil))
           (catch ApiException e
             (log/error e "Error submitting pod:" (.getResponseBody e)))))
       ; Because of the complicated nature of task-metadata-seq, we can't easily run the V1Pod creation code for a

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -107,16 +107,26 @@
     (into {}
           (map (fn [[k v]] [k (task-ent->expected-state v)]) all-task-id->task))))
 
+(defn- get-namespace-for-task-metadata
+  [{:keys [kind] :as namespace-config} task-metadata]
+  (case kind
+    :static (:namespace namespace-config)
+    :per-user (-> task-metadata
+                  :command
+                  :user)))
+
 (defrecord KubernetesComputeCluster [^ApiClient api-client name entity-id match-trigger-chan exit-code-syncer-state
                                      current-pods-atom current-nodes-atom expected-state-map existing-state-map
-                                     pool->fenzo-atom]
+                                     pool->fenzo-atom namespace-config]
   cc/ComputeCluster
   (launch-tasks [this offers task-metadata-seq]
-      (doseq [task-metadata task-metadata-seq]
+    (doseq [task-metadata task-metadata-seq]
+      (let [pod-namespace (get-namespace-for-task-metadata namespace-config task-metadata)]
         (controller/update-expected-state
           this
           (:task-id task-metadata)
-          {:expected-state :expected/starting :launch-pod (api/task-metadata->pod task-metadata)})))
+          {:expected-state :expected/starting :launch-pod {:pod (api/task-metadata->pod task-metadata)
+                                                           :namespace pod-namespace}}))))
 
   (kill-task [this task-id]
     (controller/update-expected-state this task-id {:expected-state :expected/killed}))
@@ -231,8 +241,11 @@
            base-path
            google-credentials
            verifying-ssl
-           bearer-token-refresh-seconds]
-    :or {bearer-token-refresh-seconds 300}}
+           bearer-token-refresh-seconds
+           namespace]
+    :or {bearer-token-refresh-seconds 300
+         namespace {:kind :static
+                    :namespace "cook"}}}
    {:keys [exit-code-syncer-state
            trigger-chans]}]
   (let [conn cook.datomic/conn
@@ -245,6 +258,7 @@
                                                     ; when debugging and exist for no other reason.
                                                     (atom {:type :expected-state-map})
                                                     (atom {:type :existing-state-map})
-                                                    (atom nil))]
+                                                    (atom nil)
+                                                    namespace)]
     (cc/register-compute-cluster! compute-cluster)
     compute-cluster))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -107,10 +107,10 @@
     (into {}
           (map (fn [[k v]] [k (task-ent->expected-state v)]) all-task-id->task))))
 
-(defn- get-namespace-for-task-metadata
-  [{:keys [kind] :as namespace-config} task-metadata]
+(defn- get-namespace-from-task-metadata
+  [{:keys [kind namespace]} task-metadata]
   (case kind
-    :static (:namespace namespace-config)
+    :static namespace
     :per-user (-> task-metadata
                   :command
                   :user)))
@@ -121,7 +121,7 @@
   cc/ComputeCluster
   (launch-tasks [this offers task-metadata-seq]
     (doseq [task-metadata task-metadata-seq]
-      (let [pod-namespace (get-namespace-for-task-metadata namespace-config task-metadata)]
+      (let [pod-namespace (get-namespace-from-task-metadata namespace-config task-metadata)]
         (controller/update-expected-state
           this
           (:task-id task-metadata)


### PR DESCRIPTION
## Changes proposed in this PR
- Support configurable namespaces for Kubernetes pods
- Support per-user pod namespaces

## Why are we making these changes?
In some environments it is desirable to have per-user Kubernetes namespaces, but we want to keep "single namespace" support for local development.