### PR TITLE
State scanner on startup and on an interval.

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -179,7 +179,7 @@
                                    expected-state-dict))]
       (when-not (expected-state-equivalent? expected-state-dict new-expected-state-dict)
         (update-or-delete! expected-state-map pod-name new-expected-state-dict)
-        (log/info "Processing: WANT TO RECUR" new-expected-state-dict " ---- " existing-state-dict)
+        (log/info "Processing: WANT TO RECUR")
         (recur new-expected-state-dict existing-state-dict)
         ; TODO: Recur. We hay have changed the expected state, so we should reprocess it.
         ))))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -41,7 +41,7 @@
       (testing "static namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                              {:kind :static :namespace "cook"})
+                                                              {:kind :static :namespace "cook"} nil)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -53,7 +53,7 @@
       (testing "per-user namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                              {:kind :per-user})
+                                                              {:kind :per-user} nil)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -66,7 +66,7 @@
     (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")
           compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                           (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                          {:kind :static :namespace "cook"})
+                                                          {:kind :static :namespace "cook"} nil)
           node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0)
                            "nodeB" (tu/node-helper "nodeB" 1.0 1000.0)
                            "nodeC" (tu/node-helper "nodeC" 1.0 1000.0)


### PR DESCRIPTION
## Changes proposed in this PR

- Scan and reprocess all of the task states on startup and on an interval.
- 
- 

## Why are we making these changes?
- Cook more correctly recovers after a restart. It can also retry failed kubernetes now.

