### PR TITLE
Refactor straggler handler to not use global compute cluster

### DIFF
--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -184,8 +184,7 @@
                                     ; Many of these should look at the compute-cluster of the underlying jobs, and not use driver at all.
                                     (cook.scheduler.scheduler/lingering-task-killer mesos-datomic-conn compute-cluster
                                                                                     task-constraints lingering-task-trigger-chan)
-                                    (cook.scheduler.scheduler/straggler-handler mesos-datomic-conn compute-cluster
-                                                                                straggler-trigger-chan)
+                                    (cook.scheduler.scheduler/straggler-handler mesos-datomic-conn straggler-trigger-chan)
                                     (cook.scheduler.scheduler/cancelled-task-killer mesos-datomic-conn
                                                                                     cancelled-task-trigger-chan)
                                     (cook.mesos.heartbeat/start-heartbeat-watcher! mesos-datomic-conn mesos-heartbeat-chan)

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1053,10 +1053,10 @@
 (defn straggler-handler
   "Periodically checks for running jobs that are in groups and runs the associated
    straggler handler."
-  [conn compute-cluster trigger-chan]
+  [conn trigger-chan]
   (util/chime-at-ch trigger-chan
                     (fn straggler-handler-event []
-                      (handle-stragglers conn #(cc/kill-task compute-cluster (:instance/task-id %))))
+                      (handle-stragglers conn (fn [task-ent] (cc/kill-task (cook.task/task-ent->ComputeCluster task-ent) (:instance/task-id task-ent)))))
                     {:error-handler (fn [e]
                                       (log/error e "Failed to handle stragglers"))}))
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1056,7 +1056,9 @@
   [conn trigger-chan]
   (util/chime-at-ch trigger-chan
                     (fn straggler-handler-event []
-                      (handle-stragglers conn (fn [task-ent] (cc/kill-task (cook.task/task-ent->ComputeCluster task-ent) (:instance/task-id task-ent)))))
+                      (handle-stragglers conn (fn [task-ent]
+                                                (cc/kill-task (cook.task/task-ent->ComputeCluster task-ent)
+                                                              (:instance/task-id task-ent)))))
                     {:error-handler (fn [e]
                                       (log/error e "Failed to handle stragglers"))}))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Refactor straggler handler to not use global compute cluster

## Why are we making these changes?
Prepare for supporting multiple compute clusters

