### PR TITLE
Use namespaced pod names for map keys

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -70,6 +70,15 @@
   [^V1Pod pod]
   (-> pod .getMetadata .getName))
 
+(defn get-pod-namespaced-key
+  [^V1Pod pod]
+  {:namespace (-> pod
+                  .getMetadata
+                  .getNamespace)
+   :name (-> pod
+             .getMetadata
+             .getName)})
+
 (defn get-all-pods-in-kubernetes
   "Get all pods in kubernetes."
   [api-client]
@@ -85,13 +94,7 @@
                                                nil ; timeoutSeconds
                                                nil ; watch
                                                )
-        namespaced-pod-name->pod (pc/map-from-vals (fn [^V1Pod pod]
-                                                     {:namespace (-> pod
-                                                                     .getMetadata
-                                                                     .getNamespace)
-                                                      :name (-> pod
-                                                                .getMetadata
-                                                                .getName)})
+        namespaced-pod-name->pod (pc/map-from-vals get-pod-namespaced-key
                                                    (.getItems current-pods))]
     [current-pods namespaced-pod-name->pod]))
 

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -363,7 +363,8 @@
   "Given a V1Pod, launch it."
   [api-client {:keys [launch-pod] :as expected-state-dict}]
   ;; TODO: make namespace configurable
-  (let [{:keys [pod namespace]} launch-pod]
+  (let [{:keys [pod]} launch-pod
+        namespace (-> pod .getMetadata .getNamespace)]
     ;; TODO: IF there's an error, log it and move on. We'll try again later.
     (if launch-pod
       (let [api (CoreV1Api. api-client)]

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -159,8 +159,7 @@
         (controller/update-expected-state
           this
           (:task-id task-metadata)
-          {:expected-state :expected/starting :launch-pod {:pod (api/task-metadata->pod pod-namespace task-metadata)
-                                                           :namespace pod-namespace}}))))
+          {:expected-state :expected/starting :launch-pod {:pod (api/task-metadata->pod pod-namespace task-metadata)}}))))
 
   (kill-task [this task-id]
     (controller/update-expected-state this task-id {:expected-state :expected/killed}))

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -224,9 +224,7 @@
                       (some? (:pod launch-pod)))))
        (map (fn [[_ {:keys [launch-pod]}]]
               (let [{:keys [pod]} launch-pod]
-                [{:namespace (-> pod .getMetadata .getNamespace)
-                  :name (-> pod .getMetadata .getName)}
-                 pod])))
+                [(api/get-pod-namespaced-key pod) pod])))
        (into {})))
 
 (defn scan-process

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -214,15 +214,19 @@
         (swap! expected-state-map assoc pod-name new-expected-state-dict)
         (process kcc pod-name)))))
 
-(defn starting-pod-name->pod
-  "Returns a map from pod-name->pod for all tasks that we're attempting to send to kubernetes to start."
+(defn starting-namespaced-pod-name->pod
+  "Returns a map from {:namespace pod-namespace :name pod-name}->pod for all tasks that we're attempting to send to
+   kubernetes to start."
   [{:keys [expected-state-map] :as kcc}]
   (->> @expected-state-map
        (filter (fn [[_ {:keys [expected-state launch-pod]}]]
                  (and (= :expected/starting expected-state)
                       (some? (:pod launch-pod)))))
-       (map (fn [[task-id {:keys [launch-pod]}]]
-              [task-id (:pod launch-pod)]))
+       (map (fn [[_ {:keys [launch-pod]}]]
+              (let [{:keys [pod]} launch-pod]
+                [{:namespace (-> pod .getMetadata .getNamespace)
+                  :name (-> pod .getMetadata .getName)}
+                 pod])))
        (into {})))
 
 (defn scan-process

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -483,6 +483,7 @@
                (.addContainersItem spec container))))
     (.setNodeName spec node-name)
     (.setName metadata pod-name)
+    (.setNamespace metadata "cook")
     (.setMetadata pod metadata)
     (.setSpec pod spec)
     pod))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -56,8 +56,9 @@
                        :task-request {:resources {:mem 512
                                                   :cpus 1.0}}
                        :hostname "kubehost"}
