### PR TITLE
Better logging about startup/initializing.

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -123,7 +123,7 @@
         [(make-atom-updater all-pods-atom) ; Update the set of all pods.
          (partial cook-pod-callback-wrap cook-pod-callback compute-cluster-name)] ; Invoke the cook-pod-callback if its a cook pod.
         old-all-pods @all-pods-atom]
-    (log/info "Processing pods" (keys namespaced-pod-name->pod))
+    (log/info "Processing pods for compute cluster " compute-cluster-name " are "(keys namespaced-pod-name->pod))
     ; We want to process all changes through the callback process.
     ; So compute the delta between the old and new and process those via the callbacks.
     ; Note as a side effect, the callbacks mutate all-pods-atom

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -123,7 +123,7 @@
         [(make-atom-updater all-pods-atom) ; Update the set of all pods.
          (partial cook-pod-callback-wrap cook-pod-callback compute-cluster-name)] ; Invoke the cook-pod-callback if its a cook pod.
         old-all-pods @all-pods-atom]
-    (log/info "Processing pods for compute cluster " compute-cluster-name " are "(keys namespaced-pod-name->pod))
+    (log/info "Processing pods for compute cluster" compute-cluster-name ":" (keys namespaced-pod-name->pod))
     ; We want to process all changes through the callback process.
     ; So compute the delta between the old and new and process those via the callbacks.
     ; Note as a side effect, the callbacks mutate all-pods-atom

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -179,6 +179,7 @@
 
   (initialize-cluster [this pool->fenzo running-task-ents]
     ; Initialize the pod watch path.
+    (log/info "Initializing Kubernetes cluster " name)
     (let [conn cook.datomic/conn
           cook-pod-callback (make-cook-pod-watch-callback this)]
       ; We set expected state first because initialize-pod-watch sets (and invokes callbacks on and reacts to) the expected and the gruadually discovere existing.

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -179,7 +179,7 @@
 
   (initialize-cluster [this pool->fenzo running-task-ents]
     ; Initialize the pod watch path.
-    (log/info "Initializing Kubernetes cluster " name)
+    (log/info "Initializing Kubernetes compute cluster" name)
     (let [conn cook.datomic/conn
           cook-pod-callback (make-cook-pod-watch-callback this)]
       ; We set expected state first because initialize-pod-watch sets (and invokes callbacks on and reacts to) the expected and the gruadually discovere existing.

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -239,7 +239,7 @@
     (not (nil? @driver-atom)))
 
   (initialize-cluster [this pool->fenzo _]
-    (log/info "Initializing Mesos cluster " compute-cluster-name)
+    (log/info "Initializing Mesos compute cluster" compute-cluster-name)
     (let [settings (:settings config/config)
           progress-config (:progress settings)
           conn cook.datomic/conn

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -239,6 +239,7 @@
     (not (nil? @driver-atom)))
 
   (initialize-cluster [this pool->fenzo _]
+    (log/info "Initializing Mesos cluster " compute-cluster-name)
     (let [settings (:settings config/config)
           progress-config (:progress settings)
           conn cook.datomic/conn


### PR DESCRIPTION
## Changes proposed in this PR

- Better contextual logging on startup.

## Why are we making these changes?
With multiple compute clusters, have the log indicate each one as it starts up.

