### PR TITLE
Tweaks GKE setup scripts

### DIFF
--- a/scheduler/bin/help-delete-temporary-clusters
+++ b/scheduler/bin/help-delete-temporary-clusters
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 
-# Usage: ./bin/help-delete-temporary-clusters <zone>
+# Usage: ./bin/help-delete-temporary-clusters <project> <zone>
 #   Delete all temporary clusters within a zone. The sibling scripts here mark clusters they create.
 #   This is intended to be used by other scripts and not directly.
+#   <project> is a gcloud project.
 #   <zone> can be a zone. E.g., us-central1-a
 
 
 set -e
 
-ZONE=$1
+PROJECT=$1
+ZONE=$2
+
+gcloud="gcloud --project $PROJECT"
 
 # Nuke all existing temporary clusters; don't want to keep on making more idle clusters each time you invoke this.
 echo "---- Deleting any existing temporary clusters."
-gcloud container clusters list --filter 'resourceLabels.longevity=temporary'
-for i in `gcloud container clusters list --filter 'resourceLabels.longevity=temporary' --format="value(name)"`
+$gcloud container clusters list --filter 'resourceLabels.longevity=temporary'
+for i in $($gcloud container clusters list --filter 'resourceLabels.longevity=temporary' --format="value(name)")
 do
-    gcloud --quiet container clusters delete $i --zone $ZONE
+    $gcloud --quiet container clusters delete "$i" --zone "$ZONE" || echo "Error while attempting to delete $i"
 done

--- a/scheduler/bin/help-make-cluster
+++ b/scheduler/bin/help-make-cluster
@@ -14,6 +14,9 @@ PROJECT=$1
 ZONE=$2
 CLUSTERNAME=$3
 COOK_KUBECONFIG=$4
+
+gcloud="gcloud --project $PROJECT"
+
 echo "---- Building kubernetes cluster for project=$PROJECT zone=$ZONE clustername=$CLUSTERNAME kubeconfig=$COOK_KUBECONFIG"
 
 # This creates a cluster, with some nodes that are needed for kubernetes management.
@@ -21,22 +24,22 @@ echo "---- Building kubernetes cluster for project=$PROJECT zone=$ZONE clusterna
 # The untainted ones are for GKE's own uses for its system pods. Also convenient to have around if I'm doing non-pool tests.
 # The second line of flags about upgrades and legacy endpoints is to suppress some warnings.
 echo "---- Creating new cluster (please wait 5 minutes)"
-time gcloud container clusters create $CLUSTERNAME --zone $ZONE --disk-size=20gb --machine-type=g1-small --num-nodes=3 --preemptible  \
-     --enable-autoupgrade --no-enable-basic-auth --no-issue-client-certificate --no-enable-ip-alias --metadata disable-legacy-endpoints=true \
+time $gcloud container clusters create "$CLUSTERNAME" --zone "$ZONE" --disk-size=20gb --machine-type=g1-small --num-nodes=3 --preemptible  \
+     --no-enable-autoupgrade --no-enable-basic-auth --no-issue-client-certificate --no-enable-ip-alias --metadata disable-legacy-endpoints=true \
      --labels longevity=temporary
 
 echo "---- Setting up gcloud credentials"
 # Add credentials to the kubeconfig used by cook.
-(export KUBECONFIG=${COOK_KUBECONFIG} ; gcloud container clusters get-credentials $CLUSTERNAME --zone $ZONE)
+(export KUBECONFIG=${COOK_KUBECONFIG} ; $gcloud container clusters get-credentials "$CLUSTERNAME" --zone "$ZONE")
 # Add credentials to default kubeconfig for convenience purposes.
-gcloud container clusters get-credentials $CLUSTERNAME --zone $ZONE
+$gcloud container clusters get-credentials "$CLUSTERNAME" --zone "$ZONE"
 
 # Make some node-pools --- this takes a while, but it helps guarantee that we have nodes with the appropriate cook-pool taints.
 echo "---- Making extra alpha and gamma nodepools for cook pools (please wait 5-10 minutes)"
-gcloud container node-pools create cook-pool-gamma --zone $ZONE --cluster=$CLUSTERNAME --disk-size=20gb --machine-type=g1-small \
+$gcloud container node-pools create cook-pool-gamma --zone "$ZONE" --cluster="$CLUSTERNAME" --disk-size=20gb --machine-type=g1-small \
        --node-taints=cook-pool=gamma:NoSchedule \
        --num-nodes=3
