### PR TITLE
Improvements to k8s volumes

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2606,3 +2606,25 @@ class CookTest(util.CookTest):
             self.assertEqual([1, 2], exit_codes, job)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
+
+    @unittest.skipUnless(util.using_kubernetes(), 'Test requires kubernetes')
+    def test_kubernetes_disallowed_volumes(self):
+        settings = util.settings(self.cook_url)
+        disallowed_container_paths = util.get_in(settings, 'kubernetes', 'disallowed-container-paths')
+        if disallowed_container_paths is None:
+            self.skipTest('Requires disallowed container paths')
+        path = disallowed_container_paths[0]
+        command = f'bash -c \'if [[ -e {path} ]]; then exit 1; fi\''
+        docker_image = util.docker_image()
+        container = {'type': 'docker',
+                     'docker': {'image': docker_image,
+                                'network': 'HOST',
+                                'force-pull-image': False},
+                     'volumes': [{'host-path': '/tmp',
+                                  'container-path': path}]}
+        job_uuid, resp = util.submit_job(self.cook_url, command=command, container=container)
+        self.assertEqual(201, resp.status_code)
+        try:
+            util.wait_for_instance(self.cook_url, job_uuid, status='success')
+        finally:
+            util.kill_jobs(self.cook_url, [job_uuid])

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -32,6 +32,7 @@
                                :age-out-seen-count 10
                                :factory-fn "cook.plugins.demo-plugin/launch-factory"}}
  :hostname #config/env "COOK_HOSTNAME"
+ :kubernetes {:disallowed-container-paths #{"/mnt/bad"}}
  :log {:file #config/env "COOK_LOG_FILE"
        :levels {"datomic.db" :warn
                 "datomic.kv-cluster" :warn

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -428,7 +428,9 @@
                           :pool-selection
                           (merge {:attribute-name "cook-pool"
                                   :default-pool "no-pool"}
-                                 pool-selection)})))}))
+                                 pool-selection)})))
+     :kubernetes (fnk [[:config {kubernetes {}}]]
+                   kubernetes)}))
 
 (defn read-config
   "Given a config file path, reads the config and returns the map"
@@ -538,3 +540,7 @@
 (defn compute-clusters
   []
   (get-in config [:settings :compute-clusters]))
+
+(defn kubernetes
+  []
+  (get-in config [:settings :kubernetes]))


### PR DESCRIPTION
## Changes proposed in this PR
- Use uuids to for Kubernetes volume names  
- Add support for disallowed container mount paths

## Why are we making these changes?
UUIDs are guaranteed to pass the Kubernetes name validation regex.
Disallowing container paths allows blocking paths that may be added elsewhere in Kubernetes (for instance, in an admission controller.)

