### PR TITLE
Makes test_instance_stats_supports_epoch_time_params more reliable

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -723,11 +723,12 @@ class MultiUserCookTest(util.CookTest):
 
     def test_instance_stats_supports_epoch_time_params(self):
         name = str(util.make_temporal_uuid())
-        job_uuid_1, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
+        sleep_command = f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'
+        job_uuid_1, resp = util.submit_job(self.cook_url, command=sleep_command, name=name, max_retries=2)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
+        job_uuid_2, resp = util.submit_job(self.cook_url, command=sleep_command, name=name, max_retries=2)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
+        job_uuid_3, resp = util.submit_job(self.cook_url, command=sleep_command, name=name, max_retries=2)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
         try:


### PR DESCRIPTION
## Changes proposed in this PR

- changing the job commands from `sleep 300` to `sleep {util.DEFAULT_TEST_TIMEOUT_SECS}`

## Why are we making these changes?

We need to guarantee that the jobs will be running for the duration of the test. We've seen cases where one of the jobs runs and completes before the test is complete, which causes the test to fail.