-gcloud container node-pools create cook-pool-alpha --zone $ZONE --cluster=$CLUSTERNAME --disk-size=20gb --machine-type=g1-small \
+$gcloud container node-pools create cook-pool-alpha --zone "$ZONE" --cluster="$CLUSTERNAME" --disk-size=20gb --machine-type=g1-small \
        --node-taints=cook-pool=alpha:NoSchedule \
        --num-nodes=2
 
@@ -44,5 +47,5 @@ echo "---- Setting up cook namespace in kubernetes"
 (export KUBECONFIG=${COOK_KUBECONFIG} ; kubectl create -f docs/make-kubernetes-namespace.json)
 
 echo "---- Showing the clusters and nodes we generated"
-gcloud container clusters list
+$gcloud container clusters list
 (export KUBECONFIG=${COOK_KUBECONFIG} ; kubectl get nodes)

--- a/scheduler/bin/make-gke-test-cluster
+++ b/scheduler/bin/make-gke-test-cluster
@@ -7,16 +7,27 @@
 #   <zone> can be a zone. E.g., us-central1-a
 #   <clustername> is the name of a cluster. E.g., 'test-cluster-1'
 
+# Prerequesites:
+# - Install gcloud (https://cloud.google.com/sdk/docs/quickstarts)
+# - Log in: gcloud auth login
+# - Install kubectl: gcloud components install kubectl
+
 set -e
 
