### PR TITLE
Additional file to .dockerignore.

### DIFF
--- a/scheduler/.dockerignore
+++ b/scheduler/.dockerignore
@@ -6,6 +6,7 @@ bin
 classes
 datomic/datomic*/data
 datomic/datomic*/log
+datomic/datomic*/lib/cook*.jar
 docs
 gclog.*
 log


### PR DESCRIPTION
## Changes proposed in this PR

- Ignore a jar when building docker images.

## Why are we making these changes?

The cook jar is built within the docker image, so there's no need to copy
the for-local-invocation cook jar into the docker image. It just bloats it.
