### PR TITLE
Workaround bug in running with minimesos.

### DIFF
--- a/executor/Dockerfile.build
+++ b/executor/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.5.9-stretch
 
 RUN pip install pyinstaller==3.3
 


### PR DESCRIPTION
## Changes proposed in this PR
- Hardcode an earlier python image into the executor build

## Why are we making these changes?

We do testing in minimesos, which is unmaintained and 2 years old.
Our cook-executor docker image is based on python. As of 6 days ago,
its been updated. It now requires a version of glibc that is too new
and unsupported in minimesos's images. Temporary fix to force a specific
python image.
