### PR TITLE
Marks `test_tail_zero_byte_file` as `xfail`

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -851,6 +851,7 @@ class CookCliTest(util.CookTest):
             proc.kill()
             cli.kill(uuids, self.cook_url)
 
+    @pytest.mark.xfail
     def test_tail_zero_byte_file(self):
         cp, uuids = cli.submit('touch file.txt', self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)


### PR DESCRIPTION
## Changes proposed in this PR

- marking `test_tail_zero_byte_file` as `xfail`

## Why are we making these changes?

We've seen this test fail in certain environments.
