### PR TITLE
Avoids Cook executor when launching on k8s

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -670,7 +670,7 @@ class MultiUserCookTest(util.CookTest):
         job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
         try:
             util.wait_for_jobs(self.cook_url, job_uuids, 'completed')
-            instances = [util.wait_for_instance(self.cook_url, j) for j in job_uuids]
+            instances = [util.wait_for_instance(self.cook_url, j, status='success') for j in job_uuids]
             try:
                 for instance in instances:
                     self.assertEqual('success', instance['parent']['state'])

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1305,6 +1305,9 @@ def is_cook_executor_in_use():
             logger.info('Using mesos executor (cook executor is configured, but so is HTTP basic auth, and they are '
                         'incompatible)')
             return False
+        elif using_kubernetes():
+            logger.info('Not using cook executor (it is configured, but we are using k8s)')
+            return False
         else:
             logger.info('Using cook executor as configured')
             return True

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -42,7 +42,10 @@
     "Retrieve pending offers for the given pool")
 
   (restore-offers [this pool-name offers]
-    "Called when offers are not processed to ensure they're still available."))
+    "Called when offers are not processed to ensure they're still available.")
+
+  (use-cook-executor? [this]
+    "Returns true if this compute cluster makes use of the Cook executor for running tasks"))
 
 (defn safe-kill-task
   "A safe version of kill task that never throws. This reduces the risk that errors in one compute cluster propagate and cause problems in another compute cluster."

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -222,7 +222,9 @@
                      (into [] (map #(into {} (select-keys % [:hostname :resources])) offers-this-pool)))
       offers-this-pool))
 
-  (restore-offers [this pool-name offers]))
+  (restore-offers [this pool-name offers])
+
+  (use-cook-executor? [_] false))
 
 (defn get-or-create-cluster-entity-id
   [conn compute-cluster-name]

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -284,7 +284,9 @@
 
   (restore-offers [this pool-name offers]
     (async/go
-      (async/>! (pool->offers-chan pool-name) offers))))
+      (async/>! (pool->offers-chan pool-name) offers)))
+
+  (use-cook-executor? [_] true))
 
 ; Internal method
 (defn- mesos-cluster->compute-cluster-map-for-datomic

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -3,6 +3,7 @@
   (:require [clojure.data.json :as json]
             [clojure.edn :as edn]
             [clojure.string :as str]
+            [cook.compute-cluster :as cc]
             [cook.config :as config]
             [cook.scheduler.scheduler :as sched]
             [cook.mesos.task :as task]
@@ -346,7 +347,8 @@
                         :extract false
                         :value "file:///path/to/cook-executor"}}
         mesos-run-as-user nil]
-    (with-redefs [cook.config/executor-config (constantly executor)]
+    (with-redefs [cook.config/executor-config (constantly executor)
+                  cc/use-cook-executor? (constantly true)]
       (testing "custom-executor with simple job"
         (let [task-id (str (UUID/randomUUID))
               job (tu/create-dummy-job conn :user "test-user" :job-state :job.state/running :command "run-my-command")
@@ -360,7 +362,7 @@
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}]
 
           (testing "mesos-run-as-user absent"
-            (let [task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+            (let [task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
               (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                       :container nil
                       :environment environment
@@ -376,7 +378,7 @@
 
           (testing "mesos-run-as-user present"
             (let [mesos-run-as-user "mesos-run-as-user"
-                  task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+                  task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
               (is (= {:command {:value "run-my-command", :environment environment, :user mesos-run-as-user, :uris []}
                       :container nil
                       :environment environment
@@ -405,7 +407,7 @@
                            "COOK_JOB_GROUP_UUID" (-> group-ent :group/uuid str)
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                   :container nil
                   :environment environment
@@ -431,7 +433,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                   :container nil
                   :environment environment
@@ -461,7 +463,7 @@
                            "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                            "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
                            "PROGRESS_SAMPLE_INTERVAL_MS" (:progress-sample-interval-ms executor)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris [(:uri executor)]
                             :user "test-user"
@@ -499,7 +501,7 @@
                            "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                            "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
                            "PROGRESS_SAMPLE_INTERVAL_MS" (:progress-sample-interval-ms executor)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris [(:uri executor)]
                             :user "test-user"
@@ -529,7 +531,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris []
                             :user "test-user"
@@ -566,7 +568,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris []
                             :user "test-user"
@@ -606,7 +608,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "200.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris []
                             :user "test-user"
@@ -651,7 +653,7 @@
                            "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                            "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
                            "PROGRESS_SAMPLE_INTERVAL_MS" (:progress-sample-interval-ms executor)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris [(:uri executor)]
                             :user "test-user"

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1900,7 +1900,8 @@
                     log/log* (fn [_ level throwable message]
                                (when (= :warn level)
                                  (reset! logged-atom {:throwable throwable
-                                                      :message message})))]
+                                                      :message message})))
+                    cc/use-cook-executor? (constantly true)]
         (is (thrown? ExceptionInfo (sched/launch-matched-tasks! matches conn nil nil nil nil)))
         (is (= timeout-exception (:throwable @logged-atom)))
         (is (str/includes? (:message @logged-atom) (str job-id))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adding `use-cook-executor?` to the `ComputeCluster` protocol
- in `job->task-metadata`, consulting `use-cook-executor?` to determine whether or not to do all the Cook executor stuff

## Why are we making these changes?

The Cook executor is a Mesos-only thing. Even if we're configured to use, it doesn't make sense to use it on k8s.
