### PR TITLE
Fixes key function used in pod watch

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -81,11 +81,6 @@
           (catch Exception e
             (log/error e "Error while processing callback")))))))
 
-(defn get-pod-name
-  "Given a V1Pod, return its name"
-  [^V1Pod pod]
-  (-> pod .getMetadata .getName))
-
 (defn get-pod-namespaced-key
   [^V1Pod pod]
   {:namespace (-> pod
@@ -141,7 +136,7 @@
       (.submit kubernetes-executor ^Callable
       (fn []
         (try
-          (handle-watch-updates all-pods-atom watch get-pod-name
+          (handle-watch-updates all-pods-atom watch get-pod-namespaced-key
                                 callbacks)
           (catch Exception e
             (log/error e "Error during watch"))


### PR DESCRIPTION
## Changes proposed in this PR

- using `get-pod-namespaced-key` for `handle-watch-updates`
- deleting the now-unused `get-pod-name`

## Why are we making these changes?

This was a bug; the pod watch code was expecting to be using the namespaced key and was not for pod watch updates, resulting in e.g.:

```
2019-11-15 22:11:13,453 ERROR cook.kubernetes.controller [pool-4-thread-1] - Unexpected state:  [:expected/running :missing] for pod 5dcf7623-080e-4995-983a-a0faa52994ac
```
