### PR TITLE
Logs the zookeeper connection string, leader path

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -156,6 +156,7 @@
 (def curator-framework
   (fnk [[:settings zookeeper]]
     (when zookeeper
+      (log/info "Using zookeeper connection string:" zookeeper)
       (let [retry-policy (BoundedExponentialBackoffRetry. 100 120000 10)
             curator-framework (CuratorFrameworkFactory/newClient zookeeper 180000 30000 retry-policy)]
         (.. curator-framework

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -145,6 +145,7 @@
 
         compute-cluster (cc/get-default-cluster-for-legacy)
         rebalancer-reservation-atom (atom {})
+        _ (log/info "Using path" zk-prefix "for leader selection")
         leader-selector (LeaderSelector.
                           curator-framework
                           zk-prefix


### PR DESCRIPTION
## Changes proposed in this PR

- logging the zookeeper connection string on startup
- logging the leader path

## Why are we making these changes?

Better debugging.
