### PR TITLE
Removes :type keys from state maps

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -319,10 +319,8 @@
         compute-cluster (->KubernetesComputeCluster api-client compute-cluster-name cluster-entity-id
                                                     (:match-trigger-chan trigger-chans)
                                                     exit-code-syncer-state (atom {}) (atom {})
-                                                    ; These :type keys are here to make it easier to trace provenance
-                                                    ; when debugging and exist for no other reason.
-                                                    (atom {:type :expected-state-map})
-                                                    (atom {:type :existing-state-map})
+                                                    (atom {})
+                                                    (atom {})
                                                     (atom nil)
                                                     namespace
                                                     scan-frequency-seconds)]


### PR DESCRIPTION
## Changes proposed in this PR

- removing `:type` keys from the existing and expected state maps

## Why are we making these changes?

These are actually being processed by downstream code, as if they were real states, which is not what we want.