-        pod (api/task-metadata->pod task-metadata)]
+        pod (api/task-metadata->pod "cook" task-metadata)]
     (is (= "my-task" (-> pod .getMetadata .getName)))
+    (is (= "cook" (-> pod .getMetadata .getNamespace)))
     (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
     (is (= "kubehost" (-> pod .getSpec .getNodeName)))
     (is (= 1 (count (-> pod .getSpec .getContainers))))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -40,7 +40,7 @@
                                     (reset! launched-pod-atom launch-pod))]
       (testing "static namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
-                                                              (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
+                                                              (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                               {:kind :static :namespace "cook"} nil)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
@@ -52,7 +52,7 @@
 
       (testing "per-user namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
-                                                              (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
+                                                              (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                               {:kind :per-user} nil)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
@@ -65,7 +65,7 @@
   (with-redefs [api/launch-task (constantly nil)]
     (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")
           compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
-                                                          (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
+                                                          (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                           {:kind :static :namespace "cook"} nil)
           node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0)
                            "nodeB" (tu/node-helper "nodeB" 1.0 1000.0)
@@ -80,17 +80,17 @@
           _ (cc/launch-tasks compute-cluster nil [task-1
                                                   (tu/make-task-metadata job-ent-2 db compute-cluster)])
           task-1-id (-> task-1 :task-request :task-id)
-          pod-name->pod {"podA" (tu/pod-helper "podA" "nodeA"
-                                               {:cpus 0.25 :mem 250.0}
-                                               {:cpus 0.1 :mem 100.0})
-                         "podB" (tu/pod-helper "podB" "nodeA"
-                                               {:cpus 0.25 :mem 250.0})
-                         "podC" (tu/pod-helper "podC" "nodeB"
-                                               {:cpus 1.0 :mem 1100.0})
-                         task-1-id (tu/pod-helper task-1-id "my.fake.host"
-                                                  {:cpus 0.1 :mem 10.0})}
+          pod-name->pod {{:namespace "cook" :name "podA"} (tu/pod-helper "podA" "nodeA"
+                                                                         {:cpus 0.25 :mem 250.0}
+                                                                         {:cpus 0.1 :mem 100.0})
+                         {:namespace "cook" :name "podB"} (tu/pod-helper "podB" "nodeA"
+                                                                         {:cpus 0.25 :mem 250.0})
+                         {:namespace "cook" :name "podC"} (tu/pod-helper "podC" "nodeB"
+                                                                         {:cpus 1.0 :mem 1100.0})
+                         {:namespace "cook" :name task-1-id} (tu/pod-helper task-1-id "my.fake.host"
+                                                                            {:cpus 0.1 :mem 10.0})}
           offers (kcc/generate-offers compute-cluster node-name->node pod-name->pod
-                                      (controller/starting-pod-name->pod compute-cluster))]
+                                      (controller/starting-namespaced-pod-name->pod compute-cluster))]
       (is (= 4 (count offers)))
       (let [offer (first (filter #(= "nodeA" (:hostname %))
                                  offers))]

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -48,7 +48,10 @@
                                                                       (task-assignment-result-helper "testuser"))]
 
           (cc/launch-tasks compute-cluster [] [task-metadata])
-          (is (= "cook" (:namespace @launched-pod-atom)))))
+          (is (= "cook" (-> @launched-pod-atom
+                            :pod
+                            .getMetadata
+                            .getNamespace)))))
 
       (testing "per-user namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
@@ -59,7 +62,10 @@
                                                                       compute-cluster
                                                                       (task-assignment-result-helper "testuser"))]
           (cc/launch-tasks compute-cluster [] [task-metadata])
-          (is (= "testuser" (:namespace @launched-pod-atom))))))))
+          (is (= "testuser" (-> @launched-pod-atom
+                            :pod
+                            .getMetadata
+                            .getNamespace))))))))
 
 (deftest test-generate-offers
   (with-redefs [api/launch-task (constantly nil)]


### PR DESCRIPTION
## Changes proposed in this PR
- Use `{:namespace namespace :name name}` for map keys

## Why are we making these changes?
Names are not unique globally.
