### PR TITLE
Removes node name from pod spec

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -412,7 +412,7 @@
 
     ; pod-spec
     (.addContainersItem pod-spec container)
-    (.setNodeName pod-spec hostname)
+    ;(.setNodeName pod-spec hostname)
     (.setRestartPolicy pod-spec "Never")
     (when pool-name
       (.addTolerationsItem pod-spec (toleration-for-pool pool-name)))


### PR DESCRIPTION
## Changes proposed in this PR

- commenting out the `.setNodeName` call on the pod spec

## Why are we making these changes?

To run an experiment comparing Cook's bin packing with k8s packing.
