### PR TITLE
Makes pod-watch exception log INFO level

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -133,7 +133,7 @@
           (handle-watch-updates all-pods-atom watch get-pod-namespaced-key
                                 callbacks)
           (catch Exception e
-            (log/error e "Error during pod watch for compute cluster" compute-cluster-name))
+            (log/info e "Error during pod watch for compute cluster" compute-cluster-name))
           (finally
             (.close watch)
             (initialize-pod-watch api-client compute-cluster-name all-pods-atom cook-pod-callback)))))))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -133,7 +133,10 @@
           (handle-watch-updates all-pods-atom watch get-pod-namespaced-key
                                 callbacks)
           (catch Exception e
-            (log/info e "Error during pod watch for compute cluster" compute-cluster-name))
+            (let [cause (.getCause e)]
+              (if (and cause (instance? java.net.SocketTimeoutException cause))
+                (log/info e "In" compute-cluster-name "compute cluster, pod watch timed out")
+                (log/error e "In" compute-cluster-name "compute cluster, error during pod watch"))))
           (finally
             (.close watch)
             (initialize-pod-watch api-client compute-cluster-name all-pods-atom cook-pod-callback)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- changing the pod-watch exception log from `ERROR` level to `INFO` level

## Why are we making these changes?

It's expected and frequent for the pod-watch to throw when it times out.

`ERROR` makes it harder to distinguish these from unexpected errors, and `INFO` will still allow us to view these in the normal places.