### PR TITLE
Add REST endpoint for posting job progress updates

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -701,6 +701,58 @@ class CookTest(util.CookTest):
         self.assertEqual(80, instance['progress'], message)
         self.assertEqual('80%', instance['progress_message'], message)
 
+    def test_progress_update_rest(self):
+        job_uuid, resp = util.submit_job(self.cook_url)
+        self.assertEqual(201, resp.status_code, msg=resp.content)
+        util.wait_for_job_in_statuses(self.cook_url, job_uuid, ['running', 'completed'])
+        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        instance_uuid = instance['task_id']
+        message = json.dumps(instance, sort_keys=True)
+        self.assertIsNotNone(instance['output_url'], message)
+        self.assertIsNotNone(instance['sandbox_directory'], message)
+        def wait_until_instance(predicate):
+            util.wait_until(lambda: util.load_instance(self.cook_url, instance_uuid),
+                            predicate, max_wait_ms=10000)
+        # send progress percentage update
+        util.send_progress_update(self.cook_url, instance_uuid, percent=10)
+        wait_until_instance(lambda i: i['progress'] == 10)
+        # send progress message update
+        util.send_progress_update(self.cook_url, instance_uuid, message='working')
+        wait_until_instance(lambda i: i['progress'] == 10 and i['progress_message'] == 'working')
+        # send both progress message and percentage update
+        util.send_progress_update(self.cook_url, instance_uuid, percent=99, message='finalizing')
+        wait_until_instance(lambda i: i['progress'] == 99 and i['progress_message'] == 'finalizing')
+        # out-of-sequence progress updates should be ignored
+        util.send_progress_update(self.cook_url, instance_uuid, sequence=0, message='ignored')
+        # send progress percentage update (message unchanged)
+        util.send_progress_update(self.cook_url, instance_uuid, percent=100)
+        wait_until_instance(lambda i: i['progress'] == 100 and i['progress_message'] == 'finalizing')
+        # send progress message update (percentage unchanged)
+        util.send_progress_update(self.cook_url, instance_uuid, message='done')
+        wait_until_instance(lambda i: i['progress'] == 100 and i['progress_message'] == 'done')
+        # send progress update with empty json body
+        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, json={})
+        assert response.status_code == 400, response.content
+        # send progress update without message or percentage
+        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False)
+        assert response.status_code == 400, response.content
+        # send progress update with non-integer sequence id
+        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, sequence=0.1, percent=0)
+        assert response.status_code == 400, response.content
+        # send progress update with non-integer percentage
+        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, percent=0.1)
+        assert response.status_code == 400, response.content
+        # send progress update with non-string message
+        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, message=12345)
+        assert response.status_code == 400, response.content
+        # send progress update with instance id that does not exist
+        response = util.send_progress_update(self.cook_url, job_uuid, assert_response=False, percent=0)
+        assert response.status_code == 404, response.content
+        # ensure that none of the above errors erased our previous progress state
+        i = util.load_instance(self.cook_url, instance_uuid)
+        assert i['progress'] == 100, i
+        assert i['progress_message'] == 'done', i
+
     @pytest.mark.timeout((2 * util.timeout_interval_minutes() * 60) + 60)
     # This test fails when the job fails due to "Container launch failed"
     @pytest.mark.xfail

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -714,39 +714,39 @@ class CookTest(util.CookTest):
             util.wait_until(lambda: util.load_instance(self.cook_url, instance_uuid),
                             predicate, max_wait_ms=10000)
         # send progress percentage update
-        util.send_progress_update(self.cook_url, instance_uuid, percent=10)
+        util.send_progress_update(self.cook_url, instance_uuid, sequence=100, percent=10)
         wait_until_instance(lambda i: i['progress'] == 10)
         # send progress message update
-        util.send_progress_update(self.cook_url, instance_uuid, message='working')
+        util.send_progress_update(self.cook_url, instance_uuid, sequence=200, message='working')
         wait_until_instance(lambda i: i['progress'] == 10 and i['progress_message'] == 'working')
         # send both progress message and percentage update
