### PR TITLE
Move some handlers from a compute-cluster/kill to compute-cluster/kill-task-if-possible.

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -48,7 +48,10 @@
     "Called when offers are not processed to ensure they're still available."))
 
 (defn kill-task-if-possible [compute-cluster task-id]
-  "If compute cluster is nil, print a warning instead of killing the task"
+  "If compute cluster is nil, print a warning instead of killing the task. There are cases, in particular,
+  lingering tasks, stragglers, or cancelled tasks where the task might outlive the compute cluster it was
+  member of. When this occurs, the looked up compute cluster is null and trying to kill via it would cause an NPE,
+  when in really, its relatively innocuous. So, we have this wrapper to use in those circumstances."
   (if compute-cluster
     (kill-task compute-cluster task-id)
     (log/warn "Unable to kill task " task-id " because compute-cluster is nil")))

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -51,7 +51,7 @@
   "If compute cluster is nil, print a warning instead of killing the task. There are cases, in particular,
   lingering tasks, stragglers, or cancelled tasks where the task might outlive the compute cluster it was
   member of. When this occurs, the looked up compute cluster is null and trying to kill via it would cause an NPE,
-  when in reality, its relatively innocuous. So, we have this wrapper to use in those circumstances."
+  when in reality, it's relatively innocuous. So, we have this wrapper to use in those circumstances."
   (if compute-cluster
     (kill-task compute-cluster task-id)
     (log/warn "Unable to kill task " task-id " because compute-cluster is nil")))

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -51,7 +51,7 @@
   "If compute cluster is nil, print a warning instead of killing the task. There are cases, in particular,
   lingering tasks, stragglers, or cancelled tasks where the task might outlive the compute cluster it was
   member of. When this occurs, the looked up compute cluster is null and trying to kill via it would cause an NPE,
-  when in really, its relatively innocuous. So, we have this wrapper to use in those circumstances."
+  when in reality, its relatively innocuous. So, we have this wrapper to use in those circumstances."
   (if compute-cluster
     (kill-task compute-cluster task-id)
     (log/warn "Unable to kill task " task-id " because compute-cluster is nil")))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1010,7 +1010,7 @@
           ;; Note that we probably should update db to mark a task failed as well.
           ;; However in the case that we fail to kill a particular task in Mesos,
           ;; we could lose the chances to kill this task again.
-          (cc/kill-task (cook.task/task-ent->ComputeCluster task-entity) task-id)
+          (cc/kill-task-if-possible (cook.task/task-ent->ComputeCluster task-entity) task-id)
           ;; BUG - the following transaction races with the update that is triggered
           ;; when the task is actually killed and sends its exit status code.
           ;; See issue #515 on GitHub.
@@ -1062,7 +1062,7 @@
   (util/chime-at-ch trigger-chan
                     (fn straggler-handler-event []
                       (handle-stragglers conn (fn [task-ent]
-                                                (cc/kill-task (cook.task/task-ent->ComputeCluster task-ent)
+                                                (cc/kill-task-if-possible (cook.task/task-ent->ComputeCluster task-ent)
                                                               (:instance/task-id task-ent)))))
                     {:error-handler (fn [e]
                                       (log/error e "Failed to handle stragglers"))}))


### PR DESCRIPTION
## Changes proposed in this PR
- Change lingering task and straggler handler to use the wrapper.

## Why are we making these changes?
There are cases, in particular, lingering tasks, stragglers, or cancelled tasks where the task might
outlive the compute cluster it was member of. When this occurs, the looked up compute cluster
is nil and trying to kill via it would cause an NPE. Switch them to using this wrapper function.


