### PR TITLE
Tests the output_url API

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -677,7 +677,7 @@ class CookCliTest(util.CookTest):
             self.assertEqual(0, cp.returncode, cp.stderr)
             self.assertEqual(len(pools) + 1, len(jobs))
         finally:
-            util.kill_jobs(self.cook_url, job_uuids)
+            util.kill_jobs(self.cook_url, job_uuids, assert_response=False)
 
     def test_ssh_job_uuid(self):
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_name()}')

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -574,7 +574,7 @@ class MultiUserCookTest(util.CookTest):
                                                    start=util.to_iso(start_time),
                                                    end=util.to_iso(end_time + 1),
                                                    name=name)
-            user = util.get_user(self.cook_url, job_uuid_1)
+            user = util.get_user(self.cook_url, job_uuids[0])
             # We can't guarantee that all of the test instances will remain running for the duration
             # of the test. For example, an instance might get killed with "Agent removed".
             self.assertTrue(2 <= stats['overall']['count'] <= num_jobs)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -428,6 +428,10 @@ def make_temporal_uuid():
     return temporal_uuid
 
 
+def job_label():
+    return os.getenv('COOK_TEST_JOB_LABEL')
+
+
 def minimal_job(**kwargs):
     job = {
         'command': 'echo Default Test Command',
@@ -448,6 +452,18 @@ def minimal_job(**kwargs):
                 'force-pull-image': False
             }
         }
+
+    label = job_label()
+    if label:
+        label_parts = label.split('=')
+        if len(label_parts) != 2:
+            raise Exception('COOK_TEST_JOB_LABEL must be of the form "key=value"')
+
+        if 'labels' not in job:
+            job['labels'] = {}
+
+        job['labels'][label_parts[0]] = label_parts[1]
+
     job.update(kwargs)
     no_container_volume = os.getenv('COOK_NO_CONTAINER_VOLUME') is not None
     if (not no_container_volume


### PR DESCRIPTION
## Changes proposed in this PR

- adding checks to `test_output_url` to actually confirm that the API works as expected

## Why are we making these changes?

We are going to be supporting the same API in the k8s world, so we want our tests to make sure it works.
