### PR TITLE
Refactor fenzo initialization to not use global compute cluster.

### DIFF
--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -160,7 +160,7 @@
                                   (let [{:keys [pool-name->fenzo view-incubating-offers]}
                                         (sched/create-datomic-scheduler
                                          {:conn mesos-datomic-conn
-                                          :compute-cluster compute-cluster
+                                          :compute-clusters (vals @cook.compute-cluster/cluster-name->compute-cluster-atom)
                                           :fenzo-fitness-calculator fenzo-fitness-calculator
                                           :fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-reset
                                           :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn

--- a/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
+++ b/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
@@ -166,7 +166,7 @@
         driver (reify msched/SchedulerDriver
                  (kill-task! [_ task] (swap! tasks-killed conj (:value task)))) ; Conjoin the task-id
         compute-cluster (testutil/fake-test-compute-cluster-with-driver conn uri driver)
-        fenzo (sched/make-fenzo-scheduler compute-cluster 1500 nil 0.8)
+        fenzo (sched/make-fenzo-scheduler 1500 nil 0.8)
         synced-agents-atom (atom [])
         sync-agent-sandboxes-fn (fn sync-agent-sandboxes-fn [hostname _]
                                   (swap! synced-agents-atom conj hostname))]


### PR DESCRIPTION
## Changes proposed in this PR

- Refactor fenzo initialization to not use global compute cluster.
- Discovered some dead code and deleted it

## Why are we making these changes?
Prepare for supporting multiple compute clusters

