### PR TITLE
Pool support

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1822,6 +1822,9 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, uuids)
 
+    @unittest.skipIf(util.using_kubernetes(), "Kubernetes pod deletion is slow enough that the resources consumed by "
+                                              "pods in the process of being deleted interfere with this test.")
+    # Test passes fine in isolation. We should revisit this when we come up with our kubernetes integration test story.
     def test_balanced_host_constraint_can_place(self):
         num_hosts = util.num_hosts_to_consider(self.cook_url)
         if num_hosts < 2:

--- a/integration/tests/cook/test_pools.py
+++ b/integration/tests/cook/test_pools.py
@@ -44,8 +44,6 @@ class PoolsCookTest(util.CookTest):
                     quota_multiplier = 1 if pool_name == default_pool else 2
                     util.set_limit(self.cook_url, 'quota', user.name, cpus=cpus * quota_multiplier, pool=pool_name)
 
-            logging.info(f"User to access: {user}")
-
             with user:
                 util.kill_running_and_waiting_jobs(self.cook_url, user.name)
                 for pool in pools:

--- a/integration/tests/cook/test_pools.py
+++ b/integration/tests/cook/test_pools.py
@@ -21,7 +21,6 @@ class PoolsCookTest(util.CookTest):
 
     def setUp(self):
         self.cook_url = type(self).cook_url
-        self.mesos_url = util.retrieve_mesos_url()
         self.logger = logging.getLogger(__name__)
         self.user_factory = util.UserFactory(self)
 
@@ -45,6 +44,8 @@ class PoolsCookTest(util.CookTest):
                     quota_multiplier = 1 if pool_name == default_pool else 2
                     util.set_limit(self.cook_url, 'quota', user.name, cpus=cpus * quota_multiplier, pool=pool_name)
 
+            logging.info(f"User to access: {user}")
+
             with user:
                 util.kill_running_and_waiting_jobs(self.cook_url, user.name)
                 for pool in pools:
@@ -57,7 +58,7 @@ class PoolsCookTest(util.CookTest):
                                                           command='sleep 600', pool=pool_name)
                     all_job_uuids.append(filling_job_uuid)
                     instance = util.wait_for_running_instance(self.cook_url, filling_job_uuid)
-                    slave_pool = util.slave_pool(self.cook_url, self.mesos_url, instance['hostname'])
+                    slave_pool = util.node_pool(instance['hostname'])
                     self.assertEqual(pool_name, slave_pool)
 
                     # Submit a job that should not get scheduled

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1322,7 +1322,7 @@ def node_pool(nodename):
     elif using_kubernetes():
         return kubernetes_node_pool(nodename)
     else:
