### PR TITLE
Also log in which compute cluster and pool we generate offers for kub…

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -208,7 +208,7 @@
           ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
           ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
           offers-this-pool (get offers-all-pools pool-name)]
-      (log/info (str "Generated offers " (count offers-this-pool) " for pool " pool-name " "
+      (log/info (str "Generated offers " (count offers-this-pool) " for pool " pool-name " in cluster " name
                      (into [] (map #(into {} (select-keys % [:hostname :resources])) offers-this-pool))))
       offers-this-pool))
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -208,7 +208,7 @@
           ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
           ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
           offers-this-pool (get offers-all-pools pool-name)]
-      (log/info (str "Generated offers " (count offers-this-pool) " for pool " pool-name " in cluster " name
+      (log/info "Generated" (count offers-this-pool) "offers for pool" pool-name "in cluster" name
                      (into [] (map #(into {} (select-keys % [:hostname :resources])) offers-this-pool))))
       offers-this-pool))
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -208,7 +208,7 @@
           ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
           ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
           offers-this-pool (get offers-all-pools pool-name)]
-      (log/info "Generated" (count offers-this-pool) "offers for pool" pool-name "in cluster" name
+      (log/info "Generated" (count offers-this-pool) "offers for pool" pool-name "in compute cluster" name
                      (into [] (map #(into {} (select-keys % [:hostname :resources])) offers-this-pool)))
       offers-this-pool))
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -209,7 +209,7 @@
           ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
           offers-this-pool (get offers-all-pools pool-name)]
       (log/info "Generated" (count offers-this-pool) "offers for pool" pool-name "in cluster" name
-                     (into [] (map #(into {} (select-keys % [:hostname :resources])) offers-this-pool))))
+                     (into [] (map #(into {} (select-keys % [:hostname :resources])) offers-this-pool)))
       offers-this-pool))
 
   (restore-offers [this pool-name offers]))


### PR DESCRIPTION
## Changes proposed in this PR

- When logging generated offers, state for which compute cluster they're fore.

## Why are we making these changes?
Easier to understand logs

