### PR TITLE
Use /slaves instead of state.json

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1617,13 +1617,13 @@ class CookTest(util.CookTest):
         self.logger.debug('instance: %s' % instance)
         try:
             # Get agent host/port
-            state = util.get_mesos_state(util.retrieve_mesos_url())
-            agent = [agent for agent in state['slaves']
-                       if agent['hostname'] == instance['hostname']][0]
+            slaves = util.get_mesos_slaves(util.retrieve_mesos_url())['slaves']
+            agent = [agent for agent in slaves
+                     if agent['hostname'] == instance['hostname']][0]
 
             # Get container ID from agent
             def agent_query():
-                return util.session.get(util.get_agent_endpoint(state, instance['hostname']))
+                return util.session.get(util.get_agent_endpoint(slaves, instance['hostname']))
 
             def contains_executor_predicate(agent_response):
                 agent_state = agent_response.json()
@@ -2828,8 +2828,8 @@ class CookTest(util.CookTest):
             self.assertEqual(201, resp.status_code, resp.text)
             instance = util.wait_for_instance(self.cook_url, job_uuid, status='success')
             slave_host = instance['hostname']
-            master_state = util.get_mesos_state(util.retrieve_mesos_url())
-            slave_state = util.session.get(util.get_agent_endpoint(master_state, slave_host)).json()
+            slaves = util.get_mesos_slaves(util.retrieve_mesos_url())['slaves']
+            slave_state = util.session.get(util.get_agent_endpoint(slaves, slave_host)).json()
 
             executor = util.get_executor(slave_state, instance['executor_id'], True)
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -830,12 +830,11 @@ def wait_for_running_instance(cook_url, job_id, max_wait_ms=DEFAULT_TIMEOUT_MS):
     return response.json()[0]['instances'][0]
 
 
-@functools.lru_cache()
 def get_mesos_slaves(mesos_url):
     """
     Queries mesos slave state from /slaves
     """
-    return session.get('%s/state.json' % mesos_url).json()
+    return session.get('%s/slaves' % mesos_url).json()
 
 
 def wait_for_output_url(cook_url, job_uuid):

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -830,9 +830,10 @@ def wait_for_running_instance(cook_url, job_id, max_wait_ms=DEFAULT_TIMEOUT_MS):
     return response.json()[0]['instances'][0]
 
 
-def get_mesos_state(mesos_url):
+@functools.lru_cache()
+def get_mesos_slaves(mesos_url):
     """
-    Queries the state.json from mesos
+    Queries mesos slave state from /slaves
     """
     return session.get('%s/state.json' % mesos_url).json()
 
@@ -1189,7 +1190,7 @@ def is_cook_executor_in_use():
 
 def slave_cpus(mesos_url, hostname):
     """Returns the cpus of the specified Mesos agent"""
-    slaves = get_mesos_state(mesos_url)['slaves']
+    slaves = get_mesos_slaves(mesos_url)['slaves']
     # Here we need to use unreserved_resources because Mesos might only
     # send offers for the unreserved (role = "*") portions of the agents.
     slave_cpus = next(s['unreserved_resources']['cpus'] for s in slaves if s['hostname'] == hostname)
@@ -1201,7 +1202,7 @@ def _pool_attribute_name(cook_url):
 
 def slave_pool(cook_url, mesos_url, hostname):
     """Returns the pool of the specified Mesos agent, or None if the agent doesn't have the attribute"""
-    slaves = get_mesos_state(mesos_url)['slaves']
+    slaves = get_mesos_slaves(mesos_url)['slaves']
     attribute_name = _pool_attribute_name(cook_url)
     pool = next(s.get('attributes', {}).get(attribute_name, None) for s in slaves if s['hostname'] == hostname)
     return pool
@@ -1209,7 +1210,7 @@ def slave_pool(cook_url, mesos_url, hostname):
 
 def max_mesos_slave_cpus(mesos_url):
     """Returns the max cpus of all current Mesos agents"""
-    slaves = get_mesos_state(mesos_url)['slaves']
+    slaves = get_mesos_slaves(mesos_url)['slaves']
     max_slave_cpus = max([s['resources']['cpus'] for s in slaves])
     return max_slave_cpus
 
@@ -1261,7 +1262,7 @@ def max_node_cpus():
 
 def node_count():
     if using_mesos():
-        return len(get_mesos_state(retrieve_mesos_url())['slaves'])
+        return len(get_mesos_slaves(retrieve_mesos_url())['slaves'])
     elif using_kubernetes():
         return len(get_kubernetes_nodes())
     else:
@@ -1316,8 +1317,7 @@ def mesos_hostnames_to_consider(cook_url, mesos_url):
     """
     Returns the hostnames in the default pool, or all hosts if the cluster is not using pools
     """
-    state = get_mesos_state(mesos_url)
-    slaves = state['slaves']
+    slaves = get_mesos_slaves(mesos_url)['slaves']
     pool = default_pool(cook_url)
     attribute_name = _pool_attribute_name(cook_url)
     slaves = [s for s in slaves if s['attributes'].get(attribute_name, None) == pool] if pool else slaves
@@ -1409,12 +1409,12 @@ def using_data_local_fitness_calculator():
     return _fenzo_fitness_calculator() == 'cook.scheduler.data-locality/make-data-local-fitness-calculator'
 
 
-def get_agent_endpoint(master_state, agent_hostname):
-    agent = [agent for agent in master_state['slaves']
+def get_agent_endpoint(slaves, agent_hostname):
+    agent = [agent for agent in slaves
              if agent['hostname'] == agent_hostname][0]
     if agent is None:
         logger.warning(f"Could not find agent for hostname {agent_hostname}")
-        logger.warning(f"slaves: {master_state['slaves']}")
+        logger.warning(f"slaves: {slaves}")
         return None
     else:
         # Get the host and port of the agent API.
@@ -1427,8 +1427,8 @@ def get_agent_endpoint(master_state, agent_hostname):
 @functools.lru_cache()
 def _supported_isolators():
     mesos_url = retrieve_mesos_url()
-    mesos_state = get_mesos_state(mesos_url)
-    slave_endpoint = get_agent_endpoint(mesos_state, mesos_state['slaves'][0]['hostname'])
+    slaves = get_mesos_slaves(mesos_url)['slaves']
+    slave_endpoint = get_agent_endpoint(slaves, slaves[0]['hostname'])
     slave_response = session.get(slave_endpoint)
     try:
         slave_state = slave_response.json()


### PR DESCRIPTION
## Changes proposed in this PR
- Use `/slaves` instead of `/state.json` for retrieving slaves

## Why are we making these changes?
The `/slaves` endpoint is much faster.
