### PR TITLE
Introduces x-cook-truncated-results

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2610,8 +2610,8 @@
     :handle-ok (fn [ctx]
                  (timers/time!
                    (timers/timer ["cook-scheduler" "handler" "list-endpoint-duration"])
-                   (let [job-ents (list-job-ents db false ctx)]
-                     (doall (mapv (partial fetch-job-map-from-entity db) job-ents)))))))
+                   (let [{:keys [jobs]} (list-job-ents db false ctx)]
+                     (doall (mapv (partial fetch-job-map-from-entity db) jobs)))))))
 
 ;;
 ;; /unscheduled_jobs

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -48,7 +48,6 @@
             [datomic.api :as d :refer [q]]
             [liberator.core :as liberator]
             [liberator.util :refer [combine]]
-            [liberator.representation]
             [me.raynes.conch :as sh]
             [mesomatic.scheduler]
             [metatransaction.core :refer [db]]


### PR DESCRIPTION
## Changes proposed in this PR

- adding the `x-cook-truncated-results` response header when there are more jobs than the limit you asked for

## Why are we making these changes?

To let clients know when they need to ask for more with a smaller time window.
