### PR TITLE
Improve our node and pod watches so that they retry forever instead of exiting on certain errors

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -438,7 +438,8 @@
                                   :default-pool "no-pool"}
                                  pool-selection)})))
      :kubernetes (fnk [[:config {kubernetes {}}]]
-                   (merge {:default-workdir "/mnt/sandbox"}
+                   (merge {:default-workdir "/mnt/sandbox"
+                           :reconnect-delay-ms 60000}
                           (update kubernetes :pod-ip->hostname-fn resolve-optional-function identity)))}))
 
 (defn read-config

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -147,7 +147,7 @@
                   (initialize-pod-watch-helper api-client compute-cluster-name all-pods-atom cook-pod-callback)
                   (catch Exception e
                     (log/error e "Error during initial setup of looking at pods for" compute-cluster-name)
-                    (Thread/sleep 60000)
+                    (Thread/sleep (get-in config/config [:settings :kubernetes :reconnect-delay-ms]))
                     nil)))
         ^Callable first-success (->> tmpfn repeatedly (some identity))]
     (.submit kubernetes-executor ^Callable first-success)))
@@ -192,7 +192,7 @@
                   (initialize-node-watch-helper api-client compute-cluster-name current-nodes-atom)
                   (catch Exception e
                     (log/error e "Error during initial setup of looking at nodes for" compute-cluster-name)
-                    (Thread/sleep 60000)
+                    (Thread/sleep (get-in config/config [:settings :kubernetes :reconnect-delay-ms]))
                     nil)))
         ^Callable first-success (->> tmpfn repeatedly (some identity))]
     (.submit kubernetes-executor ^Callable first-success)))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -102,8 +102,10 @@
                                                    (.getItems current-pods))]
     [current-pods namespaced-pod-name->pod]))
 
-(defn initialize-pod-watch
-  "Initialize the pod watch. This fills all-pods-atom with data and invokes the callback on pod changes."
+
+(declare initialize-pod-watch)
+(defn ^Callable initialize-pod-watch-helper
+  "Help creating pod watch. Returns a new watch Callable"
   [^ApiClient api-client compute-cluster-name all-pods-atom cook-pod-callback]
   (let [[current-pods namespaced-pod-name->pod] (get-all-pods-in-kubernetes api-client)
         ; 2 callbacks;
@@ -116,9 +118,9 @@
     ; So compute the delta between the old and new and process those via the callbacks.
     ; Note as a side effect, the callbacks mutate all-pods-atom
     (doseq [task (set/union (keys namespaced-pod-name->pod) (keys old-all-pods))]
+      (log/info "In" compute-cluster-name "compute cluster, doing (startup) callback for" task)
       (doseq [callback callbacks]
         (try
-          (log/info "In" compute-cluster-name "compute cluster, doing (startup) callback for" task)
           (callback task (get old-all-pods task) (get namespaced-pod-name->pod task))
           (catch Exception e
             (log/error e "Error while processing callback for" task)))))
@@ -126,20 +128,33 @@
     (let [watch (WatchHelper/createPodWatch api-client (-> current-pods
                                                            .getMetadata
                                                            .getResourceVersion))]
-      (.submit kubernetes-executor ^Callable
       (fn []
         (try
           (handle-watch-updates all-pods-atom watch get-pod-namespaced-key
                                 callbacks)
           (catch Exception e
-            (log/error e "Error during watch"))
+            (log/error e "Error during pod watch for compute cluster" compute-cluster-name))
           (finally
             (.close watch)
-            (initialize-pod-watch api-client compute-cluster-name all-pods-atom cook-pod-callback))))))))
+            (initialize-pod-watch api-client compute-cluster-name all-pods-atom cook-pod-callback)))))))
 
