### PR TITLE
Avoids matching onto nodes that have reached their pod limit

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2897,6 +2897,21 @@ class CookTest(util.CookTest):
             util.wait_for_jobs_in_statuses(self.cook_url, job_uuids, ['running', 'completed'])
             hosts = [util.wait_for_instance(self.cook_url, j)['hostname'] for j in job_uuids]
             host_count = Counter(hosts)
+            self.logger.info(host_count)
             self.assertLessEqual(2, len(host_count), hosts)
+
+            # def query_unscheduled():
+            #     resp = util.unscheduled_jobs(self.cook_url, job_uuid)[0][0]
+            #     placement_reasons = [reason for reason in resp['reasons']
+            #                          if reason['reason'] == reasons.COULD_NOT_PLACE_JOB]
+            #     self.logger.info(f"unscheduled_jobs response: {resp}")
+            #     return placement_reasons
+            #
+            # placement_reasons = util.wait_until(query_unscheduled, lambda r: len(r) > 0)
+            # self.assertEqual(1, len(placement_reasons), str(placement_reasons))
+            # reason = placement_reasons[0]
+            # data_locality_reasons = [r for r in reason['data']['reasons']
+            #                          if r['reason'] == 'data-locality-constraint']
+            # self.assertEqual(1, len(data_locality_reasons))
         finally:
             util.kill_jobs(self.cook_url, job_uuids)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2899,19 +2899,5 @@ class CookTest(util.CookTest):
             host_count = Counter(hosts)
             self.logger.info(host_count)
             self.assertLessEqual(2, len(host_count), hosts)
-
-            # def query_unscheduled():
-            #     resp = util.unscheduled_jobs(self.cook_url, job_uuid)[0][0]
-            #     placement_reasons = [reason for reason in resp['reasons']
-            #                          if reason['reason'] == reasons.COULD_NOT_PLACE_JOB]
-            #     self.logger.info(f"unscheduled_jobs response: {resp}")
-            #     return placement_reasons
-            #
-            # placement_reasons = util.wait_until(query_unscheduled, lambda r: len(r) > 0)
-            # self.assertEqual(1, len(placement_reasons), str(placement_reasons))
-            # reason = placement_reasons[0]
-            # data_locality_reasons = [r for r in reason['data']['reasons']
-            #                          if r['reason'] == 'data-locality-constraint']
-            # self.assertEqual(1, len(data_locality_reasons))
         finally:
             util.kill_jobs(self.cook_url, job_uuids)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -427,7 +427,7 @@ def docker_image():
 
 
 def get_default_cpus():
-    return float(os.getenv('COOK_DEFAULT_JOB_CPUS', 1.0))
+    return float(os.getenv('COOK_DEFAULT_JOB_CPUS', 0.5))
 
 
 def make_temporal_uuid():
@@ -1350,13 +1350,19 @@ def max_mesos_slave_cpus(mesos_url):
 
 
 @functools.lru_cache()
-def get_kubernetes_compute_cluster():
+def get_kubernetes_compute_clusters():
     cook_url = retrieve_cook_url()
     _wait_for_cook(cook_url)
     init_cook_session(cook_url)
     compute_clusters = settings(cook_url)['compute-clusters']
     kubernetes_compute_clusters = [cc for cc in compute_clusters
                                    if cc['factory-fn'] == 'cook.kubernetes.compute-cluster/factory-fn']
+    return kubernetes_compute_clusters
+
+
+@functools.lru_cache()
+def get_kubernetes_compute_cluster():
+    kubernetes_compute_clusters = get_kubernetes_compute_clusters()
     if len(kubernetes_compute_clusters) > 0:
         return kubernetes_compute_clusters[0]
     else:

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -48,7 +48,10 @@
     "Returns true if this compute cluster makes use of the Cook executor for running tasks")
 
   (container-defaults [this]
-    "Default values to use for containers launched in this compute cluster"))
+    "Default values to use for containers launched in this compute cluster")
+
+  (max-tasks-per-host [this]
+    "The maximum number of tasks that a given host should run at the same time"))
 
 (defn safe-kill-task
   "A safe version of kill task that never throws. This reduces the risk that errors in one compute cluster propagate and cause problems in another compute cluster."

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -53,8 +53,8 @@
   (max-tasks-per-host [this]
     "The maximum number of tasks that a given host should run at the same time")
 
-  (num-tasks-on-host [this]
-    "TODO(DPO)"))
+  (num-tasks-on-host [this hostname]
+    "The number of tasks currently running on the given hostname"))
 
 (defn safe-kill-task
   "A safe version of kill task that never throws. This reduces the risk that errors in one compute cluster propagate and cause problems in another compute cluster."

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -51,7 +51,10 @@
     "Default values to use for containers launched in this compute cluster")
 
   (max-tasks-per-host [this]
-    "The maximum number of tasks that a given host should run at the same time"))
+    "The maximum number of tasks that a given host should run at the same time")
+
+  (num-tasks-on-host [this]
+    "TODO(DPO)"))
 
 (defn safe-kill-task
   "A safe version of kill task that never throws. This reduces the risk that errors in one compute cluster propagate and cause problems in another compute cluster."

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -200,17 +200,28 @@
           (-> cook-pool-taint first .getValue)
       "no-pool")))
 
