### PR TITLE
Make max_cpus platform independent

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -32,7 +32,8 @@ class CookTest(util.CookTest):
 
     def setUp(self):
         self.cook_url = type(self).cook_url
-        self.mesos_url = util.retrieve_mesos_url()
+        if util.using_mesos():
+            self.mesos_url = util.retrieve_mesos_url()
         self.logger = logging.getLogger(__name__)
         self.cors_origin = os.getenv('COOK_ALLOWED_ORIGIN', 'http://cors.example.com')
 
@@ -1558,6 +1559,7 @@ class CookTest(util.CookTest):
         resp = util.query_groups(self.cook_url)
         self.assertEqual(400, resp.status_code)
 
+    @unittest.skipIf(util.using_kubernetes(), 'Test needs to be rewritten for kubernetes')
     def test_queue_endpoint(self):
         group = {'uuid': str(uuid.uuid4())}
         job_spec = {'group': group['uuid'],
@@ -1667,6 +1669,7 @@ class CookTest(util.CookTest):
             util.session.delete('%s/rawscheduler?job=%s' % (self.cook_url, job_uuid))
             mesos.dump_sandbox_files(util.session, instance, job)
 
+    @unittest.skipIf(util.using_kubernetes(), 'Test needs to be rewritten for kubernetes')
     def test_unscheduled_jobs(self):
         job_spec = {'command': 'sleep 30',
                     'priority': 100,
@@ -1878,6 +1881,7 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, uuids)
 
+    @unittest.skipIf(util.using_kubernetes(), 'Test needs to be rewritten for kubernetes')
     def test_attribute_equals_hostname_constraint(self):
         max_slave_cpus = util.max_slave_cpus(self.mesos_url)
         task_constraint_cpus = util.task_constraint_cpus(self.cook_url)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1559,12 +1559,11 @@ class CookTest(util.CookTest):
         resp = util.query_groups(self.cook_url)
         self.assertEqual(400, resp.status_code)
 
-    @unittest.skipIf(util.using_kubernetes(), 'Test needs to be rewritten for kubernetes')
     def test_queue_endpoint(self):
         group = {'uuid': str(uuid.uuid4())}
         job_spec = {'group': group['uuid'],
                     'command': 'sleep 30',
-                    'cpus': util.max_cpus(self.mesos_url, self.cook_url)}
+                    'cpus': util.max_cpus()}
         uuids, resp = util.submit_jobs(self.cook_url, job_spec, clones=100, groups=[group])
         self.assertEqual(201, resp.status_code, resp.content)
         try:
@@ -1669,11 +1668,10 @@ class CookTest(util.CookTest):
             util.session.delete('%s/rawscheduler?job=%s' % (self.cook_url, job_uuid))
             mesos.dump_sandbox_files(util.session, instance, job)
 
-    @unittest.skipIf(util.using_kubernetes(), 'Test needs to be rewritten for kubernetes')
     def test_unscheduled_jobs(self):
         job_spec = {'command': 'sleep 30',
                     'priority': 100,
-                    'cpus': util.max_cpus(self.mesos_url, self.cook_url)}
+                    'cpus': util.max_cpus()}
         uuids, resp = util.submit_jobs(self.cook_url, job_spec, clones=100)
         self.assertEqual(resp.status_code, 201, resp.content)
         try:
@@ -1881,9 +1879,8 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, uuids)
 
-    @unittest.skipIf(util.using_kubernetes(), 'Test needs to be rewritten for kubernetes')
     def test_attribute_equals_hostname_constraint(self):
-        max_slave_cpus = util.max_slave_cpus(self.mesos_url)
+        max_slave_cpus = util.max_node_cpus()
         task_constraint_cpus = util.task_constraint_cpus(self.cook_url)
         # The largest job we can submit that actually fits on a slave
         max_cpus = min(max_slave_cpus, task_constraint_cpus)

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -22,7 +22,8 @@ class MultiUserCookTest(util.CookTest):
 
     def setUp(self):
         self.cook_url = type(self).cook_url
-        self.mesos_url = util.retrieve_mesos_url()
+        if util.using_mesos():
+            self.mesos_url = util.retrieve_mesos_url()
         self.logger = logging.getLogger(__name__)
         self.user_factory = util.UserFactory(self)
 

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -22,8 +22,6 @@ class MultiUserCookTest(util.CookTest):
 
     def setUp(self):
         self.cook_url = type(self).cook_url
-        if util.using_mesos():
-            self.mesos_url = util.retrieve_mesos_url()
         self.logger = logging.getLogger(__name__)
         self.user_factory = util.UserFactory(self)
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1210,7 +1210,7 @@ def get_kubernetes_nodes():
                                          'get', 'nodes', '-o=json'])
         node_json = json.loads(nodes)
     elif 'base-path' in kubernetes_compute_cluster['config']:
-        authorization_header = subprocess.check_output(os.getenv('COOK_KUBERNETES_AUTH_CMD')).decode('utf-8').strip()
+        authorization_header = subprocess.check_output(os.getenv('COOK_KUBERNETES_AUTH_CMD'), shell=True).decode('utf-8').strip()
         nodes_url = kubernetes_compute_cluster['config']['base-path'] + '/api/v1/nodes'
         node_json = requests.get(nodes_url, headers={'Authorization': authorization_header}, verify=False).json()
     else:

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1210,13 +1210,9 @@ def get_kubernetes_nodes():
                                          'get', 'nodes', '-o=json'])
         node_json = json.loads(nodes)
     elif 'base-path' in kubernetes_compute_cluster['config']:
