### PR TITLE
Refactor lingering tasks killer to not use global compute cluster

### DIFF
--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -181,7 +181,7 @@
                                                                                        running-tasks-ents)]
                                     (cook.monitor/start-collecting-stats)
                                     ; Many of these should look at the compute-cluster of the underlying jobs, and not use driver at all.
-                                    (cook.scheduler.scheduler/lingering-task-killer mesos-datomic-conn compute-cluster
+                                    (cook.scheduler.scheduler/lingering-task-killer mesos-datomic-conn
                                                                                     task-constraints lingering-task-trigger-chan)
                                     (cook.scheduler.scheduler/straggler-handler mesos-datomic-conn compute-cluster
                                                                                 straggler-trigger-chan)


### PR DESCRIPTION
## Changes proposed in this PR

- Refactor lingering tasks killer to not use global compute cluster

## Why are we making these changes?
Prepare for multiple compute cluster support

