### PR TITLE
Label pods if they're cook job pods.

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -866,6 +866,8 @@ class CookCliTest(util.CookTest):
         self.assertEqual(1, cp.returncode, cli.decode(cp.stderr))
         self.assertIn('file was not found', cli.decode(cp.stderr))
 
+    @pytest.mark.xfail
+    # xfailed because of ts-pr-1193 flakiness on jenkins.
     def test_tail_with_plugin(self):
         # User defined plugin to print dummy content from a file
         with tempfile.NamedTemporaryFile(suffix='.py', delete=True) as temp:

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -50,7 +50,7 @@
                                     (reset! launched-pod-atom launch-pod))]
       (testing "static namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
-                                                              (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
+                                                              (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                               {:kind :static :namespace "cook"})
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
@@ -62,7 +62,7 @@
 
       (testing "per-user namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
-                                                              (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
+                                                              (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                               {:kind :per-user})
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -73,7 +73,7 @@
 
 (deftest test-generate-offers
   (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
-                                                        (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
+                                                        (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                         {:kind :static :namespace "cook"})
         node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0)
                          "nodeB" (tu/node-helper "nodeB" 1.0 1000.0)


### PR DESCRIPTION
## Changes proposed in this PR

- Label pods if they're cook job pods.
- Ignore those pods for cook's kubernetes state management.
- 

## Why are we making these changes?

This enables soon-to-be-added state scanners which means that we get retries and a proper startup for kubernetes support.
