### PR TITLE
Improves `test_change_retries_deprecated_post`

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1191,7 +1191,7 @@ class CookTest(util.CookTest):
     def test_change_retries_deprecated_post(self):
         job_uuid, _ = util.submit_job(self.cook_url, command='sleep 60', disable_mea_culpa_retries=True)
         try:
-            util.wait_for_job(self.cook_url, job_uuid, 'running')
+            util.wait_for_job_in_statuses(self.cook_url, job_uuid, ['completed', 'running'])
             util.kill_jobs(self.cook_url, [job_uuid])
 
             def instance_query():


### PR DESCRIPTION
## Changes proposed in this PR

- allowing for the job to go to completed instead of running due to e.g. `Invalid Mesos offer`

## Why are we making these changes?

The job can fail instead of run, and we want to allow for that case in the test.
