### PR TITLE
Makes test_basic_docker_job more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1595,7 +1595,7 @@ class CookTest(util.CookTest):
                        'docker': {'image': image}})
         self.assertEqual(resp.status_code, 201)
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
-        self.assertEqual('success', job['instances'][0]['status'])
+        self.assertIn('success', [i['status'] for i in job['instances']])
 
     @unittest.skipUnless(util.has_docker_service() and not util.using_kubernetes(),
                          "Requires `docker inspect`. On kubernetes, need to add support and write a separate test.")


### PR DESCRIPTION
## Changes proposed in this PR

- checking for any successful instance, instead of the 0th one

## Why are we making these changes?

Jobs can retry, and we really just need to make sure that the job eventually succeeds.