### PR TITLE
The cook pool kubernetes taint/toleration is cook-pool, not cook.pool

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1313,7 +1313,7 @@ def get_kubernetes_nodes():
 @functools.lru_cache()
 def kubernetes_node_pool(nodename):
     node = [node for node in get_kubernetes_nodes() if node['metadata']['name'] == nodename]
-    poolname_taint = [taint for taint in node[0]['spec']['taints'] if taint['key'] == 'cook.pool']
+    poolname_taint = [taint for taint in node[0]['spec']['taints'] if taint['key'] == 'cook-pool']
     if len(poolname_taint) == 0:
         return None
     poolname = poolname_taint[0].get('value',None)

--- a/scheduler/bin/make-gke-test-cluster
+++ b/scheduler/bin/make-gke-test-cluster
@@ -35,13 +35,13 @@ time gcloud container clusters create $CLUSTERNAME --disk-size=20gb --machine-ty
 echo "---- Setting up gcloud credentials"
 gcloud container clusters get-credentials $CLUSTERNAME --region $ZONE
 
-# Make some node-pools --- this takes a while, but it helps guarantee that we have nodes with the appropriate cook.pool taints.
+# Make some node-pools --- this takes a while, but it helps guarantee that we have nodes with the appropriate cook-pool taints.
 echo "---- Making extra alpha and gamma nodepools for cook pools (please wait 5-10 minutes)"
 gcloud container node-pools create cook-pool-gamma --cluster=$CLUSTERNAME --disk-size=20gb --machine-type=g1-small \
-       --node-taints=cook.pool=gamma:NoSchedule \
+       --node-taints=cook-pool=gamma:NoSchedule \
        --num-nodes=3
 gcloud container node-pools create cook-pool-alpha --cluster=$CLUSTERNAME --disk-size=20gb --machine-type=g1-small \
-       --node-taints=cook.pool=alpha:NoSchedule \
+       --node-taints=cook-pool=alpha:NoSchedule \
        --num-nodes=2
 
 echo "---- Setting up cook namespace in kubernetes"

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -189,7 +189,7 @@
   [^V1Node node]
   ; In the case of nil, we have taints-on-node == [], and we'll map to no-pool.
   (let [taints-on-node (or (some-> node .getSpec .getTaints) [])
-        cook-pool-taint (filter #(= "cook.pool" (.getKey %)) taints-on-node)]
+        cook-pool-taint (filter #(= "cook-pool" (.getKey %)) taints-on-node)]
     (if (= 1 (count cook-pool-taint))
           (-> cook-pool-taint first .getValue)
       "no-pool")))
@@ -200,7 +200,7 @@
   (if (nil? node)
     false
     (let [taints-on-node (or (some-> node .getSpec .getTaints) [])
-          other-taints (remove #(= "cook.pool" (.getKey %)) taints-on-node)]
+          other-taints (remove #(= "cook-pool" (.getKey %)) taints-on-node)]
       (zero? (count other-taints)))))
 
 (defn get-capacity
@@ -281,10 +281,10 @@
      :volume-mounts volume-mounts}))
 
 (defn toleration-for-pool
-  "For a given cook pool name, create the right V1Toleration so that Cook will ignore that cook.pool taint."
+  "For a given cook pool name, create the right V1Toleration so that Cook will ignore that cook-pool taint."
   [pool-name]
   (let [^V1Toleration toleration (V1Toleration.)]
-    (.setKey toleration "cook.pool")
+    (.setKey toleration "cook-pool")
     (.setValue toleration pool-name)
     (.setOperator toleration "Equal")
     (.setEffect toleration "NoSchedule")

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -507,7 +507,7 @@
                                                       Quantity$Format/DECIMAL_SI)))
     (when pool
       (let [^V1Taint taint (V1Taint.)]
-        (.setKey taint "cook.pool")
+        (.setKey taint "cook-pool")
         (.setValue taint pool)
         (.setEffect taint "NoSchedule")
         (-> spec (.addTaintsItem taint))


### PR DESCRIPTION
## Changes proposed in this PR
- The cook pool kubernetes taint/toleration is cook-pool, not cook.pool

## Why are we making these changes?
This is per-the-spec. It is also more greppable.


