### PR TITLE
Reduce scheduler docker image size; cuts docker image growth by 15%

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -y update
 RUN apt-get -y install software-properties-common
 RUN add-apt-repository ppa:openjdk-r/ppa
 RUN apt-get -y update
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends -y install \
     curl \
     openjdk-8-jdk \
     unzip

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -86,7 +86,8 @@
                  [metrics-clojure-jvm "2.6.1"]
                  [io.dropwizard.metrics/metrics-graphite "3.1.2"]
                  [com.aphyr/metrics3-riemann-reporter "0.4.0"
-                  :exclusions [com.google.protobuf/protobuf-java]]
+                  :exclusions [com.google.protobuf/protobuf-java
+                               com.amazonaws/aws-java-sdk]] ; Brings in a lot of dependencies
 
                  ;;External system integrations
                  [me.raynes/conch "0.5.2"]
@@ -156,7 +157,8 @@
                                  org.slf4j/jul-to-slf4j
                                  org.slf4j/log4j-over-slf4j
                                  org.slf4j/slf4j-api
-                                 org.slf4j/slf4j-nop]]
+                                 org.slf4j/slf4j-nop
+                                 com.amazonaws/aws-java-sdk]]
                    ; Similarly, one could use an older version of the
                    ; mesomatic library in environments that require it
                    [twosigma/mesomatic "1.5.0-r4"]]}
@@ -170,7 +172,8 @@
                                  org.slf4j/jul-to-slf4j
                                  org.slf4j/log4j-over-slf4j
                                  org.slf4j/slf4j-api
-                                 org.slf4j/slf4j-nop]]]}
+                                 org.slf4j/slf4j-nop
+                                 com.amazonaws/aws-java-sdk]]]} ; aws brings in a lot of dependencies.
 
    :dev
    {:dependencies [[criterium "0.4.4"]


### PR DESCRIPTION
## Changes proposed in this PR

- Reduces the amount we put on top of the existing image by about 140mb.
- 
- 

## Why are we making these changes?
Smaller dockers build faster and waste less space locally.

