### PR TITLE
Makes test_progress_update_submit more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -437,7 +437,7 @@ class CookTest(util.CookTest):
                                          env={progress_file_env: 'progress.txt'},
                                          executor=job_executor_type, max_runtime=60000)
         self.assertEqual(201, resp.status_code, msg=resp.content)
-
+        util.wait_for_job_in_statuses(self.cook_url, job_uuid, ['running', 'completed'])
         instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
         message = json.dumps(instance, sort_keys=True)
         self.assertIsNotNone(instance['output_url'], message)


### PR DESCRIPTION
## Changes proposed in this PR

- fixing flakiness accidentally introduced in #1331
- waiting for job to reach `running` or `completed` before calling `util.wait_for_sandbox_directory`

## Why are we making these changes?

As it turns out, `util.wait_for_sandbox_directory` has a custom wait timeout, so we have been seeing this test fail in Travis ever since #1331 got merged. This change lets us wait for the normal timeout until the job is either running or completed before we wait for the sandbox directory to show up.