-(defn initialize-node-watch
-  "Initialize the node watch. This fills current-nodes-atom with data and invokes the callback on pod changes."
-  [^ApiClient api-client current-nodes-atom]
+(defn initialize-pod-watch
+  "Initialize the pod watch. This fills all-pods-atom with data and invokes the callback on pod changes."
+  [^ApiClient api-client compute-cluster-name all-pods-atom cook-pod-callback]
+  ; We'll iterate trying to connect to k8s until the initilzie-pod-watch-helper returns a watch function.
+  (let [tmpfn (fn [] (try
+                       (initialize-pod-watch-helper api-client compute-cluster-name all-pods-atom cook-pod-callback)
+                       (catch Exception e
+                         (log/error e "Error during initial setup of looking at pods for" compute-cluster-name)
+                         (Thread/sleep 60000)
+                         nil)))
+        ^Callable first-success (->> tmpfn repeatedly (some identity))]
+    (.submit kubernetes-executor ^Callable first-success)))
+
+(declare initialize-node-watch)
+(defn initialize-node-watch-helper
+  "Help creating node watch. Returns a new watch Callable"
+  [^ApiClient api-client compute-cluster-name current-nodes-atom]
   (let [api (CoreV1Api. api-client)
         current-nodes (.listNode api
                                  nil ; includeUninitialized
@@ -157,16 +172,28 @@
                                           (.getItems current-nodes))]
     (reset! current-nodes-atom node-name->node)
     (let [watch (WatchHelper/createNodeWatch api-client (-> current-nodes .getMetadata .getResourceVersion))]
-      (.submit kubernetes-executor ^Callable
       (fn []
         (try
           (handle-watch-updates current-nodes-atom watch (fn [n] (-> n .getMetadata .getName))
                                 [(make-atom-updater current-nodes-atom)]) ; Update the set of all nodes.
           (catch Exception e
-            (log/warn e "Error during node watch"))
+            (log/warn e "Error during node watch for compute cluster" compute-cluster-name))
           (finally
             (.close watch)
-            (initialize-node-watch api-client current-nodes-atom))))))))
+            (initialize-node-watch api-client compute-cluster-name current-nodes-atom)))))))
+
+(defn initialize-node-watch
+  "Initialize the node watch. This fills current-nodes-atom with data and invokes the callback on pod changes."
+  [^ApiClient api-client compute-cluster-name current-nodes-atom]
+    ; We'll iterate trying to connect to k8s until the initilzie-pod-watch-helper returns a watch function.
+  (let [tmpfn (fn [] (try
+                       (initialize-node-watch-helper api-client compute-cluster-name current-nodes-atom)
+                       (catch Exception e
+                         (log/error e "Error during initial setup of looking at nodes for" compute-cluster-name)
+                         (Thread/sleep 60000)
+                         nil)))
+        ^Callable first-success (->> tmpfn repeatedly (some identity))]
+    (.submit kubernetes-executor ^Callable first-success)))
 
 (defn to-double
   "Map a quantity to a double, whether integer, double, or float."

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -147,7 +147,7 @@
                   (initialize-pod-watch-helper api-client compute-cluster-name all-pods-atom cook-pod-callback)
                   (catch Exception e
                     (log/error e "Error during initial setup of looking at pods for" compute-cluster-name)
-                    (Thread/sleep (get-in config/config [:settings :kubernetes :reconnect-delay-ms]))
+                    (Thread/sleep (:reconnect-delay-ms config/kubernetes))
                     nil)))
         ^Callable first-success (->> tmpfn repeatedly (some identity))]
     (.submit kubernetes-executor ^Callable first-success)))
