### PR TITLE
Improve logging as we filter jobs from being considered.

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -582,18 +582,24 @@
             (when is-rate-limited?
               (swap! user->rate-limit-count update user #(inc (or % 0))))
             (not (and is-rate-limited? enforcing-job-launch-rate-limit?))))
-        considerable-jobs
-        (->> pending-jobs
-             (util/filter-based-on-quota user->quota user->usage)
-             (filter (fn [job] (util/job-allowed-to-start? db job)))
-             (filter user-within-launch-rate-limit?-fn)
-             (filter launch-plugin/filter-job-launches)
-             (take num-considerable)
-             ; Force this to be taken eagerly so that the log line is accurate.
-             (doall))]
+        quota-filter-jobs (util/filter-based-on-quota user->quota user->usage pending-jobs)
+        allowed-to-start-jobs (filter (fn [job] (util/job-allowed-to-start? db job)) quota-filter-jobs)
+        within-launch-rate-jobs (filter user-within-launch-rate-limit?-fn allowed-to-start-jobs)
+        launch-plugin-jobs (filter launch-plugin/filter-job-launches within-launch-rate-jobs)
+        considerable-jobs (take num-considerable launch-plugin-jobs)
+        ; Force this to be taken eagerly so that the log line is accurate.
+        considerable-jobs* (doall considerable-jobs)]
     (swap! pool->user->number-jobs update pool-name (constantly @user->number-jobs))
     (log/info "Users whose job launches are rate-limited " @user->rate-limit-count "( enforcing =" enforcing-job-launch-rate-limit? ")")
-    considerable-jobs))
+    (log/info "In" pool-name "pool, there are"
+              (count pending-jobs) " pending ->"
+              (count quota-filter-jobs) " quota-filtered ->"
+              (count allowed-to-start-jobs) " allowed-start ->"
+              (count within-launch-rate-jobs) " launch-rate ->"
+              (count launch-plugin-jobs) " launch-plugin ->"
+              "and"
+              (count considerable-jobs) "considerable jobs.")
+    considerable-jobs*))
 
 
 (defn matches->job-uuids

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -592,12 +592,12 @@
     (swap! pool->user->number-jobs update pool-name (constantly @user->number-jobs))
     (log/info "Users whose job launches are rate-limited " @user->rate-limit-count "( enforcing =" enforcing-job-launch-rate-limit? ")")
     (log/info "In" pool-name "pool, there are"
-              (count pending-jobs) " pending ->"
-              (count quota-filter-jobs) " quota-filtered ->"
-              (count allowed-to-start-jobs) " allowed-to-start ->"
-              (count within-launch-rate-jobs) " within-launch-rate ->"
-              (count launch-plugin-jobs) " allowed by launch-plugin ->"
-              "and"
+              (count pending-jobs) "pending ->"
+              (count quota-filter-jobs) "quota-filtered ->"
+              (count allowed-to-start-jobs) "allowed-to-start ->"
+              (count within-launch-rate-jobs) "within-launch-rate ->"
+              (count launch-plugin-jobs) "allowed by launch-plugin ->"
+              " and"
               (count considerable-jobs*) "considerable jobs")
     considerable-jobs*))
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -596,9 +596,9 @@
               (count quota-filter-jobs) " quota-filtered ->"
               (count allowed-to-start-jobs) " allowed-to-start ->"
               (count within-launch-rate-jobs) " within-launch-rate ->"
-              (count launch-plugin-jobs) " launch-plugin ->"
+              (count launch-plugin-jobs) " allowed by launch-plugin ->"
               "and"
-              (count considerable-jobs) "considerable jobs.")
+              (count considerable-jobs*) "considerable jobs")
     considerable-jobs*))
 
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -597,7 +597,7 @@
               (count allowed-to-start-jobs) "allowed-to-start ->"
               (count within-launch-rate-jobs) "within-launch-rate ->"
               (count launch-plugin-jobs) "allowed by launch-plugin ->"
-              " and"
+              "and"
               (count considerable-jobs*) "considerable jobs")
     considerable-jobs*))
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -594,8 +594,8 @@
     (log/info "In" pool-name "pool, there are"
               (count pending-jobs) " pending ->"
               (count quota-filter-jobs) " quota-filtered ->"
-              (count allowed-to-start-jobs) " allowed-start ->"
-              (count within-launch-rate-jobs) " launch-rate ->"
+              (count allowed-to-start-jobs) " allowed-to-start ->"
+              (count within-launch-rate-jobs) " within-launch-rate ->"
               (count launch-plugin-jobs) " launch-plugin ->"
               "and"
               (count considerable-jobs) "considerable jobs.")


### PR DESCRIPTION
## Changes proposed in this PR

- Log as we filter out jobs from being considered

## Why are we making these changes?
- Make it easier to determine where and why we cease to consider jobs for scheduling

