### PR TITLE
populates the user parameter in docker container parameters

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -368,7 +368,7 @@ class CookTest(util.CookTest):
         self.assertEqual(False, docker['force-pull-image'])
         # the user parameter is added when missing
         self.assertEqual(3, len(docker['parameters']))
-        self.assertTrue(next(True for p in docker['parameters'] if p['key'] == 'env'))
+        self.assertTrue(any(p['key'] == 'user' for p in docker['parameters']))
         self.assertEqual('FOO=bar', next(p['value'] for p in docker['parameters'] if p['key'] == 'env'))
         self.assertEqual('/var/lib/pqr', next(p['value'] for p in docker['parameters'] if p['key'] == 'workdir'))
         self.assertLessEqual(4, len(volumes))

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -366,7 +366,9 @@ class CookTest(util.CookTest):
         self.assertEqual(docker_image, docker['image'])
         self.assertEqual('HOST', docker['network'])
         self.assertEqual(False, docker['force-pull-image'])
-        self.assertEqual(2, len(docker['parameters']))
+        # the user parameter is added when missing
+        self.assertEqual(3, len(docker['parameters']))
+        self.assertTrue(next(True for p in docker['parameters'] if p['key'] == 'env'))
         self.assertEqual('FOO=bar', next(p['value'] for p in docker['parameters'] if p['key'] == 'env'))
         self.assertEqual('/var/lib/pqr', next(p['value'] for p in docker['parameters'] if p['key'] == 'workdir'))
         self.assertLessEqual(4, len(volumes))

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -427,6 +427,10 @@ def docker_image():
     return os.getenv('COOK_TEST_DOCKER_IMAGE')
 
 
+def docker_working_directory():
+    return os.getenv('COOK_TEST_DOCKER_WORKING_DIRECTORY')
+
+
 def get_default_cpus():
     return float(os.getenv('COOK_DEFAULT_JOB_CPUS', 0.5))
 
@@ -459,12 +463,17 @@ def minimal_job(**kwargs):
     }
     image = docker_image()
     if image:
+        work_dir = docker_working_directory()
+        docker_parameters = []
+        if work_dir:
+            docker_parameters.append({'key': 'workdir', 'value': work_dir})
         job['container'] = {
             'type': 'docker',
             'docker': {
                 'image': image,
                 'network': 'HOST',
-                'force-pull-image': False
+                'force-pull-image': False,
+                'parameters': docker_parameters
             }
         }
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -88,7 +88,6 @@
                                com.amazonaws/aws-java-sdk]] ; Brings in a lot of dependencies
 
                  ;;External system integrations
-                 [me.raynes/conch "0.5.2"]
                  [org.clojure/tools.nrepl "0.2.3"]
 
                  ;;Ring

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -333,7 +333,8 @@
                         (filter (fn [{:keys [key]}] (= key "user")))
                         first)
         [uid gid] (if user-param
-                    ;; TODO validate whether the user can run with these credentials
+                    ;; TODO new jobs should always have the user with correct credentials;
+                    ;; TODO validate and fail when the user parameter is missing.
                     (let [[uid gid] (str/split (:value user-param) #":")]
                       [(Long/parseLong uid) (Long/parseLong gid)])
                     [(util/user->user-id user) (util/user->group-id user)])

--- a/simulator/resources/job_schedule.edn
+++ b/simulator/resources/job_schedule.edn
@@ -99,11 +99,6 @@
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id #db/id[:db.part/db]
-    :db/ident :job/docker?
-    :db/valueType :db.type/boolean
-    :db/cardinality :db.cardinality/one
-    :db.install/_attribute :db.part/db}
-   {:db/id #db/id[:db.part/db]
     :db/ident :job/exit-code
     :db/valueType :db.type/long
     :db/cardinality :db.cardinality/one

--- a/simulator/src/main/cook/sim/runner.clj
+++ b/simulator/src/main/cook/sim/runner.clj
@@ -31,7 +31,6 @@
                     duration :job/duration
                     mem :job/memory
                     cpu :job/cpu
-                    docker? :job/docker?
                     exit-code :job/exit-code}]
   (let [cmd (str "sleep " duration "; exit " exit-code)
         group-id (@group-ids-atom group)
@@ -47,12 +46,6 @@
                               :cpus cpu
                               :uuid job-id
                               :command cmd}
-                             (when docker?
-                               {:container {:type "docker"
-                                            :docker {:image "python:3"}
-                                            :volumes [{:container-path "/host-tmp"
-                                                       :host-path "/tmp"
-                                                       :mode "RW"}]}})
                              (when group-id {:group group-id}))]})]
     (println "scheduling cook job with payload: " body)
     (http/post (str cook-uri "/rawscheduler")

--- a/simulator/src/main/cook/sim/schedule.clj
+++ b/simulator/src/main/cook/sim/schedule.clj
@@ -41,7 +41,6 @@
                               :job/duration (:duration job-spec)
                               :job/memory (:memory job-spec)
                               :job/cpu (:cpu job-spec)
-                              :job/docker? (:docker? job-spec)
                               :job/exit-code (:exit-code job-spec)}
                        (:group job-spec) (assoc :job/group (:group job-spec)))]))
 
@@ -80,7 +79,6 @@
    :duration (random-long (:job-duration profile))
    :memory (random-long (:job-memory profile))
    :cpu (float (random-long (:job-cpu profile)))
-   :docker? (<= (rand) (:docker-tendency profile))
    ;; TODO simulate jobs that will always fail, or fail sometimes?
    :exit-code 0})
 


### PR DESCRIPTION


## Changes proposed in this PR

- populates the user parameter in docker container parameters when not provided explicitly in the job
- removes dependency on me.raynes/conch

## Why are we making these changes?

When docker user parameters are not provided, the command runs as root inside the docker container. Instead, we would like to limit the container to always run as the user on the job.