-        raise RuntimeError('Unable to determine cluster max CPUs')
+        raise RuntimeError(f'Unable to determine node pool for {nodename}')
 
 def max_kubernetes_node_cpus():
     nodes = get_kubernetes_nodes()

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -24,7 +24,6 @@
   "Given a compute cluster and maps with node capacity and existing pods, return a map from pool to offers."
   [compute-cluster node-name->node namespaced-pod-name->pod starting-namespaced-pod-name->pod]
   (let [node-name->capacity (api/get-capacity node-name->node)
-        node-name->processed-taints (api/process-taints node-name->node)
         node-name->consumed (api/get-consumption (merge namespaced-pod-name->pod
                                                         starting-namespaced-pod-name->pod))
         node-name->available (pc/map-from-keys (fn [node-name]
@@ -34,7 +33,7 @@
                                                (keys node-name->capacity))]
     (log/info "Capacity: " node-name->capacity "Consumption:" node-name->consumed)
     (->> node-name->available
-         (filter (fn [[node-name _]] (api/node-schedulable? node-name->processed-taints node-name)))
+         (filter (fn [[node-name _]] (-> node-name node-name->node api/node-schedulable?)))
          (map (fn [[node-name available]]
                 {:id {:value (str (UUID/randomUUID))}
                  :framework-id (cc/compute-cluster-name compute-cluster)
@@ -47,7 +46,7 @@
                  :executor-ids []
                  :compute-cluster compute-cluster
                  :reject-after-match-attempt true}))
-         (group-by (fn [offer] (api/get-node-pool node-name->processed-taints (:hostname offer)))))))
+         (group-by (fn [offer] (-> offer :hostname node-name->node api/get-node-pool))))))
 
 (defn taskids-to-scan
   "Determine all taskids to scan by unioning task id's from expected and existing taskid maps. "
@@ -203,12 +202,13 @@
     (let [nodes @current-nodes-atom
           pods @all-pods-atom
           starting-instances (controller/starting-namespaced-pod-name->pod this)
-          offers-all-pools (generate-offers this nodes pods starting-instances)]
-      (doseq [[pool offers] offers-all-pools]
-        (log/info (str "Generated offers " (count offers) " for pool " pool " " (into [] (map #(into {} (select-keys % [:hostname :resources])) offers)))))
-      ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
-      ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
-      (get offers-all-pools pool-name)))
+          offers-all-pools (generate-offers this nodes pods starting-instances)
+          ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
+          ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
+          offers-this-pool (get offers-all-pools pool-name)]
+      (log/info (str "Generated offers " (count offers-this-pool) " for pool " pool-name " "
+                     (into [] (map #(into {} (select-keys % [:hostname :resources])) offers-this-pool))))
+      offers-this-pool))
 
   (restore-offers [this pool-name offers]))
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -206,6 +206,8 @@
           offers-all-pools (generate-offers this nodes pods starting-instances)]
       (doseq [[pool offers] offers-all-pools]
         (log/info (str "Generated offers " (count offers) " for pool " pool " " (into [] (map #(into {} (select-keys % [:hostname :resources])) offers)))))
+      ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
+      ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
       (get offers-all-pools pool-name)))
 
   (restore-offers [this pool-name offers]))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -38,10 +38,10 @@
              (api/get-consumption pod-name->pod))))))
 
 (deftest test-get-capacity
-  (let [node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 100.0)
-                         "nodeB" (tu/node-helper "nodeB" 1.0 nil)
-                         "nodeC" (tu/node-helper "nodeC" nil 100.0)
-                         "nodeD" (tu/node-helper "nodeD" nil nil)}]
+  (let [node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 100.0 nil)
+                         "nodeB" (tu/node-helper "nodeB" 1.0 nil nil)
+                         "nodeC" (tu/node-helper "nodeC" nil 100.0 nil)
+                         "nodeD" (tu/node-helper "nodeD" nil nil nil)}]
     (is (= {"nodeA" {:cpus 1.0 :mem 100.0}
             "nodeB" {:cpus 1.0 :mem 0.0}
             "nodeC" {:cpus 0.0 :mem 100.0}

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -74,10 +74,10 @@
           compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                           (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                           {:kind :static :namespace "cook"} nil)
-          node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0)
-                           "nodeB" (tu/node-helper "nodeB" 1.0 1000.0)
-                           "nodeC" (tu/node-helper "nodeC" 1.0 1000.0)
-                           "my.fake.host" (tu/node-helper "my.fake.host" 1.0 1000.0)}
+          node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 nil)
+                           "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 nil)
+                           "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil)
+                           "my.fake.host" (tu/node-helper "my.fake.host" 1.0 1000.0 nil)}
           j1 (tu/create-dummy-job conn :ncpus 0.1)
           j2 (tu/create-dummy-job conn :ncpus 0.2)
           db (d/db conn)
@@ -96,8 +96,9 @@
                                                                          {:cpus 1.0 :mem 1100.0})
                          {:namespace "cook" :name task-1-id} (tu/pod-helper task-1-id "my.fake.host"
                                                                             {:cpus 0.1 :mem 10.0})}
-          offers (kcc/generate-offers compute-cluster node-name->node pod-name->pod
-                                      (controller/starting-namespaced-pod-name->pod compute-cluster))]
+          all-offers (kcc/generate-offers compute-cluster node-name->node pod-name->pod
+                                      (controller/starting-namespaced-pod-name->pod compute-cluster))
+          offers (get all-offers "no-pool")]
       (is (= 4 (count offers)))
       (let [offer (first (filter #(= "nodeA" (:hostname %))
                                  offers))]


### PR DESCRIPTION
## Changes proposed in this PR

- Support multiple pools with kubernetes, using taints and tolerations.

## Why are we making these changes?
To make this feature work in kubernetes as well as the existing mesos support.

