### PR TITLE
Fixes bugs in `util.wait_for_running_instance`

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -907,10 +907,13 @@ def wait_for_running_instance(cook_url, job_id, max_wait_ms=DEFAULT_TIMEOUT_MS):
             for inst in job['instances']:
                 status = inst['status']
                 logger.info(f"Job {job_id} instance {inst['task_id']} has status {status}, expected running.")
-                return status == 'running'
+                if status == 'running':
+                    return True
+            logger.info(f"Job {job_id} has no running instances.")
+            return False
 
     response = wait_until(query, predicate, max_wait_ms=max_wait_ms)
-    return response.json()[0]['instances'][0]
+    return next(i for i in response.json()[0]['instances'] if i['status'] == 'running')
 
 
 def get_mesos_slaves(mesos_url):


### PR DESCRIPTION
## Changes proposed in this PR

- making the `for` loop actually check all instances until it finds a running one
- returning the running instance instead of the 0th one

## Why are we making these changes?

The function is broken and is causing at least one test that relies on it (`test_instance_stats_running`) to be flaky.