+(defn pod->node-name
+  "Given a pod, returns the node name on the pod spec"
+  [^V1Pod pod]
+  (-> pod .getSpec .getNodeName))
+
 (defn node-schedulable?
   "Can we schedule on a node. For now, yes, unless there are other taints on it. TODO: Incorporate other node-health measures here."
-  [^V1Node node]
+  [^V1Node node pod-count-capacity pods]
   (if (nil? node)
     false
     (let [taints-on-node (or (some-> node .getSpec .getTaints) [])
           other-taints (remove #(= "cook-pool" (.getKey %)) taints-on-node)
-          schedulable (zero? (count other-taints))]
+          schedulable (zero? (count other-taints))
+          node-name (some-> node .getMetadata .getName)
+          node-name->pods (group-by pod->node-name pods)
+          num-pods-on-node (-> node-name->pods (get node-name []) count)
+          below-pod-count-capacity (< num-pods-on-node pod-count-capacity)]
       (when-not schedulable
-        (log/info "Filtering out" (some-> node .getMetadata .getName) "because it has taints" other-taints))
-      schedulable)))
+        (log/info "Filtering out" node-name "because it has taints" other-taints))
+      (when-not below-pod-count-capacity
+        (log/info "Filtering out" node-name "because it has reached its pod count capacity of" pod-count-capacity))
+      (and schedulable below-pod-count-capacity))))
 
 (defn get-capacity
   "Given a map from node-name to node, generate a map from node-name->resource-type-><capacity>"
@@ -225,7 +236,7 @@
   When accounting for resources, we use resource requests to determine how much is used, not limits.
   See https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container"
   [namespaced-pod-name->pod]
-  (let [node-name->pods (group-by (fn [^V1Pod p] (-> p .getSpec .getNodeName))
+  (let [node-name->pods (group-by pod->node-name
                                   (vals namespaced-pod-name->pod))
         node-name->requests (pc/map-vals (fn [pods]
                                            (->> pods

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -206,7 +206,7 @@
   (-> pod .getSpec .getNodeName))
 
 (defn num-pods-on-node
-  "TODO(DPO)"
+  "Returns the number of pods assigned to the given node"
   [node-name pods]
   (let [node-name->pods (group-by pod->node-name pods)]
     (-> node-name->pods (get node-name []) count)))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -167,10 +167,10 @@
                   :command
                   :user)))
 
-(defn- all-pods
-  [compute-cluster all-pods-atom]
+(defn all-pods
+  [compute-cluster pods]
   (let [starting-pods (controller/starting-namespaced-pod-name->pod compute-cluster)]
-    (-> @all-pods-atom (merge starting-pods) vals)))
+    (-> pods (merge starting-pods) vals)))
 
 (defrecord KubernetesComputeCluster [^ApiClient api-client name entity-id match-trigger-chan exit-code-syncer-state
                                      all-pods-atom current-nodes-atom expected-state-map existing-state-map
@@ -219,7 +219,7 @@
 
   (pending-offers [this pool-name]
     (let [nodes @current-nodes-atom
-          pods (all-pods this all-pods-atom)
+          pods (all-pods this @all-pods-atom)
           offers-all-pools (generate-offers this nodes pods)
           ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
           ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
@@ -240,7 +240,7 @@
   (max-tasks-per-host [_] max-pods-per-node)
 
   (num-tasks-on-host [this hostname]
-    (->> all-pods-atom
+    (->> @all-pods-atom
          (all-pods this)
          (api/num-pods-on-node hostname))))
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -240,8 +240,9 @@
   (max-tasks-per-host [_] max-pods-per-node)
 
   (num-tasks-on-host [this hostname]
-    (let [pods (all-pods this all-pods-atom)]
-      (api/num-pods-on-node hostname pods))))
+    (->> all-pods-atom
+         (all-pods this)
+         (api/num-pods-on-node hostname))))
 
 (defn get-or-create-cluster-entity-id
   [conn compute-cluster-name]

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -289,7 +289,9 @@
   (use-cook-executor? [_] true)
 
   (container-defaults [_]
-    container-defaults))
+    container-defaults)
+
+  (max-tasks-per-host [_]))
 
 ; Internal method
 (defn mesos-cluster->compute-cluster-map-for-datomic

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -291,7 +291,9 @@
   (container-defaults [_]
     container-defaults)
 
-  (max-tasks-per-host [_]))
+  (max-tasks-per-host [_])
+
+  (num-tasks-on-host [_ _]))
 
 ; Internal method
 (defn mesos-cluster->compute-cluster-map-for-datomic

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -316,8 +316,7 @@
                  (remove nil?)
                  (map fenzoize-job-constraint))
             launch-max-tasks-constraint (conj (build-launch-max-tasks-constraint))
-            true (conj (build-max-tasks-per-host-constraint))
-            )))
+            true (conj (build-max-tasks-per-host-constraint)))))
 
 (defn build-rebalancer-reservation-constraint
   "Constructs a rebalancer-reservation-constraint"

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -270,12 +270,12 @@
             vm-attributes (get-vm-lease-attr-map vm-resources)
             max-per-host (get vm-attributes "COOK_MAX_TASKS_PER_HOST")]
         (if max-per-host
-          (let [num-running (-> target-vm .getRunningTasks count)
+          (let [num-running (get vm-attributes "COOK_NUM_TASKS_ON_HOST")
                 num-assigned (-> target-vm .getTasksCurrentlyAssigned count)
                 num-total (+ num-running num-assigned)]
             (ConstraintEvaluator$Result.
               (< num-total max-per-host)
-              "Host is already running or assigned the maximum number of tasks"))
+              "Host already has the maximum number of tasks"))
           (ConstraintEvaluator$Result.
             true
             ""))))))

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -25,10 +25,13 @@
             [cook.tools :as util]
             [cook.rate-limit :as ratelimit]
             [swiss.arrows :refer :all])
