### PR TITLE
Allows adjusting jobs on submission via plugin

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2770,3 +2770,16 @@ class CookTest(util.CookTest):
                             resp.text)
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
+
+    @unittest.skipUnless(util.demo_job_adjuster_plugin_configured(), 'Requires the "demo" job adjuster plugin')
+    def test_job_adjuster_plugin(self):
+        job_uuid, resp = util.submit_job(self.cook_url)
+        self.assertEqual(resp.status_code, 201, resp.content)
+        try:
+            job = util.load_job(self.cook_url, job_uuid)
+            self.logger.info(json.dumps(job, indent=2))
+            self.assertIn('labels', job)
+            self.assertIn('demo-add-label-job-adjuster', job['labels'])
+            self.assertEqual('', job['labels']['demo-add-label-job-adjuster'])
+        finally:
+            util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1503,6 +1503,15 @@ def demo_plugins_are_configured(cook_url):
 
 
 @functools.lru_cache()
+def demo_job_adjuster_plugin_configured():
+    cook_url = retrieve_cook_url()
+    settings_dict = settings(cook_url)
+    configured = settings_dict['plugins']['job-adjuster'].get('factory-fn') == \
+                 "cook.plugins.demo-plugin/adjuster-factory"
+    return configured
+
+
+@functools.lru_cache()
 def _fenzo_fitness_calculator():
     """Get the cook executor config from the /settings endpoint"""
     cook_url = retrieve_cook_url()

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1506,7 +1506,7 @@ def demo_plugins_are_configured(cook_url):
 def demo_job_adjuster_plugin_configured():
     cook_url = retrieve_cook_url()
     settings_dict = settings(cook_url)
