### PR TITLE
Increases timeout for test_straggler_handling

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1291,6 +1291,9 @@ class CookTest(util.CookTest):
         util.wait_for_job(self.cook_url, jobs[1], 'completed')
 
     @pytest.mark.xfail
+    # The test timeout needs to be a little more than 2 times the timeout
+    # interval to allow at least two runs of the straggler handler
+    @pytest.mark.timeout((2 * util.timeout_interval_minutes() * 60) + 60)
     def test_straggler_handling(self):
         straggler_handling = {
             'type': 'quantile-deviation',


### PR DESCRIPTION
## Changes proposed in this PR

- making the test timeout be a function of the scheduler's timeout interval

## Why are we making these changes?

Even though the test is marked `xfail`, if it times out, the test run is considered a failure. So we want this test to run to completion.
