### PR TITLE
Increases timeout for `test_max_runtime_exceeded`

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -561,13 +561,12 @@ class CookTest(util.CookTest):
         self.assertEqual(80, instance['progress'], message)
         self.assertEqual('80%', instance['progress_message'], message)
 
+    @pytest.mark.timeout((2 * util.timeout_interval_minutes() * 60) + 60)
     def test_max_runtime_exceeded(self):
         job_executor_type = util.get_job_executor_type()
-        settings_timeout_interval_minutes = util.get_in(util.settings(self.cook_url), 'task-constraints',
-                                                        'timeout-interval-minutes')
-        # the value needs to be a little more than 2 times settings_timeout_interval_minutes to allow
+        # the value needs to be a little more than 2 times the timeout interval to allow
         # at least two runs of the lingering task killer
-        job_sleep_seconds = (2 * settings_timeout_interval_minutes * 60) + 15
+        job_sleep_seconds = (2 * util.timeout_interval_minutes() * 60) + 15
         job_sleep_ms = job_sleep_seconds * 1000
         max_runtime_ms = 5000
         assert max_runtime_ms < job_sleep_ms

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1620,7 +1620,7 @@ def running_tasks(cook_url):
     return session.get(f'{cook_url}/running', params={'limit': 20}).json()
 
 
-@functools.lru_cache()                     
+@functools.lru_cache()
 def timeout_interval_minutes()
     cook_url = retrieve_cook_url()
     _wait_for_cook(cook_url)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1618,3 +1618,12 @@ def kill_running_and_waiting_jobs(cook_url, user):
 
 def running_tasks(cook_url):
     return session.get(f'{cook_url}/running', params={'limit': 20}).json()
+
+
+@functools.lru_cache()                     
+def timeout_interval_minutes()
+    cook_url = retrieve_cook_url()
+    _wait_for_cook(cook_url)
+    settings_timeout_interval_minutes = get_in(settings(cook_url), 'task-constraints', 
+                                               'timeout-interval-minutes')
+    return settings_timeout_interval_minutes

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1621,7 +1621,7 @@ def running_tasks(cook_url):
 
 
 @functools.lru_cache()
-def timeout_interval_minutes()
+def timeout_interval_minutes():
     cook_url = retrieve_cook_url()
     _wait_for_cook(cook_url)
     settings_timeout_interval_minutes = get_in(settings(cook_url), 'task-constraints', 


### PR DESCRIPTION
## Changes proposed in this PR

- adding `util.timeout_interval_minutes`
- making the test timeout for `test_max_runtime_exceeded` be a function of the timeout interval

## Why are we making these changes?

Otherwise, it's possible for the test to timeout before the timeout loop has a chance to mark the job as having exceeded its max runtime.
