### PR TITLE
Support multiple kubernetes compute clusters

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -252,16 +252,15 @@ class CookTest(util.CookTest):
             instance_compute_cluster_type = instance['compute-cluster']['type']
             self.assertIn(instance_compute_cluster_type, ['mesos', 'kubernetes'], message)
             filtered_compute_clusters = [compute_cluster for compute_cluster in settings_dict['compute-clusters']
-                                     if compute_cluster['config']['compute-cluster-name'] == instance_compute_cluster_name]
+                                         if compute_cluster['config']['compute-cluster-name'] == instance_compute_cluster_name]
             self.assertEqual(1, len(filtered_compute_clusters), "Unable to find " + instance_compute_cluster_name + " in compute clusters")
             found_compute_cluster = filtered_compute_clusters[0]
 
             self.assertIsNotNone(found_compute_cluster, message + str(settings_dict['compute-clusters']))
-            expected_mesos_framework = found_compute_cluster['config'].get('framework-id', None)
 
             self.assertEqual(util.get_compute_cluster_type(found_compute_cluster), instance_compute_cluster_type, message)
-            self.assertEqual(found_compute_cluster['config']['compute-cluster-name'], instance_compute_cluster_name, message)
             if found_compute_cluster['factory-fn'] == 'cook.mesos.mesos-compute-cluster/factory-fn':
+                expected_mesos_framework = found_compute_cluster['config'].get('framework-id', None)
                 self.assertEqual(expected_mesos_framework, instance['compute-cluster']['mesos']['framework-id'],
                                  message)
         finally:

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -236,6 +236,7 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, [uuid])
 
+    @unittest.skipUnless(len(util.get_compute_clusters()) == 1, 'Test is only well-founed if there is only a single compute cluster')
     def test_compute_cluster(self):
         settings_dict = util.settings(self.cook_url)
         if util.using_kubernetes():

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -250,10 +250,10 @@ class CookTest(util.CookTest):
 
             instance_compute_cluster_name = instance['compute-cluster']['name']
             instance_compute_cluster_type = instance['compute-cluster']['type']
-            self.assert_(instance_compute_cluster_type in ['mesos','kubernetes'],message)
+            self.assertIn(instance_compute_cluster_type, ['mesos', 'kubernetes'], message)
             filtered_compute_clusters = [compute_cluster for compute_cluster in settings_dict['compute-clusters']
                                      if compute_cluster['config']['compute-cluster-name'] == instance_compute_cluster_name]
-            self.assertEquals(1,len(filtered_compute_clusters), "Unable to find "+instance_compute_cluster_name+" in compute clusters")
+            self.assertEqual(1, len(filtered_compute_clusters), "Unable to find " + instance_compute_cluster_name + " in compute clusters")
             found_compute_cluster = filtered_compute_clusters[0]
 
             self.assertIsNotNone(found_compute_cluster, message + str(settings_dict['compute-clusters']))

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -236,7 +236,6 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, [uuid])
 
-    @unittest.skipUnless(len(util.get_compute_clusters()) == 1, 'Test is only well-founed if there is only a single compute cluster')
     def test_compute_cluster(self):
         settings_dict = util.settings(self.cook_url)
         if util.using_kubernetes():

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1285,20 +1285,27 @@ def max_mesos_slave_cpus(mesos_url):
     max_slave_cpus = max([s['resources']['cpus'] for s in slaves])
     return max_slave_cpus
 
-
 @functools.lru_cache()
-def get_kubernetes_compute_cluster():
+def get_compute_clusters():
     cook_url = retrieve_cook_url()
     _wait_for_cook(cook_url)
     init_cook_session(cook_url)
-    compute_clusters = settings(cook_url)['compute-clusters']
+    return settings(cook_url)['compute-clusters']
+
+@functools.lru_cache()
+def get_kubernetes_compute_clusters():
+    compute_clusters = get_compute_clusters()
     kubernetes_compute_clusters = [cc for cc in compute_clusters
                                    if cc['factory-fn'] == 'cook.kubernetes.compute-cluster/factory-fn']
+    return kubernetes_compute_clusters
+
+@functools.lru_cache()
+def get_kubernetes_compute_cluster():
+    kubernetes_compute_clusters = get_kubernetes_compute_clusters()
     if len(kubernetes_compute_clusters) > 0:
         return kubernetes_compute_clusters[0]
     else:
         return None
-
 
 def get_kubernetes_nodes():
     kubernetes_compute_cluster = get_kubernetes_compute_cluster()

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1285,27 +1285,20 @@ def max_mesos_slave_cpus(mesos_url):
     max_slave_cpus = max([s['resources']['cpus'] for s in slaves])
     return max_slave_cpus
 