-        util.send_progress_update(self.cook_url, instance_uuid, percent=99, message='finalizing')
+        util.send_progress_update(self.cook_url, instance_uuid, sequence=300, percent=99, message='finalizing')
         wait_until_instance(lambda i: i['progress'] == 99 and i['progress_message'] == 'finalizing')
         # out-of-sequence progress updates should be ignored
         util.send_progress_update(self.cook_url, instance_uuid, sequence=0, message='ignored')
         # send progress percentage update (message unchanged)
-        util.send_progress_update(self.cook_url, instance_uuid, percent=100)
+        util.send_progress_update(self.cook_url, instance_uuid, sequence=400, percent=100)
         wait_until_instance(lambda i: i['progress'] == 100 and i['progress_message'] == 'finalizing')
         # send progress message update (percentage unchanged)
-        util.send_progress_update(self.cook_url, instance_uuid, message='done')
+        util.send_progress_update(self.cook_url, instance_uuid, sequence=500, message='done')
         wait_until_instance(lambda i: i['progress'] == 100 and i['progress_message'] == 'done')
         # send progress update with empty json body
-        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, json={})
+        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False)
         assert response.status_code == 400, response.content
         # send progress update without message or percentage
-        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False)
+        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, sequence=600)
         assert response.status_code == 400, response.content
         # send progress update with non-integer sequence id
         response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, sequence=0.1, percent=0)
         assert response.status_code == 400, response.content
         # send progress update with non-integer percentage
-        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, percent=0.1)
+        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, sequence=700, percent=0.1)
         assert response.status_code == 400, response.content
         # send progress update with non-string message
-        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, message=12345)
+        response = util.send_progress_update(self.cook_url, instance_uuid, assert_response=False, sequence=800, message=12345)
         assert response.status_code == 400, response.content
         # send progress update with instance id that does not exist
-        response = util.send_progress_update(self.cook_url, job_uuid, assert_response=False, percent=0)
+        response = util.send_progress_update(self.cook_url, job_uuid, assert_response=False, sequence=900, percent=0)
         assert response.status_code == 404, response.content
         # ensure that none of the above errors erased our previous progress state
         i = util.load_instance(self.cook_url, instance_uuid)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -704,12 +704,9 @@ class CookTest(util.CookTest):
     def test_progress_update_rest(self):
         job_uuid, resp = util.submit_job(self.cook_url)
         self.assertEqual(201, resp.status_code, msg=resp.content)
-        util.wait_for_job_in_statuses(self.cook_url, job_uuid, ['running', 'completed'])
-        instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid)
+        job = util.wait_for_job_in_statuses(self.cook_url, job_uuid, ['running', 'completed'])
+        instance = job['instances'][0]
         instance_uuid = instance['task_id']
-        message = json.dumps(instance, sort_keys=True)
-        self.assertIsNotNone(instance['output_url'], message)
-        self.assertIsNotNone(instance['sandbox_directory'], message)
         def wait_until_instance(predicate):
             util.wait_until(lambda: util.load_instance(self.cook_url, instance_uuid),
                             predicate, max_wait_ms=10000)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -704,8 +704,7 @@ class CookTest(util.CookTest):
     def test_progress_update_rest(self):
         job_uuid, resp = util.submit_job(self.cook_url)
         self.assertEqual(201, resp.status_code, msg=resp.content)
-        job = util.wait_for_job_in_statuses(self.cook_url, job_uuid, ['running', 'completed'])
-        instance = job['instances'][0]
+        instance = util.wait_for_instance(self.cook_url, job_uuid)
         instance_uuid = instance['task_id']
         def wait_until_instance(predicate):
             util.wait_until(lambda: util.load_instance(self.cook_url, instance_uuid),

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1732,28 +1732,16 @@ def rebalancer_interval_seconds():
     return interval_seconds
 
 
-__auto_sequence_lock = threading.Lock()
-__auto_sequence_counter = 0
-
-
 def send_progress_update(cook_url, instance, assert_response=True, allow_redirects=True,
-                         sequence=None, percent=None, message=None, json=None):
+                         sequence=None, percent=None, message=None):
     """Submit a job instance progress update via the rest api"""
