### PR TITLE
Makes test_progress_update_submit more reliable

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1686,3 +1686,10 @@ def reset_share_and_quota(cook_url, user):
     logger.info(f'Resetting share and quota for {user} in pool {pool}')
     set_limit_to_default(cook_url, 'share', user, pool)
     set_limit_to_default(cook_url, 'quota', user, pool)
+
+
+def job_progress_is_present(job, progress):
+    present = any(i['progress'] == progress for i in job['instances'])
+    if not present:
+        logger.info(f'Job does not yet have progress {progress}: {json.dumps(job, indent=2)}')
+    return present


### PR DESCRIPTION
## Changes proposed in this PR

- don't require the job to complete for the test to complete

## Why are we making these changes?

In the wild, we sometimes see jobs take a long time to complete, and this test shouldn't rely on the test completing, only on the progress being posted to the instance.