-@functools.lru_cache()
-def get_compute_clusters():
-    cook_url = retrieve_cook_url()
-    _wait_for_cook(cook_url)
-    init_cook_session(cook_url)
-    return settings(cook_url)['compute-clusters']
-
-@functools.lru_cache()
-def get_kubernetes_compute_clusters():
-    compute_clusters = get_compute_clusters()
-    kubernetes_compute_clusters = [cc for cc in compute_clusters
-                                   if cc['factory-fn'] == 'cook.kubernetes.compute-cluster/factory-fn']
-    return kubernetes_compute_clusters
 
 @functools.lru_cache()
 def get_kubernetes_compute_cluster():
-    kubernetes_compute_clusters = get_kubernetes_compute_clusters()
+    cook_url = retrieve_cook_url()
+    _wait_for_cook(cook_url)
+    init_cook_session(cook_url)
+    compute_clusters = settings(cook_url)['compute-clusters']
+    kubernetes_compute_clusters = [cc for cc in compute_clusters
+                                   if cc['factory-fn'] == 'cook.kubernetes.compute-cluster/factory-fn']
     if len(kubernetes_compute_clusters) > 0:
         return kubernetes_compute_clusters[0]
     else:
         return None
+
 
 def get_kubernetes_nodes():
     kubernetes_compute_cluster = get_kubernetes_compute_cluster()

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1316,6 +1316,7 @@ def get_kubernetes_nodes():
     logging.info(f'Retrieved kubernetes nodes: {node_json}')
     return node_json['items']
 
+
 @functools.lru_cache()
 def kubernetes_node_pool(nodename):
     node = [node for node in get_kubernetes_nodes() if node['metadata']['name'] == nodename]
@@ -1347,6 +1348,15 @@ def max_kubernetes_node_cpus():
     return max([float(n['status']['capacity']['cpu'])
                 for n in nodes])
 
+def get_compute_cluster_type(compute_cluster_dictionary):
+    if compute_cluster_dictionary is None:
+        raise Exception("compute-cluster-dictionary is None. Cannot determine the type")
+    elif compute_cluster_dictionary['factory-fn'] == 'cook.mesos.mesos-compute-cluster/factory-fn':
+        return 'mesos'
+    elif compute_cluster_dictionary['factory-fn'] == 'cook.kubernetes.compute-cluster/factory-fn':
+        return 'kubernetes'
+    else:
+        raise Exception("compute-cluster-dictionary is "+repr(compute_cluster_dictionary)+" Cannot determine the type")
 
 def task_constraint_cpus(cook_url):
     """Returns the max cpus that can be submitted to the cluster"""

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1348,6 +1348,7 @@ def max_kubernetes_node_cpus():
     return max([float(n['status']['capacity']['cpu'])
                 for n in nodes])
 
+
 def get_compute_cluster_type(compute_cluster_dictionary):
     if compute_cluster_dictionary is None:
         raise Exception("compute-cluster-dictionary is None. Cannot determine the type")
@@ -1356,7 +1357,8 @@ def get_compute_cluster_type(compute_cluster_dictionary):
     elif compute_cluster_dictionary['factory-fn'] == 'cook.kubernetes.compute-cluster/factory-fn':
         return 'kubernetes'
     else:
-        raise Exception("compute-cluster-dictionary is "+repr(compute_cluster_dictionary)+" Cannot determine the type")
+        raise Exception(
+            "compute-cluster-dictionary is " + repr(compute_cluster_dictionary) + " Cannot determine the type")
 
 def task_constraint_cpus(cook_url):
     """Returns the max cpus that can be submitted to the cluster"""

--- a/scheduler/bin/run-local-kubernetes.sh
+++ b/scheduler/bin/run-local-kubernetes.sh
@@ -59,7 +59,7 @@ export MESOS_NATIVE_JAVA_LIBRARY="${MESOS_NATIVE_JAVA_LIBRARY}"
 export COOK_SSL_PORT="${COOK_SSL_PORT}"
 export COOK_KEYSTORE_PATH="${COOK_KEYSTORE_PATH}"
 export DATA_LOCAL_ENDPOINT="http://localhost:35847/retrieve-costs"
