### PR TITLE
Makes `process` log more clear

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -107,6 +107,12 @@
     (assoc expected-state-dict :launch-pod [:elided-for-brevity])
     expected-state-dict))
 
+(defn prepare-existing-state-dict-for-logging
+  [existing-state-dict]
+  (-> existing-state-dict
+      (update-in [:synthesized-state :state] #(or % :missing))
+      (dissoc :pod)))
+
 (defn pod-has-started
   "A pod has started. So now we need to update the status in datomic."
   [kcc {:keys [pod] :as existing-state-dictionary}]
@@ -130,12 +136,12 @@
 (defn process
   "Visit this pod-name, processing the new level-state. Returns the new expected state. Returns
   empty dictionary to indicate that the result should be deleted. NOTE: Must be invoked with the lock."
-  [{:keys [api-client existing-state-map expected-state-map] :as kcc} ^String pod-name]
+  [{:keys [api-client existing-state-map expected-state-map name] :as kcc} ^String pod-name]
   (loop [{:keys [expected-state] :as expected-state-dict} (get @expected-state-map pod-name)
          {:keys [synthesized-state pod] :as existing-state-dict} (get @existing-state-map pod-name)]
-    ;; TODO: Remove the printing of existing-state-dict once we test on real kubernetes and get synthesized-pod-state robust.
-    (log/info "Processing: " pod-name ": ((" (prepare-expected-state-dict-for-logging expected-state-dict)
-              " ===== " (or (:state synthesized-state) :missing)  "///" existing-state-dict  "))")
+    (log/info "In compute cluster" name ", processing pod" pod-name ";"
+              "expected:" (prepare-expected-state-dict-for-logging expected-state-dict) ","
+              "existing:" (prepare-existing-state-dict-for-logging existing-state-dict))
     ; TODO: We added an :expected/starting state to the machine, to represent when a pod is starting. We map instance.status/unknown to that state
     ; The todo is to add in cases for [:expected/starting *] for those other states.
     (let


### PR DESCRIPTION
## Changes proposed in this PR

- making the log at the top of `process` more clear

## Why are we making these changes?

So that you can tell from the log what each part of the log means without having to look at the code.

## Examples

```
2019-11-18 21:40:52,700 INFO  cook.kubernetes.controller [pool-4-thread-5] - In compute cluster gke-2 , processing pod 5dd36440-8652-42ab-a816-b0a47752b831 ; expected: {:expected-state :expected/completed} , existing: {:synthesized-state {:state :pod/succeeded, :exit 0, :reason Completed}}

2019-11-18 21:40:52,787 INFO  cook.kubernetes.controller [pool-4-thread-5] - In compute cluster gke-2 , processing pod 5dd36440-8652-42ab-a816-b0a47752b831 ; expected: {:expected-state :expected/completed} , existing: {:synthesized-state {:state :missing, :reason Pod was explicitly deleted}}

2019-11-18 21:40:52,787 INFO  cook.kubernetes.controller [pool-4-thread-5] - In compute cluster gke-2 , processing pod 5dd36440-8652-42ab-a816-b0a47752b831 ; expected: nil , existing: {:synthesized-state {:state :missing, :reason Pod was explicitly deleted}}

2019-11-18 21:40:52,787 INFO  cook.kubernetes.controller [pool-4-thread-5] - In compute cluster gke-2 , processing pod 5dd36440-8652-42ab-a816-b0a47752b831 ; expected: nil , existing: {:synthesized-state {:state :missing}}
```