-    global __auto_sequence_counter
-    if json is not None:
-        payload = json
-    else:
-        payload = {}
-        if sequence is not None:
-            payload['progress_sequence'] = sequence
-        elif sequence is not False:
-            with __auto_sequence_lock:
-                __auto_sequence_counter += 1
-                payload['progress_sequence'] = __auto_sequence_counter
-        if percent is not None:
-            payload['progress_percent'] = percent
-        if message is not None:
-            payload['progress_message'] = message
+    payload = {}
+    if sequence is not None:
+        payload['progress_sequence'] = sequence
+    if percent is not None:
+        payload['progress_percent'] = percent
+    if message is not None:
+        payload['progress_message'] = message
     # NOTE: using `requests` rather than `session` here because this endpoint should not require authentication
     response = requests.post(f'{cook_url}/progress/{instance}', allow_redirects=allow_redirects, json=payload)
     if assert_response:

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1732,6 +1732,39 @@ def rebalancer_interval_seconds():
     return interval_seconds
 
 
+__auto_sequence_lock = threading.Lock()
+__auto_sequence_counter = 0
+
+
+def send_progress_update(cook_url, instance, assert_response=True, allow_redirects=True,
+                         sequence=None, percent=None, message=None, json=None):
+    """Submit a job instance progress update via the rest api"""
+    global __auto_sequence_counter
+    if json is not None:
+        payload = json
+    else:
+        payload = {}
+        if sequence is not None:
+            payload['progress_sequence'] = sequence
+        elif sequence is not False:
+            with __auto_sequence_lock:
+                __auto_sequence_counter += 1
+                payload['progress_sequence'] = __auto_sequence_counter
+        if percent is not None:
+            payload['progress_percent'] = percent
+        if message is not None:
+            payload['progress_message'] = message
+    # NOTE: using `requests` rather than `session` here because this endpoint should not require authentication
+    response = requests.post(f'{cook_url}/progress/{instance}', allow_redirects=allow_redirects, json=payload)
+    if assert_response:
+        response_info = {'code': response.status_code, 'msg': response.content}
+        assert response.status_code == 202, response_info
+        response_json = response.json()
+        assert response_json['instance'] == instance, response_info
+        assert response_json['message'] == 'progress update accepted', response_info
+    return response
+
+
 def job_progress_is_present(job, progress):
     present = any(i['progress'] == progress for i in job['instances'])
     if not present:

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -241,8 +241,9 @@
     (let [conn cook.datomic/conn
           {:keys [match-trigger-chan]} trigger-chans
           {:keys [progress-aggregator-chan]} progress-update-chans
-          handle-progress-message (fn handle-progress-message-curried [progress-message-map]
-                                    (progress/handle-progress-message! progress-aggregator-chan progress-message-map))
+          handle-progress-message (fn handle-progress-message-curried [db task-id progress-message-map]
+                                    (progress/handle-progress-message!
+                                      db task-id progress-aggregator-chan progress-message-map))
           handle-exit-code (fn handle-exit-code [task-id exit-code]
                              (sandbox/aggregate-exit-code exit-code-syncer-state task-id exit-code))
           scheduler (create-mesos-scheduler (:gpu-enabled? mesos-config)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -68,8 +68,8 @@
            (java.net ServerSocket)
            (java.util Date UUID)
            javax.servlet.ServletResponse
-           org.apache.curator.test.TestingServer
            (org.apache.curator.framework.recipes.leader LeaderSelector)
+           org.apache.curator.test.TestingServer
            (org.joda.time DateTime Minutes)
            schema.core.OptionalKey))
 
@@ -3229,7 +3229,8 @@
                       :responses {202 {:description "The progress update was accepted."}
                                   307 {:description "Redirecting request to leader node."}
                                   400 {:description "Invalid request format."}
-                                  404 {:description "The supplied UUID doesn't correspond to a valid job instance."}}
+                                  404 {:description "The supplied UUID doesn't correspond to a valid job instance."}
+                                  503 {:description "The leader node is temporarily unavailable."}}
                       :handler (let [;; TODO: add lightweight auth -- https://github.com/twosigma/Cook/issues/1367
                                      mock-auth-fn (constantly true)]
                                  (update-instance-progress-handler

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -345,19 +345,14 @@
     (try
       (when (str/blank? task-id)
         (throw (ex-info "task-id is empty in framework message" {:message message})))
-      (let [instance-id (task-id->instance-id (db conn) task-id)]
-        (if (nil? instance-id)
-          (throw (ex-info "No instance found!" {:task-id task-id}))
-          (do
-            (when (or progress-message progress-percent)
-              (log/debug "Updating instance" instance-id "progress to" progress-percent progress-message)
-              (handle-progress-message {:instance-id instance-id
-                                        :progress-message progress-message
-                                        :progress-percent progress-percent
-                                        :progress-sequence progress-sequence}))
-            (when exit-code
-              (log/info "Updating instance" instance-id "exit-code to" exit-code)
-              (handle-exit-code task-id exit-code)))))
+      (when (or progress-message progress-percent)
+        (handle-progress-message (d/db conn) task-id
+                                 {:progress-message progress-message
+                                  :progress-percent progress-percent
+                                  :progress-sequence progress-sequence}))
+      (when exit-code
+        (log/info "Updating instance" task-id "exit-code to" exit-code)
+        (handle-exit-code task-id exit-code))
       (catch Exception e
         (log/error e "Mesos scheduler framework message error")))))
 

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -131,7 +131,8 @@
                                                :mesos-gpu-enabled false
                                                :task-constraints {:cpus 12 :memory-gb 100 :retry-limit 200}}
                                               (Object.)
