### PR TITLE
Release Cook 1.36.1

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.36.1] - 2019-12-05
+### Changed
+- Reverted a change that added unexpectedly expensive logging, from @scrosby
+
 ## [1.36.0] - 2019-12-04
 ### Added
 - Support for multiple kubernetes compute clusters, from @scrosby

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.36.1-SNAPSHOT"
+(defproject cook "1.36.1"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.36.1"
+(defproject cook "1.36.2-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]


### PR DESCRIPTION
## Changes proposed in this PR

- Release cook. 

## Why are we making these changes?

Revert a change that added extra logging to jobs being considered for scheduling, this was slowing down matching offers.
