### PR TITLE
increase max priority to 16,000,000

### DIFF
--- a/cli/cook/subcommands/submit.py
+++ b/cli/cook/subcommands/submit.py
@@ -242,15 +242,24 @@ def valid_uuid(s):
     else:
         raise argparse.ArgumentTypeError('%s is not a valid UUID' % s)
 
+def valid_priority(value):
+    """Checks that the given value is a valid priority"""
+    try:
+        integer = int(value)
+    except:
+        raise argparse.ArgumentTypeError(f'{value} is not an integer')
+    if integer < 0 or integer > 16777216:
+        raise argparse.ArgumentTypeError(f'{integer} must be between 0 and 16777216 inclusive')
+    return integer
 
 def register(add_parser, add_defaults):
     """Adds this sub-command's parser and returns the action function"""
     submit_parser = add_parser('submit', help='create job for command')
     submit_parser.add_argument('--uuid', '-u', help='uuid of job', type=valid_uuid)
     submit_parser.add_argument('--name', '-n', help='name of job')
-    submit_parser.add_argument('--priority', '-p', help='priority of job, between 0 and 100 (inclusive), with 100 '
-                                                        'being highest priority (default = 50)',
-                               type=int, choices=range(0, 101), metavar='')
+    submit_parser.add_argument('--priority', '-p', help='priority of job, usually between 0 and 100 (inclusive), with 100 '
+                                                        'being highest priority (default = 50) (priority values up to 2^24 are allowed)',
+                               type=valid_priority, metavar='')
     submit_parser.add_argument('--max-retries', help='maximum retries for job',
                                dest='max-retries', type=int, metavar='COUNT')
     submit_parser.add_argument('--max-runtime', help='maximum runtime for job',

--- a/cli/cook/subcommands/submit.py
+++ b/cli/cook/subcommands/submit.py
@@ -249,7 +249,7 @@ def valid_priority(value):
     except:
         raise argparse.ArgumentTypeError(f'{value} is not an integer')
     if integer < 0 or integer > 16777216:
-        raise argparse.ArgumentTypeError(f'{integer} must be between 0 and 16777216 inclusive')
+        raise argparse.ArgumentTypeError(f'Job priority must be between 0 and 16777216 inclusive')
     return integer
 
 def register(add_parser, add_defaults):

--- a/cli/cook/subcommands/submit.py
+++ b/cli/cook/subcommands/submit.py
@@ -248,8 +248,8 @@ def valid_priority(value):
         integer = int(value)
     except:
         raise argparse.ArgumentTypeError(f'{value} is not an integer')
-    if integer < 0 or integer > 16777216:
-        raise argparse.ArgumentTypeError(f'Job priority must be between 0 and 16777216 inclusive')
+    if integer < 0 or integer > 16000000:
+        raise argparse.ArgumentTypeError(f'Job priority must be between 0 and 16000000 inclusive')
     return integer
 
 def register(add_parser, add_defaults):
@@ -257,8 +257,9 @@ def register(add_parser, add_defaults):
     submit_parser = add_parser('submit', help='create job for command')
     submit_parser.add_argument('--uuid', '-u', help='uuid of job', type=valid_uuid)
     submit_parser.add_argument('--name', '-n', help='name of job')
-    submit_parser.add_argument('--priority', '-p', help='priority of job, usually between 0 and 100 (inclusive), with 100 '
-                                                        'being highest priority (default = 50) (priority values up to 2^24 are allowed)',
+    submit_parser.add_argument('--priority', '-p', help='Per-user job priority. Allows values between 0 and 16,000,000 '
+                                                        '(inclusive), with higher values having higher priority. '
+                                                        'Defaults to 50 and typically set between 0 and 100.',
                                type=valid_priority, metavar='')
     submit_parser.add_argument('--max-retries', help='maximum retries for job',
                                dest='max-retries', type=int, metavar='COUNT')

--- a/cli/cook/subcommands/submit.py
+++ b/cli/cook/subcommands/submit.py
@@ -249,7 +249,7 @@ def valid_priority(value):
     except:
         raise argparse.ArgumentTypeError(f'{value} is not an integer')
     if integer < 0 or integer > 16000000:
-        raise argparse.ArgumentTypeError(f'Job priority must be between 0 and 16000000 inclusive')
+        raise argparse.ArgumentTypeError(f'Job priority must be between 0 and 16,000,000 (inclusive)')
     return integer
 
 def register(add_parser, add_defaults):

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2650,3 +2650,26 @@ class CookTest(util.CookTest):
         job_uuid, resp = util.submit_job(self.cook_url, container=container)
         self.assertEqual(400, resp.status_code)
         self.assertTrue('this_should_not_be_allowed' in resp.text, resp.text)
+
+    def test_priority(self):
+        job_spec = util.minimal_job(priority=0)
+        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        self.assertEqual(201, resp.status_code, msg=resp.content)
+
+        job_spec = util.minimal_job(priority=100)
+        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        self.assertEqual(201, resp.status_code, msg=resp.content)
+
+        job_spec = util.minimal_job(priority=16777216)
+        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        self.assertEqual(201, resp.status_code, msg=resp.content)
+
+        job_spec = util.minimal_job(priority=-1)
+        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        self.assertEqual(400, resp.status_code, msg=resp.content)
+        self.assertTrue(f'priority":"(not (between-0-and-16777216' in str(resp.content))
+
+        job_spec = util.minimal_job(priority=16777217)
+        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        self.assertEqual(400, resp.status_code, msg=resp.content)
+        self.assertTrue(f'priority":"(not (between-0-and-16777216' in str(resp.content))

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2652,24 +2652,19 @@ class CookTest(util.CookTest):
         self.assertTrue('this_should_not_be_allowed' in resp.text, resp.text)
 
     def test_priority(self):
-        job_spec = util.minimal_job(priority=0)
-        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        _, resp = util.submit_job(self.cook_url,priority=0)
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
-        job_spec = util.minimal_job(priority=100)
-        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        _, resp = util.submit_job(self.cook_url,priority=100)
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
-        job_spec = util.minimal_job(priority=16777216)
-        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        _, resp = util.submit_job(self.cook_url,priority=16777216)
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
-        job_spec = util.minimal_job(priority=-1)
-        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        _, resp = util.submit_job(self.cook_url,priority=-1)
         self.assertEqual(400, resp.status_code, msg=resp.content)
         self.assertTrue(f'priority":"(not (between-0-and-16777216' in str(resp.content))
 
-        job_spec = util.minimal_job(priority=16777217)
-        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        _, resp = util.submit_job(self.cook_url,priority=16777217)
         self.assertEqual(400, resp.status_code, msg=resp.content)
         self.assertTrue(f'priority":"(not (between-0-and-16777216' in str(resp.content))

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2658,13 +2658,13 @@ class CookTest(util.CookTest):
         _, resp = util.submit_job(self.cook_url,priority=100)
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
-        _, resp = util.submit_job(self.cook_url,priority=16777216)
+        _, resp = util.submit_job(self.cook_url,priority=16000000)
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
         _, resp = util.submit_job(self.cook_url,priority=-1)
         self.assertEqual(400, resp.status_code, msg=resp.content)
-        self.assertTrue(f'priority":"(not (between-0-and-16777216' in str(resp.content))
+        self.assertTrue(f'priority":"(not (between-0-and-16000000' in str(resp.content))
 
-        _, resp = util.submit_job(self.cook_url,priority=16777217)
+        _, resp = util.submit_job(self.cook_url,priority=16000001)
         self.assertEqual(400, resp.status_code, msg=resp.content)
-        self.assertTrue(f'priority":"(not (between-0-and-16777216' in str(resp.content))
+        self.assertTrue(f'priority":"(not (between-0-and-16000000' in str(resp.content))

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2652,19 +2652,19 @@ class CookTest(util.CookTest):
         self.assertTrue('this_should_not_be_allowed' in resp.text, resp.text)
 
     def test_priority(self):
-        _, resp = util.submit_job(self.cook_url,priority=0)
+        _, resp = util.submit_job(self.cook_url, priority=0)
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
-        _, resp = util.submit_job(self.cook_url,priority=100)
+        _, resp = util.submit_job(self.cook_url, priority=100)
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
-        _, resp = util.submit_job(self.cook_url,priority=16000000)
+        _, resp = util.submit_job(self.cook_url, priority=16000000)
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
-        _, resp = util.submit_job(self.cook_url,priority=-1)
+        _, resp = util.submit_job(self.cook_url, priority=-1)
         self.assertEqual(400, resp.status_code, msg=resp.content)
         self.assertTrue(f'priority":"(not (between-0-and-16000000' in str(resp.content))
 
-        _, resp = util.submit_job(self.cook_url,priority=16000001)
+        _, resp = util.submit_job(self.cook_url, priority=16000001)
         self.assertEqual(400, resp.status_code, msg=resp.content)
         self.assertTrue(f'priority":"(not (between-0-and-16000000' in str(resp.content))

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -354,19 +354,19 @@ class CookCliTest(util.CookTest):
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(100, jobs[0]['priority'])
 
-        cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority 16777216')
+        cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority 16000000')
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
-        self.assertEqual(16777216, jobs[0]['priority'])
+        self.assertEqual(16000000, jobs[0]['priority'])
 
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority -1')
         self.assertEqual(2, cp.returncode, cp.stderr)
-        self.assertIn('--priority/-p: -1 must be between', cli.decode(cp.stderr))
+        self.assertIn('--priority/-p: Job priority must be between', cli.decode(cp.stderr))
 
-        cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority 16777217')
+        cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority 16000001')
         self.assertEqual(2, cp.returncode, cp.stderr)
-        self.assertIn('--priority/-p: 16777217 must be between', cli.decode(cp.stderr))
+        self.assertIn('--priority/-p: Job priority must be between', cli.decode(cp.stderr))
 
     def test_submit_output_should_explain_what_happened(self):
         cp, _ = cli.submit('ls', self.cook_url)

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -347,17 +347,26 @@ class CookCliTest(util.CookTest):
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(0, jobs[0]['priority'])
+
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority 100')
         self.assertEqual(0, cp.returncode, cp.stderr)
         cp, jobs = cli.show_jobs(uuids, self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual(100, jobs[0]['priority'])
+
+        cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority 16777216')
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp, jobs = cli.show_jobs(uuids, self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertEqual(16777216, jobs[0]['priority'])
+
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority -1')
         self.assertEqual(2, cp.returncode, cp.stderr)
-        self.assertIn('--priority/-p: invalid choice', cli.decode(cp.stderr))
-        cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority 101')
+        self.assertIn('--priority/-p: -1 must be between', cli.decode(cp.stderr))
+
+        cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--priority 16777217')
         self.assertEqual(2, cp.returncode, cp.stderr)
-        self.assertIn('--priority/-p: invalid choice', cli.decode(cp.stderr))
+        self.assertIn('--priority/-p: 16777217 must be between', cli.decode(cp.stderr))
 
     def test_submit_output_should_explain_what_happened(self):
         cp, _ = cli.submit('ls', self.cook_url)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -292,7 +292,7 @@
                           (re-matches #"[\.a-zA-Z0-9_\-\*]*" s)))))
 
 (s/defschema JobPriority
-  (s/both s/Int (s/pred #(<= 0 % 16777216) 'between-0-and-16777216)))
+  (s/both s/Int (s/pred #(<= 0 % 16000000) 'between-0-and-16000000)))
 
 (defn valid-runtimes?
   "Returns false if the expected-runtime of the given job

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -292,7 +292,7 @@
                           (re-matches #"[\.a-zA-Z0-9_\-\*]*" s)))))
 
 (s/defschema JobPriority
-  (s/both s/Int (s/pred #(<= 0 % 100) 'between-0-and-100)))
+  (s/both s/Int (s/pred #(<= 0 % 16777216) 'between-0-and-16777216)))
 
 (defn valid-runtimes?
   "Returns false if the expected-runtime of the given job


### PR DESCRIPTION
## Changes proposed in this PR

- increase max job priority to 2^24

## Why are we making these changes?

Some users need priority over 100 (e.g. IDs used as a priority that fit in a 2^24 namespace)
