### PR TITLE
Refactor rebalancer to not use global compute cluster

### DIFF
--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -188,8 +188,7 @@
                                     (cook.scheduler.scheduler/cancelled-task-killer mesos-datomic-conn compute-cluster
                                                                                     cancelled-task-trigger-chan)
                                     (cook.mesos.heartbeat/start-heartbeat-watcher! mesos-datomic-conn mesos-heartbeat-chan)
-                                    (cook.rebalancer/start-rebalancer! {:compute-cluster compute-cluster
-                                                                        :config rebalancer-config
+                                    (cook.rebalancer/start-rebalancer! {:config rebalancer-config
                                                                         :conn mesos-datomic-conn
                                                                         :agent-attributes-cache agent-attributes-cache
                                                                         :pool-name->pending-jobs-atom pool-name->pending-jobs-atom

--- a/scheduler/src/cook/task.clj
+++ b/scheduler/src/cook/task.clj
@@ -15,7 +15,8 @@
 ;;
 (ns cook.task
   (:require
-    [datomic.api :as d]))
+    [datomic.api :as d]
+    [cook.compute-cluster :as cc]))
 
 (defn task-entity-id->task-id
   "Given a task entity, what is the task-id associated with it?"
@@ -37,3 +38,11 @@
   (->> task-entity-id
        (d/entity db)
        task-entity->compute-cluster-name))
+
+(defn task-ent->ComputeCluster
+  "Given a task entity, return the compute cluster object for it, if it exists. May return nil if that compute cluster on the task
+  is no longer in service."
+  [task-ent]
+  (some-> task-ent
+          task-entity->compute-cluster-name
+          cc/compute-cluster-name->ComputeCluster))

--- a/scheduler/src/cook/task.clj
+++ b/scheduler/src/cook/task.clj
@@ -15,8 +15,8 @@
 ;;
 (ns cook.task
   (:require
-    [datomic.api :as d]
-    [cook.compute-cluster :as cc]))
+    [cook.compute-cluster :as cc]
+    [datomic.api :as d]))
 
 (defn task-entity-id->task-id
   "Given a task entity, what is the task-id associated with it?"


### PR DESCRIPTION
## Changes proposed in this PR
- Refactor rebalancer to not use global compute cluster

## Why are we making these changes?
Intermediate step to supporting multiple compute clusters.

