### PR TITLE
WIP: Test running mesos + kubernetes compute clusters

### DIFF
--- a/integration/.dockerignore
+++ b/integration/.dockerignore
@@ -9,3 +9,4 @@ dist
 integration.iml
 travis
 **/__pycache__
+virtualenv*

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -68,6 +68,10 @@ class CookTest(util.CookTest):
             self.logger.info(f'Exit code not checked because cook executor was not used for {instance}')
 
     @unittest.skipUnless(util.docker_tests_enabled(), 'requires docker')
+    @pytest.mark.scheduler_not_in_docker
+    # If the cook scheduler is running in a docker container, it won't be able to lookup UID's or GID's. Under those circumstances,
+    # the cook scheduler won't be able to validate that the docker container is running as the right UID/GID and it will fail.
+    # Thus, in such an integration testing environment, we need to disable this test.
     def test_uid(self):
         settings = util.settings(self.cook_url)
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -724,7 +724,7 @@ class CookTest(util.CookTest):
     def test_get_job(self):
         # schedule a job
         job_spec = util.minimal_job()
-        resp = util.session.post('%s/rawscheduler' % self.cook_url, json={'jobs': [job_spec]})
+        _, resp = util.submit_jobs(self.cook_url, [job_spec])
         self.assertEqual(201, resp.status_code, msg=resp.content)
 
         # query for the same job & ensure the response has what it's supposed to have
@@ -1973,6 +1973,7 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, uuids)
 
+    @unittest.skipIf(util.has_ephemeral_hosts(), util.EPHEMERAL_HOSTS_SKIP_REASON)
     def test_attribute_equals_hostname_constraint(self):
         max_slave_cpus = util.max_node_cpus()
         task_constraint_cpus = util.task_constraint_cpus(self.cook_url)
@@ -2142,7 +2143,7 @@ class CookTest(util.CookTest):
                 pool_usage = usage_data['pools'][pool['name']]
                 self.assertEqual(set(pool_usage.keys()), {'total_usage', 'grouped', 'ungrouped'}, pool_usage)
                 self.assertEqual(set(pool_usage['ungrouped'].keys()), {'running_jobs', 'usage'}, pool_usage)
-            default_pool = util.default_pool(self.cook_url)
+            default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)
             if default_pool:
                 # If there is a default pool configured, make sure that our jobs,
                 # which don't have a pool, are counted as being in the default pool

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -800,11 +800,11 @@ class MultiUserCookTest(util.CookTest):
             resp = util.reset_limit(self.cook_url, 'share', user, reason=None)
             self.assertEqual(resp.status_code, 400, resp.text)
 
-            default_pool = util.default_pool(self.cook_url)
+            default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)
             if default_pool is not None:
                 for limit in ['quota', 'share']:
                     # Get the default cpus limit
-                    resp = util.get_limit(self.cook_url, limit, "default")
+                    resp = util.get_limit(self.cook_url, limit, "default", pool=default_pool)
                     self.assertEqual(200, resp.status_code, resp.text)
                     self.logger.info(f'The default limit in the {default_pool} pool is {resp.json()}')
                     default_cpus = resp.json()['cpus']
@@ -814,7 +814,7 @@ class MultiUserCookTest(util.CookTest):
                     self.assertEqual(resp.status_code, 201, resp.text)
 
                     # Check that the limit is returned for no pool
-                    resp = util.get_limit(self.cook_url, limit, user)
+                    resp = util.get_limit(self.cook_url, limit, user, pool=default_pool)
                     self.assertEqual(resp.status_code, 200, resp.text)
                     self.assertEqual(100, resp.json()['cpus'], resp.text)
 
@@ -886,7 +886,7 @@ class MultiUserCookTest(util.CookTest):
         uuids, resp = util.submit_jobs(self.cook_url, job_spec, clones=100, groups=[group])
         self.assertEqual(201, resp.status_code, resp.content)
         try:
-            default_pool = util.default_pool(self.cook_url)
+            default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)
             pool = default_pool or 'no-pool'
             self.logger.info(f'Checking the queue endpoint for pool {pool}')
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -532,6 +532,8 @@ def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, log_requ
     if pool:
         logger.info(f'Submitting explicitly to the {pool} pool')
         request_body['pool'] = pool
