### PR TITLE
Fix Kubernetes Node Watch

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -171,7 +171,8 @@
       (.submit kubernetes-executor ^Callable
       (fn []
         (try
-          (handle-watch-updates current-nodes-atom watch (fn [n] (-> n .getMetadata .getName)) [])
+          (handle-watch-updates current-nodes-atom watch (fn [n] (-> n .getMetadata .getName))
+                                [(make-atom-updater current-nodes-atom)]) ; Update the set of all nodes.
           (catch Exception e
             (log/warn e "Error during node watch")
             (initialize-node-watch api-client current-nodes-atom))


### PR DESCRIPTION
## Changes proposed in this PR

- We weren't actually updating our node dictionary when membership changed, so would miss k8s node changes.

## Why are we making these changes?
So we can see new nodes when they occur.