-PROJECT=$1
-ZONE=$2
-CLUSTERNAME=$3
+if [ $# -eq 0 ]
+then
+    echo "You must provide the GCP project to use!"
+    exit 1
+fi
 
-bin/help-delete-temporary-clusters $ZONE
-bin/help-make-cluster $PROJECT $ZONE $CLUSTERNAME .cook_kubeconfig_1
+PROJECT=$1
+ZONE=${2:-us-central1-a}
+CLUSTERNAME=${3:-$USER-test-cluster-$(date '+%Y%m%d-%H%M%S')}
+
+gcloud="gcloud --project $PROJECT"
+
+bin/help-delete-temporary-clusters "$PROJECT" "$ZONE"
+bin/help-make-cluster "$PROJECT" "$ZONE" "$CLUSTERNAME" .cook_kubeconfig_1
 
 echo "---- Showing all of the clusters we generated"
-gcloud container clusters list
-
-
+$gcloud container clusters list

--- a/scheduler/bin/make-gke-test-clusters
+++ b/scheduler/bin/make-gke-test-clusters
@@ -7,21 +7,31 @@
 #   <zone> can be a zone. E.g., us-central1-a
 #   <clustername> is the name of a cluster. E.g., 'test-cluster-1'
 
+# Prerequesites:
+# - Install gcloud (https://cloud.google.com/sdk/docs/quickstarts)
+# - Log in: gcloud auth login
+# - Install kubectl: gcloud components install kubectl
+
 set -e
 
-PROJECT=$1
-ZONE=$2
-CLUSTERNAME=$3
+if [ $# -eq 0 ]
+then
+    echo "You must provide the GCP project to use!"
+    exit 1
+fi
 
-bin/help-delete-temporary-clusters $ZONE
+PROJECT=$1
+ZONE=${2:-us-central1-a}
+CLUSTERNAME=${3:-$USER-test-cluster-$(date '+%Y%m%d-%H%M%S')}
+
+gcloud="gcloud --project $PROJECT"
+
+bin/help-delete-temporary-clusters "$PROJECT" "$ZONE"
 
 # Make 2 clusters.
-bin/help-make-cluster $PROJECT $ZONE ${CLUSTERNAME}-a .cook_kubeconfig_1 &
-bin/help-make-cluster $PROJECT $ZONE ${CLUSTERNAME}-b .cook_kubeconfig_2 &
+bin/help-make-cluster "$PROJECT" "$ZONE" "${CLUSTERNAME}"-a .cook_kubeconfig_1 &
+bin/help-make-cluster "$PROJECT" "$ZONE" "${CLUSTERNAME}"-b .cook_kubeconfig_2 &
 wait
 
-
 echo "---- Showing all of the clusters we generated"
-gcloud container clusters list
-
-
+$gcloud container clusters list

--- a/scheduler/bin/run-local-kubernetes.sh
+++ b/scheduler/bin/run-local-kubernetes.sh
@@ -5,7 +5,7 @@
 
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SCHEDULER_DIR="$( dirname ${DIR} )"
+SCHEDULER_DIR="$( dirname "${DIR}" )"
 
 # Defaults (overridable via environment)
 : ${COOK_DATOMIC_URI="datomic:mem://cook-jobs"}
@@ -17,8 +17,6 @@ SCHEDULER_DIR="$( dirname ${DIR} )"
 : ${MASTER_IP:="127.0.0.2"}
 : ${ZOOKEEPER_IP:="127.0.0.1"}
 : ${MESOS_NATIVE_JAVA_LIBRARY:="/usr/local/lib/libmesos.dylib"}
-
-NAME=cook-scheduler-${COOK_PORT}
 
 
 if [ "${COOK_ZOOKEEPER_LOCAL}" = false ] ; then
@@ -32,16 +30,8 @@ fi
 
 if [ ! -f "${COOK_KEYSTORE_PATH}" ];
 then
-    keytool -genkeypair -keystore ${COOK_KEYSTORE_PATH} -storetype PKCS12 -storepass cookstore -dname "CN=cook, OU=Cook Developers, O=Two Sigma Investments, L=New York, ST=New York, C=US" -keyalg RSA -keysize 2048
+    keytool -genkeypair -keystore "${COOK_KEYSTORE_PATH}" -storetype PKCS12 -storepass cookstore -dname "CN=cook, OU=Cook Developers, O=Two Sigma Investments, L=New York, ST=New York, C=US" -keyalg RSA -keysize 2048
 fi
-
-if ! [ -x "$(command -v flask)" ]; then
-    echo "Please install flask"
-    exit 1
-fi
-
-INTEGRATION_DIR="$(dirname ${SCHEDULER_DIR})/integration"
-FLASK_APP=${INTEGRATION_DIR}/src/data_locality/service.py flask run -p 35847 &
 
 echo "Creating environment variables..."
 export COOK_DATOMIC_URI="${COOK_DATOMIC_URI}"
@@ -58,8 +48,7 @@ export MESOS_MASTER="${MASTER_IP}:5050"
 export MESOS_NATIVE_JAVA_LIBRARY="${MESOS_NATIVE_JAVA_LIBRARY}"
 export COOK_SSL_PORT="${COOK_SSL_PORT}"
 export COOK_KEYSTORE_PATH="${COOK_KEYSTORE_PATH}"
-export DATA_LOCAL_ENDPOINT="http://localhost:35847/retrieve-costs"
-export COOK_K8S_CONFIG_FILE=~/.kube/config 
+export COOK_K8S_CONFIG_FILE=~/.kube/config
 
 echo "Starting cook..."
 lein run config-k8s.edn

--- a/scheduler/bin/run-local-kubernetes.sh
+++ b/scheduler/bin/run-local-kubernetes.sh
@@ -48,7 +48,6 @@ export MESOS_MASTER="${MASTER_IP}:5050"
 export MESOS_NATIVE_JAVA_LIBRARY="${MESOS_NATIVE_JAVA_LIBRARY}"
 export COOK_SSL_PORT="${COOK_SSL_PORT}"
 export COOK_KEYSTORE_PATH="${COOK_KEYSTORE_PATH}"
-export COOK_K8S_CONFIG_FILE=~/.kube/config
 
 echo "Starting cook..."
 lein run config-k8s.edn

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -24,9 +24,6 @@
                               ;; Location of the kubernetes config file, e.g. $HOME/.kube/config
                               :config-file #config/env "COOK_K8S_CONFIG_FILE"}}]
  :cors-origins ["https?://cors.example.com"]
- :data-local {:fitness-calculator {:cache-ttl-ms 60000
-                                   :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"
-                                   :update-interval-ms 1000}}
  :database {:datomic-uri #config/env "COOK_DATOMIC_URI"}
  :plugins {:job-submission-validator {:batch-timeout-seconds 40
                                       :factory-fn "cook.plugins.demo-plugin/submission-factory"}


### PR DESCRIPTION
## Changes proposed in this PR

- adding project arg to `help-delete-temporary-clusters`
- adding `--project` to all `glcoud` invocations
- adding a comment with prerequisites to the `make-` scripts
- removing the data local server from the k8s config

## Why are we making these changes?

The GKE setup script changes are so that the scripts respect the project passed in at the top level.

The data local server removal is because we don't run with the data local server configured in any environment, so there's no need to configure it here.
