### PR TITLE
Fix warnings from pytest

### DIFF
--- a/integration/setup.cfg
+++ b/integration/setup.cfg
@@ -3,7 +3,9 @@ addopts = -n10 -v --timeout-method=thread --maxfail=5 --log-level=DEBUG --durati
 timeout = 1200
 usefixtures = record_test_metric
 markers =
-    multi_user: marks tests as using multiple users (e.g. one admin and one non-admin)
     cli: marks tests as testing the cs CLI
-    serial: marks tests as needing to run in series rather than in parallel with other tests
     memlimit: marks tests as checking that exceeding the memory limit works as expected
+    multi_user: marks tests as using multiple users (e.g. one admin and one non-admin)
+    scheduler_not_in_docker: marks tests that should be skipped when Cook itself runs in Docker
+    serial: marks tests as needing to run in series rather than in parallel with other tests
+    travis_skip: marks tests that should be skipped in Travis CI

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -48,7 +48,7 @@ class CookTest(util.CookTest):
         except:
             self.fail(f"Unable to parse start time: {info_details}")
         if 'leader-url' in info:
-            url_regex = 'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+            url_regex = r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
             self.assertIsNotNone(re.match(url_regex, info['leader-url']), info_details)
 
     def test_basic_submit(self):
@@ -593,12 +593,12 @@ class CookTest(util.CookTest):
         command = 'echo "message: 25 Twenty-five percent" > progress_file.txt; sleep 1; exit 0'
         job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=job_executor_type, max_runtime=60000,
                                          progress_output_file='progress_file.txt',
-                                         progress_regex_string='message: (\d*) (.*)')
+                                         progress_regex_string='message: (\\d*) (.*)')
         self.assertEqual(201, resp.status_code, msg=resp.content)
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
         message = json.dumps(job, sort_keys=True)
         self.assertEqual('progress_file.txt', job['progress_output_file'], message)
-        self.assertEqual('message: (\d*) (.*)', job['progress_regex_string'], message)
+        self.assertEqual('message: (\\d*) (.*)', job['progress_regex_string'], message)
         self.assertEqual('success', job['state'], message)
 
         instance = util.wait_for_sandbox_directory(self.cook_url, job_uuid, 'success')
@@ -1301,7 +1301,7 @@ class CookTest(util.CookTest):
         self.assertEqual(400, resp.status_code)
         resp = util.list_jobs(self.cook_url, user=user, state=any_state, name='[a-z0-9_-]')
         self.assertEqual(400, resp.status_code)
-        resp = util.list_jobs(self.cook_url, user=user, state=any_state, name='\d+')
+        resp = util.list_jobs(self.cook_url, user=user, state=any_state, name='\\d+')
         self.assertEqual(400, resp.status_code)
         resp = util.list_jobs(self.cook_url, user=user, state=any_state, name='a+')
         self.assertEqual(400, resp.status_code)


### PR DESCRIPTION


## Changes proposed in this PR

- Fix invalid strings escapes in regular expressions
- Add unregistered pytest marks to config

## Why are we making these changes?

Eliminate warnings from pytest output:

```
==================================================================================================================================== warnings summary ====================================================================================================================================
tests/cook/test_basic.py:51
  /home/nickv/projects/cook/integration/tests/cook/test_basic.py:51: DeprecationWarning: invalid escape sequence \(
    url_regex = 'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'

tests/cook/test_basic.py:596
  /home/nickv/projects/cook/integration/tests/cook/test_basic.py:596: DeprecationWarning: invalid escape sequence \d
    progress_regex_string='message: (\d*) (.*)')

tests/cook/test_basic.py:601
  /home/nickv/projects/cook/integration/tests/cook/test_basic.py:601: DeprecationWarning: invalid escape sequence \d
    self.assertEqual('message: (\d*) (.*)', job['progress_regex_string'], message)

tests/cook/test_basic.py:1353
  /home/nickv/projects/cook/integration/tests/cook/test_basic.py:1353: DeprecationWarning: invalid escape sequence \d
    resp = util.list_jobs(self.cook_url, user=user, state=any_state, name='\d+')

/home/nickv/.local/share/virtualenvs/integration-WG99ZIgz/lib/python3.7/site-packages/_pytest/mark/structures.py:324
  /home/nickv/.local/share/virtualenvs/integration-WG99ZIgz/lib/python3.7/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.scheduler_not_in_docker - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/nickv/.local/share/virtualenvs/integration-WG99ZIgz/lib/python3.7/site-packages/_pytest/mark/structures.py:324
  /home/nickv/.local/share/virtualenvs/integration-WG99ZIgz/lib/python3.7/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.travis_skip - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```
