### PR TITLE
Lets capture the time it takes to get a list endpoint out.

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2604,7 +2604,7 @@
                  (timers/time!
                    (timers/timer ["cook-scheduler" "handler" "list-endpoint-duration"])
                    (let [job-ents (list-job-ents db false ctx)]
-                     (mapv (partial fetch-job-map-from-entity db) job-ents))))))
+                     (doall (mapv (partial fetch-job-map-from-entity db) job-ents)))))))
 
 ;;
 ;; /unscheduled_jobs


### PR DESCRIPTION
## Changes proposed in this PR

- Unlazy the datomic fetch operation so that our metric is more accurate.
- 
- 

## Why are we making these changes?
More accurate metrics on list-resources

