### PR TITLE
get rid of "dropped heartbeat from task" errors

### DIFF
--- a/scheduler/src/cook/mesos/heartbeat.clj
+++ b/scheduler/src/cook/mesos/heartbeat.clj
@@ -43,7 +43,7 @@
             [[ch data]] :success
             :default :dropped
             :priority true)
-      :dropped (log/error "Dropped heartbeat from task" task-id)
+      :dropped (log/debug "Dropped heartbeat from task" task-id)
       :success (log/debug "Received heartbeat from task" task-id)
       nil)
     (catch Throwable ex


### PR DESCRIPTION
## Changes proposed in this PR

- get rid of "dropped heartbeat from task" errors, make them debug level 

## Why are we making these changes?

not needed, too much log spam
