### PR TITLE
Make our compute cluster code more robust between compute clusters.

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -44,13 +44,21 @@
   (restore-offers [this pool-name offers]
     "Called when offers are not processed to ensure they're still available."))
 
+(defn safe-kill-task
+  "A safe version of kill task that never throws. This reduces the risk that errors in one compute cluster propagate and cause problems in another compute cluster."
+  [compute-cluster task-id]
+  (try
+    (kill-task compute-cluster task-id)
+    (catch Throwable t
+      (log/error t "In compute cluster" compute-cluster "error killing task" task-id))))
+
 (defn kill-task-if-possible [compute-cluster task-id]
   "If compute cluster is nil, print a warning instead of killing the task. There are cases, in particular,
   lingering tasks, stragglers, or cancelled tasks where the task might outlive the compute cluster it was
   member of. When this occurs, the looked up compute cluster is null and trying to kill via it would cause an NPE,
   when in reality, it's relatively innocuous. So, we have this wrapper to use in those circumstances."
   (if compute-cluster
-    (kill-task compute-cluster task-id)
+    (safe-kill-task compute-cluster task-id)
     (log/warn "Unable to kill task " task-id " because compute-cluster is nil")))
 
 ; Internal method

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -73,7 +73,7 @@
                   "as instance" instance "with" prior-job-state "and" prior-instance-status
                   "should've been put down already")
         (meters/mark! (meters/meter (sched/metric-title "tasks-killed-in-status-update" pool-name)))
-        (cc/kill-task compute-cluster task-id))
+        (cc/safe-kill-task compute-cluster task-id))
       (sched/write-status-to-datomic conn pool->fenzo status))
     (conditionally-sync-sandbox conn task-id (:state status) sync-agent-sandboxes-fn)))
 

--- a/scheduler/src/cook/rebalancer.clj
+++ b/scheduler/src/cook/rebalancer.clj
@@ -516,7 +516,7 @@
               (log/warn e "Failed to transact preemption")))
           (when-let [task-id (:instance/task-id task-ent)]
             (when-let [compute-cluster (task/task-ent->ComputeCluster task-ent)]
-              (cc/kill-task compute-cluster task-id))))))))
+              (cc/safe-kill-task compute-cluster task-id))))))))
 
 (def datomic-params [:max-preemption
                      :min-dru-diff


### PR DESCRIPTION
## Changes proposed in this PR

-  Wrap most ComputeCluster API calls in a try-catch. everything in a try-catch.
- launch-tasks is done in PR#1322
- 

## Why are we making these changes?

We don't want a single compute cluster failing to take down all of cook.

