### PR TITLE
Increase kubernetes timeout from 10 seconds to 120 seconds.

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -216,6 +216,8 @@
   (let [api-client (if (some? config-file)
                      (Config/fromConfig config-file)
                      (ApiClient.))]
+    ; Reset to a more sane timeout from the default 10 seconds.
+    (some-> api-client .getHttpClient (.setReadTimeout 120 TimeUnit/SECONDS))
     (when base-path
       (.setBasePath api-client base-path))
     (when (some? verifying-ssl)


### PR DESCRIPTION
## Changes proposed in this PR

- Increase the timeout
- 
- 

## Why are we making these changes?

Avoid a lot of log spam

