### PR TITLE
Bug fix: We need a variable sized threadpool for our watcher threads

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -22,7 +22,7 @@
 
 (def cook-pod-label "twosigma.com/cook-scheduler-job")
 
-(def ^ExecutorService kubernetes-executor (Executors/newFixedThreadPool 2))
+(def ^ExecutorService kubernetes-executor (Executors/newCachedThreadPool))
 
 ; Cook, Fenzo, and Mesos use MB for memory. Convert bytes from k8s to MB when passing to fenzo, and MB back to bytes
 ; when submitting to k8s.


### PR DESCRIPTION
## Changes proposed in this PR

- Use a cached threadpool for the watches to run in.

## Why are we making these changes?
If the threadpool is a fixed size, too many compute clusters would cause us to not launch all of out watchers. We need to threads per compute cluster, so the old code broke with only 2 compute clusters.


