### PR TITLE
improves time to build user->quota-fn by aggregating queries

### DIFF
--- a/scheduler/src/cook/quota.clj
+++ b/scheduler/src/cook/quota.clj
@@ -181,7 +181,9 @@
     (pc/map-from-keys
       (fn [user]
         (int
-          ; prefer resource over the field on the user for count quota
+          ; As part of the pool migration, there might be a mix of quotas that have the count as an attribute or a resource.
+          ; Hence, we prefer resource over the field on the user for count quota.
+          ; Refer to the implementation of `get-quota` for further details.
           (or (get user->resource-count-quota user)
               (get user->entity-count-quota user)
               default-quota)))


### PR DESCRIPTION
## Changes proposed in this PR

- improves time to build `user->quota-fn` by aggregating queries (gives around **4X** improvement in my tests)
- improves time to build user->quota-fn by aggregating count quota query (gives another **3X to 5X** improvement in my tests)

## Why are we making these changes?

`create-user->quota-fn` (used in `rank-jobs`) makes lots of individual queries against datomic to build the `user->quota-cache`. Improve the execution time of `create-user->quota-fn` ends up improving the time spent ranking jobs.


