### PR TITLE
Add max-ports to task constraints

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2671,3 +2671,15 @@ class CookTest(util.CookTest):
         _, resp = util.submit_job(self.cook_url, priority=16000001)
         self.assertEqual(400, resp.status_code, msg=resp.content)
         self.assertTrue(f'priority":"(not (between-0-and-16000000' in str(resp.content))
+
+    def test_max_ports(self):
+        settings = util.settings(self.cook_url)
+        max_ports = util.get_in(settings, 'task-constraints', 'max-ports')
+        job_uuid, resp = util.submit_job(self.cook_url, ports=(max_ports + 1))
+        try:
+            self.assertEqual(resp.status_code, 400, resp.content)
+            self.assertTrue(f'Requested {max_ports+1} ports, but only allowed to use {max_ports}'
+                            in resp.text,
+                            resp.text)
+        finally:
+            util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1322,9 +1322,9 @@ class CookTest(util.CookTest):
         job_uuid, resp = util.submit_job(self.cook_url, ports=1)
         instance = util.wait_for_instance(self.cook_url, job_uuid)
         self.assertEqual(1, len(instance['ports']))
-        job_uuid, resp = util.submit_job(self.cook_url, ports=10)
+        job_uuid, resp = util.submit_job(self.cook_url, ports=5)
         instance = util.wait_for_instance(self.cook_url, job_uuid)
-        self.assertEqual(10, len(instance['ports']))
+        self.assertEqual(5, len(instance['ports']))
 
     def test_allow_partial_for_groups(self):
         def absent_uuids(response):

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -290,7 +290,8 @@
                             :timeout-interval-minutes 1
                             :retry-limit 20
                             :memory-gb 12
-                            :cpus 4}
+                            :cpus 4
+                            :max-ports 5}
                            (:task-constraints scheduler)))
      :offer-incubate-time-ms (fnk [[:config {scheduler nil}]]
                                (when scheduler

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -858,7 +858,7 @@
    & {:keys [commit-latch-id override-group-immutability?]
       :or {commit-latch-id nil
            override-group-immutability? false}}]
-  (let [{:keys [docker-parameters-allowed]} (config/task-constraints)
+  (let [{:keys [docker-parameters-allowed max-ports]} (config/task-constraints)
         group-uuid (when group group)
         munged (merge
                  {:user user
@@ -903,6 +903,10 @@
     (when (> mem (* 1024 (:memory-gb task-constraints)))
       (throw (ex-info (str "Requested " mem "mb memory, but only allowed to use "
                            (* 1024 (:memory-gb task-constraints)))
+                      {:constraints task-constraints
+                       :job job})))
+    (when (> (:ports munged) max-ports)
+      (throw (ex-info (str "Requested " ports " ports, but only allowed to use " max-ports)
                       {:constraints task-constraints
                        :job job})))
     (when (and (:retry-limit task-constraints)


### PR DESCRIPTION
## Changes proposed in this PR
- Add a `max-ports` config to task constraints

## Why are we making these changes?
Allows administrators to set a maximum number of ports per job.

