### PR TITLE
Removes 'mesos' from leadership logs

### DIFF
--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -152,7 +152,7 @@
                           ;clojure.lang.Agent/pooledExecutor
                           (reify LeaderSelectorListener
                             (takeLeadership [_ client]
-                              (log/warn "Taking mesos leadership")
+                              (log/warn "Taking leadership")
                               (reset! mesos-leadership-atom true)
                               ;; TODO: get the framework ID and try to reregister
                               (let [normal-exit (atom true)]
@@ -223,10 +223,10 @@
                                     (reset! mesos-leadership-atom false)
                                     (counters/dec! mesos-leader)
                                     (when @normal-exit
-                                      (log/warn "Lost mesos leadership naturally"))
+                                      (log/warn "Lost leadership naturally"))
                                     ;; Better to fail over and rely on start up code we trust then rely on rarely run code
                                     ;; to make sure we yield leadership correctly (and fully)
-                                    (log/fatal "Lost mesos leadership. Exiting. Expecting a supervisor to restart me!")
+                                    (log/fatal "Lost leadership. Exiting. Expecting a supervisor to restart me!")
                                     (System/exit 0)))))
                             (stateChanged [_ client newState]
                               ;; We will give up our leadership whenever it seems that we lost
@@ -248,7 +248,7 @@
                                  (java.util.UUID/randomUUID)))
     (.autoRequeue leader-selector)
     (.start leader-selector)
-    (log/info "Started the mesos leader selector")
+    (log/info "Started the leader selector")
     {:submitter (partial submit-to-mesos mesos-datomic-conn)
      :leader-selector leader-selector}))
 


### PR DESCRIPTION
## Changes proposed in this PR

- removing "mesos" from the leadership logs

## Why are we making these changes?

The leadership has nothing to do with mesos, and having "mesos" in the logs is particularly confusing when running against k8s.