### PR TITLE
disable test that can't run in travis

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -96,6 +96,7 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 
+    @pytest.mark.travis_skip
     def test_output_url(self):
         job_executor_type = util.get_job_executor_type()
         job_uuid, resp = util.submit_job(self.cook_url,

--- a/integration/travis/run_integration.sh
+++ b/integration/travis/run_integration.sh
@@ -177,8 +177,8 @@ export COOK_SLAVE_URL=http://localhost:12323
 export COOK_MESOS_LEADER_URL=${MINIMESOS_MASTER}
 {
     echo "Using Mesos leader URL: ${COOK_MESOS_LEADER_URL}"
-    pytest -n4 -v --color=no --timeout-method=thread --boxed -m "not serial" || test_failures=true
-    pytest -n0 -v --color=no --timeout-method=thread --boxed -m "serial" || test_failures=true
+    pytest -n4 -v --color=no --timeout-method=thread --boxed -m "not serial and not travis_skip" || test_failures=true
+    pytest -n0 -v --color=no --timeout-method=thread --boxed -m "serial and not travis_skip" || test_failures=true
 } &> >(tee ./log/pytest.log)
  
 


### PR DESCRIPTION
## Changes proposed in this PR

- add functionality to disable integration tests in travis using travis_skip test marker

## Why are we making these changes?

Some integration tests require too much modification to the travis pipeline (e.g. upgrading mesos) to work. Add the travis_skip test marker to those tests to skip

