### PR TITLE
Removes 2 builds from travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,6 @@ matrix:
         - pushd ../jobclient && mvn test
         - popd && lein with-profile +test test :all-but-benchmark
 
-    - name: 'Cook Scheduler integration tests with Cook Executor'
-      services: docker
-      install: sudo ./travis/install_mesos.sh
-      before_script: cd integration && ./travis/prepare_integration.sh
-      script: ./travis/run_integration.sh --executor=cook
-
     - name: 'Cook Scheduler integration tests with Cook Executor and Docker'
       services: docker
       install: sudo ./travis/install_mesos.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,6 @@ matrix:
         - pushd ../jobclient && mvn test
         - popd && lein with-profile +test test :all-but-benchmark
 
-    - name: 'Cook Scheduler integration tests with HTTP Basic Auth'
-      services: docker
-      install: sudo ./travis/install_mesos.sh
-      before_script: cd integration && ./travis/prepare_integration.sh
-      script: ./travis/run_integration.sh --auth=http-basic
-
     - name: 'Cook Scheduler integration tests with Cook Executor'
       services: docker
       install: sudo ./travis/install_mesos.sh

--- a/integration/setup.cfg
+++ b/integration/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -n10 -v --timeout-method=thread --maxfail=5 --log-level=DEBUG
+addopts = -n10 -v --timeout-method=thread --maxfail=5 --log-level=DEBUG --durations=25
 timeout = 1200
 usefixtures = record_test_metric
 markers =

--- a/integration/tests/conftest.py
+++ b/integration/tests/conftest.py
@@ -63,7 +63,7 @@ if 'TEST_METRICS_URL' in os.environ:
                 'run-description': os.getenv('TEST_METRICS_RUN_DESCRIPTION', 'open source integration tests'),
                 'build-id': os.getenv('TEST_METRICS_BUILD_ID', None),
                 'result': result,
-                'runtime-milliseconds': (end - start)*1000,
+                'runtime-milliseconds': (end - start) * 1000,
                 'expected-to-fail': xfail_mark is not None and xfail_mark.name == 'xfail'
             }
             logging.info(f'Updating test metrics: {json.dumps(metrics, indent=2)}')
@@ -74,7 +74,7 @@ if 'TEST_METRICS_URL' in os.environ:
 
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
-    def pytest_runtest_makereport(item, call):
+    def pytest_runtest_makereport(item, _):
         # execute all other hooks to obtain the report object
         outcome = yield
         rep = outcome.get_result()

--- a/integration/tests/conftest.py
+++ b/integration/tests/conftest.py
@@ -74,7 +74,7 @@ if 'TEST_METRICS_URL' in os.environ:
 
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
-    def pytest_runtest_makereport(item, _):
+    def pytest_runtest_makereport(item, call):
         # execute all other hooks to obtain the report object
         outcome = yield
         rep = outcome.get_result()

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -779,7 +779,7 @@ class CookCliTest(util.CookTest):
 
     @pytest.mark.xfail
     def test_tail_large_file(self):
-        iterations = 20
+        iterations = 10
         cp, uuids = cli.submit('bash -c \'printf "hello\\nworld\\n" > file.txt; '
                                f'for i in {{1..{iterations}}}; do '
                                'cat file.txt file.txt > file2.txt && '


### PR DESCRIPTION
## Changes proposed in this PR

- removing the basic auth and cook executor builds from the travis run
- adding `--durations=25` to the pytest config
- changing iterations from 20 to 10 in `test_tail_large_file`

## Why are we making these changes?

We have equivalent test runs internally, and removing these from travis will free up precious travis workers.

`test_tail_large_file` is often the longest-running test in the pipeline, and it probably doesn't need to be so extreme to be valuable.
