### PR TITLE
Use COOK_DEFAULT_JOB_CPUS in preemption tests

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -394,8 +394,8 @@ class MultiUserCookTest(util.CookTest):
         user = self.user_factory.new_user()
         all_job_uuids = []
         try:
-            small_cpus = 0.1
-            large_cpus = small_cpus * 10
+            large_cpus = util.get_default_cpus()
+            small_cpus = large_cpus / 10
             with admin:
                 # Lower the user's cpu share and quota
                 util.set_limit(self.cook_url, 'share', user.name, cpus=small_cpus, pool=pool)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -387,11 +387,14 @@ def scheduler_info(cook_url):
 def docker_image():
     return os.getenv('COOK_TEST_DOCKER_IMAGE')
 
+def get_default_cpus():
+    return float(os.getenv('COOK_DEFAULT_JOB_CPUS', 1.0))
+
 
 def minimal_job(**kwargs):
     job = {
         'command': 'echo Default Test Command',
-        'cpus': float(os.getenv('COOK_DEFAULT_JOB_CPUS', 1.0)),
+        'cpus': get_default_cpus(),
         'max_retries': 1,
         'mem': int(os.getenv('COOK_DEFAULT_JOB_MEM_MB', 256)),
         'name': 'default_test_job',


### PR DESCRIPTION
## Changes proposed in this PR
- Uses `COOK_DEFAULT_JOB_CPUS` in the preemption tests

## Why are we making these changes?
Makes test perform better in environments where `COOK_DEFAULT_JOB_CPUS` has been reduced.
