### PR TITLE
Fixes incorrect rate-limit reason in /unscheduled_jobs

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -563,8 +563,9 @@
                              (map util/job->usage)
                              (reduce (partial merge-with +))))))))
 
-;Shared as we use this for unscheduled too.
-(defonce pool->user->number-jobs (atom {}))
+; This is used by the /unscheduled_jobs code to determine whether
+; or not to report rate-limiting as a reason for being pending
+(defonce pool->user->num-rate-limited-jobs (atom {}))
 
 (defn pending-jobs->considerable-jobs
   "Limit the pending jobs to considerable jobs based on usage and quota.
@@ -594,7 +595,7 @@
              (take num-considerable)
              ; Force this to be taken eagerly so that the log line is accurate.
              (doall))]
-    (swap! pool->user->number-jobs update pool-name (constantly @user->rate-limit-count))
+    (swap! pool->user->num-rate-limited-jobs update pool-name (constantly @user->rate-limit-count))
     (log/info "Users whose job launches are rate-limited " @user->rate-limit-count "( enforcing =" enforcing-job-launch-rate-limit? ")")
     considerable-jobs))
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -594,7 +594,7 @@
              (take num-considerable)
              ; Force this to be taken eagerly so that the log line is accurate.
              (doall))]
-    (swap! pool->user->number-jobs update pool-name (constantly @user->number-jobs))
+    (swap! pool->user->number-jobs update pool-name (constantly @user->rate-limit-count))
     (log/info "Users whose job launches are rate-limited " @user->rate-limit-count "( enforcing =" enforcing-job-launch-rate-limit? ")")
     considerable-jobs))
 

--- a/scheduler/src/cook/unscheduled.clj
+++ b/scheduler/src/cook/unscheduled.clj
@@ -152,11 +152,11 @@
   "Return the appropriate error message if a user's job is unscheduled because they're over the job launch rate limit threshold"
   [{:keys [job/user]}]
   (let [enforcing-job-launch-rate-limit? (ratelimit/enforce? ratelimit/job-launch-rate-limiter)
-        num-ratelimited (->> @scheduler/pool->user->number-jobs
+        num-ratelimited (->> @scheduler/pool->user->num-rate-limited-jobs
                              vals
                              (map #(get % user 0))
                              (reduce + 0))
-        being-ratelimited? (not (zero? num-ratelimited))
+        being-ratelimited? (pos? num-ratelimited)
         {:keys [tokens-replenished-per-minute]} ratelimit/job-launch-rate-limiter]
     (when (and enforcing-job-launch-rate-limit? being-ratelimited?)
       ["You are currently rate limited on how many jobs you launch per minute."

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1292,27 +1292,27 @@
             user->quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}}
             num-considerable 5]
         (with-redefs [launch-plugin/plugin-object cook.test.testutil/defer-launch-plugin]
-          (reset! sched/pool->user->number-jobs {})
+          (reset! sched/pool->user->num-rate-limited-jobs {})
           (is (= [] ; Everything should be deferred
                  (sched/pending-jobs->considerable-jobs
                    (d/db conn) non-gpu-jobs user->quota user->usage num-considerable nil)))
-          (is (= {nil {}} @sched/pool->user->number-jobs)))))
+          (is (= {nil {}} @sched/pool->user->num-rate-limited-jobs)))))
 
     ;; Cache expired, so when we run this time, it's found (and will be cached as 'accepted'
     (testing "jobs inside usage quota"
       (let [user->usage {test-user {:count 1, :cpus 2, :mem 1024, :gpus 0}}
             user->quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}}
             num-considerable 5]
-        (reset! sched/pool->user->number-jobs {})
+        (reset! sched/pool->user->num-rate-limited-jobs {})
         (is (= non-gpu-jobs
                (sched/pending-jobs->considerable-jobs
                  (d/db conn) non-gpu-jobs user->quota user->usage num-considerable nil)))
-        (is (= {nil {}} @sched/pool->user->number-jobs))
-        (reset! sched/pool->user->number-jobs {})
+        (is (= {nil {}} @sched/pool->user->num-rate-limited-jobs))
+        (reset! sched/pool->user->num-rate-limited-jobs {})
         (is (= gpu-jobs
                (sched/pending-jobs->considerable-jobs
                  (d/db conn) gpu-jobs user->quota user->usage num-considerable nil)))
