### PR TITLE
Count starting pods against offers

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -11,7 +11,6 @@
             [plumbing.core :as pc])
   (:import (com.google.auth.oauth2 GoogleCredentials)
            (io.kubernetes.client ApiClient)
-           (io.kubernetes.client.apis CoreV1Api)
            (io.kubernetes.client.util Config)
            (java.io FileInputStream File)
            (java.util UUID)
@@ -19,10 +18,10 @@
 
 (defn generate-offers
   "Given a compute cluster and maps with node capacity and existing pods, return a list of offers."
-  [node-name->node pod-name->pod compute-cluster]
+  [node-name->node pod-name->pod starting-pod-name->pod compute-cluster]
   (let [node-name->capacity (api/get-capacity node-name->node)
-        node-name->consumed (api/get-consumption pod-name->pod)
-        ; TODO(pschorf): Should also include recently launched jobs
+        node-name->consumed (api/get-consumption (merge pod-name->pod
+                                                        starting-pod-name->pod))
         node-name->available (pc/map-from-keys (fn [node-name]
                                                  (merge-with -
                                                              (node-name->capacity node-name)
@@ -165,7 +164,7 @@
             (= pool-name "no-pool"))
       (let [nodes @current-nodes-atom
             pods @all-pods-atom]
-        (generate-offers nodes pods this))
+        (generate-offers nodes pods (controller/starting-pod-name->pod this) this))
       []))
 
   (restore-offers [this pool-name offers]))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -18,7 +18,7 @@
 
 (defn generate-offers
   "Given a compute cluster and maps with node capacity and existing pods, return a list of offers."
-  [node-name->node pod-name->pod starting-pod-name->pod compute-cluster]
+  [compute-cluster node-name->node pod-name->pod starting-pod-name->pod]
   (let [node-name->capacity (api/get-capacity node-name->node)
         node-name->consumed (api/get-consumption (merge pod-name->pod
                                                         starting-pod-name->pod))
@@ -164,7 +164,7 @@
             (= pool-name "no-pool"))
       (let [nodes @current-nodes-atom
             pods @all-pods-atom]
-        (generate-offers nodes pods (controller/starting-pod-name->pod this) this))
+        (generate-offers this nodes pods (controller/starting-pod-name->pod this)))
       []))
 
   (restore-offers [this pool-name offers]))

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -215,6 +215,7 @@
         (process kcc pod-name)))))
 
 (defn starting-pod-name->pod
+  "Returns a map from pod-name->pod for all pods in the :expected/starting state."
   [{:keys [expected-state-map] :as kcc}]
   (->> @expected-state-map
        (filter (fn [[_ {:keys [expected-state launch-pod]}]]

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -215,7 +215,7 @@
         (process kcc pod-name)))))
 
 (defn starting-pod-name->pod
-  "Returns a map from pod-name->pod for all pods in the :expected/starting state."
+  "Returns a map from pod-name->pod for all tasks that we're attempting to send to kubernetes to start."
   [{:keys [expected-state-map] :as kcc}]
   (->> @expected-state-map
        (filter (fn [[_ {:keys [expected-state launch-pod]}]]

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -214,6 +214,16 @@
         (swap! expected-state-map assoc pod-name new-expected-state-dict)
         (process kcc pod-name)))))
 
