### PR TITLE
Move other python:3.5 docker image references to python:3.5.9-stretch

### DIFF
--- a/executor/bin/check-version.sh
+++ b/executor/bin/check-version.sh
@@ -79,7 +79,7 @@ elif host-libc-matches-container-libc; then
     installed_version="$(${binary_app} --version)"
 else
     # Run the executor directly on all other platforms
-    installed_version="$(docker run --rm -v $(pwd):/opt/cook python:3.5 /opt/cook/${binary_app} --version)"
+    installed_version="$(docker run --rm -v $(pwd):/opt/cook python:3.5.9-stretch /opt/cook/${binary_app} --version)"
 fi
 
 #

--- a/integration/bin/run-integration.sh
+++ b/integration/bin/run-integration.sh
@@ -87,7 +87,7 @@ docker create \
        -e "COOK_SCHEDULER_URL=${COOK_URL}" \
        -e "USER=root" \
        -e "COOK_MESOS_LEADER_URL=http://${MESOS_MASTER_IP}:5050" \
-       -e "COOK_TEST_DOCKER_IMAGE=python:3.5" \
+       -e "COOK_TEST_DOCKER_IMAGE=python:3.5.9-stretch" \
        -v "/tmp/cook-integration-mount:/tmp/cook-integration-mount" \
        ${COOK_MULTICLUSTER_ENV} \
        ${DATA_LOCAL_ENV} \

--- a/scheduler/bin/submit-docker.sh
+++ b/scheduler/bin/submit-docker.sh
@@ -2,4 +2,4 @@
 
 UUID=$(uuidgen)
 
-curl -XPOST -H"Content-Type: application/json" http://localhost:12321/rawscheduler -d"{\"jobs\": [{\"uuid\": \"$UUID\", \"env\": {\"EXECUTOR_TEST_EXIT\": \"1\"}, \"executor\": \"cook\", \"mem\": 128, \"cpus\": 1, \"command\": \"echo progress: 50 test_progress && exit 0\", \"max_retries\": 1, \"container\": {\"type\": \"DOCKER\", \"docker\": {\"image\": \"python:3.5\", \"network\": \"HOST\", \"force-pull-image\": false}, \"volumes\": [{\"container-path\": \"/Users/paul/src/Cook/executor/dist\", \"host-path\": \"/Users/paul/src/Cook/executor/dist\"}]}}]}"
+curl -XPOST -H"Content-Type: application/json" http://localhost:12321/rawscheduler -d"{\"jobs\": [{\"uuid\": \"$UUID\", \"env\": {\"EXECUTOR_TEST_EXIT\": \"1\"}, \"executor\": \"cook\", \"mem\": 128, \"cpus\": 1, \"command\": \"echo progress: 50 test_progress && exit 0\", \"max_retries\": 1, \"container\": {\"type\": \"DOCKER\", \"docker\": {\"image\": \"python:3.5.9-stretch\", \"network\": \"HOST\", \"force-pull-image\": false}, \"volumes\": [{\"container-path\": \"/Users/paul/src/Cook/executor/dist\", \"host-path\": \"/Users/paul/src/Cook/executor/dist\"}]}}]}"


### PR DESCRIPTION
## Changes proposed in this PR
- Remove python:3.5 docker image references. Migrate everything to python:3.5.9-stretch.

## Why are we making these changes?
Avoids having to bring down python:3.5 at all, saving a gig of docker space.

