### PR TITLE
Remove missing plugin from config.edn

### DIFF
--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -39,8 +39,7 @@
            :job-launch-filter {:age-out-last-seen-deadline-minutes 10
                                :age-out-first-seen-deadline-minutes 10000
                                :age-out-seen-count 10
-                               :factory-fn "cook.plugins.demo-plugin/launch-factory"}
-           :job-adjuster {:factory-fn "cook.plugins.demo-plugin/adjuster-factory"}}
+                               :factory-fn "cook.plugins.demo-plugin/launch-factory"}}
  :hostname #config/env "COOK_HOSTNAME"
  :log {:file #config/env "COOK_LOG_FILE"
        :levels {"datomic.db" :warn


### PR DESCRIPTION
## Changes proposed in this PR

- Delete `job-adjuster` plugin config from config.edn

## Why are we making these changes?

The `job-adjuster` plugin implementation doesn't exist.