### PR TITLE
Makes `test_rate_limit_while_creating_job` more reliable

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -490,7 +490,7 @@ def minimal_group(**kwargs):
     return dict(uuid=str(make_temporal_uuid()), **kwargs)
 
 
-def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, **kwargs):
+def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, log_request_body=True, **kwargs):
     """
     Create and submit multiple jobs, either cloned from a single job spec,
     or specified individually in multiple job specs.
@@ -512,7 +512,11 @@ def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, **kwargs
     if pool:
         request_body['pool'] = pool
     request_body.update(kwargs)
-    logger.info(request_body)
+    if log_request_body:
+        logger.info(request_body)
+    else:
+        logger.info('Not logging request body for job submission')
+
     resp = session.post(f'{cook_url}/jobs', json=request_body, headers=headers)
     return [j['uuid'] for j in jobs], resp
 


### PR DESCRIPTION
## Changes proposed in this PR

- retrying inside the test to avoid failures from delays
- allowing callers to specify not to log the request body when submitting jobs

## Why are we making these changes?

Timing issues can cause this test fail, e.g. a delay between the bucket-emptying requests and the request that's expected to fail can cause it not to fail. So, we'll retry this a few times.

Avoiding logging the request body makes viewing the logs for this test much nicer, because you don't get a huge JSON blob from the large job submissions.
