### PR TITLE
Bug fix: We want to restart the k8s node watch even on a clean exit.

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -174,10 +174,10 @@
           (handle-watch-updates current-nodes-atom watch (fn [n] (-> n .getMetadata .getName))
                                 [(make-atom-updater current-nodes-atom)]) ; Update the set of all nodes.
           (catch Exception e
-            (log/warn e "Error during node watch")
-            (initialize-node-watch api-client current-nodes-atom))
+            (log/warn e "Error during node watch"))
           (finally
-            (.close watch))))))))
+            (.close watch)
+            (initialize-node-watch api-client current-nodes-atom))))))))
 
 (defn to-double
   "Map a quantity to a double, whether integer, double, or float."


### PR DESCRIPTION
## Changes proposed in this PR

- Move the code that relaunches the watcher to the finally block so it always runs.

## Why are we making these changes?
Without this change, we'd not restart the watch on a clean exit of the watcher, and we'd cease watching for node changes.