-  (:import com.netflix.fenzo.VirtualMachineLease
-           java.util.Date
-    ; TODO(DPO): Fix these imports
-           (com.netflix.fenzo ConstraintEvaluator VirtualMachineCurrentState ConstraintEvaluator$Result TaskRequest TaskTrackerState)))
+  (:import (com.netflix.fenzo ConstraintEvaluator
+                              ConstraintEvaluator$Result
+                              TaskRequest
+                              TaskTrackerState
+                              VirtualMachineCurrentState
+                              VirtualMachineLease)
+           java.util.Date))
 
 ;; Wisdom:
 ;; * This code expects that attributes COOK_GPU? and HOSTNAME are set for all
@@ -257,7 +260,8 @@
               (str "Hit the global rate limit"))))))))
 
 (defn build-max-tasks-per-host-constraint
-  "TODO(DPO)"
+  "Returns a Fenzo constraint that ensures that we don't
+  match more tasks per host than is allowed (configured)"
   []
   (reify ConstraintEvaluator
     (getName [_] "max_tasks_per_host")

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -89,7 +89,10 @@
                          "COOK_GPU?" (-> offer
                                          (offer-resource-scalar "gpus")
                                          (or 0.0)
-                                         pos?)}]
+                                         pos?)
+                         "COOK_MAX_TASKS_PER_HOST" (-> offer
+                                                       :compute-cluster
+                                                       cc/max-tasks-per-host)}]
     (merge mesos-attributes cook-attributes)))
 
 (timers/deftimer [cook-mesos scheduler handle-status-update-duration])

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -84,13 +84,15 @@
                                                         ; Default
                                                         (:value %))))
                               (into {}))