-    configured = settings_dict['plugins']['job-adjuster'].get('factory-fn') == \
+    configured = settings_dict['plugins'].get('job-adjuster', {}).get('factory-fn') == \
                  "cook.plugins.demo-plugin/adjuster-factory"
     return configured
 

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -39,7 +39,8 @@
            :job-launch-filter {:age-out-last-seen-deadline-minutes 10
                                :age-out-first-seen-deadline-minutes 10000
                                :age-out-seen-count 10
-                               :factory-fn "cook.plugins.demo-plugin/launch-factory"}}
+                               :factory-fn "cook.plugins.demo-plugin/launch-factory"}
+           :job-adjuster {:factory-fn "cook.plugins.demo-plugin/adjuster-factory"}}
  :hostname #config/env "COOK_HOSTNAME"
  :log {:file #config/env "COOK_LOG_FILE"
        :levels {"datomic.db" :warn

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -88,6 +88,8 @@ If need it to bind to another port, you can specify that with the `:local-port` 
 ** `:factory-fn` contains a string with a namespace-qualified path of a function for creating a `JobSubmissionValidator`. The factory function can fetch the current configuration out of the config `defstate` in `cook.config/config`
 ** `:batch-timeout-seconds`: This includes a critical timeout value. We check job launches synchronously, so the plugin has to respond fast. In particular, we must complete all of the launch checks before the HTTP timeout. To do this we implement another timeout, defaulting to 40 seconds. Once we cross this soft timeout, a default accept/reject policy is implemented for submitted jobs, one that cannot look at jobs individually.
 
+* `:job-adjuster` TODO(DPO)
+
 `:rate-limit`::
   Configure rate limits for the scheduler. `rate-limit` is a map with three possible keys: `:user-limit-per-m` , `:job-submission`, `:expire-minutes`. These keys control rate limits.
 

--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -84,11 +84,13 @@ If need it to bind to another port, you can specify that with the `:local-port` 
 ** `:age-out-first-seen-deadline-minutes` controls how we get rid of jobs whose launch is perpetually deferred by a plugin. When a job 'ages out', we force it to launch now, to keep the queue from being cluttered with always deferred jobs. The clock for aging out starts when a job is near enough to the front of the queue to be eligible to run, not when it is added to the queue. A job is eligible for aging out when it was first seen in the scheudler queue at least this long ago. If you want jobs to sit longer in the queue than the default 10 hours before being aged out, increase this number.
 ** `:age-out-last-seen-deadline-minutes` A job is eligible for aging out when it has been seen in the launch queue at least this recently.
 ** `:age-out-seen-count` We must have attempted to schedule the job at least this many times before we age it out.
+
 * `:job-submission-validator`  configures the entrypoint for filtering job submissions. It has several keys:
 ** `:factory-fn` contains a string with a namespace-qualified path of a function for creating a `JobSubmissionValidator`. The factory function can fetch the current configuration out of the config `defstate` in `cook.config/config`
 ** `:batch-timeout-seconds`: This includes a critical timeout value. We check job launches synchronously, so the plugin has to respond fast. In particular, we must complete all of the launch checks before the HTTP timeout. To do this we implement another timeout, defaulting to 40 seconds. Once we cross this soft timeout, a default accept/reject policy is implemented for submitted jobs, one that cannot look at jobs individually.
 
-* `:job-adjuster` TODO(DPO)
+* `:job-adjuster` configures a plugin for adjusting jobs on submission.
+** `:factory-fn` contains a string with a namespace-qualified path of a function for creating a `JobAdjuster`.
 
 `:rate-limit`::
   Configure rate limits for the scheduler. `rate-limit` is a map with three possible keys: `:user-limit-per-m` , `:job-submission`, `:expire-minutes`. These keys control rate limits.

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -26,7 +26,7 @@
             [cook.curator :as curator]
             [cook.datomic :as datomic]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.adjustment namespace.
-            ;[cook.plugins.adjustment]
+            [cook.plugins.adjustment]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.completion namespace.
             [cook.plugins.completion]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.submission namespace.

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -25,6 +25,8 @@
             [cook.rest.cors :as cors]
             [cook.curator :as curator]
             [cook.datomic :as datomic]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.adjustment namespace.
+            ;[cook.plugins.adjustment]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.completion namespace.
             [cook.plugins.completion]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.submission namespace.

--- a/scheduler/src/cook/plugins/adjustment.clj
+++ b/scheduler/src/cook/plugins/adjustment.clj
@@ -18,7 +18,7 @@
         (log/info "Creating job adjuster plugin with" factory-fn)
         (if-let [resolved-fn (cook.plugins.util/resolve-symbol (symbol factory-fn))]
           (resolved-fn config)
-          (throw (ex-info (str "Unable to resolve factory fn " factory-fn)))))
+          (throw (ex-info (str "Unable to resolve factory fn " factory-fn) {}))))
       no-op)))
 
 (mount/defstate plugin

--- a/scheduler/src/cook/plugins/adjustment.clj
+++ b/scheduler/src/cook/plugins/adjustment.clj
@@ -1,0 +1,25 @@
+(ns cook.plugins.adjustment
+  (:require [clojure.tools.logging :as log]
+            [cook.config :as config]
+            [cook.plugins.definitions :refer [JobAdjuster]]
+            [cook.plugins.util]
+            [mount.core :as mount]))
+
+(def no-op
+  (reify JobAdjuster
+    (adjust-job [_ job-map] job-map)))
+
+(defn create-default-plugin-object
+  "Returns the configured JobAdjuster, or a no-op if none is defined."
+  [config]
+  (let [factory-fn (get-in config [:settings :plugins :job-adjuster :factory-fn])]
+    (if factory-fn
+      (do
+        (log/info "Creating job adjuster plugin with" factory-fn)
+        (if-let [resolved-fn (cook.plugins.util/resolve-symbol (symbol factory-fn))]
+          (resolved-fn config)
+          (throw (ex-info (str "Unable to resolve factory fn " factory-fn)))))
+      no-op)))
+
+(mount/defstate plugin
+                :start (create-default-plugin-object config/config))

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -56,4 +56,4 @@
 
 (defprotocol JobAdjuster
   (adjust-job [this job-map]
-    "TODO(DPO)"))
+    "Given a job-map, returns an adjusted job-map for downstream use"))

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -29,7 +29,6 @@
       thousands of jobs), the whole batch of responeses MUST complete within the HTTP timeout. We set ourselves a lower timeout;
       (see documentation for `:batch-timeout-seconds`) before switching to the default."))
 