+    elif 'x-cook-pool' in headers:
+        logger.info(f"Submitting explicitly to the {headers['x-cook-pool']} pool via x-cook-pool header")
     elif default_pool:
         logger.info(f'Submitting explicitly to the {default_pool} pool (set as default)')
         request_body['pool'] = default_pool

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1180,6 +1180,8 @@ def set_limit(cook_url, limit_type, user, mem=None, cpus=None, gpus=None, count=
     """
     if headers is None:
         headers = {}
+    if pool is None and not 'x-cook-pool' in headers:
+        pool = default_submit_pool()
     limits = {}
     body = {'user': user, limit_type: limits}
     if reason is not None:
@@ -1213,6 +1215,8 @@ def reset_limit(cook_url, limit_type, user, reason='testing', pool=None, headers
     """
     if headers is None:
         headers = {}
+    if pool is None and not 'x-cook-pool' in headers:
+        pool = default_submit_pool()
     params = {'user': user}
     if reason is not None:
         params['reason'] = reason
@@ -1350,7 +1354,7 @@ def get_kubernetes_compute_cluster():
     else:
         return None
 
-
+@functools.lru_cache()
 def get_kubernetes_nodes():
     kubernetes_compute_cluster = get_kubernetes_compute_cluster()
     if 'config-file' in kubernetes_compute_cluster['config']:

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -48,6 +48,9 @@ COPY src /opt/cook/src
 RUN lein uberjar
 RUN cp "target/cook-$(lein print :version | tr -d '"').jar" datomic-free-0.9.5394/lib/cook-$(lein print :version | tr -d '"').jar
 
+# Ugly hack. Our .cook_kubeconfig lookup assumes it can be found in ../scheduler/ so make a symlink
+RUN ln -s /opt/cook /opt/scheduler
+
 # Run cook
 EXPOSE \
     4334 \

--- a/scheduler/bin/run-local-composite.sh
+++ b/scheduler/bin/run-local-composite.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Usage: ./bin/run-local-composite.sh
+# Runs the cook scheduler locally.
+
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCHEDULER_DIR="$( dirname ${DIR} )"
+
+# Defaults (overridable via environment)
+: ${COOK_DATOMIC_URI="datomic:mem://cook-jobs"}
+: ${COOK_FRAMEWORK_ID:=cook-framework-$(date +%s)}
+: ${COOK_KEYSTORE_PATH:="${SCHEDULER_DIR}/cook.p12"}
+: ${COOK_NREPL_PORT:=${2:-8888}}
+: ${COOK_PORT:=${1:-12321}}
+: ${COOK_SSL_PORT:=${3:-12322}}
+: ${MASTER_IP:="127.0.0.2"}
+: ${ZOOKEEPER_IP:="127.0.0.1"}
+: ${MESOS_NATIVE_JAVA_LIBRARY:="/usr/local/lib/libmesos.dylib"}
+
+if [ -z "$( curl -Is --connect-timeout 2 --max-time 4 http://${MASTER_IP}:5050/state.json | head -1 )" ]; then
+  echo "Mesos master (${MASTER_IP}) is unavailable"
+  exit 1
+fi
+
+NAME=cook-scheduler-${COOK_PORT}
+
+SCHEDULER_EXECUTOR_DIR=${SCHEDULER_DIR}/resources/public
+
+EXECUTOR_DIR="$(dirname ${SCHEDULER_DIR})/executor"
+EXECUTOR_NAME=cook-executor-local
+COOK_EXECUTOR_COMMAND="${EXECUTOR_DIR}/dist/${EXECUTOR_NAME}/${EXECUTOR_NAME}"
+SCHEDULER_EXECUTOR_DIR=${SCHEDULER_DIR}/resources/public
+
+${EXECUTOR_DIR}/bin/prepare-executor.sh local ${SCHEDULER_EXECUTOR_DIR}
+
+if [ "${COOK_ZOOKEEPER_LOCAL}" = false ] ; then
+    COOK_ZOOKEEPER="${ZOOKEEPER_IP}:2181"
+    echo "Cook ZooKeeper configured to ${COOK_ZOOKEEPER}"
+else
+    COOK_ZOOKEEPER=""
+    COOK_ZOOKEEPER_LOCAL=true
+    echo "Cook will use local ZooKeeper"
+fi
+
+if [ ! -f "${COOK_KEYSTORE_PATH}" ];
+then
+    keytool -genkeypair -keystore ${COOK_KEYSTORE_PATH} -storetype PKCS12 -storepass cookstore -dname "CN=cook, OU=Cook Developers, O=Two Sigma Investments, L=New York, ST=New York, C=US" -keyalg RSA -keysize 2048
+fi
+
+if ! [ -x "$(command -v flask)" ]; then
+    echo "Please install flask"
+    exit 1
+fi
+
+INTEGRATION_DIR="$(dirname ${SCHEDULER_DIR})/integration"
+FLASK_APP=${INTEGRATION_DIR}/src/data_locality/service.py flask run -p 35847 &
+
+echo "Mesos Master IP is ${MASTER_IP}"
+
+echo "Creating environment variables..."
+export COOK_DATOMIC_URI="${COOK_DATOMIC_URI}"
+export COOK_FRAMEWORK_ID="${COOK_FRAMEWORK_ID}"
+export COOK_EXECUTOR=""
+export COOK_EXECUTOR_COMMAND="${COOK_EXECUTOR_COMMAND}"
+export COOK_EXECUTOR_PORTION=1
+export COOK_ONE_USER_AUTH=$(whoami)
+export COOK_HOSTNAME="cook-scheduler-${COOK_PORT}"
+export COOK_LOG_FILE="log/cook-${COOK_PORT}.log"
+export COOK_NREPL_PORT="${COOK_NREPL_PORT}"
+export COOK_PORT="${COOK_PORT}"
+export COOK_ZOOKEEPER="${COOK_ZOOKEEPER}"
+export COOK_ZOOKEEPER_LOCAL="${COOK_ZOOKEEPER_LOCAL}"
+export LIBPROCESS_IP="${MASTER_IP}"
+export MESOS_MASTER="${MASTER_IP}:5050"
+export MESOS_NATIVE_JAVA_LIBRARY="${MESOS_NATIVE_JAVA_LIBRARY}"
+export COOK_SSL_PORT="${COOK_SSL_PORT}"
+export COOK_KEYSTORE_PATH="${COOK_KEYSTORE_PATH}"
+export DATA_LOCAL_ENDPOINT="http://localhost:35847/retrieve-costs"
+
+echo "Starting cook..."
+lein run config-composite.edn

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -1,0 +1,100 @@
+{:agent-query-cache {:ttl-ms 1000}
+ :authorization {;; Note that internally, Cook will select :http-basic if it's set to true,
+                 ;; and fall back to :one-user only if :http-basic is false.
+                 :http-basic #config/env-bool "COOK_HTTP_BASIC_AUTH"
+                 :one-user #config/env "COOK_ONE_USER_AUTH"}
+ :authorization-config {;; These users have admin privileges when using configfile-admins-auth;
+                        ;; e.g., they can view and modify other users' jobs.
+                        ;; Sets "admin" and the user defined in "COOK_ONE_USER_AUTH" to be admins for local development.
+                        :admins #{"admin" #config/env "COOK_ONE_USER_AUTH"}
+                        ;; What function should be used to perform user authorization?
+                        ;; See the docstring in cook.rest.authorization for details.
+                        :authorization-fn cook.rest.authorization/configfile-admins-auth-open-gets
+                        ;; users that are allowed to do things on behalf of others
+                        :impersonators #{"poser" "other-impersonator"}}
+ :container-defaults {:volumes [{:host-path "/tmp/cook-integration-mount"
+                                 :container-path "/mnt/cook-integration"
+                                 :mode "RW"}]}
+ :mesos {:leader-path "/cook-scheduler"
+         ; because the minikube users and the local users may have different IDs, tests that require file permissions
+         ; (like test_default_container_volumes) will fail without this set.
+         :run-as-user "root"}
+ :compute-clusters [{:factory-fn cook.kubernetes.compute-cluster/factory-fn
+                     :config {:compute-cluster-name "minikube"
+                              ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
+                              :config-file "../scheduler/.cook_kubeconfig_1"}}
+                    {:factory-fn cook.kubernetes.compute-cluster/factory-fn
+                     :config {:compute-cluster-name "minikube-2"
+                              ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
+                              :config-file "../scheduler/.cook_kubeconfig_2"}}
+                    {:factory-fn cook.mesos.mesos-compute-cluster/factory-fn
+                     :config {:failover-timeout-ms nil ; When we close the instance of Cook, all its tasks are killed by Mesos
+                              :master #config/env "MESOS_MASTER"
+                              :framework-id #config/env "COOK_FRAMEWORK_ID"
+                              :compute-cluster-name "local-mesos"}}]
+ :cors-origins ["https?://cors.example.com"]
+ :data-local {:fitness-calculator {:cache-ttl-ms 60000
+                                   :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"
+                                   :update-interval-ms 1000}}
+ :database {:datomic-uri #config/env "COOK_DATOMIC_URI"}
+ :plugins {:job-submission-validator {:batch-timeout-seconds 40
+                                      :factory-fns ["cook.plugins.demo-plugin/submission-factory"
+                                                    "cook.plugins.demo-plugin/submission-factory2"]}
+           :job-launch-filter {:age-out-last-seen-deadline-minutes 10
+                               :age-out-first-seen-deadline-minutes 10000
+                               :age-out-seen-count 10
+                               :factory-fn "cook.plugins.demo-plugin/launch-factory"}}
+ :hostname #config/env "COOK_HOSTNAME"
+ :kubernetes {:disallowed-container-paths #{"/mnt/bad"}
+              :disallowed-var-names #{"BADVAR"}}
+ :log {:file #config/env "COOK_LOG_FILE"
+       :levels {"datomic.db" :warn
+                "datomic.kv-cluster" :warn
+                "datomic.peer" :warn
+                "cook.scheduler.data-locality" :debug
+                "cook.mesos.fenzo-utils" :debug
+                "cook.scheduler.rebalancer" :debug
+                "cook.scheduler.scheduler" :debug
+                "cook.kubernetes.compute-cluster" :debug
+                :default :info}}
+ :metrics {:jmx true
+           :user-metrics-interval-seconds 60}
+ :nrepl {:enabled? true
+         :port #config/env-int "COOK_NREPL_PORT"}
+ :pools {:default "mesos-gamma"}
+ :port #config/env-int "COOK_PORT"
+ :ssl {:port #config/env-int "COOK_SSL_PORT"
+       :keystore-path #config/env "COOK_KEYSTORE_PATH"
+       :keystore-type "pkcs12"
+       :keystore-pass "cookstore"}
+ :rate-limit {:expire-minutes 1200 ; Expire unused rate limit entries after 20 hours.
+              ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
+              ; spurious failures, and making them larger will cause test_rate_limit_launching_jobs to skip itself.
+              :global-job-launch {:bucket-size 10000
+                                  :enforce? true
+                                  :tokens-replenished-per-minute 5000}
+              :job-launch {:bucket-size 10000
+                           :enforce? true
+                           :tokens-replenished-per-minute 5000}
+              :job-submission {:bucket-size 1000
+                               :enforce? true
+                               :tokens-replenished-per-minute 600}
+              :user-limit-per-m 1000000}
+ :rebalancer {:dru-scale 1
+              :interval-seconds 30
+              :max-preemption 500.0
+              :min-dru-diff 1.0
+              :safe-dru-threshold 1.0}
+ :sandbox-syncer {:sync-interval-ms 1000}
+ :scheduler {:fenzo-fitness-calculator "cook.scheduler.data-locality/make-data-local-fitness-calculator"
+             :offer-incubate-ms 15000
+             :task-constraints {:command-length-limit 5000
+                                :cpus 10
+                                :memory-gb 48
+                                :retry-limit 15
+                                :timeout-hours 1
+                                :timeout-interval-minutes 1
+                                :docker-parameters-allowed #{"device" "env" "user" "workdir"}}}
+ :unhandled-exceptions {:log-level :error}
+ :zookeeper {:local? #config/env-bool "COOK_ZOOKEEPER_LOCAL"
+             :connection #config/env "COOK_ZOOKEEPER"}}

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -52,6 +52,7 @@
            :user-metrics-interval-seconds 60}
  :nrepl {:enabled? true
          :port #config/env-int "COOK_NREPL_PORT"}
+ :pools {:default "k8s-gamma"}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/docker/run-cook.sh
+++ b/scheduler/docker/run-cook.sh
@@ -6,5 +6,6 @@ echo "alt-host=$(hostname -i | cut -d' ' -f2)" >> ${DATOMIC_PROPERTIES_FILE}
 /opt/cook/datomic-free-0.9.5394/bin/transactor ${DATOMIC_PROPERTIES_FILE} &
 echo "Seeding test data..."
 lein exec -p /opt/cook/datomic/data/seed_pools.clj ${COOK_DATOMIC_URI}
+lein exec -p /opt/cook/datomic/data/seed_k8s_pools.clj ${COOK_DATOMIC_URI}
 lein exec -p /opt/cook/datomic/data/seed_running_jobs.clj ${COOK_DATOMIC_URI}
 lein with-profiles +docker run $1

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -315,6 +315,8 @@
   "Checks datomic for a compute cluster with the given name and framework-id. If present, returns the entity id.
    If missing, installs in datomic and returns the entity id."
   [conn compute-cluster-name framework-id]
+  {:pre [compute-cluster-name
+         framework-id]}
   (let [compute-cluster-entity-id (get-mesos-cluster-entity-id (d/db conn)
                                                                {:compute-cluster-name compute-cluster-name
                                                                 :framework-id framework-id})]


### PR DESCRIPTION
## Changes proposed in this PR

- Get our tests to pass with mesos or kubernetes within one scheduler invocation.

## Why are we making these changes?
Test kubernetes + mesos within one cook. This is planned as a throwaway PR, to test the integration test infrastructure to determine what changes are needed, there, to support kubernetes+mesos.

The good news: This version does pass integration testing, running locally (with integration testing on both k8s and mesos, run within a single launch.)