### PR TITLE
Kill flask server on exit in run-local.sh

### DIFF
--- a/scheduler/bin/run-local.sh
+++ b/scheduler/bin/run-local.sh
@@ -53,6 +53,13 @@ if ! [ -x "$(command -v flask)" ]; then
     exit 1
 fi
 
+function cleanup {
+    echo CLEANUP: Attempting to kill flask...
+    kill %1
+    echo CLEANUP: Done
+}
+trap cleanup EXIT
+
 INTEGRATION_DIR="$(dirname ${SCHEDULER_DIR})/integration"
 FLASK_APP=${INTEGRATION_DIR}/src/data_locality/service.py flask run -p 35847 &
 
@@ -79,4 +86,4 @@ export COOK_KEYSTORE_PATH="${COOK_KEYSTORE_PATH}"
 export DATA_LOCAL_ENDPOINT="http://localhost:35847/retrieve-costs"
 
 echo "Starting cook..."
-lein run config.edn
+lein run ${COOK_CONFIG:-config.edn}


### PR DESCRIPTION
## Changes proposed in this PR

- Kill flask server on exit in run-local.sh
- Allow setting `COOK_CONFIG` to override the config file path

## Why are we making these changes?

- Since we start a background progress in this script, we should at least try to clean it up on exit.
- The run-docker.sh script allows using `COOK_CONFIG` like this, so it seems reasonable to add it here as well. This way I can override the default when running my test setup.