### PR TITLE
Makes container defaults be compute-cluster specific

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -12,9 +12,6 @@
                         :authorization-fn cook.rest.authorization/configfile-admins-auth-open-gets
                         ;; users that are allowed to do things on behalf of others
                         :impersonators #{"poser" "other-impersonator"}}
- :container-defaults {:volumes [{:host-path "/tmp/cook-integration-mount"
-                                 :container-path "/mnt/cook-integration"
-                                 :mode "RW"}]}
  :mesos {:leader-path "/cook-scheduler"
          ; because the minikube users and the local users may have different IDs, tests that require file permissions
          ; (like test_default_container_volumes) will fail without this set.

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -12,15 +12,15 @@
                         :authorization-fn cook.rest.authorization/configfile-admins-auth-open-gets
                         ;; users that are allowed to do things on behalf of others
                         :impersonators #{"poser" "other-impersonator"}}
- :container-defaults {:volumes [{:host-path "/tmp/cook-integration-mount"
-                                 :container-path "/mnt/cook-integration"
-                                 :mode "RW"}]}
  :mesos {:leader-path "/cook-scheduler"}
  :compute-clusters [{:factory-fn cook.mesos.mesos-compute-cluster/factory-fn
                      :config {:failover-timeout-ms nil ; When we close the instance of Cook, all its tasks are killed by Mesos
                               :master #config/env "MESOS_MASTER"
                               :framework-id #config/env "COOK_FRAMEWORK_ID"
-                              :compute-cluster-name "local-mesos"}}]
+                              :compute-cluster-name "local-mesos"
+                              :container-defaults {:volumes [{:host-path "/tmp/cook-integration-mount"
+                                                              :container-path "/mnt/cook-integration"
+                                                              :mode "RW"}]}}}]
  :cors-origins ["https?://cors.example.com"]
  :data-local {:fitness-calculator {:cache-ttl-ms 60000
                                    :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -42,7 +42,10 @@
     "Retrieve pending offers for the given pool")
 
   (restore-offers [this pool-name offers]
-    "Called when offers are not processed to ensure they're still available."))
+    "Called when offers are not processed to ensure they're still available.")
+
+  (container-defaults [this]
+    "Default values to use for containers launched in this compute cluster"))
 
 (defn safe-kill-task
   "A safe version of kill task that never throws. This reduces the risk that errors in one compute cluster propagate and cause problems in another compute cluster."

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -152,8 +152,6 @@
                                       :principal (:principal mesos)
                                       :role (:role mesos)
                                       :framework-name (:framework-name mesos)}}]))