-export COOK_K8S_CONFIG_FILE=~/.kube/config 
+
 
 echo "Starting cook..."
 lein run config-k8s.edn

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -20,11 +20,11 @@
          ; (like test_default_container_volumes) will fail without this set.
          :run-as-user "root"}
  :compute-clusters [{:factory-fn cook.kubernetes.compute-cluster/factory-fn
-                     :config {:compute-cluster-name "minikube"
+                     :config {:compute-cluster-name "gke-1"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_1"}}
                     {:factory-fn cook.kubernetes.compute-cluster/factory-fn
-                     :config {:compute-cluster-name "minikube-2"
+                     :config {:compute-cluster-name "gke-2"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_2"}}]
  :cors-origins ["https?://cors.example.com"]

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -22,7 +22,11 @@
  :compute-clusters [{:factory-fn cook.kubernetes.compute-cluster/factory-fn
                      :config {:compute-cluster-name "minikube"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
-                              :config-file "../scheduler/.cook_kubeconfig_1"}}]
+                              :config-file "../scheduler/.cook_kubeconfig_1"}}
+                    {:factory-fn cook.kubernetes.compute-cluster/factory-fn
+                     :config {:compute-cluster-name "minikube-2"
+                              ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
+                              :config-file "../scheduler/.cook_kubeconfig_2"}}]
  :cors-origins ["https?://cors.example.com"]
  :data-local {:fitness-calculator {:cache-ttl-ms 60000
                                    :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -21,8 +21,8 @@
          :run-as-user "root"}
  :compute-clusters [{:factory-fn cook.kubernetes.compute-cluster/factory-fn
                      :config {:compute-cluster-name "minikube"
-                              ;; Location of the kubernetes config file, e.g. $HOME/.kube/config
-                              :config-file #config/env "COOK_K8S_CONFIG_FILE"}}]
+                              ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
+                              :config-file "../scheduler/.cook_kubeconfig_1"}}]
  :cors-origins ["https?://cors.example.com"]
  :data-local {:fitness-calculator {:cache-ttl-ms 60000
                                    :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -32,9 +32,6 @@
      We expect Cook to give up leadership when a compute cluster loses leadership, so leadership is not expected to be regained.
      The channel result will be an exception if an error occurred, or a status message if leadership was lost normally.")
 
-  (current-leader? [this]
-    "Returns true if this cook instance is currently the leader for the compute cluster")
-
   (kill-task [this task-id]
     "Kill the task with the given task id")
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -210,9 +210,6 @@
     ; We keep leadership indefinitely in kubernetes.
     (async/chan 1))
 
-  (current-leader? [this]
-    true)
-
   (pending-offers [this pool-name]
     (let [nodes @current-nodes-atom
           pods @all-pods-atom

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -245,8 +245,7 @@
                               ;; We will give up our leadership whenever it seems that we lost
                               ;; ZK connection
                               (when (#{ConnectionState/LOST ConnectionState/SUSPENDED} newState)
-                                (reset! leadership-atom false)
-                                (when (cc/current-leader? compute-cluster)
+                                (when @leadership-atom
                                   (counters/dec! mesos-leader)
                                   ;; Better to fail over and rely on start up code we trust then rely on rarely run code
                                   ;; to make sure we yield leadership correctly (and fully)

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -224,8 +224,8 @@
                                     ; driver connection to the backend, we want cook to suicide. If we lose any of our kubernetes connections
                                     ; we ignore it and work with the remaining cluster.
                                     ;
-                                    ; WARNING: This code is very misleading. It looks like we'll suicide if ANY of the cluster's lose leadership.
-                                    ; However, kubernetes currently can't lose leadership, so this is the equivalent of only looking at mesos.
+                                    ; WARNING: This code is very misleading. It looks like we'll suicide if ANY of the clusters lose leadership.
+                                    ; However, the kubernetes compute clusters never put anything on their chan, so this is the equivalent of only looking at mesos.
                                     ; During code review, we didn't want to implement the special case for mesos.
                                     (let [res (async/<!! (async/merge (vals cluster-connected-chans)))]
                                       (when (instance? Throwable res)

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -142,7 +142,7 @@
                 rebalancer-trigger-chan straggler-trigger-chan]} trigger-chans
         {:keys [hostname server-port server-https-port]} server-config
         datomic-report-chan (async/chan (async/sliding-buffer 4096))
-        compute-clusters @cc/cluster-name->compute-cluster-atom
+        cluster-name->compute-cluster @cc/cluster-name->compute-cluster-atom
         rebalancer-reservation-atom (atom {})
         _ (log/info "Using path" zk-prefix "for leader selection")
         leader-selector (LeaderSelector.
@@ -176,7 +176,7 @@
                                           :task-constraints task-constraints
                                           :trigger-chans trigger-chans})
                                         running-tasks-ents (cook.tools/get-running-task-ents (d/db mesos-datomic-conn))
-                                        cluster-connected-chans (->> compute-clusters
+                                        cluster-connected-chans (->> cluster-name->compute-cluster
                                                                      vals
                                                                      (map #(cc/initialize-cluster %
                                                                                                  pool-name->fenzo

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -235,9 +235,6 @@
   (db-id [this]
     db-id)
 
-  (current-leader? [this]
-    (not (nil? @driver-atom)))
-
   (initialize-cluster [this pool->fenzo _]
     (log/info "Initializing Mesos compute cluster" compute-cluster-name)
     (let [settings (:settings config/config)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1940,7 +1940,7 @@
 
 (timers/deftimer [cook-scheduler handler queue-endpoint])
 (defn waiting-jobs
-  [conn mesos-pending-jobs-fn is-authorized-fn mesos-leadership-atom leader-selector]
+  [conn mesos-pending-jobs-fn is-authorized-fn leadership-atom leader-selector]
   (liberator/resource
     :available-media-types ["application/json"]
     :allowed-methods [:get]
@@ -1961,10 +1961,10 @@
                     (do
                       (log/info user " has failed auth")
                       [false {::error "Unauthorized"}]))))
-    :exists? (fn [_] [@mesos-leadership-atom {}])
+    :exists? (fn [_] [@leadership-atom {}])
     :existed? (fn [_] [true {}])
     :moved-temporarily? (fn [_]
-                          (if @mesos-leadership-atom
+                          (if @leadership-atom
                             [false {}]
                             [true {:location (str (leader-url leader-selector) "/queue")}]))
     :handle-forbidden (fn [ctx]
@@ -2901,7 +2901,7 @@
     gpu-enabled? :mesos-gpu-enabled
     :as settings}
    leader-selector
-   mesos-leadership-atom]
+   leadership-atom]
   (->
     (routes
       (c-api/api
@@ -3163,7 +3163,7 @@
                  :handler (data-local-update-time-handler conn)}}))
 
       (ANY "/queue" []
-        (waiting-jobs conn mesos-pending-jobs-fn is-authorized-fn mesos-leadership-atom leader-selector))
+        (waiting-jobs conn mesos-pending-jobs-fn is-authorized-fn leadership-atom leader-selector))
       (ANY "/running" []
         (running-jobs conn is-authorized-fn))
       (ANY "/list" []

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -710,9 +710,9 @@
 
 (defn clear-old-uncommitted-jobs
   "Returns a function that will, when invoked, clear any uncommitted jobs older than a week if the leadership atom is true."
-  [conn mesos-leadership-atom]
+  [conn leadership-atom]
     (try
-      (when @mesos-leadership-atom
+      (when @leadership-atom
         (let [age (-> -7 t/days t/from-now tc/to-date-time)]
           (clear-uncommitted-jobs conn age false)))
       (catch Exception e
@@ -728,13 +728,13 @@
 
    This is a simple loop that nukes any uncommitted jobs older than a few days. It runs every 24 hours. There will be a minor
    performance hiccough lasting around 1 minute per 1000 jobs or so as this runs and flushes."
-  [conn mesos-leadership-atom]
+  [conn leadership-atom]
   (let [start-time (-> 12 t/hours t/from-now)
         frequency (-> 1 t/days)
         schedule (tp/periodic-seq start-time frequency)]
     (log/info "Launching clear-uncommitted-jobs-on-schedule")
     (chime/chime-at schedule
-                    (fn [_] (clear-old-uncommitted-jobs conn mesos-leadership-atom)))))
+                    (fn [_] (clear-old-uncommitted-jobs conn leadership-atom)))))
 
 (defn instance-running?
   [instance]

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -122,7 +122,7 @@
          exit-code-syncer-state# {:task-id->exit-code-agent (agent {})}
          sandbox-syncer-state# {:task-id->sandbox-agent (agent {})}
          host-settings# {:server-port 12321 :hostname "localhost"}
-         mesos-leadership-atom# (atom false)
+         leadership-atom# (atom false)
          fenzo-config# (merge default-fenzo-config (:fenzo-config ~scheduler-config))
          optimizer-config# (or (:optimizer-config ~scheduler-config)
                                {})
@@ -160,7 +160,7 @@
             :mesos-datomic-conn ~conn
             :mesos-datomic-mult mesos-mult#
             :mesos-heartbeat-chan mesos-heartbeat-chan#
-            :mesos-leadership-atom mesos-leadership-atom#
+            :leadership-atom leadership-atom#
             :pool-name->pending-jobs-atom pool-name->pending-jobs-atom#
             :mesos-run-as-user nil
             :agent-attributes-cache agent-attributes-cache#


### PR DESCRIPTION
## Changes proposed in this PR

- Iterate over all of the compute clusters in the config.edn and initialize them.

## Why are we making these changes?
- Initial support and testing for multiple kubernetes compute clusters.