@@ -192,7 +192,7 @@
                   (initialize-node-watch-helper api-client compute-cluster-name current-nodes-atom)
                   (catch Exception e
                     (log/error e "Error during initial setup of looking at nodes for" compute-cluster-name)
-                    (Thread/sleep (get-in config/config [:settings :kubernetes :reconnect-delay-ms]))
+                    (Thread/sleep (:reconnect-delay-ms config/kubernetes))
                     nil)))
         ^Callable first-success (->> tmpfn repeatedly (some identity))]
     (.submit kubernetes-executor ^Callable first-success)))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -141,13 +141,14 @@
 (defn initialize-pod-watch
   "Initialize the pod watch. This fills all-pods-atom with data and invokes the callback on pod changes."
   [^ApiClient api-client compute-cluster-name all-pods-atom cook-pod-callback]
-  ; We'll iterate trying to connect to k8s until the initilzie-pod-watch-helper returns a watch function.
-  (let [tmpfn (fn [] (try
-                       (initialize-pod-watch-helper api-client compute-cluster-name all-pods-atom cook-pod-callback)
-                       (catch Exception e
-                         (log/error e "Error during initial setup of looking at pods for" compute-cluster-name)
-                         (Thread/sleep 60000)
-                         nil)))
+  ; We'll iterate trying to connect to k8s until the initialize-pod-watch-helper returns a watch function.
+  (let [tmpfn (fn []
+                (try
+                  (initialize-pod-watch-helper api-client compute-cluster-name all-pods-atom cook-pod-callback)
+                  (catch Exception e
+                    (log/error e "Error during initial setup of looking at pods for" compute-cluster-name)
+                    (Thread/sleep 60000)
+                    nil)))
         ^Callable first-success (->> tmpfn repeatedly (some identity))]
     (.submit kubernetes-executor ^Callable first-success)))
 
@@ -185,13 +186,14 @@
 (defn initialize-node-watch
   "Initialize the node watch. This fills current-nodes-atom with data and invokes the callback on pod changes."
   [^ApiClient api-client compute-cluster-name current-nodes-atom]
-    ; We'll iterate trying to connect to k8s until the initilzie-pod-watch-helper returns a watch function.
-  (let [tmpfn (fn [] (try
-                       (initialize-node-watch-helper api-client compute-cluster-name current-nodes-atom)
-                       (catch Exception e
-                         (log/error e "Error during initial setup of looking at nodes for" compute-cluster-name)
-                         (Thread/sleep 60000)
-                         nil)))
+  ; We'll iterate trying to connect to k8s until the initialize-node-watch-helper returns a watch function.
+  (let [tmpfn (fn []
+                (try
+                  (initialize-node-watch-helper api-client compute-cluster-name current-nodes-atom)
+                  (catch Exception e
+                    (log/error e "Error during initial setup of looking at nodes for" compute-cluster-name)
+                    (Thread/sleep 60000)
+                    nil)))
         ^Callable first-success (->> tmpfn repeatedly (some identity))]
     (.submit kubernetes-executor ^Callable first-success)))
 

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -147,8 +147,8 @@
                 (try
                   (initialize-pod-watch-helper api-client compute-cluster-name all-pods-atom cook-pod-callback)
                   (catch Exception e
-                    (log/error e "Error during initial setup of looking at pods for" compute-cluster-name)
-                    (log/info "Sleeping" reconnect-delay-ms "milliseconds before reconnect")
+                    (log/error e "Error during initial setup of looking at pods for" compute-cluster-name
+                               "and sleeping" reconnect-delay-ms "milliseconds before reconnect")
                     (Thread/sleep reconnect-delay-ms)
                     nil)))
         ^Callable first-success (->> tmpfn repeatedly (some identity))]
@@ -194,8 +194,8 @@
                 (try
                   (initialize-node-watch-helper api-client compute-cluster-name current-nodes-atom)
                   (catch Exception e
-                    (log/error e "Error during initial setup of looking at nodes for" compute-cluster-name)
-                    (log/info "Sleeping" reconnect-delay-ms "milliseconds before reconnect")
+                    (log/error e "Error during initial setup of looking at nodes for" compute-cluster-name
+                               "and sleeping" reconnect-delay-ms "milliseconds before reconnect")
                     (Thread/sleep reconnect-delay-ms)
                     nil)))
         ^Callable first-success (->> tmpfn repeatedly (some identity))]

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -222,7 +222,7 @@
         (api/initialize-node-watch api-client name current-nodes-atom)
 
         (reset! pool->fenzo-atom pool->fenzo)
