### PR TITLE
Adds logging and other test improvements

### DIFF
--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 venv/
 virtualenv-integrationtest*
 .pytest_cache
+/.cs.json

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,7 +1,7 @@
 beakerx==0.16.1
 tornado==5.1.1
 jupyter_client==5.2.3
-nbconvert==5.3.1
+nbconvert==5.6.0
 nbformat==4.4.0
 numpy==1.15.3
 pip==9.0.1; python_version >= '3.6'

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -5,9 +5,9 @@ nbconvert==5.3.1
 nbformat==4.4.0
 numpy==1.15.3
 pip==9.0.1; python_version >= '3.6'
-pytest==3.3.1
-pytest-timeout==1.2.1
-pytest-xdist==1.20.1
+pytest==5.2.0
+pytest-timeout==1.3.3
+pytest-xdist==1.30.0
 python-dateutil==2.6.1
 requests==2.20.0
 retrying==1.3.3

--- a/integration/setup.cfg
+++ b/integration/setup.cfg
@@ -1,4 +1,9 @@
 [tool:pytest]
-addopts = -n10 -v --timeout-method=thread --maxfail=5
+addopts = -n10 -v --timeout-method=thread --maxfail=5 --log-level=DEBUG
 timeout = 1200
 usefixtures = record_test_metric
