### PR TITLE
Improves capacity and consumption logs

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -30,13 +30,15 @@
                                                  (merge-with -
                                                              (node-name->capacity node-name)
                                                              (node-name->consumed node-name)))
-                                               (keys node-name->capacity))]
-    (log/info "Capacity: " node-name->capacity "Consumption:" node-name->consumed)
+                                               (keys node-name->capacity))
+        compute-cluster-name (cc/compute-cluster-name compute-cluster)]
+    (log/info "In" compute-cluster "compute cluster, capacity:" node-name->capacity)
+    (log/info "In" compute-cluster "compute cluster, consumption:" node-name->consumed)
     (->> node-name->available
          (filter (fn [[node-name _]] (-> node-name node-name->node api/node-schedulable?)))
          (map (fn [[node-name available]]
                 {:id {:value (str (UUID/randomUUID))}
-                 :framework-id (cc/compute-cluster-name compute-cluster)
+                 :framework-id compute-cluster-name
                  :slave-id {:value node-name}
                  :hostname node-name
                  :resources [{:name "mem" :type :value-scalar :scalar (max 0.0 (:mem available))}

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -32,8 +32,8 @@
                                                              (node-name->consumed node-name)))
                                                (keys node-name->capacity))
         compute-cluster-name (cc/compute-cluster-name compute-cluster)]
-    (log/info "In" compute-cluster "compute cluster, capacity:" node-name->capacity)
-    (log/info "In" compute-cluster "compute cluster, consumption:" node-name->consumed)
+    (log/info "In" compute-cluster-name "compute cluster, capacity:" node-name->capacity)
+    (log/info "In" compute-cluster-name "compute cluster, consumption:" node-name->consumed)
     (->> node-name->available
          (filter (fn [[node-name _]] (-> node-name node-name->node api/node-schedulable?)))
          (map (fn [[node-name available]]


### PR DESCRIPTION
## Changes proposed in this PR

- splitting the log into two, one for capacity and one for consumption
- adding the compute cluster name to the log lines

## Why are we making these changes?

The split is for readability, and the compute cluster name is because multi-compute-cluster support is coming, so we'll want to know which compute cluster the logs are for.