### PR TITLE
Logs whether or not rate limiting is enforced

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -592,7 +592,7 @@
              ; Force this to be taken eagerly so that the log line is accurate.
              (doall))]
     (swap! pool->user->number-jobs update pool-name (constantly @user->number-jobs))
-    (log/info "Users whose job launches are rate-limited " @user->rate-limit-count)
+    (log/info "Users whose job launches are rate-limited " @user->rate-limit-count "( enforcing =" enforcing-job-launch-rate-limit? ")")
     considerable-jobs))
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding logging of `enforcing-job-launch-rate-limit?`

## Why are we making these changes?

Without this, operators looking at logs are easily misled into thinking that jobs are being rate limited when they actually aren't.