+markers =
+    multi_user: marks tests as using multiple users (e.g. one admin and one non-admin)
+    cli: marks tests as testing the cs CLI
+    serial: marks tests as needing to run in series rather than in parallel with other tests
+    memlimit: marks tests as checking that exceeding the memory limit works as expected

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -49,7 +49,7 @@ class CookTest(util.CookTest):
             self.fail(f"Unable to parse start time: {info_details}")
 
     def test_basic_submit(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         job_uuid, resp = util.submit_job(self.cook_url, executor=job_executor_type)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         self.assertEqual(resp.content, str.encode(f"submitted jobs {job_uuid}"))
@@ -67,7 +67,7 @@ class CookTest(util.CookTest):
 
     @unittest.skipIf(util.using_kubernetes(), 'Output url is not currently supported on kubernetes')
     def test_output_url(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         job_uuid, resp = util.submit_job(self.cook_url, command='sleep 600', executor=job_executor_type)
         try:
             self.assertTrue(len(util.wait_for_output_url(self.cook_url, job_uuid)['output_url']) > 0)
@@ -167,7 +167,7 @@ class CookTest(util.CookTest):
 
     @unittest.skipUnless(util.is_cook_executor_in_use(), 'Test assumes the Cook Executor is in use')
     def test_disable_mea_culpa(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         self.assertEqual('cook', job_executor_type)
         uuid, resp = util.submit_job(self.cook_url, command='sleep 30', env={'EXECUTOR_TEST_EXIT': '1'},
                                      disable_mea_culpa_retries=True, executor=job_executor_type)
@@ -188,7 +188,7 @@ class CookTest(util.CookTest):
 
     @unittest.skipUnless(util.is_cook_executor_in_use(), 'Test assumes the Cook Executor is in use')
     def test_mea_culpa_retries(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         self.assertEqual('cook', job_executor_type)
         uuid, resp = util.submit_job(self.cook_url, command='sleep 30', env={'EXECUTOR_TEST_EXIT': '1'}, executor=job_executor_type)
         try:
@@ -281,7 +281,7 @@ class CookTest(util.CookTest):
         self.assertEqual('success', job['instances'][0]['status'], message)
 
     def test_failing_submit(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         job_uuid, resp = util.submit_job(self.cook_url, command='exit 1', executor=job_executor_type)
         self.assertEqual(201, resp.status_code, msg=resp.content)
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
@@ -306,7 +306,7 @@ class CookTest(util.CookTest):
 
     @unittest.skipUnless(util.is_cook_executor_in_use(), 'Test assumes the Cook Executor is in use')
     def test_progress_update_submit(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         progress_file_env = util.retrieve_progress_file_env(self.cook_url)
 
         line = util.progress_line(self.cook_url, 25, f'Twenty-five percent in ${{{progress_file_env}}}', True)
@@ -333,7 +333,7 @@ class CookTest(util.CookTest):
 
     @unittest.skipUnless(util.is_cook_executor_in_use(), 'Test assumes the Cook Executor is in use')
     def test_configurable_progress_update_submit(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         command = 'echo "message: 25 Twenty-five percent" > progress_file.txt; sleep 1; exit 0'
         job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=job_executor_type, max_runtime=60000,
                                          progress_output_file='progress_file.txt',
@@ -359,7 +359,7 @@ class CookTest(util.CookTest):
 
     @unittest.skipUnless(util.is_cook_executor_in_use(), 'Test assumes the Cook Executor is in use')
     def test_multiple_progress_updates_submit(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         line_1 = util.progress_line(self.cook_url, 25, 'Twenty-five percent', True)
         line_2 = util.progress_line(self.cook_url, 50, 'Fifty percent', True)
         line_3 = util.progress_line(self.cook_url, '', 'Sixty percent invalid format', True)
@@ -389,7 +389,7 @@ class CookTest(util.CookTest):
     @unittest.skipUnless(util.is_cook_executor_in_use() and not (util.docker_tests_enabled() and util.continuous_integration()),
                          'Test assumes the Cook Executor is in use. Fails on travis with docker')
     def test_multiple_progress_updates_submit_stdout(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         line_1 = util.progress_line(self.cook_url, 25, 'Twenty-five percent')
         line_2 = util.progress_line(self.cook_url, 50, 'Fifty percent')
         line_3 = util.progress_line(self.cook_url, '', 'Sixty percent invalid format')
@@ -418,7 +418,7 @@ class CookTest(util.CookTest):
 
     @unittest.skipUnless(util.is_cook_executor_in_use(), 'Test assumes the Cook Executor is in use')
     def test_multiple_rapid_progress_updates_submit(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
 
         def progress_string(a):
             return util.progress_line(self.cook_url, a, f'{a}%', True)
@@ -444,7 +444,7 @@ class CookTest(util.CookTest):
         self.assertEqual('80%', instance['progress_message'], message)
 
     def test_max_runtime_exceeded(self):
-        job_executor_type = util.get_job_executor_type(self.cook_url)
+        job_executor_type = util.get_job_executor_type()
         settings_timeout_interval_minutes = util.get_in(util.settings(self.cook_url), 'task-constraints',
                                                         'timeout-interval-minutes')
         # the value needs to be a little more than 2 times settings_timeout_interval_minutes to allow
@@ -523,11 +523,11 @@ class CookTest(util.CookTest):
         return command
 
     @staticmethod
-    def memory_limit_script_command():
+    def memory_limit_script_command(count=1024):
         """Generates a script command that incrementally allocates large strings that cause the process to
         request more memory than it is allocated."""
         command = 'random_string() { ' \
-                  '  base64 /dev/urandom | tr -d \'/+\' | dd bs=1048576 count=1024 2>/dev/null; ' \
+                  f'  base64 /dev/urandom | tr -d \'/+\' | dd bs=1048576 count={count} 2>/dev/null; ' \
                   '}; ' \
                   'R="$(random_string)"; ' \
                   'V=""; ' \
@@ -541,16 +541,16 @@ class CookTest(util.CookTest):
                   'done'
         return command
 
-    def memory_limit_exceeded_helper(self, command, executor_type):
+    def memory_limit_exceeded_helper(self, command, executor_type, mem=128):
         """Given a command that needs more memory than it is allocated, when the command is submitted to cook,
         the job should be killed by Mesos as it exceeds its memory limits."""
-        job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=executor_type, mem=128)
+        job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=executor_type, mem=mem)
         self.assertEqual(201, resp.status_code, msg=resp.content)
         instance = util.wait_for_instance(self.cook_url, job_uuid)
         self.logger.debug('instance: %s' % instance)
         job = instance['parent']
         try:
-            job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
+            job = util.wait_for_job(self.cook_url, job_uuid, 'completed', max_wait_ms=480000)
             job_details = f"Job details: {json.dumps(job, sort_keys=True)}"
             self.assertEqual('failed', job['state'], job_details)
             self.assertLessEqual(1, len(job['instances']), job_details)
@@ -597,8 +597,8 @@ class CookTest(util.CookTest):
 
     @pytest.mark.memlimit
     def test_memory_limit_exceeded_mesos_script(self):
-        command = self.memory_limit_script_command()
-        self.memory_limit_exceeded_helper(command, 'mesos')
+        command = self.memory_limit_script_command(count=2048)
+        self.memory_limit_exceeded_helper(command, 'mesos', mem=32)
 
     def test_get_job(self):
         # schedule a job
@@ -1556,35 +1556,6 @@ class CookTest(util.CookTest):
         resp = util.query_groups(self.cook_url)
         self.assertEqual(400, resp.status_code)
 
-    def test_queue_endpoint(self):
-        group = {'uuid': str(util.make_temporal_uuid())}
-        job_spec = {'group': group['uuid'],
-                    'command': 'sleep 30',
-                    'cpus': util.max_cpus()}
-        uuids, resp = util.submit_jobs(self.cook_url, job_spec, clones=100, groups=[group])
-        self.assertEqual(201, resp.status_code, resp.content)
-        try:
-            default_pool = util.default_pool(self.cook_url)
-            pool = default_pool or 'no-pool'
-            self.logger.info(f'Checking the queue endpoint for pool {pool}')
-
-            def query_queue():
-                return util.query_queue(self.cook_url)
-
-            def queue_predicate(resp):
-                return any([job['job/uuid'] in uuids for job in resp.json()[pool]])
-
-            resp = util.wait_until(query_queue, queue_predicate)
-            job = [job for job in resp.json()[pool] if job['job/uuid'] in uuids][0]
-            job_group = job['group/_job'][0]
-            self.assertEqual(200, resp.status_code, resp.content)
-            self.assertTrue('group/_job' in job.keys())
-            self.assertEqual(group['uuid'], job_group['group/uuid'])
-            self.assertTrue('group/host-placement' in job_group.keys())
-            self.assertFalse('group/job' in job_group.keys())
-        finally:
-            util.kill_jobs(self.cook_url, uuids)
-
     @unittest.skipUnless(util.docker_tests_enabled(), "Requires a test docker image")
     def test_basic_docker_job(self):
         image = util.docker_image()
@@ -2121,111 +2092,6 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, job_uuids)
 
-    def test_user_limits_change(self):
-        user = 'limit_change_test_user'
-        # set user quota
-        resp = util.set_limit(self.cook_url, 'quota', user, cpus=20)
-        self.assertEqual(resp.status_code, 201, resp.text)
-        # set user quota fails (malformed) if no reason is given
-        resp = util.set_limit(self.cook_url, 'quota', user, cpus=10, reason=None)
-        self.assertEqual(resp.status_code, 400, resp.text)
-        # reset user quota back to default
-        resp = util.reset_limit(self.cook_url, 'quota', user, reason=self.current_name())
-        self.assertEqual(resp.status_code, 204, resp.text)
-        # reset user quota fails (malformed) if no reason is given
-        resp = util.reset_limit(self.cook_url, 'quota', user, reason=None)
-        self.assertEqual(resp.status_code, 400, resp.text)
-        # set user share
-        resp = util.set_limit(self.cook_url, 'share', user, cpus=10)
-        self.assertEqual(resp.status_code, 201, resp.text)
-        # set user share fails (malformed) if no reason is given
-        resp = util.set_limit(self.cook_url, 'share', user, cpus=10, reason=None)
-        self.assertEqual(resp.status_code, 400, resp.text)
-        # reset user share back to default
-        resp = util.reset_limit(self.cook_url, 'share', user, reason=self.current_name())
-        self.assertEqual(resp.status_code, 204, resp.text)
-        # reset user share fails (malformed) if no reason is given
-        resp = util.reset_limit(self.cook_url, 'share', user, reason=None)
-        self.assertEqual(resp.status_code, 400, resp.text)
-
-        default_pool = util.default_pool(self.cook_url)
-        if default_pool is not None:
-            for limit in ['quota', 'share']:
-                # Get the default cpus limit
-                resp = util.get_limit(self.cook_url, limit, "default")
-                self.assertEqual(200, resp.status_code, resp.text)
-                self.logger.info(f'The default limit in the {default_pool} pool is {resp.json()}')
-                default_cpus = resp.json()['cpus']
-
-                # Set a limit for the default pool
-                resp = util.set_limit(self.cook_url, limit, user, cpus=100, pool=default_pool)
-                self.assertEqual(resp.status_code, 201, resp.text)
-
-                # Check that the limit is returned for no pool
-                resp = util.get_limit(self.cook_url, limit, user)
-                self.assertEqual(resp.status_code, 200, resp.text)
-                self.assertEqual(100, resp.json()['cpus'], resp.text)
-
-                # Check that the limit is returned for the default pool
-                resp = util.get_limit(self.cook_url, limit, user, pool=default_pool)
-                self.assertEqual(resp.status_code, 200, resp.text)
-                self.assertEqual(100, resp.json()['cpus'], resp.text)
-
-                # Delete the default pool limit (no pool argument)
-                resp = util.reset_limit(self.cook_url, limit, user, reason=self.current_name())
-                self.assertEqual(resp.status_code, 204, resp.text)
-
-                # Check that the default is returned for the default pool
-                resp = util.get_limit(self.cook_url, limit, user, pool=default_pool)
-                self.assertEqual(resp.status_code, 200, resp.text)
-                self.assertEqual(default_cpus, resp.json()['cpus'], resp.text)
-
-                pools, _ = util.all_pools(self.cook_url)
-                non_default_pools = [p['name'] for p in pools if p['name'] != default_pool]
-
-                for pool in non_default_pools:
-                    # Get the default cpus limit
-                    resp = util.get_limit(self.cook_url, limit, "default", pool=pool)
-                    self.assertEqual(200, resp.status_code, resp.text)
-                    self.logger.info(f'The default limit in the {default_pool} pool is {resp.json()}')
-                    default_cpus = resp.json()['cpus']
-
-                    # delete the pool's limit
-                    resp = util.reset_limit(self.cook_url, limit, user, pool=pool, reason=self.current_name())
-                    self.assertEqual(resp.status_code, 204, resp.text)
-
-                    # check that the default value is returned
-                    resp = util.get_limit(self.cook_url, limit, user, pool=pool)
-                    self.assertEqual(resp.status_code, 200, resp.text)
-                    self.assertEqual(default_cpus, resp.json()['cpus'], resp.text)
-
-                    # set a pool-specific limit
-                    resp = util.set_limit(self.cook_url, limit, user, cpus=1000, pool=pool)
-                    self.assertEqual(resp.status_code, 201, resp.text)
-
-                    # check that the pool-specific limit is returned
-                    resp = util.get_limit(self.cook_url, limit, user, pool=pool)
-                    self.assertEqual(resp.status_code, 200, resp.text)
-                    self.assertEqual(1000, resp.json()['cpus'], resp.text)
-
-                    # now delete the pool limit with headers
-                    resp = util.reset_limit(self.cook_url, limit, user, reason=self.current_name(),
-                                            headers={'x-cook-pool': pool})
-                    self.assertEqual(resp.status_code, 204, resp.text)
-
-                    # check that the default value is returned
-                    resp = util.get_limit(self.cook_url, limit, user, headers={'x-cook-pool': pool})
-                    self.assertEqual(resp.status_code, 200, resp.text)
-                    self.assertEqual(default_cpus, resp.json()['cpus'], resp.text)
-
-                    # set a pool-specific limit
-                    resp = util.set_limit(self.cook_url, limit, user, cpus=1000, headers={'x-cook-pool': pool})
-                    self.assertEqual(resp.status_code, 201, resp.text)
-
-                    # check that the pool-specific limit is returned
-                    resp = util.get_limit(self.cook_url, limit, user, headers={'x-cook-pool': pool})
-                    self.assertEqual(resp.status_code, 200, resp.text)
-
     def test_submit_with_no_name(self):
         # We need to manually set the 'uuid' to avoid having the
         # job name automatically set by the submit_job function
@@ -2247,208 +2113,6 @@ class CookTest(util.CookTest):
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         job = util.load_job(self.cook_url, job_uuid)
         self.assertIn(job['status'], ['running', 'waiting', 'completed'])
-
-    def test_instance_stats_running(self):
-        name = str(util.make_temporal_uuid())
-        job_uuid_1, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
-        try:
-            instances = [util.wait_for_running_instance(self.cook_url, j) for j in job_uuids]
-            start_time = min(i['start_time'] for i in instances)
-            end_time = max(i['start_time'] for i in instances)
-            stats, _ = util.get_instance_stats(self.cook_url,
-                                               status='running',
-                                               start=util.to_iso(start_time),
-                                               end=util.to_iso(end_time + 1),
-                                               name=name)
-            user = util.get_user(self.cook_url, job_uuid_1)
-            self.assertEqual(3, stats['overall']['count'])
-            self.assertEqual(3, stats['by-reason']['']['count'])
-            self.assertEqual(3, stats['by-user-and-reason'][user]['']['count'])
-        finally:
-            util.kill_jobs(self.cook_url, job_uuids)
-
-    def test_instance_stats_failed(self):
-        name = str(util.make_temporal_uuid())
-        job_uuid_1, resp = util.submit_job(self.cook_url, command='exit 1', name=name, cpus=0.1, mem=32)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 1 && exit 1', name=name, cpus=0.2, mem=64)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 2 && exit 1', name=name, cpus=0.4, mem=128)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
-        try:
-            jobs = util.wait_for_jobs(self.cook_url, job_uuids, 'completed')
-            instances = []
-            non_mea_culpa_instances = []
-            for job in jobs:
-                for instance in job['instances']:
-                    instance['parent'] = job
-                    instances.append(instance)
-                    if not instance['reason_mea_culpa']:
-                        non_mea_culpa_instances.append(instance)
-            start_time = min(i['start_time'] for i in instances)
-            end_time = max(i['start_time'] for i in instances)
-            stats, _ = util.get_instance_stats(self.cook_url,
-                                               status='failed',
-                                               start=util.to_iso(start_time),
-                                               end=util.to_iso(end_time + 1),
-                                               name=name)
-            self.logger.info(json.dumps(stats, indent=2))
-            self.logger.info(f'Instances: {instances}')
-            user = util.get_user(self.cook_url, job_uuid_1)
-            stats_overall = stats['overall']
-            exited_non_zero = 'Command exited non-zero'
-            self.assertEqual(len(instances), stats_overall['count'])
-            self.assertEqual(len(non_mea_culpa_instances), stats['by-reason'][exited_non_zero]['count'])
-            self.assertEqual(len(non_mea_culpa_instances), stats['by-user-and-reason'][user][exited_non_zero]['count'])
-            run_times = [(i['end_time'] - i['start_time']) / 1000 for i in instances]
-            run_time_seconds = stats_overall['run-time-seconds']
-            percentiles = run_time_seconds['percentiles']
-            self.logger.info(f'Run times: {json.dumps(run_times, indent=2)}')
-            self.assertEqual(util.percentile(run_times, 50), percentiles['50'])
-            self.assertEqual(util.percentile(run_times, 75), percentiles['75'])
-            self.assertEqual(util.percentile(run_times, 95), percentiles['95'])
-            self.assertEqual(util.percentile(run_times, 99), percentiles['99'])
-            self.assertEqual(util.percentile(run_times, 100), percentiles['100'])
-            self.assertAlmostEqual(sum(run_times), run_time_seconds['total'])
-            cpu_times = [((i['end_time'] - i['start_time']) / 1000) * i['parent']['cpus'] for i in instances]
-            cpu_seconds = stats_overall['cpu-seconds']
-            percentiles = cpu_seconds['percentiles']
-            self.logger.info(f'CPU times: {json.dumps(cpu_times, indent=2)}')
-            self.assertEqual(util.percentile(cpu_times, 50), percentiles['50'])
-            self.assertEqual(util.percentile(cpu_times, 75), percentiles['75'])
-            self.assertEqual(util.percentile(cpu_times, 95), percentiles['95'])
-            self.assertEqual(util.percentile(cpu_times, 99), percentiles['99'])
-            self.assertEqual(util.percentile(cpu_times, 100), percentiles['100'])
-            self.assertAlmostEqual(sum(cpu_times), cpu_seconds['total'])
-            mem_times = [((i['end_time'] - i['start_time']) / 1000) * i['parent']['mem'] for i in instances]
-            mem_seconds = stats_overall['mem-seconds']
-            percentiles = mem_seconds['percentiles']
-            self.logger.info(f'Mem times: {json.dumps(mem_times, indent=2)}')
-            self.assertEqual(util.percentile(mem_times, 50), percentiles['50'])
-            self.assertEqual(util.percentile(mem_times, 75), percentiles['75'])
-            self.assertEqual(util.percentile(mem_times, 95), percentiles['95'])
-            self.assertEqual(util.percentile(mem_times, 99), percentiles['99'])
-            self.assertEqual(util.percentile(mem_times, 100), percentiles['100'])
-            self.assertAlmostEqual(sum(mem_times), mem_seconds['total'])
-        finally:
-            util.kill_jobs(self.cook_url, job_uuids)
-
-    def test_instance_stats_success(self):
-        name = str(util.make_temporal_uuid())
-        job_uuid_1, resp = util.submit_job(self.cook_url, command='exit 0', name=name, cpus=0.1, mem=32)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 1', name=name, cpus=0.2, mem=64)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 2', name=name, cpus=0.4, mem=128)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
-        try:
-            util.wait_for_jobs(self.cook_url, job_uuids, 'completed')
-            instances = [util.wait_for_instance(self.cook_url, j) for j in job_uuids]
-            try:
-                for instance in instances:
-                    self.assertEqual('success', instance['parent']['state'])
-                start_time = min(i['start_time'] for i in instances)
-                end_time = max(i['start_time'] for i in instances)
-                stats, _ = util.get_instance_stats(self.cook_url,
-                                                   status='success',
-                                                   start=util.to_iso(start_time),
-                                                   end=util.to_iso(end_time + 1),
-                                                   name=name)
-                user = util.get_user(self.cook_url, job_uuid_1)
-                stats_overall = stats['overall']
-                self.assertEqual(3, stats_overall['count'])
-                self.assertEqual(3, stats['by-reason']['']['count'])
-                self.assertEqual(3, stats['by-user-and-reason'][user]['']['count'])
-                run_times = [(i['end_time'] - i['start_time']) / 1000 for i in instances]
-                run_time_seconds = stats_overall['run-time-seconds']
-                percentiles = run_time_seconds['percentiles']
-                self.assertEqual(util.percentile(run_times, 50), percentiles['50'])
-                self.assertEqual(util.percentile(run_times, 75), percentiles['75'])
-                self.assertEqual(util.percentile(run_times, 95), percentiles['95'])
-                self.assertEqual(util.percentile(run_times, 99), percentiles['99'])
-                self.assertEqual(util.percentile(run_times, 100), percentiles['100'])
-                self.assertAlmostEqual(sum(run_times), run_time_seconds['total'])
-                cpu_times = [((i['end_time'] - i['start_time']) / 1000) * i['parent']['cpus'] for i in instances]
-                cpu_seconds = stats_overall['cpu-seconds']
-                percentiles = cpu_seconds['percentiles']
-                self.assertEqual(util.percentile(cpu_times, 50), percentiles['50'])
-                self.assertEqual(util.percentile(cpu_times, 75), percentiles['75'])
-                self.assertEqual(util.percentile(cpu_times, 95), percentiles['95'])
-                self.assertEqual(util.percentile(cpu_times, 99), percentiles['99'])
-                self.assertEqual(util.percentile(cpu_times, 100), percentiles['100'])
-                self.assertAlmostEqual(sum(cpu_times), cpu_seconds['total'])
-                mem_times = [((i['end_time'] - i['start_time']) / 1000) * i['parent']['mem'] for i in instances]
-                mem_seconds = stats_overall['mem-seconds']
-                percentiles = mem_seconds['percentiles']
-                self.assertEqual(util.percentile(mem_times, 50), percentiles['50'])
-                self.assertEqual(util.percentile(mem_times, 75), percentiles['75'])
-                self.assertEqual(util.percentile(mem_times, 95), percentiles['95'])
-                self.assertEqual(util.percentile(mem_times, 99), percentiles['99'])
-                self.assertEqual(util.percentile(mem_times, 100), percentiles['100'])
-                self.assertAlmostEqual(sum(mem_times), mem_seconds['total'])
-            except:
-                for instance in instances:
-                    mesos.dump_sandbox_files(util.session, instance, instance['parent'])
-                raise
-        finally:
-            util.kill_jobs(self.cook_url, job_uuids)
-
-    def test_instance_stats_supports_epoch_time_params(self):
-        name = str(util.make_temporal_uuid())
-        job_uuid_1, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
-        self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
-        try:
-            instances = [util.wait_for_running_instance(self.cook_url, j) for j in job_uuids]
-            start_time = min(i['start_time'] for i in instances)
-            end_time = max(i['start_time'] for i in instances)
-            stats, _ = util.get_instance_stats(self.cook_url,
-                                               status='running',
-                                               start=start_time,
-                                               end=end_time + 1,
-                                               name=name)
-            user = util.get_user(self.cook_url, job_uuid_1)
-            self.assertEqual(3, stats['overall']['count'])
-            self.assertEqual(3, stats['by-reason']['']['count'])
-            self.assertEqual(3, stats['by-user-and-reason'][user]['']['count'])
-        finally:
-            util.kill_jobs(self.cook_url, job_uuids)
-
-    def test_instance_stats_rejects_invalid_params(self):
-        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-02-20', end='2018-02-21')
-        self.assertEqual(200, resp.status_code)
-        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-02-20')
-        self.assertEqual(400, resp.status_code)
-        _, resp = util.get_instance_stats(self.cook_url, status='running', end='2018-02-21')
-        self.assertEqual(400, resp.status_code)
-        _, resp = util.get_instance_stats(self.cook_url, start='2018-02-20', end='2018-02-21')
-        self.assertEqual(400, resp.status_code)
-        _, resp = util.get_instance_stats(self.cook_url, status='bogus', start='2018-02-20', end='2018-02-21')
-        self.assertEqual(400, resp.status_code)
-        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-02-20',
-                                          end='2018-02-21', name='foo')
-        self.assertEqual(200, resp.status_code)
-        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-02-20',
-                                          end='2018-02-21', name='?')
-        self.assertEqual(400, resp.status_code)
-        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-01-01', end='2018-02-01')
-        self.assertEqual(200, resp.status_code)
-        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-01-01', end='2018-02-02')
-        self.assertEqual(400, resp.status_code)
-        _, resp = util.get_instance_stats(self.cook_url, status='running', start='2018-01-01', end='2017-12-31')
-        self.assertEqual(400, resp.status_code)
 
     def test_cors_request(self):
         resp = util.session.get(f"{self.cook_url}/settings", headers={"Origin": "http://bad.example.com"})

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -659,7 +659,7 @@ class CookTest(util.CookTest):
                 self.assertEqual(200, resp.status_code, msg=resp.content)
                 jobs = resp.json()
                 for job in jobs:
-                    self.assertEquals(state, job['status'])
+                    self.assertEqual(state, job['status'])
         finally:
             util.kill_jobs(self.cook_url, job_specs)
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -64,7 +64,6 @@ class CookTest(util.CookTest):
         else:
             self.logger.info(f'Exit code not checked because cook executor was not used for {instance}')
 
-
     @unittest.skipIf(util.using_kubernetes(), 'Output url is not currently supported on kubernetes')
     def test_output_url(self):
         job_executor_type = util.get_job_executor_type()
@@ -80,7 +79,6 @@ class CookTest(util.CookTest):
                 self.assertIsNotNone(instance['sandbox_directory'], message)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
-
 
     @unittest.skipUnless(util.docker_tests_enabled(),
                          'Requires setting the COOK_TEST_DOCKER_IMAGE environment variable')
@@ -138,7 +136,7 @@ class CookTest(util.CookTest):
             num_hosts = util.node_count()
             if retry_limit >= num_hosts:
                 pytest.skip(f'Skipping test as not enough agents to verify Mesos executor on subsequent '
-                                  f'instances (agents = {num_hosts}, retry limit = {retry_limit})')
+                            f'instances (agents = {num_hosts}, retry limit = {retry_limit})')
 
         # Should launch many instances
         job_uuid, resp = util.submit_job(self.cook_url, command='exit 1', max_retries=retry_limit * 2)
@@ -190,7 +188,8 @@ class CookTest(util.CookTest):
     def test_mea_culpa_retries(self):
         job_executor_type = util.get_job_executor_type()
         self.assertEqual('cook', job_executor_type)
-        uuid, resp = util.submit_job(self.cook_url, command='sleep 30', env={'EXECUTOR_TEST_EXIT': '1'}, executor=job_executor_type)
+        uuid, resp = util.submit_job(self.cook_url, command='sleep 30', env={'EXECUTOR_TEST_EXIT': '1'},
+                                     executor=job_executor_type)
         try:
             instance = util.wait_for_instance(self.cook_url, uuid)
             self.assertEqual('cook', instance['executor'])
@@ -233,10 +232,10 @@ class CookTest(util.CookTest):
             self.assertEqual(expected_compute_cluster_type, instance['compute-cluster']['type'], message)
             self.assertEqual(expected_compute_cluster, instance['compute-cluster']['name'], message)
             if expected_mesos_framework is not None:
-                self.assertEqual(expected_mesos_framework, instance['compute-cluster']['mesos']['framework-id'], message)
+                self.assertEqual(expected_mesos_framework, instance['compute-cluster']['mesos']['framework-id'],
+                                 message)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid])
-
 
     def test_executor_flag(self):
         job_uuid, resp = util.submit_job(self.cook_url, executor='cook')
