### PR TITLE
Make reconciler only reconcile mesos tasks.

### DIFF
--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -125,7 +125,7 @@ FLASK_APP=${PROJECT_DIR}/src/data_locality/service.py flask run --port=${DATA_LO
 
 # Seed running jobs, which are used to test the task reconciler
 cd ${SCHEDULER_DIR}
-lein exec -p datomic/data/seed_running_jobs.clj ${COOK_DATOMIC_URI_1}
+COOK_FRAMEWORK_ID=cook-framework-1 lein exec -p datomic/data/seed_running_jobs.clj ${COOK_DATOMIC_URI_1}
 
 # Start three cook schedulers.
 # We want one cluster with two cooks to run MasterSlaveTest, and a second cluster to run MultiClusterTest.
@@ -136,6 +136,7 @@ export COOK_EXECUTOR_COMMAND=${COOK_EXECUTOR_COMMAND}
 if [[ ! -z "${COOK_TEST_DOCKER_IMAGE}" ]]; then
     export COOK_TEST_DOCKER_IMAGE=${COOK_TEST_DOCKER_IMAGE}
 fi
+
 # Start one cook listening on port 12321, this will be the master of the "cook-framework-1" framework
 LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12321 COOK_SSL_PORT=12322 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12321.log" COOK_DEFAULT_POOL=${DEFAULT_POOL} lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
 # Start a second cook listening on port 22321, this will be the master of the "cook-framework-2" framework

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -105,7 +105,7 @@
         (future
           (try
             (sched/reconcile-jobs conn)
-            (sched/reconcile-tasks (d/db conn) driver pool->fenzo)
+            (sched/reconcile-tasks (d/db conn) compute-cluster driver pool->fenzo)
             (catch Exception e
               (log/error e "Reconciliation error")))))
       (reregistered
@@ -114,7 +114,7 @@
         (future
           (try
             (sched/reconcile-jobs conn)
-            (sched/reconcile-tasks (d/db conn) driver pool->fenzo)
+            (sched/reconcile-tasks (d/db conn) compute-cluster driver pool->fenzo)
             (catch Exception e
               (log/error e "Reconciliation error")))))
       ;; Ignore this--we can just wait for new offers
@@ -292,7 +292,7 @@
     container-defaults))
 
 ; Internal method
-(defn- mesos-cluster->compute-cluster-map-for-datomic
+(defn mesos-cluster->compute-cluster-map-for-datomic
   "Given a mesos cluster dictionary, determine the datomic entity it should correspond to."
   [{:keys [compute-cluster-name framework-id]}]
   {:compute-cluster/type :compute-cluster.type/mesos

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -926,16 +926,18 @@
 ;; TODO test that this fenzo recovery system actually works
 (defn reconcile-tasks
   "Finds all non-completed tasks, and has Mesos let us know if any have changed."
-  [db driver pool->fenzo]
+  [db compute-cluster driver pool->fenzo]
   (let [running-tasks (q '[:find ?task-id ?status ?slave-id
-                           :in $ [?status ...]
+                           :in $ [?status ...] ?compute-cluster-id
                            :where
                            [?i :instance/status ?status]
                            [?i :instance/task-id ?task-id]
-                           [?i :instance/slave-id ?slave-id]]
+                           [?i :instance/slave-id ?slave-id]
+                           [?i :instance/compute-cluster ?compute-cluster-id]]
                          db
                          [:instance.status/unknown
-                          :instance.status/running])
+                          :instance.status/running]
+                         (cc/db-id compute-cluster))
         sched->mesos {:instance.status/unknown :task-staging
                       :instance.status/running :task-running}]
     (when (seq running-tasks)


### PR DESCRIPTION
## Changes proposed in this PR

- Make reconciler only reconcile mesos tasks.

## Why are we making these changes?
Right now if you have kubernetes + mesos enabled, the mesos reconciler sees all these kubernetes jobs not running in mesos and kills them off. Make the mesos reconciler only look at jobs in the relevant compute cluster instead.

