### PR TITLE
Add docker parameter validation

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -77,7 +77,8 @@
                                 :memory-gb 48
                                 :retry-limit 15
                                 :timeout-hours 1
-                                :timeout-interval-minutes 1}}
+                                :timeout-interval-minutes 1
+                                :docker-parameters-allowed #{"device" "env" "user" "workdir"}}}
  :unhandled-exceptions {:log-level :error}
  :zookeeper {:local? #config/env-bool "COOK_ZOOKEEPER_LOCAL"
              :connection #config/env "COOK_ZOOKEEPER"}}

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -86,7 +86,8 @@
                                 :memory-gb 48
                                 :retry-limit 15
                                 :timeout-hours 1
-                                :timeout-interval-minutes 1}}
+                                :timeout-interval-minutes 1
+                                :docker-parameters-allowed #{"device" "env" "user" "workdir"}}}
  :unhandled-exceptions {:log-level :error}
  :zookeeper {:local? #config/env-bool "COOK_ZOOKEEPER_LOCAL"
              :connection #config/env "COOK_ZOOKEEPER"}}

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -544,3 +544,7 @@
 (defn kubernetes
   []
   (get-in config [:settings :kubernetes]))
+
+(defn task-constraints
+  []
+  (get-in config [:settings :task-constraints]))

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -333,7 +333,7 @@
                               :authorization/user "test"
                               :body-params {"jobs" [container-job]}}))))))
 
-      (testing "disallow docker paramters"
+      (testing "disallow docker parameters"
         (with-redefs [config/task-constraints (constantly {:docker-parameters-allowed #{"user"}})]
           (let [minimal-job (basic-job)
                 container-job (assoc minimal-job "container" {"type" "docker"
@@ -348,7 +348,7 @@
                                 :authorization/user "test"
                                 :body-params {"jobs" [container-job]}})))))))
 
-      (testing "allowed docker paramters"
+      (testing "allowed docker parameters"
         (with-redefs [config/task-constraints (constantly {:docker-parameters-allowed #{"foo"}})]
           (let [minimal-job (basic-job)
                 container-job (assoc minimal-job "container" {"type" "docker"


### PR DESCRIPTION
## Changes proposed in this PR
- Add support for whitelisting docker parameters

## Why are we making these changes?
Not all docker parameters will be supported by kuberenetes, so adding an explicit whitelist