@@ -386,8 +385,9 @@ class CookTest(util.CookTest):
         self.assertEqual(75, instance['progress'], message)
         self.assertEqual('Seventy-five percent', instance['progress_message'], message)
 
-    @unittest.skipUnless(util.is_cook_executor_in_use() and not (util.docker_tests_enabled() and util.continuous_integration()),
-                         'Test assumes the Cook Executor is in use. Fails on travis with docker')
+    @unittest.skipUnless(
+        util.is_cook_executor_in_use() and not (util.docker_tests_enabled() and util.continuous_integration()),
+        'Test assumes the Cook Executor is in use. Fails on travis with docker')
     def test_multiple_progress_updates_submit_stdout(self):
         job_executor_type = util.get_job_executor_type()
         line_1 = util.progress_line(self.cook_url, 25, 'Twenty-five percent')
@@ -1019,7 +1019,8 @@ class CookTest(util.CookTest):
         self.assertEqual(0, len(resp.json()))
 
         # List completed with a bogus pool
-        resp = util.jobs(self.cook_url, user=user, state=completed, start=start, end=end, pool=util.make_temporal_uuid())
+        resp = util.jobs(self.cook_url, user=user, state=completed, start=start, end=end,
+                         pool=util.make_temporal_uuid())
         self.assertEqual(200, resp.status_code)
         self.assertEqual(0, len(resp.json()))
 
