### PR TITLE
Use allocatable instead of capacity

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -166,7 +166,7 @@
   "Given a map from node-name to node, generate a map from node-name->resource-type-><capacity>"
   [node-name->node]
   (pc/map-vals (fn [^V1Node node]
-                 (-> node .getStatus .getCapacity convert-resource-map))
+                 (-> node .getStatus .getAllocatable convert-resource-map))
                node-name->node))
 
 (defn get-consumption

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -463,10 +463,14 @@
         metadata (V1ObjectMeta.)]
     (when cpus
       (.putCapacityItem status "cpu" (Quantity. (BigDecimal. cpus)
-                                                Quantity$Format/DECIMAL_SI)))
+                                                Quantity$Format/DECIMAL_SI))
+      (.putAllocatableItem status "cpu" (Quantity. (BigDecimal. cpus)
+                                                   Quantity$Format/DECIMAL_SI)))
     (when mem
       (.putCapacityItem status "memory" (Quantity. (BigDecimal. (* 1024 1024 mem))
-                                                   Quantity$Format/DECIMAL_SI)))
+                                                   Quantity$Format/DECIMAL_SI))
+      (.putAllocatableItem status "memory" (Quantity. (BigDecimal. (* 1024 1024 mem))
+                                                      Quantity$Format/DECIMAL_SI)))
     (.setStatus node status)
     (.setName metadata node-name)
     (.setMetadata node metadata)


### PR DESCRIPTION
## Changes proposed in this PR
- We should be scheduling against `allocatable` instead of `capacity`

## Why are we making these changes?
Because `capacity` does not reflect the actual resources available for scheduling.