-        (is (= {nil {}} @sched/pool->user->number-jobs))))
+        (is (= {nil {}} @sched/pool->user->num-rate-limited-jobs))))
 
     (testing "jobs inside usage quota, but beyond rate limit"
       ;; Jobs inside of usage quota, but beyond rate limit, so should return no considerable jobs.
@@ -1322,16 +1322,16 @@
         (with-redefs [rate-limit/job-launch-rate-limiter
                       (rate-limit/create-job-launch-rate-limiter job-launch-rate-limit-config-for-testing)
                       rate-limit/get-token-count! (constantly 1)]
-          (reset! sched/pool->user->number-jobs {})
+          (reset! sched/pool->user->num-rate-limited-jobs {})
           (is (= [job-1]
                  (sched/pending-jobs->considerable-jobs
                    (d/db conn) non-gpu-jobs user->quota user->usage num-considerable nil)))
-          (is (= {nil {test-user 3}} @sched/pool->user->number-jobs))
-          (reset! sched/pool->user->number-jobs {})
+          (is (= {nil {test-user 3}} @sched/pool->user->num-rate-limited-jobs))
+          (reset! sched/pool->user->num-rate-limited-jobs {})
           (is (= [job-5]
                  (sched/pending-jobs->considerable-jobs
                    (d/db conn) gpu-jobs user->quota user->usage num-considerable nil)))
-          (is (= {nil {test-user 1}} @sched/pool->user->number-jobs)))))
+          (is (= {nil {test-user 1}} @sched/pool->user->num-rate-limited-jobs)))))
 
     (testing "jobs inside usage quota limited by num-considerable of 3"
       (let [user->usage {test-user {:count 1, :cpus 2, :mem 1024, :gpus 0}}

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1292,21 +1292,27 @@
             user->quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}}
             num-considerable 5]
         (with-redefs [launch-plugin/plugin-object cook.test.testutil/defer-launch-plugin]
+          (reset! sched/pool->user->number-jobs {})
           (is (= [] ; Everything should be deferred
                  (sched/pending-jobs->considerable-jobs
-                   (d/db conn) non-gpu-jobs user->quota user->usage num-considerable nil))))))
+                   (d/db conn) non-gpu-jobs user->quota user->usage num-considerable nil)))
+          (is (= {nil {}} @sched/pool->user->number-jobs)))))
 
     ;; Cache expired, so when we run this time, it's found (and will be cached as 'accepted'
     (testing "jobs inside usage quota"
       (let [user->usage {test-user {:count 1, :cpus 2, :mem 1024, :gpus 0}}
             user->quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}}
             num-considerable 5]
+        (reset! sched/pool->user->number-jobs {})
         (is (= non-gpu-jobs
                (sched/pending-jobs->considerable-jobs
                  (d/db conn) non-gpu-jobs user->quota user->usage num-considerable nil)))
+        (is (= {nil {}} @sched/pool->user->number-jobs))
+        (reset! sched/pool->user->number-jobs {})
         (is (= gpu-jobs
                (sched/pending-jobs->considerable-jobs
-                 (d/db conn) gpu-jobs user->quota user->usage num-considerable nil)))))
+                 (d/db conn) gpu-jobs user->quota user->usage num-considerable nil)))
+        (is (= {nil {}} @sched/pool->user->number-jobs))))
 
     (testing "jobs inside usage quota, but beyond rate limit"
       ;; Jobs inside of usage quota, but beyond rate limit, so should return no considerable jobs.
@@ -1316,12 +1322,16 @@
         (with-redefs [rate-limit/job-launch-rate-limiter
                       (rate-limit/create-job-launch-rate-limiter job-launch-rate-limit-config-for-testing)
                       rate-limit/get-token-count! (constantly 1)]
+          (reset! sched/pool->user->number-jobs {})
           (is (= [job-1]
                  (sched/pending-jobs->considerable-jobs
                    (d/db conn) non-gpu-jobs user->quota user->usage num-considerable nil)))
+          (is (= {nil {test-user 3}} @sched/pool->user->number-jobs))
+          (reset! sched/pool->user->number-jobs {})
           (is (= [job-5]
                  (sched/pending-jobs->considerable-jobs
-                   (d/db conn) gpu-jobs user->quota user->usage num-considerable nil))))))
+                   (d/db conn) gpu-jobs user->quota user->usage num-considerable nil)))
+          (is (= {nil {test-user 1}} @sched/pool->user->number-jobs)))))
 
     (testing "jobs inside usage quota limited by num-considerable of 3"
       (let [user->usage {test-user {:count 1, :cpus 2, :mem 1024, :gpus 0}}

--- a/scheduler/test/cook/test/unscheduled.clj
+++ b/scheduler/test/cook/test/unscheduled.clj
@@ -134,7 +134,7 @@
             running-job-uuids [(-> running-job-ent1 :job/uuid str)
                                (-> running-job-ent2 :job/uuid str)]
             reasons
-            (with-redefs [scheduler/pool->user->number-jobs (atom {:pool0 {"mforsythr" 3}})
+            (with-redefs [scheduler/pool->user->num-rate-limited-jobs (atom {:pool0 {"mforsythr" 3}})
                           rate-limit/job-launch-rate-limiter
                           (rate-limit/create-job-launch-rate-limiter
                             {:settings {:rate-limit {:expire-minutes 180


### PR DESCRIPTION
## Changes proposed in this PR

- using `user->rate-limit-count` instead of `user->number-jobs` for determining whether to report rate-limiting as a reason why the job is not being scheduled

## Why are we making these changes?

Fixes #1356 

Please see the issue above for more context.