@@ -1569,7 +1570,8 @@ class CookTest(util.CookTest):
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
         self.assertEqual('success', job['instances'][0]['status'])
 
-    @unittest.skipUnless(util.has_docker_service() and not util.using_kubernetes(), "Requires `docker inspect`. On kubernetes, need to add support and write a separate test.")
+    @unittest.skipUnless(util.has_docker_service() and not util.using_kubernetes(),
+                         "Requires `docker inspect`. On kubernetes, need to add support and write a separate test.")
     def test_docker_port_mapping(self):
         job_uuid, resp = util.submit_job(self.cook_url,
                                          command='python -m http.server 8080',
@@ -2362,7 +2364,6 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 
-
     @unittest.skipIf(os.getenv('COOK_TEST_SKIP_RECONCILE') is not None or util.using_kubernetes(),
                      'Requires not setting the COOK_TEST_SKIP_RECONCILE environment variable. Currently not supported on kubernetes.')
     def test_reconciliation(self):
@@ -2392,7 +2393,8 @@ class CookTest(util.CookTest):
 
     @unittest.skipUnless(util.using_data_local_fitness_calculator(), "Requires the data local fitness calculator")
     def test_data_local_constraint_missing_data(self):
-        job_uuid, resp = util.submit_job(self.cook_url, datasets=[{'dataset': {'uuid': str(util.make_temporal_uuid())}}])
+        job_uuid, resp = util.submit_job(self.cook_url,
+                                         datasets=[{'dataset': {'uuid': str(util.make_temporal_uuid())}}])
         self.assertEqual(201, resp.status_code, resp.text)
 
         # Because the job has no data in the data locality service, it shouldn't be scheduled for a period of time.
@@ -2410,7 +2412,8 @@ class CookTest(util.CookTest):
                                  if r['reason'] == 'data-locality-constraint']
         self.assertEqual(1, len(data_locality_reasons))
 
