### PR TITLE
Use MB for memory instead of MiB

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -18,6 +18,10 @@
 
 (def ^ExecutorService kubernetes-executor (Executors/newFixedThreadPool 2))
 
+; Cook, Fenzo, and Mesos use MB for memory. Convert bytes from k8s to MB when passing to fenzo, and MB back to bytes
+; when submitting to k8s.
+(def memory-multiplier 1000000)
+
 (defn is-cook-scheduler-pod
   "Is this a cook pod? Uses some-> so is null-safe."
   [^V1Pod pod]
@@ -156,7 +160,7 @@
   "Converts a map of Kubernetes resources to a cook resource map {:mem double, :cpus double}"
   [m]
   {:mem (if (get m "memory")
-          (-> m (get "memory") to-double (/ 1000000))
+          (-> m (get "memory") to-double (/ memory-multiplier))
           0.0)
    :cpus (if (get m "cpu")
            (-> m (get "cpu") to-double)
@@ -233,8 +237,8 @@
     (.setEnv container (into [] env))
     (.setImage container image)
 
-    (.putRequestsItem resources "memory" (double->quantity (* 1000000 mem)))
-    (.putLimitsItem resources "memory" (double->quantity (* 1000000 mem)))
+    (.putRequestsItem resources "memory" (double->quantity (* memory-multiplier mem)))
+    (.putLimitsItem resources "memory" (double->quantity (* memory-multiplier mem)))
     (.putRequestsItem resources "cpu" (double->quantity cpus))
     (.setResources container resources)
 

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -156,7 +156,7 @@
   "Converts a map of Kubernetes resources to a cook resource map {:mem double, :cpus double}"
   [m]
   {:mem (if (get m "memory")
-          (-> m (get "memory") to-double (/ (* 1024 1024)))
+          (-> m (get "memory") to-double (/ 1000000))
           0.0)
    :cpus (if (get m "cpu")
            (-> m (get "cpu") to-double)
@@ -233,8 +233,8 @@
     (.setEnv container (into [] env))
     (.setImage container image)
 
-    (.putRequestsItem resources "memory" (double->quantity (* 1024 1024 mem)))
-    (.putLimitsItem resources "memory" (double->quantity (* 1024 1024 mem)))
+    (.putRequestsItem resources "memory" (double->quantity (* 1000000 mem)))
+    (.putLimitsItem resources "memory" (double->quantity (* 1000000 mem)))
     (.putRequestsItem resources "cpu" (double->quantity cpus))
     (.setResources container resources)
 

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -20,7 +20,7 @@
 
 ; Cook, Fenzo, and Mesos use MB for memory. Convert bytes from k8s to MB when passing to fenzo, and MB back to bytes
 ; when submitting to k8s.
-(def memory-multiplier 1000000)
+(def memory-multiplier (* 1000 1000))
 
 (defn is-cook-scheduler-pod
   "Is this a cook pod? Uses some-> so is null-safe."

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -23,6 +23,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [cook.compute-cluster :as cc]
+            [cook.kubernetes.api :as kapi]
             [cook.mesos.mesos-compute-cluster :as mcc]
             [cook.plugins.definitions :refer (JobSubmissionValidator JobLaunchFilter)]
             [cook.rest.impersonation :refer (create-impersonation-middleware)]
@@ -472,7 +473,7 @@
                (when mem
                  (.putRequestsItem resources
                                    "memory"
-                                   (Quantity. (BigDecimal. ^double (* 1000000 mem))
+                                   (Quantity. (BigDecimal. ^double (* kapi/memory-multiplier mem))
                                               Quantity$Format/DECIMAL_SI)))
                (when cpus
                  (.putRequestsItem resources
@@ -498,9 +499,9 @@
       (.putAllocatableItem status "cpu" (Quantity. (BigDecimal. cpus)
                                                    Quantity$Format/DECIMAL_SI)))
     (when mem
-      (.putCapacityItem status "memory" (Quantity. (BigDecimal. (* 1000000 mem))
+      (.putCapacityItem status "memory" (Quantity. (BigDecimal. (* kapi/memory-multiplier mem))
                                                    Quantity$Format/DECIMAL_SI))
-      (.putAllocatableItem status "memory" (Quantity. (BigDecimal. (* 1000000 mem))
+      (.putAllocatableItem status "memory" (Quantity. (BigDecimal. (* kapi/memory-multiplier mem))
                                                       Quantity$Format/DECIMAL_SI)))
     (.setStatus node status)
     (.setName metadata node-name)

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -472,7 +472,7 @@
                (when mem
                  (.putRequestsItem resources
                                    "memory"
-                                   (Quantity. (BigDecimal. ^double (* 1024 1024 mem))
+                                   (Quantity. (BigDecimal. ^double (* 1000000 mem))
                                               Quantity$Format/DECIMAL_SI)))
                (when cpus
                  (.putRequestsItem resources
@@ -498,9 +498,9 @@
       (.putAllocatableItem status "cpu" (Quantity. (BigDecimal. cpus)
                                                    Quantity$Format/DECIMAL_SI)))
     (when mem
-      (.putCapacityItem status "memory" (Quantity. (BigDecimal. (* 1024 1024 mem))
+      (.putCapacityItem status "memory" (Quantity. (BigDecimal. (* 1000000 mem))
                                                    Quantity$Format/DECIMAL_SI))
-      (.putAllocatableItem status "memory" (Quantity. (BigDecimal. (* 1024 1024 mem))
+      (.putAllocatableItem status "memory" (Quantity. (BigDecimal. (* 1000000 mem))
                                                       Quantity$Format/DECIMAL_SI)))
     (.setStatus node status)
     (.setName metadata node-name)

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -74,8 +74,8 @@
 
       (let [resources (-> container .getResources)]
         (is (= 1.0 (-> resources .getRequests (get "cpu") .getNumber .doubleValue)))
-        (is (= (* 512.0 1024 1024) (-> resources .getRequests (get "memory") .getNumber .doubleValue)))
-        (is (= (* 512.0 1024 1024) (-> resources .getLimits (get "memory") .getNumber .doubleValue)))))))
+        (is (= (* 512.0 1000000) (-> resources .getRequests (get "memory") .getNumber .doubleValue)))
+        (is (= (* 512.0 1000000) (-> resources .getLimits (get "memory") .getNumber .doubleValue)))))))
 
 (deftest test-pod->synthesized-pod-state
   (testing "returns nil for empty pod"

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -74,8 +74,8 @@
 
       (let [resources (-> container .getResources)]
         (is (= 1.0 (-> resources .getRequests (get "cpu") .getNumber .doubleValue)))
-        (is (= (* 512.0 1000000) (-> resources .getRequests (get "memory") .getNumber .doubleValue)))
-        (is (= (* 512.0 1000000) (-> resources .getLimits (get "memory") .getNumber .doubleValue)))))))
+        (is (= (* 512.0 api/memory-multiplier) (-> resources .getRequests (get "memory") .getNumber .doubleValue)))
+        (is (= (* 512.0 api/memory-multiplier) (-> resources .getLimits (get "memory") .getNumber .doubleValue)))))))
 
 (deftest test-pod->synthesized-pod-state
   (testing "returns nil for empty pod"

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -62,6 +62,7 @@
           (is (= "testuser" (:namespace @launched-pod-atom))))))))
 
 (deftest test-generate-offers
+  (tu/setup)
   (with-redefs [api/launch-task (constantly nil)]
     (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")
           compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil


### PR DESCRIPTION
## Changes proposed in this PR
- Uses MB for memory when interfacing with Kubernetes instead of MiB

## Why are we making these changes?
The Cook API, Mesos, and Fenzo all assume MB. We need to be consistent between them.
