### PR TITLE
Makes test_tail_large_file_no_newlines take less time

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -805,7 +805,7 @@ class CookCliTest(util.CookTest):
 
     @pytest.mark.xfail
     def test_tail_large_file_no_newlines(self):
-        iterations = 18
+        iterations = 10
         cp, uuids = cli.submit('bash -c \'printf "helloworld" > file.txt; '
                                f'for i in {{1..{iterations}}}; do '
                                'cat file.txt file.txt > file2.txt && '


### PR DESCRIPTION
## Changes proposed in this PR

- reducing the iterations from 18 to 10 for this test

## Why are we making these changes?

This test is consistently one of the longest-running in the suite, and it doesn't need to be so long to be useful.