-    @unittest.skipUnless(util.using_data_local_fitness_calculator() and util.data_local_service_is_set(), 'Requires the data local fitness calculator')
+    @unittest.skipUnless(util.using_data_local_fitness_calculator() and util.data_local_service_is_set(),
+                         'Requires the data local fitness calculator')
     @pytest.mark.serial
     def test_data_local_constrait_not_suitable(self):
         job_uuid, resp = util.submit_job(self.cook_url, datasets=[{'dataset': {'foo': str(util.make_temporal_uuid())}}])
@@ -2429,7 +2432,6 @@ class CookTest(util.CookTest):
             self.assertEqual(instance['hostname'], target)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid])
-
 
     @unittest.skipUnless(util.data_local_service_is_set(), "Requires a data local service")
     @pytest.mark.serial
@@ -2476,8 +2478,8 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 
-
-    @unittest.skipUnless(util.supports_mesos_containerizer_images(), "Requires support for docker images in mesos containerizer")
+    @unittest.skipUnless(util.supports_mesos_containerizer_images(),
+                         "Requires support for docker images in mesos containerizer")
     def test_mesos_containerizer_image_support(self):
         container = {'type': 'mesos', 'mesos': {'image': 'alpine'}}
         settings = util.settings(self.cook_url)
@@ -2518,9 +2520,11 @@ class CookTest(util.CookTest):
             self.assertEqual(201, resp.status_code, resp.text)
             job_uuids = [job_uuid]
         else:
-            job_uuid1, resp1 = util.submit_job(self.cook_url, executor='cook', command='if [ ${#MESOS_EXECUTOR_ID} -eq 0 ]; then echo var was not set; else exit 1; fi;',
+            job_uuid1, resp1 = util.submit_job(self.cook_url, executor='cook',
+                                               command='if [ ${#MESOS_EXECUTOR_ID} -eq 0 ]; then echo var was not set; else exit 1; fi;',
                                                env={'EXECUTOR_RESET_VARS': 'MESOS_EXECUTOR_ID'})
-            job_uuid2, resp2 = util.submit_job(self.cook_url, executor='cook', command='if [ ${#MESOS_EXECUTOR_ID} -gt 0 ]; then echo var was not set; else exit 1; fi;')
+            job_uuid2, resp2 = util.submit_job(self.cook_url, executor='cook',
+                                               command='if [ ${#MESOS_EXECUTOR_ID} -gt 0 ]; then echo var was not set; else exit 1; fi;')
             self.assertEqual(201, resp1.status_code, resp1.text)
             self.assertEqual(201, resp2.status_code, resp2.text)
             job_uuids = [job_uuid1, job_uuid2]
@@ -2529,7 +2533,6 @@ class CookTest(util.CookTest):
                 util.wait_for_instance(self.cook_url, uuid, status='success')
         finally:
             util.kill_jobs(self.cook_url, job_uuids, assert_response=False)
-
 
     @unittest.skipUnless(util.docker_tests_enabled(), "Requires docker support.")
     def test_default_container_volumes(self):
@@ -2562,7 +2565,6 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, job_uuids, assert_response=False)
 
-
     def test_command_length_limit(self):
         settings = util.settings(self.cook_url)
         command_length_limit = util.get_in(settings, 'task-constraints', 'command-length-limit')
@@ -2572,13 +2574,14 @@ class CookTest(util.CookTest):
         job_uuid, resp = util.submit_job(self.cook_url, command=long_command)
         try:
             self.assertEqual(resp.status_code, 400, resp.content)
