### PR TITLE
Tweak dockerignore for integration tests + scheduler

### DIFF
--- a/integration/.dockerignore
+++ b/integration/.dockerignore
@@ -2,6 +2,7 @@
 .idea
 .cache
 .minimesos
+.pytest_cache
 bin
 build
 cook_integration.egg-info
@@ -9,3 +10,5 @@ dist
 integration.iml
 travis
 **/__pycache__
+virtualenv*
+venv*

--- a/scheduler/.dockerignore
+++ b/scheduler/.dockerignore
@@ -16,3 +16,4 @@ test
 test-log
 test-resources
 virtualenv*
+venv*


### PR DESCRIPTION
## Changes proposed in this PR

- Ignore some virtualenv environments

## Why are we making these changes?
We tend to use these names for virtualenv environments. Lets .dockerignore them so that we get smaller docker images that build faster.