-        cook-attributes {"HOSTNAME" hostname
-                         "COOK_GPU?" (-> offer
-                                         (offer-resource-scalar "gpus")
-                                         (or 0.0)
-                                         pos?)
-                         "COOK_MAX_TASKS_PER_HOST" (cc/max-tasks-per-host compute-cluster)
-                         "COOK_NUM_TASKS_ON_HOST" (cc/num-tasks-on-host compute-cluster hostname)}]
+        cook-attributes (cond->
+                          {"HOSTNAME" hostname
+                           "COOK_GPU?" (-> offer
+                                           (offer-resource-scalar "gpus")
+                                           (or 0.0)
+                                           pos?)}
+                          compute-cluster
+                          (assoc "COOK_MAX_TASKS_PER_HOST" (cc/max-tasks-per-host compute-cluster)
+                                 "COOK_NUM_TASKS_ON_HOST" (cc/num-tasks-on-host compute-cluster hostname)))]
     (merge mesos-attributes cook-attributes)))
 
 (timers/deftimer [cook-mesos scheduler handle-status-update-duration])

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -465,7 +465,7 @@
 
 
 (defn pod-helper [pod-name node-name & requests]
-  "Make a fake node for kubernetes unit tests"
+  "Make a fake pod for kubernetes unit tests"
   (let [pod (V1Pod.)
         metadata (V1ObjectMeta.)
         spec (V1PodSpec.)]

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -8,34 +8,34 @@
 
 (deftest test-get-consumption
   (testing "correctly computes consumption for a single pod"
-    (let [pod-name->pod {"podA" (tu/pod-helper "podA" "hostA" {:cpus 1.0 :mem 100.0})}]
+    (let [pods [(tu/pod-helper "podA" "hostA" {:cpus 1.0 :mem 100.0})]]
       (is (= {"hostA" {:cpus 1.0
                        :mem 100.0}}
-             (api/get-consumption pod-name->pod)))))
+             (api/get-consumption pods)))))
 
   (testing "correctly computes consumption for a pod with multiple containers"
-    (let [pod-name->pod {"podA" (tu/pod-helper "podA" "hostA"
-                                            {:cpus 1.0 :mem 100.0}
-                                            {:cpus 1.0 :mem 0.0}
-                                            {:mem 100.0})}]
+    (let [pods [(tu/pod-helper "podA" "hostA"
+                               {:cpus 1.0 :mem 100.0}
+                               {:cpus 1.0 :mem 0.0}
+                               {:mem 100.0})]]
       (is (= {"hostA" {:cpus 2.0
                        :mem 200.0}}
-             (api/get-consumption pod-name->pod)))))
+             (api/get-consumption pods)))))
 
   (testing "correctly aggregates pods by node name"
-    (let [pod-name->pod {"podA" (tu/pod-helper "podA" "hostA"
-                                            {:cpus 1.0 :mem 100.0})
-                         "podB" (tu/pod-helper "podB" "hostA"
-                                            {:cpus 1.0})
-                         "podC" (tu/pod-helper "podC" "hostB"
-                                            {:cpus 1.0}
-                                            {:mem 100.0})
-                         "podD" (tu/pod-helper "podD" "hostC"
-                                            {:cpus 1.0})}]
+    (let [pods [(tu/pod-helper "podA" "hostA"
+                               {:cpus 1.0 :mem 100.0})
+                (tu/pod-helper "podB" "hostA"
+                               {:cpus 1.0})
+                (tu/pod-helper "podC" "hostB"
+                               {:cpus 1.0}
+                               {:mem 100.0})
+                (tu/pod-helper "podD" "hostC"
+                               {:cpus 1.0})]]
       (is (= {"hostA" {:cpus 2.0 :mem 100.0}
               "hostB" {:cpus 1.0 :mem 100.0}
               "hostC" {:cpus 1.0 :mem 0.0}}
-             (api/get-consumption pod-name->pod))))))
+             (api/get-consumption pods))))))
 
 (deftest test-get-capacity
   (let [node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 100.0 nil)

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -98,8 +98,7 @@
                                                                          {:cpus 1.0 :mem 1100.0})
                          {:namespace "cook" :name task-1-id} (tu/pod-helper task-1-id "my.fake.host"
                                                                             {:cpus 0.1 :mem 10.0})}
-          all-offers (kcc/generate-offers compute-cluster node-name->node pod-name->pod
-                                      (controller/starting-namespaced-pod-name->pod compute-cluster))
+          all-offers (kcc/generate-offers compute-cluster node-name->node (kcc/all-pods compute-cluster pod-name->pod))
           offers (get all-offers "no-pool")]
       (is (= 4 (count offers)))
       (let [offer (first (filter #(= "nodeA" (:hostname %))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -43,7 +43,7 @@
       (testing "static namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                              {:kind :static :namespace "cook"} nil)
+                                                              {:kind :static :namespace "cook"} nil nil)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -58,7 +58,7 @@
       (testing "per-user namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                              {:kind :per-user} nil)
+                                                              {:kind :per-user} nil nil)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -75,7 +75,7 @@
     (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")
           compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                           (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                          {:kind :static :namespace "cook"} nil)
+                                                          {:kind :static :namespace "cook"} nil 3)
           node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 nil)
                            "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 nil)
                            "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil)


### PR DESCRIPTION
## Changes proposed in this PR

- allowing a configurable max number of pods per node for k8s compute clusters
- filtering out nodes that are not below that threshold
- adding a new Fenzo `ConstraintEvaluator`, `"max_tasks_per_host"`, that enforces the constraint while matching

## Why are we making these changes?

We need to be able to limit the number of pods Cook will attempt to start up per node.

## `/unscheduled_jobs`

This is an example of what the `/unscheduled_jobs` output shows for a job that is hitting the new constraint:

```
      {
        "reason": "The job couldn't be placed on any available hosts.",
        "data": {
          "reasons": [
            {
              "reason": "max_tasks_per_host",
              "host_count": 1
            }
          ]
        }
      }
```