### PR TITLE
Makes test_multi_user_usage more reliable

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -71,6 +71,7 @@ class MultiUserCookTest(util.CookTest):
             # Start jobs for several users
             for i, user in enumerate(users):
                 with user:
+                    util.kill_running_and_waiting_jobs(self.cook_url, user.name)
                     for j in range(i):
                         job_uuid, resp = util.submit_job(self.cook_url, command='sleep 480',
                                                          max_retries=2, **job_resources)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1699,7 +1699,7 @@ def supports_exit_code():
 
 def kill_running_and_waiting_jobs(cook_url, user):
     one_hour_in_millis = 60 * 60 * 1000
-    start = current_milli_time() - (4 * one_hour_in_millis)
+    start = current_milli_time() - (72 * one_hour_in_millis)
     end = current_milli_time() + one_hour_in_millis
     running = jobs(cook_url, user=user, state=['running', 'waiting'], start=start, end=end).json()
     logger.info(f'Currently running/waiting jobs: {json.dumps(running, indent=2)}')


### PR DESCRIPTION
## Changes proposed in this PR

- killing all running and waiting jobs for each user at the start of test
- changing the look-back in `util. kill_running_and_waiting_jobs` from 4 hours to 72 hours

## Why are we making these changes?

If the user under test happens to already have a running job, then the usage assertions will fail. These test users need to start the test with a clean slate.
