### PR TITLE
Promote progress-aggregator-chan to components graph

### DIFF
--- a/scheduler/src/cook/progress.clj
+++ b/scheduler/src/cook/progress.clj
@@ -154,3 +154,12 @@
                                         {:error-handler progress-update-transactor-error-handler
                                          :on-finished progress-update-transactor-on-finished})
        :progress-state-chan progress-state-chan})))
+
+(defn make-progress-update-channels
+  "Top-level function for building a progress-update-transactor and progress-update-aggregator."
+  [progress-updater-trigger-chan progress-config conn]
+  (let [{:keys [batch-size]} progress-config
+        {:keys [progress-state-chan]} (progress-update-transactor progress-updater-trigger-chan batch-size conn)
+        progress-update-aggregator-chan (progress-update-aggregator progress-config progress-state-chan)]
+    {:progress-state-chan progress-state-chan
+     :progress-aggregator-chan progress-update-aggregator-chan}))

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -49,6 +49,7 @@
   (let [sandbox-syncer-state nil
         exit-code-syncer-state nil
         mesos-heartbeat-chan nil
+        progress-update-chans nil
         trigger-chans nil]
     (mcc/->MesosComputeCluster compute-cluster-name
                                framework-id
@@ -57,6 +58,7 @@
                                sandbox-syncer-state
                                exit-code-syncer-state
                                mesos-heartbeat-chan
+                               progress-update-chans
                                trigger-chans
                                {}
                                {"no-pool" (async/chan 100)}

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -21,6 +21,7 @@
             [cook.datomic :as datomic]
             [cook.mesos :as c]
             [cook.mesos.mesos-mock :as mm]
+            [cook.progress :as progress]
             [cook.scheduler.share :as share]
             [cook.tools :as util]
             [cook.plugins.completion :as completion]
@@ -87,7 +88,8 @@
 
 (defmacro with-cook-scheduler
   [conn make-mesos-driver-fn scheduler-config & body]
-  `(let [[zookeeper-server# curator-framework#] (setup-test-curator-framework)
+  `(let [conn# ~conn
+         [zookeeper-server# curator-framework#] (setup-test-curator-framework)
          mesos-mult# (or (:mesos-datomic-mult ~scheduler-config)
                          (async/mult (async/chan)))
          pool-name->pending-jobs-atom# (or (:pool-name->pending-jobs-atom ~scheduler-config)
@@ -128,6 +130,9 @@
                                {})
          trigger-chans# (or (:trigger-chans ~scheduler-config)
                             (c/make-trigger-chans rebalancer-config# progress-config# optimizer-config# task-constraints#))
+         progress-update-chans# (or (:progress-update-chans ~scheduler-config)
+                                    (progress/make-progress-update-channels
+                                      (:progress-updater-trigger-chan trigger-chans#) progress-config# conn#))
          mesos-heartbeat-chan# (async/chan 1024)
          create-compute-cluster# (fn [compute-cluster-name# framework-id# db-id# driver-atom#]
                                    (mcc/->MesosComputeCluster compute-cluster-name#
@@ -137,6 +142,7 @@
                                                               sandbox-syncer-state#
                                                               exit-code-syncer-state#
                                                               mesos-heartbeat-chan#
+                                                              progress-update-chans#
                                                               trigger-chans#
                                                               {}
                                                               {"no-pool" (async/chan 100)}
@@ -148,8 +154,8 @@
                      ; registration responses matches the configured cook scheduler passes simulator
                      ; and mesos-mock unit tests. (cook.scheduler, lines 1428 create-mesos-scheduler)
                      mcc/make-mesos-driver ~make-mesos-driver-fn
-                     datomic/conn ~conn]
-         (testutil/fake-test-compute-cluster-with-driver ~conn
+                     datomic/conn conn#]
+         (testutil/fake-test-compute-cluster-with-driver conn#
                                                          testutil/fake-test-compute-cluster-name
                                                          nil ; no dummy driver - simulator is going to call initialize
                                                          create-compute-cluster#
@@ -158,7 +164,7 @@
            {:curator-framework curator-framework#
             :fenzo-config fenzo-config#
             :mea-culpa-failure-limit mea-culpa-failure-limit#
-            :mesos-datomic-conn ~conn
+            :mesos-datomic-conn conn#
             :mesos-datomic-mult mesos-mult#
             :mesos-heartbeat-chan mesos-heartbeat-chan#
             :leadership-atom leadership-atom#


### PR DESCRIPTION
## Changes proposed in this PR

The job progress update aggregator is currently part of the Mesos scheduler component. This is for legacy reasons. We should instead initialize it in components.clj and then thread it into other components that use it.

## Why are we making these changes?

We need the progress update aggregator at the top level so that we can use it both for updates from Mesos framework messages (the current implementation) and from the REST API (wip for k8s).