+(defn starting-pod-name->pod
+  [{:keys [expected-state-map] :as kcc}]
+  (->> @expected-state-map
+       (filter (fn [[_ {:keys [expected-state launch-pod]}]]
+                 (and (= :expected/starting expected-state)
+                      (some? (:pod launch-pod)))))
+       (map (fn [[task-id {:keys [launch-pod]}]]
+              [task-id (:pod launch-pod)]))
+       (into {})))
+
 (defn scan-process
   "Special verison of process run during scanning. It grabs the lock before processing the pod."
   [{:keys [api-client existing-state-map expected-state-map] :as kcc} pod-name]

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -34,11 +34,14 @@
             [mount.core :as mount]
             [plumbing.core :refer [mapply]]
             [qbits.jet.server :refer (run-jetty)]
-            [ring.middleware.params :refer (wrap-params)])
+            [ring.middleware.params :refer (wrap-params)]
+            [cook.scheduler.scheduler :as sched]
+            [cook.mesos.task :as task])
   (:import (java.util UUID)
            (org.apache.log4j ConsoleAppender Logger PatternLayout)
            (io.kubernetes.client.custom Quantity$Format Quantity)
-           (io.kubernetes.client.models V1Container V1ResourceRequirements V1Pod V1ObjectMeta V1PodSpec V1Node V1NodeStatus)))
+           (io.kubernetes.client.models V1Container V1ResourceRequirements V1Pod V1ObjectMeta V1PodSpec V1Node V1NodeStatus)
+           (com.netflix.fenzo SimpleAssignmentResult)))
 
 (defn create-dummy-mesos-compute-cluster
   [compute-cluster-name framework-id db-id driver-atom]
@@ -301,6 +304,31 @@
                                  sandbox-directory (assoc :instance/sandbox-directory sandbox-directory)
                                  mesos-start-time (assoc :instance/mesos-start-time mesos-start-time))])]
     (d/resolve-tempid (db conn) (:tempids val) id)))
+
+(defn make-task-request [job-ent]
+  (let [considerable->task-id (plumbing.core/map-from-keys (fn [_] (str (d/squuid)))
+                                                           [job-ent])
+        running-cotask-cache (atom (cache/fifo-cache-factory {} :threshold 1))]
+    (sched/make-task-request db
+                             job-ent
+                             :guuid->considerable-cotask-ids
+                             (util/make-guuid->considerable-cotask-ids considerable->task-id)
+                             :reserved-hosts []
+                             :running-cotask-cache running-cotask-cache
+                             :task-id (considerable->task-id job-ent))))
+
+(defn make-task-assignment-result
+  [task-request]
+  (SimpleAssignmentResult. [] nil task-request))
+
+(defn make-task-metadata
+  [job db compute-cluster]
+  (let [task-request (make-task-request job)
+        task-assignment-result (make-task-assignment-result task-request)]
+    (task/TaskAssignmentResult->task-metadata db
+                                              nil
+                                              compute-cluster
+                                              task-assignment-result)))
 
 (defn create-dummy-group
   "Return the entity id for the created group"

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -306,6 +306,7 @@
     (d/resolve-tempid (db conn) (:tempids val) id)))
 
 (defn make-task-request [job-ent]
+  "Makes a dummy task request for job-ent by calling scheduler/make-task-request"
   (let [considerable->task-id (plumbing.core/map-from-keys (fn [_] (str (d/squuid)))
                                                            [job-ent])
         running-cotask-cache (atom (cache/fifo-cache-factory {} :threshold 1))]
@@ -318,10 +319,12 @@
                              :task-id (considerable->task-id job-ent))))
 
 (defn make-task-assignment-result
+  "Makes a dummy fenzo AssignmentResult for the given TaskRequest"
   [task-request]
   (SimpleAssignmentResult. [] nil task-request))
 
 (defn make-task-metadata
+  "Creates a task-metadata for the given job by calling task/TaskAssignmentResult->task-metadata"
   [job db compute-cluster]
   (let [task-request (make-task-request job)
         task-assignment-result (make-task-assignment-result task-request)]

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -4,6 +4,7 @@
             [cook.compute-cluster :as cc]
             [cook.kubernetes.api :as api]
             [cook.kubernetes.compute-cluster :as kcc]
+            [cook.kubernetes.controller :as controller]
             [cook.mesos.task :as task]
             [cook.scheduler.scheduler :as sched]
             [cook.test.testutil :as tu]
@@ -28,23 +29,12 @@
 (deftest test-namespace-config
   (tu/setup)
   (let [conn (tu/restore-fresh-database! "datomic:mem://test-namespace-config")
-        make-task-request (fn make-task-request [user]
-                            (let [job-id (tu/create-dummy-job conn :user user)
-                                  db (d/db conn)
-                                  job-ent (d/entity (d/db conn) job-id)
-                                  considerable->task-id (plumbing.core/map-from-keys (fn [_] (str (d/squuid)))
-                                                                                     [job-ent])
-                                  running-cotask-cache (atom (cache/fifo-cache-factory {} :threshold 1))]
-                              (sched/make-task-request db
-                                                       job-ent
-                                                       :guuid->considerable-cotask-ids
-                                                       (util/make-guuid->considerable-cotask-ids considerable->task-id)
-                                                       :reserved-hosts []
-                                                       :running-cotask-cache running-cotask-cache
-                                                       :task-id (considerable->task-id job-ent))))
-        make-task-asignment-result (fn make-task-assignment-result [user]
-                                     (let [task-request (make-task-request user)]
-                                       (SimpleAssignmentResult. [] nil task-request)))
+        task-assignment-result-helper (fn [user]
+                                        (let [job-id (tu/create-dummy-job conn :user user)
+                                              job-ent (d/entity (d/db conn) job-id)]
+                                          (-> job-ent
+                                              tu/make-task-request
+                                              tu/make-task-assignment-result)))
         launched-pod-atom (atom nil)]
     (with-redefs [api/launch-task (fn [api {:keys [launch-pod]}]
                                     (reset! launched-pod-atom launch-pod))]
@@ -55,7 +45,7 @@
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
-                                                                      (make-task-asignment-result "testuser"))]
+                                                                      (task-assignment-result-helper "testuser"))]
 
           (cc/launch-tasks compute-cluster [] [task-metadata])
           (is (= "cook" (:namespace @launched-pod-atom)))))
