### PR TITLE
Marks test_tail_default_path as xfail

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -860,6 +860,7 @@ class CookCliTest(util.CookTest):
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual('', cli.decode(cp.stdout))
 
+    @pytest.mark.xfail
     def test_tail_default_path(self):
         text = str(util.make_temporal_uuid())
         cp, uuids = cli.submit(f'echo {text}', self.cook_url)


### PR DESCRIPTION
## Changes proposed in this PR

- marking `test_tail_default_path` with `xfail`

## Why are we making these changes?

We've seen this test be flaky in some environments.
