### PR TITLE
Fixes bugs in util.wait_for_instance, test_change_failed_retries

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1825,7 +1825,7 @@ class CookTest(util.CookTest):
         num_hosts = util.num_hosts_to_consider(self.cook_url)
         group = {'uuid': str(util.make_temporal_uuid()),
                  'host-placement': {'type': 'unique'}}
-        job_spec = {'group': group['uuid'], 'command': 'sleep 600'}
+        job_spec = {'group': group['uuid'], 'command': f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'}
         # Don't submit too many jobs for the test. If the cluster is larger than 9 hosts, only submit 10 jobs.
         num_jobs = min(num_hosts + 1, 10)
         uuids, resp = util.submit_jobs(self.cook_url, job_spec, num_jobs, groups=[group])

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1222,50 +1222,37 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, [job_uuid])
 
     def test_change_failed_retries(self):
-        job_specs = util.minimal_jobs(2, max_retries=1, command='sleep 60')
+        jobs = []
         try:
-            jobs, resp = util.submit_jobs(self.cook_url, job_specs)
-            self.assertEqual(resp.status_code, 201)
-            # wait for first job to start running, and kill it
-            job_uuid = jobs[0]
-            util.wait_for_job(self.cook_url, job_uuid, 'running')
-            util.kill_jobs(self.cook_url, [job_uuid])
+            failed_job = util.make_failed_job(self.cook_url, max_retries=1, command='sleep 60')
+            jobs.append(failed_job['uuid'])
+            second_job_uuid, resp = util.submit_job(self.cook_url, max_retries=1, command='sleep 60')
+            self.assertEqual(resp.status_code, 201, resp.text)
+            jobs.append(second_job_uuid)
 
-            def instance_query():
-                return util.query_jobs(self.cook_url, True, uuid=[job_uuid])
-
-            # Wait for the job (and its instances) to die
-            util.wait_until(instance_query, util.all_instances_killed)
-            job = util.load_job(self.cook_url, job_uuid)
-            self.assertEqual('failed', job['state'])
             # retry both jobs, but with the failed_only=true flag
             resp = util.retry_jobs(self.cook_url, retries=4, failed_only=True, jobs=jobs)
             self.assertEqual(201, resp.status_code, resp.text)
             jobs = util.query_jobs(self.cook_url, True, uuid=jobs).json()
+
             # We expect both jobs to be waiting or running now.
+
+            # The first job (which we killed and retried) should have 3 retries remaining
+            # (the attempt before resetting the total retries count is still included).
             job_details = f"Job details: {json.dumps(jobs[0], sort_keys=True, indent=2)}"
             self.logger.info(job_details)
             self.assertIn(jobs[0]['status'], ['waiting', 'running'], job_details)
-            non_mea_culpa_failure_exists = any(not i['reason_mea_culpa'] for i in jobs[0]['instances'])
-            if non_mea_culpa_failure_exists:
-                self.logger.info(f'Job {job_uuid} has a non-mea-culpa failure (because we killed it)')
-                # There was a non-mea-culpa failure on the first job, so:
-                # The first job (which we killed and retried) should have 3 retries remaining
-                # (the attempt before resetting the total retries count is still included).
-                self.assertEqual(3, jobs[0]['retries_remaining'], job_details)
-            else:
-                self.logger.info(f'Job {job_uuid} does not have a non-mea-culpa failure')
-                # There was no non-mea-culpa failure on the first job, so:
-                # We should now have the full 4 retries that we asked for.
-                self.assertEqual(4, jobs[0]['retries_remaining'], job_details)
+            self.assertEqual(4, jobs[0]['max_retries'], job_details)
+            self.assertEqual(3, jobs[0]['retries_remaining'], job_details)
 
             # The second job (which started with the default 1 retries)
             # should have 1 remaining since the failed_only flag was set.
             job_details = f"Job details: {json.dumps(jobs[1], sort_keys=True)}"
             self.assertIn(jobs[1]['status'], ['waiting', 'running'], job_details)
+            self.assertEqual(1, jobs[1]['max_retries'], job_details)
             self.assertEqual(1, jobs[1]['retries_remaining'], job_details)
         finally:
-            util.kill_jobs(self.cook_url, job_specs)
+            util.kill_jobs(self.cook_url, jobs)
 
     @unittest.skipIf(util.has_one_agent(), 'Test requires multiple agents')
     def test_cancel_instance(self):

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1015,7 +1015,7 @@ def wait_for_instance(cook_url, job_uuid, max_wait_ms=DEFAULT_TIMEOUT_MS, wait_i
 
     job = wait_until(lambda: load_job(cook_url, job_uuid), lambda j: len(instances_with_status(j)) >= 1,
                      max_wait_ms=max_wait_ms, wait_interval_ms=wait_interval_ms)
-    instance = job['instances'][0]
+    instance = instances_with_status(job)[0]
     instance['parent'] = job
     return instance
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -414,7 +414,8 @@ def settings(cook_url):
 @functools.lru_cache()
 def scheduler_info(cook_url):
     resp = session.get(f'{cook_url}/info', auth=None)
-    assert resp.status_code == 200
+    response_info = {'code': resp.status_code, 'msg': resp.content}
+    assert resp.status_code == 200, response_info
     return resp.json()
 
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -423,7 +423,7 @@ def docker_image():
 
 
 def get_default_cpus():
-    return float(os.getenv('COOK_DEFAULT_JOB_CPUS', 1.0))
+    return float(os.getenv('COOK_DEFAULT_JOB_CPUS', 0.5))
 
 
 def make_temporal_uuid():


### PR DESCRIPTION
## Changes proposed in this PR

1. in `wait_for_instance`, instead of returning the 0th instance, return the 0th instance that has the desired status
1. in `test_change_failed_retries`, don't assume that there was a non-mea-culpa failure on the job

## Why are we making these changes?

1. Despite the `wait_until` filtering on status, this function is always blindly returning the 0th instance, which can have a different status, causing tests to fail.
1. If the job fails with a mea-culpa reason, e.g. `Agent removed`, then it will have the full 4 retries instead of only 3.