-        configured_google_credentials = kubernetes_compute_cluster['config'].get('google-credentials')
-        google_credentials = os.getenv('COOK_GKE_CREDENTIALS', configured_google_credentials)
-        subprocess.check_call(['gcloud', 'auth', 'activate-service-account', '--key-file', google_credentials])
-        access_token = subprocess.check_output(['gcloud', 'auth', 'print-access-token']).decode('utf-8').strip()
-        authorization = 'Bearer ' + access_token
+        authorization_header = subprocess.check_output(os.getenv('COOK_KUBERNETES_AUTH_CMD')).decode('utf-8').strip()
         nodes_url = kubernetes_compute_cluster['config']['base-path'] + '/api/v1/nodes'
-        node_json = requests.get(nodes_url, headers={'Authorization': authorization}, verify=False).json()
+        node_json = requests.get(nodes_url, headers={'Authorization': authorization_header}, verify=False).json()
     else:
         raise RuntimeError('Unable to get node info for configured kubernetes cluster: ' + str(kubernetes_compute_cluster))
     logging.info(f'Retrieved kubernetes nodes: {node_json}')

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1362,6 +1362,8 @@ def _supported_isolators():
 
 
 def supports_mesos_containerizer_images():
+    if using_kubernetes():
+        return False
     isolators = _supported_isolators()
     return 'filesystem/linux' in isolators and 'docker/runtime' in isolators
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1214,7 +1214,7 @@ def get_kubernetes_nodes():
         nodes_url = kubernetes_compute_cluster['config']['base-path'] + '/api/v1/nodes'
         node_json = requests.get(nodes_url, headers={'Authorization': authorization_header}, verify=False).json()
     else:
-        raise RuntimeError('Unable to get node info for configured kubernetes cluster: ' + str(kubernetes_compute_cluster))
+        raise RuntimeError(f'Unable to get node info for configured kubernetes cluster: {kubernetes_compute_cluster}')
     logging.info(f'Retrieved kubernetes nodes: {node_json}')
     return node_json['items']
 
@@ -1239,7 +1239,6 @@ def max_node_cpus():
 def max_cpus():
     """Returns the maximum cpus we can submit that actually fits on a slave"""
     cook_url = retrieve_cook_url()
-    cpu_candidates = [task_constraint_cpus(cook_url)]
     slave_cpus = max_node_cpus()
     constraint_cpus = task_constraint_cpus(cook_url)
     max_cpus = min(slave_cpus, constraint_cpus)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1194,22 +1194,50 @@ def slave_pool(cook_url, mesos_url, hostname):
     return pool
 
 
-def max_slave_cpus(mesos_url):
+def max_mesos_slave_cpus(mesos_url):
     """Returns the max cpus of all current Mesos agents"""
     slaves = get_mesos_state(mesos_url)['slaves']
     max_slave_cpus = max([s['resources']['cpus'] for s in slaves])
     return max_slave_cpus
 
+def get_kubernetes_nodes():
+    cook_url = retrieve_cook_url()
+    compute_clusters = settings(cook_url)['compute-clusters']
+    kubernetes_compute_cluster = [cc for cc in compute_clusters
+                                  if cc['factory-fn'] == 'cook.kubernetes.compute-cluster/factory-fn'][0]
+    if 'config-file' in kubernetes_compute_cluster['config']:
+        nodes = subprocess.check_output(['kubectl', '--kubeconfig', kubernetes_compute_cluster['config']['config-file'],
+                                         'get', 'nodes', '-o=json'])
+        node_json = json.loads(nodes)
+
+    else:
+        raise RuntimeError('Unable to get node info for configured kubernetes cluster: ' + str(kubernetes_compute_cluster))
+    logging.info(f'Retrieved kubernetes nodes: {node_json}')
+    return node_json['items']
+
+def max_kubernetes_node_cpus():
+    nodes = get_kubernetes_nodes()
+    return max([float(n['status']['capacity']['cpu'])
+                for n in nodes])
 
 def task_constraint_cpus(cook_url):
     """Returns the max cpus that can be submitted to the cluster"""
     task_constraint_cpus = settings(cook_url)['task-constraints']['cpus']
     return task_constraint_cpus
 
+def max_node_cpus():
+    if using_mesos():
+        return max_mesos_slave_cpus(retrieve_mesos_url())
+    elif using_kubernetes():
+        return max_kubernetes_node_cpus()
+    else:
+        raise RuntimeError('Unable to determine cluster max CPUs')
 
-def max_cpus(mesos_url, cook_url):
+def max_cpus():
     """Returns the maximum cpus we can submit that actually fits on a slave"""
-    slave_cpus = max_slave_cpus(mesos_url)
+    cook_url = retrieve_cook_url()
+    cpu_candidates = [task_constraint_cpus(cook_url)]
+    slave_cpus = max_node_cpus()
     constraint_cpus = task_constraint_cpus(cook_url)
     max_cpus = min(slave_cpus, constraint_cpus)
     logging.debug(f'Max cpus we can submit that will get scheduled is {max_cpus}')

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1203,6 +1203,8 @@ def max_mesos_slave_cpus(mesos_url):
 @functools.lru_cache()
 def get_kubernetes_compute_cluster():
     cook_url = retrieve_cook_url()
+    _wait_for_cook(cook_url)
+    init_cook_session(cook_url)
     compute_clusters = settings(cook_url)['compute-clusters']
     kubernetes_compute_clusters = [cc for cc in compute_clusters
                                    if cc['factory-fn'] == 'cook.kubernetes.compute-cluster/factory-fn']


### PR DESCRIPTION
## Changes proposed in this PR
- Fix more errors with referencing `mesos_url` on Kubernetes
- Make `util.max_cpus()` callable on both Mesos and Kubernetes

## Why are we making these changes?
Improves integration test coverage of Kubernetes scheduler.

