### PR TITLE
Docker image generation improvements

### DIFF
--- a/scheduler/.dockerignore
+++ b/scheduler/.dockerignore
@@ -4,6 +4,8 @@
 .nrepl-port
 bin
 classes
+datomic/datomic*/data
+datomic/datomic*/log
 docs
 gclog.*
 log
@@ -12,3 +14,4 @@ target
 test
 test-log
 test-resources
+virtualenv*

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -40,7 +40,11 @@ COPY datomic /opt/cook/datomic
 RUN unzip -uo /opt/cook/datomic/datomic-free-0.9.5394.zip
 
 # Copy the whole scheduler into the container
-COPY . /opt/cook/
+COPY docker /opt/cook/docker
+COPY config* /opt/cook/
+COPY resources /opt/cook/resources
+COPY java /opt/cook/java
+COPY src /opt/cook/src
 RUN lein uberjar
 RUN cp "target/cook-$(lein print :version | tr -d '"').jar" datomic-free-0.9.5394/lib/cook-$(lein print :version | tr -d '"').jar
 


### PR DESCRIPTION
## Changes proposed in this PR
- Improve docker image generation.

## Why are we making these changes?
Copying just the subdirs lets us avoid bringing in log files and datomic storage allowing both smaller images and less image churn. E.g., if we relaunch without changing anything, we won't have to rebuild the image!