-            self.assertTrue(f'Job command length of {len(long_command)} is greater than the maximum command length ({command_length_limit})'
-                            in str(resp.content))
+            self.assertTrue(
+                f'Job command length of {len(long_command)} is greater than the maximum command length ({command_length_limit})'
+                in str(resp.content))
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 
-
-    @unittest.skipUnless(util.supports_exit_code() and not util.has_one_agent(), "Requires exit code support and multiple agents")
+    @unittest.skipUnless(util.supports_exit_code() and not util.has_one_agent(),
+                         "Requires exit code support and multiple agents")
     def test_cook_instance_num(self):
         command = 'bash -c \'exit $(($COOK_INSTANCE_NUM + 1))\''
         job_uuid, resp = util.submit_job(self.cook_url, command=command, max_retries=2)
@@ -2587,6 +2590,7 @@ class CookTest(util.CookTest):
                 jobs = util.query_jobs(self.cook_url, True, uuid=[job_uuid]).json()
                 self.logger.info(f'Found jobs: {jobs}')
                 return jobs[0]
+
             def predicate(job):
                 if job['status'] != 'completed':
                     return False
@@ -2594,6 +2598,7 @@ class CookTest(util.CookTest):
                     if 'exit_code' not in instance:
                         return False
                 return True
+
             job = util.wait_until(query, predicate)
             self.assertEqual(2, len(job['instances']), job)
             exit_codes = [i['exit_code'] for i in job['instances']]
@@ -2601,4 +2606,3 @@ class CookTest(util.CookTest):
             self.assertEqual([1, 2], exit_codes, job)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
-

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1732,13 +1732,14 @@ def dummy_ls_entries(_, __, ___):
         cp = cli.cat(uuids[0], util.make_temporal_uuid(), self.cook_url)
         self.assertEqual(1, cp.returncode, cp.stderr)
 
