### PR TITLE
Refactor handle-resource-offers to not use global compute-cluster

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -781,8 +781,8 @@
           (log/error t "In" pool-name "pool, error in match:" (ex-data t))
           (when-let [offers @offer-stash]
             ; Group the set of all offers by compute cluster and route them to that compute cluster for restoring.
-            (doseq [[compute-cluster offersubset] (group-by :compute-cluster offers)]
-              (cc/restore-offers compute-cluster pool-name offersubset)))
+            (doseq [[compute-cluster offer-subset] (group-by :compute-cluster offers)]
+              (cc/restore-offers compute-cluster pool-name offer-subset)))
           ; if an error happened, it doesn't mean we need to penalize Fenzo
           true)))))
 

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1589,7 +1589,7 @@
                                             mesos-run-as-user nil
                                             result (sched/handle-resource-offers!
                                                      conn fenzo pool-name->pending-jobs-atom mesos-run-as-user
-                                                     user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom pool)]
+                                                     user->usage user->quota num-considerable offers rebalancer-reservation-atom pool)]
                                         (async/>!! offers-chan :end-marker)
                                         result))]
     (with-redefs [cook.config/executor-config (constantly executor)]
@@ -1850,7 +1850,7 @@
                                               mesos-run-as-user nil
                                               result (sched/handle-resource-offers!
                                                        conn fenzo pool-name->pending-jobs-atom mesos-run-as-user
-                                                       user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom :normal)]
+                                                       user->usage user->quota num-considerable offers rebalancer-reservation-atom :normal)]
                                           result))]
       (testing "enough offers for all normal jobs"
         (let [num-considerable 10


### PR DESCRIPTION
## Changes proposed in this PR
- Refactor handle-resource-offers-refactor to not use global compute-cluster

## Why are we making these changes?
Intermediate step to supporting multiple compute clusters.

