### PR TITLE
More logging on nodes being filtered

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -210,8 +210,11 @@
   (if (nil? node)
     false
     (let [taints-on-node (or (some-> node .getSpec .getTaints) [])
-          other-taints (remove #(= "cook-pool" (.getKey %)) taints-on-node)]
-      (zero? (count other-taints)))))
+          other-taints (remove #(= "cook-pool" (.getKey %)) taints-on-node)
+          schedulable (zero? (count other-taints))]
+      (when-not schedulable
+        (log/info "Filtering out " (some-> node .getMetadata .getName) " because it has taints " other-taints))
+      schedulable)))
 
 (defn get-capacity
   "Given a map from node-name to node, generate a map from node-name->resource-type-><capacity>"

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -213,7 +213,7 @@
           other-taints (remove #(= "cook-pool" (.getKey %)) taints-on-node)
           schedulable (zero? (count other-taints))]
       (when-not schedulable
-        (log/info "Filtering out " (some-> node .getMetadata .getName) " because it has taints " other-taints))
+        (log/info "Filtering out" (some-> node .getMetadata .getName) "because it has taints" other-taints))
       schedulable)))
 
 (defn get-capacity

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -24,7 +24,7 @@
   "Is a node schedulable?"
   [node-name->node [node-name _]]
   (when-not (-> node-name node-name->node)
-    (log/error "Why are we getting a null node for " node-name))
+    (log/error "Unable to get node from node name" node-name))
   (-> node-name node-name->node api/node-schedulable?))
 
 
@@ -42,9 +42,9 @@
         compute-cluster-name (cc/compute-cluster-name compute-cluster)]
     (log/info "In" compute-cluster-name "compute cluster, capacity:" node-name->capacity)
     (log/info "In" compute-cluster-name "compute cluster, consumption:" node-name->consumed)
-    (log/info "In" compute-cluster-name "filtering out" (->> node-name->available
+    (log/info "In" compute-cluster-name "compute cluster, filtering out" (->> node-name->available
                                                              (remove #(schedulable-node-filter node-name->node %))
-                                                             count) "nodes as not schedulable ")
+                                                             count) "nodes as not schedulable")
     (->> node-name->available
          (filter #(schedulable-node-filter node-name->node %))
          (map (fn [[node-name available]]


### PR DESCRIPTION
## Changes proposed in this PR
- Improve the logging about filtering out nodes at the kubernetes level

## Why are we making these changes?
Make it easier to determine why we're not logging on certain nodes.