-     :container-defaults (fnk [[:config {container-defaults {}}]]
-                           container-defaults)
      :cors-origins (fnk [[:config {cors-origins nil}]]
                      (map re-pattern (or cors-origins [])))
      :exit-code-syncer (fnk [[:config {exit-code-syncer nil}]]
@@ -534,10 +532,6 @@
 (defn max-over-quota-jobs
   []
   (get-in config [:settings :max-over-quota-jobs]))
-
-(defn container-defaults
-  []
-  (get-in config [:settings :container-defaults]))
 
 (defn compute-clusters
   []

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -224,7 +224,10 @@
 
   (restore-offers [this pool-name offers])
 
-  (container-defaults [_] {}))
+  (container-defaults [_]
+    ; We don't currently support specifying
+    ; container defaults for k8s compute clusters
+    {}))
 
 (defn get-or-create-cluster-entity-id
   [conn compute-cluster-name]

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -222,7 +222,9 @@
                      (into [] (map #(into {} (select-keys % [:hostname :resources])) offers-this-pool)))
       offers-this-pool))
 
-  (restore-offers [this pool-name offers]))
+  (restore-offers [this pool-name offers])
+
+  (container-defaults [_] {}))
 
 (defn get-or-create-cluster-entity-id
   [conn compute-cluster-name]

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -215,7 +215,7 @@
 
 (defrecord MesosComputeCluster [compute-cluster-name framework-id db-id driver-atom
                                 sandbox-syncer-state exit-code-syncer-state mesos-heartbeat-chan
-                                trigger-chans mesos-config pool->offers-chan]
+                                trigger-chans mesos-config pool->offers-chan container-defaults]
   cc/ComputeCluster
   (compute-cluster-name [this]
     compute-cluster-name)
@@ -284,7 +284,10 @@
 
   (restore-offers [this pool-name offers]
     (async/go
-      (async/>! (pool->offers-chan pool-name) offers))))
+      (async/>! (pool->offers-chan pool-name) offers)))
+
+  (container-defaults [_]
+    container-defaults))
 
 ; Internal method
 (defn- mesos-cluster->compute-cluster-map-for-datomic
@@ -333,7 +336,8 @@
            principal
            role
            framework-name
-           gpu-enabled?]}
+           gpu-enabled?
+           container-defaults]}
    {:keys [exit-code-syncer-state
            mesos-agent-query-cache
            mesos-heartbeat-chan
@@ -371,7 +375,8 @@
                                                        mesos-heartbeat-chan
                                                        trigger-chans
                                                        mesos-config
-                                                       pool->offer-chan)]
+                                                       pool->offer-chan
+                                                       container-defaults)]
       (log/info "Registering compute cluster" mesos-compute-cluster)
       (cc/register-compute-cluster! mesos-compute-cluster)
       mesos-compute-cluster)

--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -80,9 +80,9 @@
 (defn merge-container-defaults
   "Takes a job container specification and applies any defaults from the config.
    Currently only supports volumes."
-  [container]
+  [container compute-cluster]
   (when container
-    (let [{:keys [volumes]} (config/container-defaults)
+    (let [{:keys [volumes]} (cc/container-defaults compute-cluster)
           get-path (fn [{:keys [container-path host-path]}]
                      (or container-path
                          host-path))]
@@ -127,10 +127,10 @@
 
 (defn job->task-metadata
   "Takes a job entity, returns task metadata"
-  [db mesos-run-as-user job-ent task-id]
+  [mesos-run-as-user job-ent task-id compute-cluster]
   (let [container (-> job-ent
                       util/job-ent->container
-                      merge-container-defaults)
+                      (merge-container-defaults compute-cluster))
         cook-executor? (use-cook-executor? job-ent)
         executor-key (job->executor-key job-ent)
         executor (executor-key->executor executor-key)
@@ -177,7 +177,7 @@
   "Organizes the info Fenzo has already told us about the task we need to run"
   [db mesos-run-as-user compute-cluster ^TaskAssignmentResult task-result]
   (let [{:keys [job task-id] :as task-request} (.getRequest task-result)]
-    (merge (job->task-metadata db mesos-run-as-user job task-id)
+    (merge (job->task-metadata mesos-run-as-user job task-id compute-cluster)
            {:hostname (.getHostname task-result)
             :ports-assigned (vec (sort (.getAssignedPorts task-result)))
             :task-request task-request})))

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -59,7 +59,8 @@
                                mesos-heartbeat-chan
                                trigger-chans
                                {}
-                               {"no-pool" (async/chan 100)})))
+                               {"no-pool" (async/chan 100)}
+                               {})))
 
 (defn fake-test-compute-cluster-with-driver
   "Create a test compute cluster with associated driver attached to it. Returns the compute cluster."

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -347,7 +347,8 @@
                         :extract false
                         :value "file:///path/to/cook-executor"}}
         mesos-run-as-user nil]