-        (catch Exception e
+        (catch Throwable e
           (log/error e "Failed to bring up compute cluster" name))))
 
     ; We keep leadership indefinitely in kubernetes.

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -204,23 +204,26 @@
     ; We may iterate forever trying to bring up kubernetes. However, our caller expects us to eventually return,
     ; so we launch within a future so that our caller can continue initializing other clusters.
     (future
-      ; Initialize the pod watch path.
-      (log/info "Initializing Kubernetes compute cluster" name)
-      (let [conn cook.datomic/conn
-            cook-pod-callback (make-cook-pod-watch-callback this)]
-        ; We set cook expected state first because initialize-pod-watch sets (and invokes callbacks on and reacts to) the
-        ; expected and the gradually discovered existing pods.
-        (reset! cook-expected-state-map (determine-cook-expected-state-on-startup conn api-client name running-task-ents))
+      (try
+        ; Initialize the pod watch path.
+        (log/info "Initializing Kubernetes compute cluster" name)
+        (let [conn cook.datomic/conn
+              cook-pod-callback (make-cook-pod-watch-callback this)]
+          ; We set cook expected state first because initialize-pod-watch sets (and invokes callbacks on and reacts to) the
+          ; expected and the gradually discovered existing pods.
+          (reset! cook-expected-state-map (determine-cook-expected-state-on-startup conn api-client name running-task-ents))
 
-        (api/initialize-pod-watch api-client name all-pods-atom cook-pod-callback)
-        (if scan-frequency-seconds-config
-          (regular-scanner this (time/seconds scan-frequency-seconds-config))
-          (log/info "State scan disabled because no interval has been set")))
+          (api/initialize-pod-watch api-client name all-pods-atom cook-pod-callback)
+          (if scan-frequency-seconds-config
+            (regular-scanner this (time/seconds scan-frequency-seconds-config))
+            (log/info "State scan disabled because no interval has been set")))
 
-      ; Initialize the node watch path.
-      (api/initialize-node-watch api-client name current-nodes-atom)
+        ; Initialize the node watch path.
+        (api/initialize-node-watch api-client name current-nodes-atom)
 
-      (reset! pool->fenzo-atom pool->fenzo))
+        (reset! pool->fenzo-atom pool->fenzo)
+        (catch Exception e
+          (log/error e "Failed to bring up compute cluster" name))))
 
     ; We keep leadership indefinitely in kubernetes.
     (async/chan 1))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -201,23 +201,26 @@
     name)
 
   (initialize-cluster [this pool->fenzo running-task-ents]
-    ; Initialize the pod watch path.
-    (log/info "Initializing Kubernetes compute cluster" name)
-    (let [conn cook.datomic/conn
-          cook-pod-callback (make-cook-pod-watch-callback this)]
-      ; We set cook expected state first because initialize-pod-watch sets (and invokes callbacks on and reacts to) the
-      ; expected and the gradually discovered existing pods.
-      (reset! cook-expected-state-map (determine-cook-expected-state-on-startup conn api-client name running-task-ents))
+    ; We may iterate forever trying to bring up kubernetes. However, our caller expects us to eventually return,
+    ; so we launch within a future so that our caller can continue initializing other clusters.
+    (future
+      ; Initialize the pod watch path.
+      (log/info "Initializing Kubernetes compute cluster" name)
+      (let [conn cook.datomic/conn
+            cook-pod-callback (make-cook-pod-watch-callback this)]
+        ; We set cook expected state first because initialize-pod-watch sets (and invokes callbacks on and reacts to) the
+        ; expected and the gradually discovered existing pods.
+        (reset! cook-expected-state-map (determine-cook-expected-state-on-startup conn api-client name running-task-ents))
 
-      (api/initialize-pod-watch api-client name all-pods-atom cook-pod-callback)
-      (if scan-frequency-seconds-config
-        (regular-scanner this (time/seconds scan-frequency-seconds-config))
-        (log/info "State scan disabled because no interval has been set")))
+        (api/initialize-pod-watch api-client name all-pods-atom cook-pod-callback)
+        (if scan-frequency-seconds-config
+          (regular-scanner this (time/seconds scan-frequency-seconds-config))
+          (log/info "State scan disabled because no interval has been set")))
 
-    ; Initialize the node watch path.
-    (api/initialize-node-watch api-client current-nodes-atom)
+      ; Initialize the node watch path.
+      (api/initialize-node-watch api-client name current-nodes-atom)
 
-    (reset! pool->fenzo-atom pool->fenzo)
+      (reset! pool->fenzo-atom pool->fenzo))
 
     ; We keep leadership indefinitely in kubernetes.
     (async/chan 1))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -223,7 +223,8 @@
 
         (reset! pool->fenzo-atom pool->fenzo)
         (catch Throwable e
-          (log/error e "Failed to bring up compute cluster" name))))
+          (log/error e "Failed to bring up compute cluster" name)
+          (throw e))))
 
     ; We keep leadership indefinitely in kubernetes.
     (async/chan 1))


### PR DESCRIPTION
## Changes proposed in this PR

- Improve our node and pod watches so that they retry forever instead of exiting on certain errors. 
- Also improve logging.

## Why are we making these changes?

Fix a bug where we lose track of whats going on.