@@ -67,44 +57,65 @@
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
-                                                                      (make-task-asignment-result "testuser"))]
+                                                                      (task-assignment-result-helper "testuser"))]
           (cc/launch-tasks compute-cluster [] [task-metadata])
           (is (= "testuser" (:namespace @launched-pod-atom))))))))
 
 (deftest test-generate-offers
-  (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
-                                                        (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                        {:kind :static :namespace "cook"})
-        node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0)
-                         "nodeB" (tu/node-helper "nodeB" 1.0 1000.0)
-                         "nodeC" (tu/node-helper "nodeC" 1.0 1000.0)}
-        pod-name->pod {"podA" (tu/pod-helper "podA" "nodeA"
-                                          {:cpus 0.25 :mem 250.0}
-                                          {:cpus 0.1 :mem 100.0})
-                       "podB" (tu/pod-helper "podB" "nodeA"
-                                          {:cpus 0.25 :mem 250.0})
-                       "podC" (tu/pod-helper "podC" "nodeB"
-                                          {:cpus 1.0 :mem 1100.0})}
-        offers (kcc/generate-offers node-name->node pod-name->pod compute-cluster)]
-    (is (= 3 (count offers)))
-    (let [offer (first (filter #(= "nodeA" (:hostname %))
-                                     offers))]
-      (is (not (nil? offer)))
-      (is (= "kubecompute" (:framework-id offer)))
-      (is (= {:value "nodeA"} (:slave-id offer)))
-      (is (= [{:name "mem" :type :value-scalar :scalar 400.0}
-              {:name "cpus" :type :value-scalar :scalar 0.4}
-              {:name "disk" :type :value-scalar :scalar 0.0}]
-             (:resources offer)))
-      (is (:reject-after-match-attempt offer)))
+  (with-redefs [api/launch-task (constantly nil)]
+    (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")
+          compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
+                                                          (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
+                                                          {:kind :static :namespace "cook"})
+          node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0)
+                           "nodeB" (tu/node-helper "nodeB" 1.0 1000.0)
+                           "nodeC" (tu/node-helper "nodeC" 1.0 1000.0)
+                           "my.fake.host" (tu/node-helper "my.fake.host" 1.0 1000.0)}
+          j1 (tu/create-dummy-job conn :ncpus 0.1)
+          j2 (tu/create-dummy-job conn :ncpus 0.2)
+          db (d/db conn)
+          job-ent-1 (d/entity db j1)
+          job-ent-2 (d/entity db j2)
+          task-1 (tu/make-task-metadata job-ent-1 db compute-cluster)
+          _ (cc/launch-tasks compute-cluster nil [task-1
+                                                  (tu/make-task-metadata job-ent-2 db compute-cluster)])
+          task-1-id (-> task-1 :task-request :task-id)
+          pod-name->pod {"podA" (tu/pod-helper "podA" "nodeA"
+                                               {:cpus 0.25 :mem 250.0}
+                                               {:cpus 0.1 :mem 100.0})
+                         "podB" (tu/pod-helper "podB" "nodeA"
+                                               {:cpus 0.25 :mem 250.0})
+                         "podC" (tu/pod-helper "podC" "nodeB"
+                                               {:cpus 1.0 :mem 1100.0})
+                         task-1-id (tu/pod-helper task-1-id "my.fake.host"
+                                                  {:cpus 0.1 :mem 10.0})}
+          offers (kcc/generate-offers node-name->node pod-name->pod (controller/starting-pod-name->pod compute-cluster)
+                                      compute-cluster)]
+      (is (= 4 (count offers)))
+      (let [offer (first (filter #(= "nodeA" (:hostname %))
+                                 offers))]
+        (is (not (nil? offer)))
+        (is (= "kubecompute" (:framework-id offer)))
+        (is (= {:value "nodeA"} (:slave-id offer)))
+        (is (= [{:name "mem" :type :value-scalar :scalar 400.0}
+                {:name "cpus" :type :value-scalar :scalar 0.4}
+                {:name "disk" :type :value-scalar :scalar 0.0}]
+               (:resources offer)))
+        (is (:reject-after-match-attempt offer)))
 
