### PR TITLE
Makes test_balanced_host_constraint_can_place more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1879,7 +1879,7 @@ class CookTest(util.CookTest):
         uuids, resp = util.submit_jobs(self.cook_url, job_spec, num_jobs, groups=[group])
         self.assertEqual(201, resp.status_code, resp.content)
         try:
-            jobs = util.wait_for_jobs(self.cook_url, uuids, 'running')
+            jobs = util.wait_for_jobs_in_statuses(self.cook_url, uuids, ['running', 'completed'])
             hosts = [j['instances'][0]['hostname'] for j in jobs]
             host_count = Counter(hosts)
             self.assertGreaterEqual(len(host_count), minimum_hosts, hosts)


### PR DESCRIPTION
## Changes proposed in this PR

- allowing the test to pass when the jobs complete

## Why are we making these changes?

We don't actually care for the purpose of this test whether the jobs are still running or not, we just need them to have an instance.
