### PR TITLE
Makes test_list_jobs_by_pool complete faster

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1048,11 +1048,13 @@ class CookTest(util.CookTest):
         self.assertFalse(util.contains_job_uuid(resp.json(), job_uuid_6), job_uuid_6)
 
     def test_list_jobs_by_pool(self):
-        # Submit two jobs to each active pool -- one that will be
+        # Submit two jobs to each of up to two active pools -- one that will be
         # running or waiting for the duration of this test, and another that will complete
         jobs = []
         name = str(util.make_temporal_uuid())
         pools, _ = util.active_pools(self.cook_url)
+        # Running this for the first two pools only is enough
+        pools = pools[:2]
         start = util.current_milli_time()
         sleep_command = f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'
         for pool in pools:


### PR DESCRIPTION
## Changes proposed in this PR

- using up to 2 pools, instead of all active pools

## Why are we making these changes?

We've seen this test time out in the initial `for` loop over pools, and it's not really necessary to run this for every single active pool under test.