-
 (defprotocol JobLaunchFilter
   (check-job-launch [this job-map]
     "Check a job submission for if we can run it now. Returns a map with one of two possibilities:
@@ -54,3 +53,7 @@
 (defprotocol FileUrlGenerator
   (file-url [this instance]
     "Returns the file URL endpoint for the instance"))
+
+(defprotocol JobAdjuster
+  (adjust-job [this job-map]
+    "TODO(DPO)"))

--- a/scheduler/src/cook/plugins/demo_plugin.clj
+++ b/scheduler/src/cook/plugins/demo_plugin.clj
@@ -53,6 +53,12 @@
         (generate-result :deferred "Message3")
         (generate-result :accepted "Message4")))))
 
+(defrecord DemoAddLabelJobAdjuster []
+  chd/JobAdjuster
+  (chd/adjust-job
+    [_ {:keys [labels] :as job-map}]
+    (assoc job-map :labels (assoc (or labels {}) "demo-add-label-job-adjuster" ""))))
+
 (defn launch-factory
   "Factory method for the launch-plugin to be used in config.edn"
   []
@@ -67,3 +73,8 @@
   "Factory method for the second submission plugin to be used in config.edn"
   []
   (->DemoValidateSubmission2))
+
+(defn adjuster-factory
+  "TODO(DPO)"
+  []
+  (->DemoAddLabelJobAdjuster))

--- a/scheduler/src/cook/plugins/demo_plugin.clj
+++ b/scheduler/src/cook/plugins/demo_plugin.clj
@@ -76,5 +76,5 @@
 
 (defn adjuster-factory
   "TODO(DPO)"
-  []
+  [_]
   (->DemoAddLabelJobAdjuster))

--- a/scheduler/src/cook/plugins/demo_plugin.clj
+++ b/scheduler/src/cook/plugins/demo_plugin.clj
@@ -75,6 +75,6 @@
   (->DemoValidateSubmission2))
 
 (defn adjuster-factory
-  "TODO(DPO)"
+  "Factory function for the 'demo' job adjuster, which simply adds a label to jobs"
   [_]
   (->DemoAddLabelJobAdjuster))

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -40,6 +40,7 @@
             [cook.unscheduled :as unscheduled]
             [cook.tools :as util]
             [cook.mesos]
+            [cook.plugins.adjustment :as adjustment]
             [cook.plugins.definitions :as plugins]
             [cook.plugins.file :as file-plugin]
             [cook.plugins.submission :as submission-plugin]
@@ -1647,8 +1648,10 @@
   ::jobs and ::groups, which specify the jobs and job groups."
   [conn {:keys [::groups ::jobs ::pool] :as ctx}]
   (try
+    (let [])
     (log/info "Submitting jobs through raw api:" (map #(dissoc % :command) jobs))
-    (let [group-uuids (set (map :uuid groups))
+    (let [jobs (mapv #(plugins/adjust-job adjustment/plugin %) jobs)
+          group-uuids (set (map :uuid groups))
           group-asserts (map (fn [guuid] [:entity/ensure-not-exists [:group/uuid guuid]])
                              group-uuids)
           ;; Create new implicit groups (with all default settings)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1648,7 +1648,6 @@
   ::jobs and ::groups, which specify the jobs and job groups."
   [conn {:keys [::groups ::jobs ::pool] :as ctx}]
   (try
-    (let [])
     (log/info "Submitting jobs through raw api:" (map #(dissoc % :command) jobs))
     (let [jobs (mapv #(plugins/adjust-job adjustment/plugin %) jobs)
           group-uuids (set (map :uuid groups))

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -107,6 +107,7 @@
                            #'cook.config/config
                            #'cook.rate-limit/job-launch-rate-limiter
                            #'cook.rate-limit/global-job-launch-rate-limiter
+                           #'cook.plugins.adjustment/plugin
                            #'cook.plugins.file/plugin
                            #'cook.plugins.launch/plugin-object
                            #'cook.plugins.pool/plugin


### PR DESCRIPTION
## Changes proposed in this PR

- introducing the `JobAdjuster` plugin
- adding a "demo" implementation that simply adds a label
- adding a test that verifies the "demo" implementation actually modifies the job

## Why are we making these changes?

We want to allow plugins that can, for example, modify the pool on job submissions.

## What's not in here?

This PR sets up the plumbing for the plugin, and a future PR will introduce the real implementation, which will modify the pool on job submission based on configuration.
