### PR TITLE
Adds timeout on sending framework messages

### DIFF
--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -37,6 +37,7 @@ def main(args=None):
     executor_id = environment.get('MESOS_EXECUTOR_ID', '1')
     log_level = environment.get('EXECUTOR_LOG_LEVEL', 'INFO')
     sandbox_directory = environment.get('MESOS_SANDBOX', '.')
+    http_timeout_seconds = int(environment.get('EXECUTOR_HTTP_TIMEOUT_SECONDS', 120))
 
     logging.basicConfig(level = log_level,
                         filename = os.path.join(sandbox_directory, 'executor.log'),
@@ -74,7 +75,7 @@ def main(args=None):
 
     try:
         executor = ce.CookExecutor(stop_signal, config)
-        driver = pm.MesosExecutorDriver(executor)
+        driver = pm.MesosExecutorDriver(executor, timeout=http_timeout_seconds)
 
         logging.info('MesosExecutorDriver is starting...')
         driver.start()

--- a/executor/cook/__main__.py
+++ b/executor/cook/__main__.py
@@ -75,6 +75,7 @@ def main(args=None):
 
     try:
         executor = ce.CookExecutor(stop_signal, config)
+        logging.info('Initializing MesosExecutorDriver with {} second HTTP timeout'.format(http_timeout_seconds))
         driver = pm.MesosExecutorDriver(executor, timeout=http_timeout_seconds)
 
         logging.info('MesosExecutorDriver is starting...')

--- a/executor/cook/util.py
+++ b/executor/cook/util.py
@@ -2,6 +2,8 @@ import errno
 import logging
 import resource
 import sys
+import threading
+import traceback
 
 __rusage_denom_mb = 1024.0
 if sys.platform == 'darwin':
@@ -21,3 +23,14 @@ def print_memory_usage():
 def is_out_of_memory_error(exception):
     """Returns true iff exception is an instance of OSError and error code represents an out of memory error."""
     return isinstance(exception, OSError) and exception.errno == errno.ENOMEM
+
+
+def log_thread_stack_traces():
+    """Logs the stack traces for all threads."""
+    try:
+        logging.info('Logging stack traces for all threads')
+        for th in threading.enumerate():
+            logging.info(th)
+            logging.info(''.join(traceback.format_stack(sys._current_frames()[th.ident])))
+    except:
+        logging.exception('Error in logging thread stack traces')


### PR DESCRIPTION
## Changes proposed in this PR

- adding `EXECUTOR_HTTP_TIMEOUT_SECONDS` for configuring the HTTP timeout used when sending framework messages
- adding a log right after a framework message is sent
- logging the stack traces for all threads when a task is killed

## Why are we making these changes?

We've seen the executor get stuck sending framework messages and we want to both prevent this and be able to observe better what happens in these situations.

## Example of logging stack traces

```
INFO:root:Logging stack traces for all threads
INFO:root:<_MainThread(MainThread, started 140614201771840)>
INFO:root:  File "/snap/pycharm-community/155/helpers/pydev/pydevconsole.py", line 483, in <module>
    pydevconsole.start_client(host, port)
  File "/snap/pycharm-community/155/helpers/pydev/pydevconsole.py", line 411, in start_client
    process_exec_queue(interpreter)
  File "/snap/pycharm-community/155/helpers/pydev/pydevconsole.py", line 258, in process_exec_queue
    more = interpreter.add_exec(code_fragment)
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_bundle/pydev_code_executor.py", line 106, in add_exec
    more = self.do_add_exec(code_fragment)
  File "/snap/pycharm-community/155/helpers/pydev/pydevconsole.py", line 84, in do_add_exec
    command.run()
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_bundle/pydev_console_types.py", line 35, in run
    self.more = self.interpreter.runsource(text, '<input>', symbol)
  File "/usr/lib/python3.6/code.py", line 75, in runsource
    self.runcode(code)
  File "/usr/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "<input>", line 7, in log_thread_stack_traces
INFO:root:<Thread(Thread-1, started daemon 140614120904448)>
INFO:root:  File "/usr/lib/python3.6/threading.py", line 884, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_comm/pydev_transport.py", line 64, in _read_forever
    self._read_and_dispatch_next_frame()
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_comm/pydev_transport.py", line 37, in _read_and_dispatch_next_frame
    direction, frame = self._read_frame()
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_comm/pydev_transport.py", line 45, in _read_frame
    buff = readall(self._socket.recv, 4)
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_comm/pydev_io.py", line 110, in readall
    chunk = read_fn(sz - have)
INFO:root:<Thread(Thread-2, started daemon 140614112511744)>
INFO:root:  File "/usr/lib/python3.6/threading.py", line 884, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_comm/pydev_server.py", line 34, in handle
    self.processor.process(iprot, oprot)
  File "/snap/pycharm-community/155/helpers/third_party/thriftpy/_shaded_thriftpy/thrift.py", line 257, in process
    api, seqid, result, call = self.process_in(iprot)
  File "/snap/pycharm-community/155/helpers/third_party/thriftpy/_shaded_thriftpy/thrift.py", line 212, in process_in
    api, type, seqid = iprot.read_message_begin()
  File "/snap/pycharm-community/155/helpers/third_party/thriftpy/_shaded_thriftpy/protocol/binary.py", line 372, in read_message_begin
    self.trans, strict=self.strict_read)
  File "/snap/pycharm-community/155/helpers/third_party/thriftpy/_shaded_thriftpy/protocol/binary.py", line 164, in read_message_begin
    sz = unpack_i32(inbuf.read(4))
  File "/snap/pycharm-community/155/helpers/third_party/thriftpy/_shaded_thriftpy/transport/__init__.py", line 32, in read
    return readall(self._read, sz)
  File "/snap/pycharm-community/155/helpers/third_party/thriftpy/_shaded_thriftpy/transport/__init__.py", line 14, in readall
    chunk = read_fn(sz - have)
  File "/snap/pycharm-community/155/helpers/third_party/thriftpy/_shaded_thriftpy/transport/buffered/__init__.py", line 39, in _read
    self._rbuf = BytesIO(self._trans.read(max(sz, self._buf_size)))
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_comm/pydev_transport.py", line 215, in read
    return self._read_fn(sz)
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_comm/pydev_transport.py", line 27, in read_request
    return self._request_pipe.read(sz)
  File "/snap/pycharm-community/155/helpers/pydev/_pydev_comm/pydev_io.py", line 40, in read
    self.bytes_produced.wait()
  File "/usr/lib/python3.6/threading.py", line 295, in wait
    waiter.acquire()
```