### PR TITLE
Marks two cs cat tests as xfail

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1784,6 +1784,7 @@ def dummy_ls_entries(_, __, ___):
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual('helloworld' * pow(2, iterations), cli.decode(cp.stdout))
 
+    @pytest.mark.xfail
     def test_cat_zero_byte_file(self):
         cp, uuids = cli.submit('touch file.txt', self.cook_url)
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -1829,6 +1830,7 @@ def dummy_ls_entries(_, __, ___):
         finally:
             cli.kill([waiting_uuid], self.cook_url)
 
+    @pytest.mark.xfail
     def test_cat_with_broken_pipe(self):
         iterations = 20
         cp, uuids = cli.submit('bash -c \'printf "hello\\nworld\\n" > file.txt; '


### PR DESCRIPTION
## Changes proposed in this PR

- marking two tests of `cs cat` as `xfail`

## Why are we making these changes?

We've seen these tests be flaky in certain environments.
