### PR TITLE
Supports disallowing certain pools for integration tests

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -2008,7 +2008,7 @@ def dummy_cat_text(_, __, ___):
             self.assertIn(uuid_9, custom_application_grouped_jobs)
 
             # Check extra pool
-            if usage_data.get('using_pools', False):
+            if extra_pool and usage_data.get('using_pools', False):
                 cluster_usage = usage['clusters'][self.cook_url]['pools'][extra_pool]
                 total_usage = cluster_usage['usage']
                 share = cluster_usage['share']

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -955,6 +955,7 @@ def wait_for_instance(cook_url, job_uuid, max_wait_ms=DEFAULT_TIMEOUT_MS, wait_i
     """Waits for the job with the given job_uuid to have at least one instance, and returns the first instance uuid"""
 
     def instances_with_status(job):
+        logger.debug(f'Job {job_uuid}: {json.dumps(job, indent=2)}')
         if status is None:
             return job['instances']
         else:

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import os.path
+import re
 import subprocess
 import threading
 import time
@@ -1197,7 +1198,11 @@ def all_pools(cook_url):
 def active_pools(cook_url):
     """Returns the list of all active pools that exist"""
     pools, resp = all_pools(cook_url)
-    return [p for p in pools if p['state'] == 'active'], resp
+    all_active_pools = [p for p in pools if p['state'] == 'active']
+    disallow_pools_regex = os.getenv('COOK_TEST_DISALLOW_POOLS_REGEX')
+    allowed_active_pools = all_active_pools if disallow_pools_regex is None else \
+        [p for p in all_active_pools if not re.match(disallow_pools_regex, p['name'])]
+    return allowed_active_pools, resp
 
 
 def has_ephemeral_hosts():


### PR DESCRIPTION
## Changes proposed in this PR

- introducing `COOK_TEST_DISALLOW_POOLS_REGEX`, which allows you to disallow testing against particular pools

## Why are we making these changes?

In some environments, you may not want to test against certain pools.