-                                              (atom true))]
+                                              (atom true)
+                                              {:progress-aggregator-chan (async/chan)})]
                         (fn [request]
                           (with-redefs [cook.config/batch-timeout-seconds-config (constantly (t/seconds 30))
                                         rate-limit/job-submission-rate-limiter rate-limit/AllowAllRateLimiter]

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -666,13 +666,13 @@
         (is (= (:status update-resp) 404))))
 
     (testing "Valid progress update posted when leader is unknown"
-      (with-redefs [error-msg "leader is currently unknown"
-                    api/leader-selector->leader-id (fn [_] (throw (IllegalStateException. error-msg)))
-                    api/streaming-json-encoder identity]
-        (let [update-resp (h update-req-attrs :leader? false)
-              redirect-location (str sample-leader-base-url target-endpoint)]
-          (is (= (:status update-resp) 503))
-          (is (= (:body update-resp) {:message error-msg})))))
+      (let [error-msg "leader is currently unknown"]
+        (with-redefs [api/leader-selector->leader-id (fn [_] (throw (IllegalStateException. error-msg)))
+                      api/streaming-json-encoder identity]
+          (let [update-resp (h update-req-attrs :leader? false)
+                redirect-location (str sample-leader-base-url target-endpoint)]
+            (is (= (:status update-resp) 503))
+            (is (= (:body update-resp) {:message error-msg}))))))
 
     (testing "Valid progress update posted to non-leader results in redirect"
       (with-redefs [api/leader-selector->leader-id (constantly sample-leader-id)

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -90,13 +90,14 @@
 (defn basic-handler
   [conn & {:keys [cpus memory-gb gpus-enabled retry-limit is-authorized-fn]
            :or {cpus 12, memory-gb 100, gpus-enabled false, retry-limit 200, is-authorized-fn authorized-fn}}]
-  (fn [request]
+  (fn [request & {:keys [leader?] :or {leader? true}}]
     (let [handler (api/main-handler conn (fn [] [])
                                     {:is-authorized-fn is-authorized-fn
                                      :mesos-gpu-enabled gpus-enabled
                                      :task-constraints {:cpus cpus :memory-gb memory-gb :retry-limit retry-limit}}
                                     (Object.)
-                                    (atom true))]
+                                    (atom leader?)
+                                    {:progress-aggregator-chan (async/chan)})]
       (with-redefs [api/retrieve-sandbox-url-path (fn [{:keys [instance/hostname instance/task-id]}]
                                                     (str "http://" hostname "/" task-id))
                     rate-limit/job-submission-rate-limiter rate-limit/AllowAllRateLimiter]
@@ -632,6 +633,53 @@
         (is (= "No content." (:body cancel-resp)))
         (is followup-instance-cancelled?)))))
 
+(deftest progress-update-api
+  (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
+        is-authorized-fn (constantly false)
+        h (basic-handler conn :is-authorized-fn is-authorized-fn)
+        [job [inst]] (create-dummy-job-with-instances conn
+                                                      :retry-count 1
+                                                      :user "nick"
+                                                      :job-state :job.state/running
+                                                      :instances [{:instance-status :instance.status/running}])
+        job-uuid (:job/uuid (d/entity (d/db conn) job))
+        task-id (str (:instance/task-id (d/entity (d/db conn) inst)))
+        target-endpoint (str "/progress/" task-id)
+        update-req-attrs {:scheme :http
+                          :uri target-endpoint
+                          :request-method :post
+                          :body-params {:progress-sequence 0
+                                        :progress-message "starting..."
+                                        :progress-percent 0}}
+        no-such-task-id (str (UUID/randomUUID))
+        no-such-task-endpoint (str "/progress/" no-such-task-id)
+        bad-update-req-attrs (assoc update-req-attrs :uri no-such-task-endpoint)
+        sample-leader-id "cook-scheduler.example#12321#http#dada4195-0b69-48a9-b288-8bbcd4ce5a88"
+        sample-leader-base-url "http://cook-scheduler.example:12321"]
+
+    (testing "Invalid progress update posted to non-leader results in 4XX"
+      (let [update-resp (h bad-update-req-attrs :leader? false)]
+        (is (= (:status update-resp) 404))))
+
+    (testing "Invalid progress update posted to leader results in 4XX"
+      (let [update-resp (h bad-update-req-attrs :leader? true)]
+        (is (= (:status update-resp) 404))))
+
+    (testing "Valid progress update posted to non-leader results in redirect"
+      (with-redefs [api/leader-selector->leader-id (constantly sample-leader-id)
+                    api/streaming-json-encoder identity]
+        (let [update-resp (h update-req-attrs :leader? false)
+              redirect-location (str sample-leader-base-url target-endpoint)]
+          (is (= (:status update-resp) 307))
+          (is (= (:location update-resp) redirect-location))
+          (is (= (:body update-resp) {:location redirect-location, :message "redirecting to master"})))))
+
+    (testing "Valid progress update posted to leader results 202 Accepted"
+      (with-redefs [api/streaming-json-encoder identity]
+        (let [update-resp (h update-req-attrs :leader? true)
+              redirect-location (str sample-leader-base-url target-endpoint)]
+          (is (= (:status update-resp) 202))
+          (is (= (:body update-resp) {:instance task-id :job job-uuid :message "progress update accepted"})))))))
 
 (deftest quota-api
   (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -665,6 +665,15 @@
       (let [update-resp (h bad-update-req-attrs :leader? true)]
         (is (= (:status update-resp) 404))))
 
+    (testing "Valid progress update posted when leader is unknown"
+      (with-redefs [error-msg "leader is currently unknown"
+                    api/leader-selector->leader-id (fn [_] (throw (IllegalStateException. error-msg)))
+                    api/streaming-json-encoder identity]
+        (let [update-resp (h update-req-attrs :leader? false)
+              redirect-location (str sample-leader-base-url target-endpoint)]
+          (is (= (:status update-resp) 503))
+          (is (= (:body update-resp) {:message error-msg})))))
+
     (testing "Valid progress update posted to non-leader results in redirect"
       (with-redefs [api/leader-selector->leader-id (constantly sample-leader-id)
                     api/streaming-json-encoder identity]


### PR DESCRIPTION
## Changes proposed in this PR

Add REST endpoint `/progress/<instance-uuid>` for POSTing job instance progress updates.

## Why are we making these changes?

Job instance progress updates are currently communicated via Mesos framework messages. We need a new mechanism for reporting progress to use on Kubernetes.

We plan to have our Kubernetes log sidecar duplicate some of the current Cook Executor functionality to monitor log files for progress messages, but then POST to this new endpoint rather than sending Mesos framework messages.

This PR only implements the endpoint. The new progress reporting functionality for the log sidecar on Kubernetes will come as a separate patch.