### PR TITLE
Do not unassign offers to fenzo when we write failed statuses to datomic

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -71,7 +71,8 @@
   [kcc mesos-status]
   (scheduler/write-status-to-datomic datomic/conn
                                      @(:pool->fenzo-atom kcc)
-                                     mesos-status))
+                                     mesos-status
+                                     false))
 
 (defn- get-job-container-status
   "Extract the container status for the main cook job container (defined in api/cook-container-name-for-job).

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -74,7 +74,7 @@
                   "should've been put down already")
         (meters/mark! (meters/meter (sched/metric-title "tasks-killed-in-status-update" pool-name)))
         (cc/kill-task compute-cluster task-id))
-      (sched/write-status-to-datomic conn pool->fenzo status))
+      (sched/write-status-to-datomic conn pool->fenzo status true))
     (conditionally-sync-sandbox conn task-id (:state status) sync-agent-sandboxes-fn)))
 
 (defn create-mesos-scheduler

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1515,7 +1515,7 @@
                                  task))
           job-id (create-dummy-job conn :user "user" :job-state :job.state/running)
           send-status-update #(->> (make-status-update "task1" :unknown :task-running %)
-                                   (sched/write-status-to-datomic conn {})
+                                   (sched/write-status-to-datomic conn {} false)
                                    async/<!!)
           instance-id (create-dummy-instance conn job-id
                                              :instance-status :instance.status/running


### PR DESCRIPTION
## Changes proposed in this PR

- Do not unassign offers to fenzo when we write failed statuses to datomic
- 
- 

## Why are we making these changes?
In the case of kubernetes, this seems unsafe. we'll mark resources as available when kubernetes
is still deleting the pods and they're not really available. We then overcommit nodes and our pods won't launch.

