### PR TITLE
Make user quota calculation more robust to roundoff.

### DIFF
--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -843,10 +843,9 @@
 
 (defn below-quota?
   "Returns true if the usage is below quota-constraints on all dimensions"
-  [{:keys [count cpus mem] :as quota}
-   {:keys [count cpus mem] :as usage}]
+  [quota usage]
   (every? (fn [[usage-key usage-val]]
-            (<= usage-val (get quota usage-key 0)))
+            (<= usage-val (+ 0.01 (get quota usage-key 0))))
           (seq usage)))
 
 (defn job->usage


### PR DESCRIPTION
## Changes proposed in this PR

- Make our quota calculation more robust to round-off errors.

## Why are we making these changes?
Should make the quota comparison more robust, when the new job would put you an epsilon over the quota.