-    (with-redefs [cook.config/executor-config (constantly executor)]
+    (with-redefs [cook.config/executor-config (constantly executor)
+                  cc/container-defaults (constantly {})]
       (testing "custom-executor with simple job"
         (let [task-id (str (UUID/randomUUID))
               job (tu/create-dummy-job conn :user "test-user" :job-state :job.state/running :command "run-my-command")
@@ -361,7 +362,7 @@
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}]
 
           (testing "mesos-run-as-user absent"
-            (let [task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+            (let [task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
               (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                       :container nil
                       :environment environment
@@ -377,7 +378,7 @@
 
           (testing "mesos-run-as-user present"
             (let [mesos-run-as-user "mesos-run-as-user"
-                  task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+                  task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
               (is (= {:command {:value "run-my-command", :environment environment, :user mesos-run-as-user, :uris []}
                       :container nil
                       :environment environment
@@ -406,7 +407,7 @@
                            "COOK_JOB_GROUP_UUID" (-> group-ent :group/uuid str)
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                   :container nil
                   :environment environment
@@ -432,7 +433,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                   :container nil
                   :environment environment
@@ -462,7 +463,7 @@
                            "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                            "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
                            "PROGRESS_SAMPLE_INTERVAL_MS" (:progress-sample-interval-ms executor)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris [(:uri executor)]
                             :user "test-user"
@@ -500,7 +501,7 @@
                            "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                            "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
                            "PROGRESS_SAMPLE_INTERVAL_MS" (:progress-sample-interval-ms executor)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris [(:uri executor)]
                             :user "test-user"
@@ -530,7 +531,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris []
                             :user "test-user"
@@ -567,7 +568,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris []
                             :user "test-user"
@@ -607,7 +608,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "200.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris []
                             :user "test-user"
@@ -652,7 +653,7 @@
                            "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                            "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
                            "PROGRESS_SAMPLE_INTERVAL_MS" (:progress-sample-interval-ms executor)}
-              task-metadata (task/job->task-metadata db mesos-run-as-user job-ent task-id)]
+              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
           (is (= {:command {:environment environment
                             :uris [(:uri executor)]
                             :user "test-user"

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -3,6 +3,7 @@
   (:require [clojure.data.json :as json]
             [clojure.edn :as edn]
             [clojure.string :as str]
+            [cook.compute-cluster :as cc]
             [cook.config :as config]
             [cook.scheduler.scheduler :as sched]
             [cook.mesos.task :as task]
@@ -887,29 +888,29 @@
 
 (deftest test-merge-container-defaults
   (testing "does not add docker info if missing"
-    (with-redefs [config/container-defaults (constantly {:docker {:parameters {"foo" "bar"}}})]
-      (is (= {:mesos {:image "baz"}} (task/merge-container-defaults {:mesos {:image "baz"}})))))
+    (with-redefs [cc/container-defaults (constantly {:docker {:parameters {"foo" "bar"}}})]
+      (is (= {:mesos {:image "baz"}} (task/merge-container-defaults {:mesos {:image "baz"}} nil)))))
   (testing "adds volumes even when missing"
     (let [volumes [{:container-path "/foo"
                     :host-path "/foo"}]]
-      (with-redefs [config/container-defaults (constantly {:volumes volumes})]
+      (with-redefs [cc/container-defaults (constantly {:volumes volumes})]
         (is (= {:mesos {:image "baz"}
                 :volumes volumes}
-               (task/merge-container-defaults {:mesos {:image "baz"}}))))))
+               (task/merge-container-defaults {:mesos {:image "baz"}} nil))))))
   (testing "merges volumes"
-    (with-redefs [config/container-defaults (constantly {:volumes [{:host-path "/h/a"
-                                                                    :container-path "/c/a"
-                                                                    :mode "rw"}
-                                                                   {:host-path "/mnt/app/data"
-                                                                    :mode "r"}]})]
-      (is (= nil (task/merge-container-defaults nil)))
+    (with-redefs [cc/container-defaults (constantly {:volumes [{:host-path "/h/a"
+                                                                :container-path "/c/a"
+                                                                :mode "rw"}
+                                                               {:host-path "/mnt/app/data"
+                                                                :mode "r"}]})]
+      (is (= nil (task/merge-container-defaults nil nil)))
       (is (= {:docker {:image "foo"}
               :volumes [{:host-path "/h/a"
                          :container-path "/c/a"
                          :mode "rw"}
                         {:host-path "/mnt/app/data"
                          :mode "r"}]}
-             (task/merge-container-defaults {:docker {:image "foo"}})))
+             (task/merge-container-defaults {:docker {:image "foo"}} nil)))
       (is (= {:docker {:image "foo"}
               :volumes [{:host-path "/mnt/app"
                          :mode "rw"}
@@ -918,7 +919,8 @@
                          :mode "rw"}]}
              (task/merge-container-defaults {:docker {:image "foo"}
                                              :volumes [{:host-path "/mnt/app"
-                                                        :mode "rw"}]})))
+                                                        :mode "rw"}]}
+                                            nil)))
       (is (= {:docker {:image "foo"}
               :volumes [{:host-path "/diff/a"
                          :container-path "/c/a"}
@@ -926,7 +928,8 @@
                          :mode "r"}]}
              (task/merge-container-defaults {:docker {:image "foo"}
                                              :volumes [{:host-path "/diff/a"
-                                                        :container-path "/c/a"}]})))
+                                                        :container-path "/c/a"}]}
+                                            nil)))
       (is (= {:docker {:image "foo"}
               :volumes [{:host-path "/diff/a"
                          :container-path "/c/a/b"}
@@ -937,4 +940,5 @@
                          :mode "r"}]}
              (task/merge-container-defaults {:docker {:image "foo"}
                                              :volumes [{:host-path "/diff/a"
-                                                        :container-path "/c/a/b"}]}))))))
+                                                        :container-path "/c/a/b"}]}
+                                            nil))))))

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -362,7 +362,7 @@
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}]
 
           (testing "mesos-run-as-user absent"
-            (let [task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+            (let [task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
               (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                       :container nil
                       :environment environment
@@ -378,7 +378,7 @@
 
           (testing "mesos-run-as-user present"
             (let [mesos-run-as-user "mesos-run-as-user"
-                  task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+                  task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
               (is (= {:command {:value "run-my-command", :environment environment, :user mesos-run-as-user, :uris []}
                       :container nil
                       :environment environment
@@ -407,7 +407,7 @@
                            "COOK_JOB_GROUP_UUID" (-> group-ent :group/uuid str)
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+              task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
           (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                   :container nil
                   :environment environment
@@ -433,7 +433,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+              task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
           (is (= {:command {:value "run-my-command", :environment environment, :user "test-user", :uris []}
                   :container nil
                   :environment environment
@@ -463,7 +463,7 @@
                            "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                            "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
                            "PROGRESS_SAMPLE_INTERVAL_MS" (:progress-sample-interval-ms executor)}
-              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+              task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
           (is (= {:command {:environment environment
                             :uris [(:uri executor)]
                             :user "test-user"
@@ -501,7 +501,7 @@
                            "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                            "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
                            "PROGRESS_SAMPLE_INTERVAL_MS" (:progress-sample-interval-ms executor)}
-              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+              task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
           (is (= {:command {:environment environment
                             :uris [(:uri executor)]
                             :user "test-user"
@@ -531,7 +531,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+              task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
           (is (= {:command {:environment environment
                             :uris []
                             :user "test-user"
@@ -568,7 +568,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "10.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+              task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
           (is (= {:command {:environment environment
                             :uris []
                             :user "test-user"
@@ -608,7 +608,7 @@
                            "COOK_JOB_CPUS" "1.0"
                            "COOK_JOB_MEM_MB" "200.0"
                            "COOK_JOB_UUID" (-> job-ent :job/uuid str)}
-              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+              task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
           (is (= {:command {:environment environment
                             :uris []
                             :user "test-user"
@@ -653,7 +653,7 @@
                            "EXECUTOR_MAX_MESSAGE_LENGTH" (:max-message-length executor)
                            "PROGRESS_REGEX_STRING" (:default-progress-regex-string executor)
                            "PROGRESS_SAMPLE_INTERVAL_MS" (:progress-sample-interval-ms executor)}
-              task-metadata (task/job->task-metadata mesos-run-as-user job-ent task-id nil)]
+              task-metadata (task/job->task-metadata nil mesos-run-as-user job-ent task-id)]
           (is (= {:command {:environment environment
                             :uris [(:uri executor)]
                             :user "test-user"
@@ -890,14 +890,14 @@
 (deftest test-merge-container-defaults
   (testing "does not add docker info if missing"
     (with-redefs [cc/container-defaults (constantly {:docker {:parameters {"foo" "bar"}}})]
-      (is (= {:mesos {:image "baz"}} (task/merge-container-defaults {:mesos {:image "baz"}} nil)))))
+      (is (= {:mesos {:image "baz"}} (task/merge-container-defaults nil {:mesos {:image "baz"}})))))
   (testing "adds volumes even when missing"
     (let [volumes [{:container-path "/foo"
                     :host-path "/foo"}]]
       (with-redefs [cc/container-defaults (constantly {:volumes volumes})]
         (is (= {:mesos {:image "baz"}
                 :volumes volumes}
-               (task/merge-container-defaults {:mesos {:image "baz"}} nil))))))
+               (task/merge-container-defaults nil {:mesos {:image "baz"}}))))))
   (testing "merges volumes"
     (with-redefs [cc/container-defaults (constantly {:volumes [{:host-path "/h/a"
                                                                 :container-path "/c/a"
@@ -911,26 +911,26 @@
                          :mode "rw"}
                         {:host-path "/mnt/app/data"
                          :mode "r"}]}
-             (task/merge-container-defaults {:docker {:image "foo"}} nil)))
+             (task/merge-container-defaults nil {:docker {:image "foo"}})))
       (is (= {:docker {:image "foo"}
               :volumes [{:host-path "/mnt/app"
                          :mode "rw"}
                         {:host-path "/h/a"
                          :container-path "/c/a"
                          :mode "rw"}]}
-             (task/merge-container-defaults {:docker {:image "foo"}
+             (task/merge-container-defaults nil
+                                            {:docker {:image "foo"}
                                              :volumes [{:host-path "/mnt/app"
-                                                        :mode "rw"}]}
-                                            nil)))
+                                                        :mode "rw"}]})))
       (is (= {:docker {:image "foo"}
               :volumes [{:host-path "/diff/a"
                          :container-path "/c/a"}
                         {:host-path "/mnt/app/data"
                          :mode "r"}]}
-             (task/merge-container-defaults {:docker {:image "foo"}
+             (task/merge-container-defaults nil
+                                            {:docker {:image "foo"}
                                              :volumes [{:host-path "/diff/a"
-                                                        :container-path "/c/a"}]}
-                                            nil)))
+                                                        :container-path "/c/a"}]})))
       (is (= {:docker {:image "foo"}
               :volumes [{:host-path "/diff/a"
                          :container-path "/c/a/b"}
@@ -939,7 +939,7 @@
                          :mode "rw"}
                         {:host-path "/mnt/app/data"
                          :mode "r"}]}
-             (task/merge-container-defaults {:docker {:image "foo"}
+             (task/merge-container-defaults nil
+                                            {:docker {:image "foo"}
                                              :volumes [{:host-path "/diff/a"
-                                                        :container-path "/c/a/b"}]}
-                                            nil))))))
+                                                        :container-path "/c/a/b"}]}))))))

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -139,7 +139,8 @@
                                                               mesos-heartbeat-chan#
                                                               trigger-chans#
                                                               {}
-                                                              {"no-pool" (async/chan 100)}))]
+                                                              {"no-pool" (async/chan 100)}
+                                                              {}))]
      (try
        (with-redefs [executor-config (constantly executor-config#)
                      completion/plugin completion/no-op


### PR DESCRIPTION
## Changes proposed in this PR

- moving the container defaults configuration from the top-level to the compute-cluster

## Why are we making these changes?

Not all compute clusters can use the same container defaults. For example, you might need to configure Mesos with one set of default volumes that don't exist and therefore don't work in k8s.
