### PR TITLE
Use compute-cluster-name in kuberentes pod label

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -159,7 +159,7 @@
         (controller/update-expected-state
           this
           (:task-id task-metadata)
-          {:expected-state :expected/starting :launch-pod {:pod (api/task-metadata->pod pod-namespace task-metadata)}}))))
+          {:expected-state :expected/starting :launch-pod {:pod (api/task-metadata->pod pod-namespace name task-metadata)}}))))
 
   (kill-task [this task-id]
     (controller/update-expected-state this task-id {:expected-state :expected/killed}))
@@ -180,7 +180,7 @@
       ; We set expected state first because initialize-pod-watch sets (and invokes callbacks on and reacts to) the expected and the gruadually discovere existing.
       (reset! expected-state-map (determine-expected-state-on-startup conn api-client name running-task-ents))
 
-      (api/initialize-pod-watch api-client all-pods-atom cook-pod-callback)
+      (api/initialize-pod-watch api-client name all-pods-atom cook-pod-callback)
       (if scan-frequency-seconds-config
         (regular-scanner this (time/seconds scan-frequency-seconds-config))
         (log/info "State scan disabled because no interval has been set")))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -56,12 +56,13 @@
                        :task-request {:resources {:mem 512
                                                   :cpus 1.0}}
                        :hostname "kubehost"}
-        pod (api/task-metadata->pod "cook" task-metadata)]
+        pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)]
     (is (= "my-task" (-> pod .getMetadata .getName)))
     (is (= "cook" (-> pod .getMetadata .getNamespace)))
     (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
     (is (= "kubehost" (-> pod .getSpec .getNodeName)))
     (is (= 1 (count (-> pod .getSpec .getContainers))))
+    (is (= {api/cook-pod-label "testing-cluster"} (-> pod .getMetadata .getLabels)))
 
     (let [^V1Container container (-> pod .getSpec .getContainers first)]
       (is (= "required-cook-job-container" (.getName container)))


### PR DESCRIPTION
## Changes proposed in this PR
- Use the compute cluster name in Kubernetes cook pod label

## Why are we making these changes?
Makes it less likely for cook clusters to stomp on each other.