### PR TITLE
Refactor cancelled task killer to remove global compute-cluster

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -47,6 +47,12 @@
   (restore-offers [this pool-name offers]
     "Called when offers are not processed to ensure they're still available."))
 
+(defn kill-task-if-possible [compute-cluster task-id]
+  "If compute cluster is nil, print a warning instead of killing the task"
+  (if compute-cluster
+    (kill-task compute-cluster task-id)
+    (log/warn "Unable to kill task " task-id " because compute-cluster is nil")))
+
 ; Internal method
 (defn write-compute-cluster
   "Create a missing compute-cluster for one that's not yet in the database."

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -185,7 +185,7 @@
                                                                                     task-constraints lingering-task-trigger-chan)
                                     (cook.scheduler.scheduler/straggler-handler mesos-datomic-conn compute-cluster
                                                                                 straggler-trigger-chan)
-                                    (cook.scheduler.scheduler/cancelled-task-killer mesos-datomic-conn compute-cluster
+                                    (cook.scheduler.scheduler/cancelled-task-killer mesos-datomic-conn
                                                                                     cancelled-task-trigger-chan)
                                     (cook.mesos.heartbeat/start-heartbeat-watcher! mesos-datomic-conn mesos-heartbeat-chan)
                                     (cook.rebalancer/start-rebalancer! {:config rebalancer-config

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1074,7 +1074,7 @@
 
 (defn cancelled-task-killer
   "Every trigger, kill tasks that have been cancelled (e.g. via the API)."
-  [conn compute-cluster trigger-chan]
+  [conn trigger-chan]
   (util/chime-at-ch
     trigger-chan
     (fn cancelled-task-killer-event []
@@ -1084,7 +1084,7 @@
           (log/warn "killing cancelled task " (:instance/task-id task))
           @(d/transact conn [[:db/add (:db/id task) :instance/reason
                               [:reason/name :mesos-executor-terminated]]])
-          (cc/kill-task compute-cluster (:instance/task-id task)))))
+          (cc/kill-task-if-possible (cook.task/task-ent->ComputeCluster task) (:instance/task-id task)))))
     {:error-handler (fn [e]
                       (log/error e "Failed to kill cancelled tasks!"))}))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Refactor cancelled task killer to remove global compute-cluster

## Why are we making these changes?
Prepare for multiple compute cluster support

