### PR TITLE
Periodically reset kerberos auth token

### DIFF
--- a/executor/setup.py
+++ b/executor/setup.py
@@ -4,9 +4,9 @@
 from setuptools import setup
 
 test_deps=[
-    'pytest==3.3.1',
-    'pytest-timeout==1.2.1',
-    'pytest-xdist==1.20.1'
+    'pytest==5.2.0',
+    'pytest-timeout==1.3.3',
+    'pytest-xdist==1.30.0'
 ]
 
 extras = { 'test': test_deps }

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -192,7 +192,6 @@ class _KerberosUser(_AuthenticatedUser):
         assert self.previous_token is None
         assert self.stop_event is None
         self.previous_token = session.headers.get('Authorization')
-        session.headers['Authorization'] = self._generate_kerberos_ticket_for_user(self.name)
         self.stop_event = threading.Event()
         self._reset_auth_header(self.stop_event)
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -182,7 +182,7 @@ class _KerberosUser(_AuthenticatedUser):
         if not stop.is_set():
             logger.info(f'Refreshing kerberos tickets for {self.name}')
             session.headers['Authorization'] = self._generate_kerberos_ticket_for_user(self.name)
-            threading.Timer(60.0, lambda: self._reset_auth_header(stop)).start
+            threading.Timer(60.0, lambda: self._reset_auth_header(stop)).start()
         else:
             logger.info(f'Stopping kerberos ticket refresh for {self.name}')
 


### PR DESCRIPTION
## Changes proposed in this PR
- Don't cache the kerberos authentication token between usages of a user object 
- While a user object is active, refresh the kerberos auth token every 60 seconds

## Why are we making these changes?
This prevents the ticket from expiring and causing spurious test failures.

