### PR TITLE
Asserts that the expected compute cluster type is being used

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -342,7 +342,7 @@ class CookTest(util.CookTest):
 
             instance_compute_cluster_name = instance['compute-cluster']['name']
             instance_compute_cluster_type = instance['compute-cluster']['type']
-            self.assertIn(instance_compute_cluster_type, ['mesos', 'kubernetes'], message)
+            self.assertEqual(instance_compute_cluster_type, util.get_compute_cluster_test_mode(), message)
             filtered_compute_clusters = [compute_cluster for compute_cluster in settings_dict['compute-clusters']
                                          if compute_cluster['config']['compute-cluster-name'] == instance_compute_cluster_name]
             self.assertEqual(1, len(filtered_compute_clusters), "Unable to find " + instance_compute_cluster_name + " in compute clusters")


### PR DESCRIPTION
## Changes proposed in this PR

- checking that the compute cluster in use is the expected one

## Why are we making these changes?

We want to ensure that when we set the compute cluster test mode, jobs are actually getting sent to that compute cluster type.
