### PR TITLE
Avoid over-verbose logging of compute cluster object

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -102,7 +102,7 @@
                (str "Multiple compute-clusters have the same name: " compute-cluster
                     " and " (get @cluster-name->compute-cluster-atom compute-cluster-name)
                     " with name " compute-cluster-name))))
-    (log/info "Setting up compute cluster: " compute-cluster)
+    (log/info "Setting up compute cluster:" compute-cluster-name)
     (swap! cluster-name->compute-cluster-atom assoc compute-cluster-name compute-cluster)
     nil))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Do not log the compute cluster object, it can be very big. Just log the name.

## Why are we making these changes?
Avoid log bloat --- found when looking for issues similar to https://github.com/twosigma/Cook/pull/1375

