### PR TITLE
fixes the compute-cluster argument in mesos-scheduler call to receive-offers

### DIFF
--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -158,14 +158,14 @@
                   (if-let [offers-chan (get pool->offers-chan pool-name)]
                     (do
                       (log/info "Processing" offer-count "offer(s) for known pool" pool-name)
-                      (sched/receive-offers offers-chan match-trigger-chan this pool-name offers))
+                      (sched/receive-offers offers-chan match-trigger-chan compute-cluster pool-name offers))
                     (do
                       (log/warn "Declining" offer-count "offer(s) for non-existent pool" pool-name)
                       (sched/decline-offers-safe compute-cluster offers)))
                   (if-let [offers-chan (get pool->offers-chan "no-pool")]
                     (do
                       (log/info "Processing" offer-count "offer(s) for pool" pool-name "(not using pools)")
-                      (sched/receive-offers offers-chan match-trigger-chan this pool-name offers))
+                      (sched/receive-offers offers-chan match-trigger-chan compute-cluster pool-name offers))
                     (do
                       (log/error "Declining" offer-count "offer(s) for pool" pool-name "(missing no-pool offer chan)")
                       (sched/decline-offers-safe compute-cluster offers))))))


### PR DESCRIPTION


## Changes proposed in this PR

- fixes the compute-cluster argument in mesos-scheduler call to receive-offers

## Why are we making these changes?

Passing incorrect argument causes the receive offer code to fail which eventually leads to no scheduling of jobs.