-    (let [offer (first (filter #(= "nodeB" (:hostname %))
-                                     offers))]
-      (is (= {:value "nodeB"} (:slave-id offer)))
-      (is (= [{:name "mem" :type :value-scalar :scalar 0.0}
-              {:name "cpus" :type :value-scalar :scalar 0.0}
-              {:name "disk" :type :value-scalar :scalar 0.0}]
-             (:resources offer))))))
+      (let [offer (first (filter #(= "nodeB" (:hostname %))
+                                 offers))]
+        (is (= {:value "nodeB"} (:slave-id offer)))
+        (is (= [{:name "mem" :type :value-scalar :scalar 0.0}
+                {:name "cpus" :type :value-scalar :scalar 0.0}
+                {:name "disk" :type :value-scalar :scalar 0.0}]
+               (:resources offer))))
+
+      (let [offer (first (filter #(= "my.fake.host" (:hostname %)) offers))]
+        (is (= [{:name "mem" :type :value-scalar :scalar 980.0}
+                {:name "cpus" :type :value-scalar :scalar 0.7}
+                {:name "disk" :type :value-scalar :scalar 0.0}]
+               (:resources offer)))))))
 
 (deftest determine-expected-state
   ; TODO

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -89,8 +89,8 @@
                                                {:cpus 1.0 :mem 1100.0})
                          task-1-id (tu/pod-helper task-1-id "my.fake.host"
                                                   {:cpus 0.1 :mem 10.0})}
-          offers (kcc/generate-offers node-name->node pod-name->pod (controller/starting-pod-name->pod compute-cluster)
-                                      compute-cluster)]
+          offers (kcc/generate-offers compute-cluster node-name->node pod-name->pod
+                                      (controller/starting-pod-name->pod compute-cluster))]
       (is (= 4 (count offers)))
       (let [offer (first (filter #(= "nodeA" (:hostname %))
                                  offers))]


### PR DESCRIPTION
## Changes proposed in this PR
- Counts the starting pods against node utilization when computing offers on kubernetes

## Why are we making these changes?
Fixes race where resources could be double-booked.