+    @pytest.mark.xfail
     def test_cat_no_newlines(self):
         cp, uuids = cli.submit('bash -c \'for i in {1..100}; do printf "$i " >> foo; done\'', self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp = cli.wait(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        cp = cli.cat(uuids[0], 'foo', self.cook_url)
-        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp = cli.cat(uuids[0], 'foo', self.cook_url, flags='--verbose')
+        self.assertEqual(0, cp.returncode, cli.output(cp))
         self.assertEqual(' '.join([str(i) for i in range(1, 101)]) + ' ', cli.decode(cp.stdout))
 
     @pytest.mark.xfail

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1131,7 +1131,7 @@ def dummy_ls_entries(_, __, ___):
 
     @unittest.skipIf(util.http_basic_auth_enabled(), 'Cook Executor does not currently support HTTP Basic Auth')
     def test_show_progress_message(self):
-        executor = util.get_job_executor_type(self.cook_url)
+        executor = util.get_job_executor_type()
         line = util.progress_line(self.cook_url, 99, 'We are so close!')
         cp, uuids = cli.submit(f'echo "{line}"', self.cook_url, submit_flags=f'--executor {executor} '
                                                                              f'--name {self.current_name()}')
@@ -1160,7 +1160,7 @@ def dummy_ls_entries(_, __, ___):
 
     @unittest.skipIf(util.http_basic_auth_enabled(), 'Cook Executor does not currently support HTTP Basic Auth')
     def test_show_progress_message_custom_progress_file(self):
-        executor = util.get_job_executor_type(self.cook_url)
+        executor = util.get_job_executor_type()
         progress_file_env = util.retrieve_progress_file_env(self.cook_url)
 
         line = util.progress_line(self.cook_url, 99, 'We are so close!')
@@ -2223,7 +2223,7 @@ def dummy_cat_text(_, __, ___):
             self.assertEqual(label_value_1, labels['label1'])
             self.assertEqual(label_value_2, labels['label2'])
         finally:
-            util.kill_jobs(self.cook_url, uuids)
+            util.kill_jobs(self.cook_url, uuids, assert_response=False)
 
     def test_bad_cluster_argument(self):
         cluster_name = 'foo'

--- a/integration/tests/cook/test_pools.py
+++ b/integration/tests/cook/test_pools.py
@@ -38,6 +38,7 @@ class PoolsCookTest(util.CookTest):
 
             cpus = 0.1
             with admin:
+                self.logger.info(f'Running tasks: {json.dumps(util.running_tasks(self.cook_url), indent=2)}')
                 for pool in pools:
                     # Lower the user's cpu quota on this pool
                     pool_name = pool['name']

--- a/integration/tests/cook/test_pools.py
+++ b/integration/tests/cook/test_pools.py
@@ -45,7 +45,7 @@ class PoolsCookTest(util.CookTest):
                     util.set_limit(self.cook_url, 'quota', user.name, cpus=cpus * quota_multiplier, pool=pool_name)
 
             with user:
-                util.kill_running_jobs(self.cook_url, user.name)
+                util.kill_running_and_waiting_jobs(self.cook_url, user.name)
                 for pool in pools:
                     pool_name = pool['name']
 

--- a/integration/tests/cook/test_pools.py
+++ b/integration/tests/cook/test_pools.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import unittest
 
@@ -44,6 +45,7 @@ class PoolsCookTest(util.CookTest):
                     util.set_limit(self.cook_url, 'quota', user.name, cpus=cpus * quota_multiplier, pool=pool_name)
 
             with user:
+                util.kill_running_jobs(self.cook_url, user.name)
                 for pool in pools:
                     pool_name = pool['name']
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1532,3 +1532,7 @@ def kill_running_and_waiting_jobs(cook_url, user):
     running = jobs(cook_url, user=user, state=['running', 'waiting'], start=start, end=end).json()
     logger.info(f'Currently running/waiting jobs: {json.dumps(running, indent=2)}')
     kill_jobs(cook_url, running)
+
+
+def running_tasks(cook_url):
+    return session.get(f'{cook_url}/running', params={'limit': 100}).json()

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -820,6 +820,8 @@ def wait_for_running_instance(cook_url, job_id, max_wait_ms=DEFAULT_TIMEOUT_MS):
         job = resp.json()[0]
         if not job['instances']:
             logger.info(f"Job {job_id} has no instances.")
+            jobs, _ = unscheduled_jobs(cook_url, job_id)
+            logger.info(f'Unscheduled info: {jobs}')
         else:
             for inst in job['instances']:
                 status = inst['status']

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -497,8 +497,11 @@ def retry_jobs(cook_url, assert_response=True, use_deprecated_post=False, **kwar
     return response
 
 
-def kill_jobs(cook_url, jobs, assert_response=True, expected_status_code=204):
+def kill_jobs(cook_url, jobs, assert_response=True, expected_status_code=204, log_before_killing=False):
     """Kill one or more jobs"""
+    if log_before_killing:
+        logger.info(f'Jobs: {json.dumps(query_jobs(cook_url, True, uuid=jobs).json(), indent=2)}')
+
     chunksize = 100
     chunks = [jobs[i:i + chunksize] for i in range(0, len(jobs), chunksize)]
     response = []

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1523,3 +1523,12 @@ def has_one_agent():
 
 def supports_exit_code():
     return using_kubernetes() or is_cook_executor_in_use()
+
+
+def kill_running_jobs(cook_url, user):
+    one_hour_in_millis = 60 * 60 * 1000
+    start = current_milli_time() - one_hour_in_millis
+    end = current_milli_time() + one_hour_in_millis
+    running = jobs(cook_url, user=user, state='running', start=start, end=end).json()
+    logger.info(f'Currently running jobs: {json.dumps(running, indent=2)}')
+    kill_jobs(cook_url, running)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1527,7 +1527,7 @@ def supports_exit_code():
 
 def kill_running_and_waiting_jobs(cook_url, user):
     one_hour_in_millis = 60 * 60 * 1000
-    start = current_milli_time() - one_hour_in_millis
+    start = current_milli_time() - (4 * one_hour_in_millis)
     end = current_milli_time() + one_hour_in_millis
     running = jobs(cook_url, user=user, state=['running', 'waiting'], start=start, end=end).json()
     logger.info(f'Currently running/waiting jobs: {json.dumps(running, indent=2)}')

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1525,10 +1525,10 @@ def supports_exit_code():
     return using_kubernetes() or is_cook_executor_in_use()
 
 
-def kill_running_jobs(cook_url, user):
+def kill_running_and_waiting_jobs(cook_url, user):
     one_hour_in_millis = 60 * 60 * 1000
     start = current_milli_time() - one_hour_in_millis
     end = current_milli_time() + one_hour_in_millis
-    running = jobs(cook_url, user=user, state='running', start=start, end=end).json()
-    logger.info(f'Currently running jobs: {json.dumps(running, indent=2)}')
+    running = jobs(cook_url, user=user, state=['running', 'waiting'], start=start, end=end).json()
+    logger.info(f'Currently running/waiting jobs: {json.dumps(running, indent=2)}')
     kill_jobs(cook_url, running)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -350,9 +350,9 @@ def is_not_blank(in_string):
     return bool(in_string and in_string.strip())
 
 
-def get_job_executor_type(cook_url):
+def get_job_executor_type():
     """Returns 'cook' or 'mesos' based on the default executor Cook is configured with."""
-    return 'cook' if is_not_blank(get_in(settings(cook_url), 'executor', 'command')) else 'mesos'
+    return 'cook' if is_cook_executor_in_use() else 'mesos'
 
 
 def is_connection_error(exception):
@@ -369,8 +369,13 @@ def _wait_for_cook(cook_url):
 def init_cook_session(*cook_urls):
     for cook_url in cook_urls:
         _wait_for_cook(cook_url)
-    if http_basic_auth_enabled():
+
+    # If we're using basic auth, init the session auth.
+    # But, don't override it if it's already set
+    # (for example, by a with user block).
+    if http_basic_auth_enabled() and session.auth is None:
         session.auth = UserFactory(None).default().auth
+        logger.info(f'Session auth set to {session.auth}')
 
 
 def settings(cook_url):
@@ -387,8 +392,10 @@ def scheduler_info(cook_url):
 def docker_image():
     return os.getenv('COOK_TEST_DOCKER_IMAGE')
 
+
 def get_default_cpus():
     return float(os.getenv('COOK_DEFAULT_JOB_CPUS', 1.0))
+
 
 def make_temporal_uuid():
     """Make a UUID object that has a datestamp as its prefix. The datestamp being yymmddhh. This will cluster
@@ -398,8 +405,9 @@ def make_temporal_uuid():
     now = datetime.now()
     date_prefix = now.strftime("%y%m%d%H")
     suffix = str(base_uuid)[8:]
-    temporal_uuid = uuid.UUID(date_prefix+suffix)
+    temporal_uuid = uuid.UUID(date_prefix + suffix)
     return temporal_uuid
+
 
 def minimal_job(**kwargs):
     job = {
@@ -424,8 +432,8 @@ def minimal_job(**kwargs):
     job.update(kwargs)
     no_container_volume = os.getenv('COOK_NO_CONTAINER_VOLUME') is not None
     if (not no_container_volume
-        and is_cook_executor_in_use()
-        and 'container' in job):
+            and is_cook_executor_in_use()
+            and 'container' in job):
         config = settings(retrieve_cook_url())
         executor_path = get_in(config, 'executor', 'command')
         if not executor_path.startswith('.'):
@@ -447,12 +455,14 @@ def minimal_group(**kwargs):
     return dict(uuid=str(make_temporal_uuid()), **kwargs)
 
 
-def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers={}, **kwargs):
+def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, **kwargs):
     """
     Create and submit multiple jobs, either cloned from a single job spec,
     or specified individually in multiple job specs.
     Arguments can be manually passed to the scheduler post via kwargs.
     """
+    if headers is None:
+        headers = {}
     if isinstance(job_specs, dict):
         job_specs = [job_specs] * clones
 
@@ -509,8 +519,10 @@ def kill_groups(cook_url, groups, assert_response=True, expected_status_code=204
     return response
 
 
-def submit_job(cook_url, pool=None, headers={}, **kwargs):
+def submit_job(cook_url, pool=None, headers=None, **kwargs):
     """Create and submit a single job"""
+    if headers is None:
+        headers = {}
     uuids, resp = submit_jobs(cook_url, job_specs=[kwargs], pool=pool, headers=headers)
     return uuids[0], resp
 
@@ -874,8 +886,10 @@ def list_jobs(cook_url, **kwargs):
     return resp
 
 
-def jobs(cook_url, headers={}, **kwargs):
+def jobs(cook_url, headers=None, **kwargs):
     """Makes a request to the /jobs endpoint using the provided kwargs as the query params"""
+    if headers is None:
+        headers = {}
     query_params = urlencode(kwargs, doseq=True)
     resp = session.get('%s/jobs?%s' % (cook_url, query_params), headers=headers)
     return resp
@@ -1061,11 +1075,13 @@ def group_submit_retry(cook_url, command, predicate_statuses, retry_failed_jobs_
         kill_groups(cook_url, [group_uuid])
 
 
-def user_current_usage(cook_url, headers={}, **kwargs):
+def user_current_usage(cook_url, headers=None, **kwargs):
     """
     Queries cook for a user's current resource usage
     based on their currently running jobs.
     """
+    if headers is None:
+        headers = {}
     return session.get('%s/usage' % cook_url, params=kwargs, headers=headers)
 
 
@@ -1074,7 +1090,9 @@ def query_queue(cook_url, **kwargs):
     return session.get(f'{cook_url}/queue', **kwargs)
 
 
-def get_limit(cook_url, limit_type, user, pool=None, headers={}):
+def get_limit(cook_url, limit_type, user, pool=None, headers=None):
+    if headers is None:
+        headers = {}
     params = {'user': user}
     if pool is not None:
         params['pool'] = pool
@@ -1082,12 +1100,14 @@ def get_limit(cook_url, limit_type, user, pool=None, headers={}):
 
 
 def set_limit(cook_url, limit_type, user, mem=None, cpus=None, gpus=None, count=None, reason='testing', pool=None,
-              headers={}):
+              headers=None):
     """
     Set resource limits for the given user.
     The limit_type parameter should be either 'share' or 'quota', specifying which type of limit is being set.
     Any subset of the mem, cpus, gpus and count (job-count) limits can be specified.
     """
+    if headers is None:
+        headers = {}
     limits = {}
     body = {'user': user, limit_type: limits}
     if reason is not None:
@@ -1106,11 +1126,13 @@ def set_limit(cook_url, limit_type, user, mem=None, cpus=None, gpus=None, count=
     return session.post(f'{cook_url}/{limit_type}', json=body, headers=headers)
 
 
-def reset_limit(cook_url, limit_type, user, reason='testing', pool=None, headers={}):
+def reset_limit(cook_url, limit_type, user, reason='testing', pool=None, headers=None):
     """
     Resets resource limits for the given user to the default for the cluster.
     The limit_type parameter should be either 'share' or 'quota', specifying which type of limit is being reset.
     """
+    if headers is None:
+        headers = {}
     params = {'user': user}
     if reason is not None:
         params['reason'] = reason
@@ -1183,10 +1205,21 @@ def _cook_executor_config():
     return cook_executor_config
 
 
+@functools.lru_cache()
 def is_cook_executor_in_use():
     """Returns true if the cook executor is configured"""
     is_cook_executor_configured = is_not_blank(get_in(_cook_executor_config(), 'command'))
-    return is_cook_executor_configured
+    if is_cook_executor_configured:
+        if http_basic_auth_enabled():
+            logger.info('Using mesos executor (cook executor is configured, but so is HTTP basic auth, and they are '
+                        'incompatible)')
+            return False
+        else:
+            logger.info('Using cook executor as configured')
+            return True
+    else:
+        logger.info('Using mesos executor (cook executor is not configured)')
+        return False
 
 
 def slave_cpus(mesos_url, hostname):
@@ -1197,9 +1230,11 @@ def slave_cpus(mesos_url, hostname):
     slave_cpus = next(s['unreserved_resources']['cpus'] for s in slaves if s['hostname'] == hostname)
     return slave_cpus
 
+
 def _pool_attribute_name(cook_url):
     pool_selection_plugin_config = settings(cook_url).get('plugins', {}).get('pool-selection', {})
     return pool_selection_plugin_config.get('attribute-name', None) or 'cook-pool'
+
 
 def slave_pool(cook_url, mesos_url, hostname):
     """Returns the pool of the specified Mesos agent, or None if the agent doesn't have the attribute"""
@@ -1215,6 +1250,7 @@ def max_mesos_slave_cpus(mesos_url):
     max_slave_cpus = max([s['resources']['cpus'] for s in slaves])
     return max_slave_cpus
 
+
 @functools.lru_cache()
 def get_kubernetes_compute_cluster():
     cook_url = retrieve_cook_url()
@@ -1228,6 +1264,7 @@ def get_kubernetes_compute_cluster():
     else:
         return None
 
+
 def get_kubernetes_nodes():
     kubernetes_compute_cluster = get_kubernetes_compute_cluster()
     if 'config-file' in kubernetes_compute_cluster['config']:
@@ -1235,7 +1272,8 @@ def get_kubernetes_nodes():
                                          'get', 'nodes', '-o=json'])
         node_json = json.loads(nodes)
     elif 'base-path' in kubernetes_compute_cluster['config']:
-        authorization_header = subprocess.check_output(os.getenv('COOK_KUBERNETES_AUTH_CMD'), shell=True).decode('utf-8').strip()
+        authorization_header = subprocess.check_output(os.getenv('COOK_KUBERNETES_AUTH_CMD'), shell=True).decode(
+            'utf-8').strip()
         nodes_url = kubernetes_compute_cluster['config']['base-path'] + '/api/v1/nodes'
         node_json = requests.get(nodes_url, headers={'Authorization': authorization_header}, verify=False).json()
     else:
@@ -1243,15 +1281,18 @@ def get_kubernetes_nodes():
     logging.info(f'Retrieved kubernetes nodes: {node_json}')
     return node_json['items']
 
+
 def max_kubernetes_node_cpus():
     nodes = get_kubernetes_nodes()
     return max([float(n['status']['capacity']['cpu'])
                 for n in nodes])
 
+
 def task_constraint_cpus(cook_url):
     """Returns the max cpus that can be submitted to the cluster"""
     task_constraint_cpus = settings(cook_url)['task-constraints']['cpus']
     return task_constraint_cpus
+
 
 def max_node_cpus():
     if using_mesos():
@@ -1261,6 +1302,7 @@ def max_node_cpus():
     else:
         raise RuntimeError('Unable to determine cluster max CPUs')
 
+
 def node_count():
     if using_mesos():
         return len(get_mesos_slaves(retrieve_mesos_url())['slaves'])
@@ -1268,6 +1310,7 @@ def node_count():
         return len(get_kubernetes_nodes())
     else:
         raise RuntimeError('Unable to determine number of nodes')
+
 
 def max_cpus():
     """Returns the maximum cpus we can submit that actually fits on a slave"""
@@ -1326,6 +1369,7 @@ def mesos_hostnames_to_consider(cook_url, mesos_url):
     logging.info(f'First {num_to_log} hosts to consider: {json.dumps(slaves[:num_to_log], indent=2)}')
     return [s['hostname'] for s in slaves]
 
+
 def kubernetes_hostnames_to_consider():
     # TODO: This should check a 'cook-pool' attribute on the node for the pool.
     # Currently, pools are not supported on kubernetes, so it's fine to ignore for now.
@@ -1337,6 +1381,7 @@ def kubernetes_hostnames_to_consider():
             if address['type'] == 'Hostname':
                 hostnames.append(address['address'])
     return hostnames
+
 
 def hostnames_to_consider(cook_url):
     if using_mesos():
@@ -1388,7 +1433,9 @@ def demo_plugins_are_configured(cook_url):
     settings_dict = settings(cook_url)
     # Because we always create plugin configuration in config.clj, the first keys always exist.
     # The actual factory-fn keys are not set unless the user specifies them.
-    if settings_dict['plugins']['job-submission-validator'].get('factory-fns') != ["cook.plugins.demo-plugin/submission-factory", "cook.plugins.demo-plugin/submission-factory2"]:
+    submission_fns = [
+        "cook.plugins.demo-plugin/submission-factory", "cook.plugins.demo-plugin/submission-factory2"]
+    if settings_dict['plugins']['job-submission-validator'].get('factory-fns') != submission_fns:
         return False
     if settings_dict['plugins']['job-launch-filter'].get('factory-fn') != "cook.plugins.demo-plugin/launch-factory":
         return False
@@ -1449,6 +1496,7 @@ def supports_mesos_containerizer_images():
     isolators = _supported_isolators()
     return 'filesystem/linux' in isolators and 'docker/runtime' in isolators
 
+
 @functools.lru_cache()
 def _get_compute_cluster_factory_fn():
     cook_url = retrieve_cook_url()
@@ -1457,15 +1505,18 @@ def _get_compute_cluster_factory_fn():
     compute_clusters = settings(cook_url)['compute-clusters']
     return compute_clusters[0]['factory-fn']
 
+
 def using_kubernetes():
     return get_kubernetes_compute_cluster() is not None
+
 
 def using_mesos():
     return _get_compute_cluster_factory_fn() == 'cook.mesos.mesos-compute-cluster/factory-fn'
 
+
 def has_one_agent():
     return node_count() == 1
 
+
 def supports_exit_code():
     return using_kubernetes() or is_cook_executor_in_use()
-


### PR DESCRIPTION
## Changes proposed in this PR

1. logging the unscheduled info when we're waiting for a job to have instances
1. moving several tests to `test_multi_user.py` and adding `with self.user_factory.admin()` for admin-only requests
1. avoiding usage of the `cook` executor when HTTP basic auth is in use

## Why are we making these changes?

1. The added logging is to help troubleshoot failures in `test_pool_scheduling` (or any other test that uses `wait_for_running_instance`).
1. The multi-user moves are needed because otherwise these tests assume that they are being run as an administrator, which is not always the case, especially in developer environments running with HTTP basic auth.
1. There were a few tests that assumed that the `cook` executor could be used successfully just because it was configured. In reality, it needs to be configured **and** basic auth needs to not be configured (there is an issue retrieving the executor from Cook Scheduler when basic auth is enabled).