### PR TITLE
Various small tweaks to the state machine

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -308,7 +308,11 @@
                                         ; normal occurrence if someone submits a kill request on a job that fails to launch.
                                         :missing (do
                                                    ; TODO: We will review these and may downgrade this to an info later.
-                                                   (log/warn "In compute cluster" name ", pod" pod-name "in a weird cook expected state:" cook-expected-state-dict "and k8s actual state" k8s-actual-state-dict)
+                                                   (log/warn "In compute cluster" name ", pod" pod-name
+                                                             "in a weird cook expected state:"
+                                                             (prepare-cook-expected-state-dict-for-logging cook-expected-state-dict)
+                                                             "and k8s actual state"
+                                                             (prepare-k8s-actual-state-dict-for-logging k8s-actual-state-dict))
                                                    ; TODO: Avoid a race. Say a launch occurs, followed by a kill, followed by a watch update.
                                                    ; Before the watch update, we'll think the k8s-actual-state is missing.
                                                    ; We see (:killed,:missing), with nothing to do, so we move to (;missing,:missing)

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -39,7 +39,7 @@
   "Kill pod is the same as deleting a pod, we semantically distinguish the two operations.
   Delete is used for completed pods that we're done with.
   Kill is used for possibly running pods we want to kill so that they fail.
-  Returns the cook-expected-state-dict of nil."
+  Returns the cook-expected-state-dict passed in."
   [api-client cook-expected-state-dict pod]
   (api/delete-pod api-client pod)
   cook-expected-state-dict)
@@ -367,7 +367,7 @@
                                         ; We shouldn't hit these unless we get a database rollback.
                                         :pod/failed (kill-pod-in-weird-state compute-cluster pod-name
                                                                              nil k8s-actual-state-dict)
-                                        ; This can only occur in testing when you're e.g., blowing away the database.
+                                        ; This can occur in testing when you're e.g., blowing away the database.
                                         ; It will go through :missing,:missing and then be deleted from the map.
                                         ; TODO: May be evidence of a bug where we process pod changes when we're starting up.
                                         ; Currently occurs because kill's can race ahead of launches, we kill something that has
@@ -379,7 +379,7 @@
                                         ; Unlike the other :pod/unknown states, no datomic state to update.
                                         :pod/unknown (kill-pod-in-weird-state compute-cluster pod-name
                                                                               nil k8s-actual-state-dict)
-                                        ; This can only occur in testing when you're e.g., blowing away the database.
+                                        ; This can occur in testing when you're e.g., blowing away the database.
                                         ; It will go through :missing,:missing and then be deleted from the map.
                                         ; TODO: May be evidence of a bug where we process pod changes when we're starting up.
                                         ; Currently occurs because kill's can race ahead of launches, we kill something that has

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -288,20 +288,24 @@
                                         ; and remove it from our tracking.
                                         :pod/failed (delete-pod api-client cook-expected-state-dict pod)
                                         ; Who resurrected this pod? Where did it come from? Do we have two instances of cook?
-                                        :pod/running (kill-pod-in-weird-state compute-cluster pod-name cook-expected-state-dict k8s-actual-state-dict)
+                                        :pod/running (kill-pod-in-weird-state compute-cluster pod-name
+                                                                              cook-expected-state-dict
+                                                                              k8s-actual-state-dict)
                                         ; The writeback to datomic has occurred, so there's nothing to do except to delete the pod from kubernetes
                                         ; and remove it from our tracking.
                                         :pod/succeeded (delete-pod api-client cook-expected-state-dict pod)
                                         ; TODO: Should mark mea culpa retry
-                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state compute-cluster pod-name k8s-actual-state-dict)
+                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
+                                                       compute-cluster pod-name k8s-actual-state-dict)
                                         ; Who resurrected this pod? Where did it come from? Do we have two instances of cook?
-                                        :pod/waiting (kill-pod-in-weird-state compute-cluster pod-name cook-expected-state-dict k8s-actual-state-dict))
+                                        :pod/waiting (kill-pod-in-weird-state compute-cluster pod-name
+                                                                              cook-expected-state-dict
+                                                                              k8s-actual-state-dict))
 
                                       :cook-expected-state/killed
                                       (case pod-synthesized-state-modified
-                                        ; TODO: Turn this into an info message and reword. Keep this message as these log
-                                        ; lines are a good sign of a bug, but it can also legitimately occur in a
-                                        ; normal occurance if someone submits a kill request on a job that fails to launch.
+                                        ; TODO: This can also legitimately occur in a
+                                        ; normal occurrence if someone submits a kill request on a job that fails to launch.
                                         :missing (do
                                                    (log/warn "In compute cluster" name ", pod" pod-name "in a weird cook expected state:" cook-expected-state-dict "and k8s actual state" k8s-actual-state-dict)
                                                    ; TODO: Avoid a race. Say a launch occurs, followed by a kill, followed by a watch update.
@@ -318,7 +322,8 @@
                                         ; There was a race and it completed normally before being it was killed.
                                         :pod/succeeded (handle-pod-completed compute-cluster k8s-actual-state-dict)
                                         ; TODO: Should mark mea culpa retry
-                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state compute-cluster pod-name k8s-actual-state-dict)
+                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
+                                                       compute-cluster pod-name k8s-actual-state-dict)
                                         :pod/waiting (kill-pod api-client cook-expected-state-dict pod))
 
                                       :cook-expected-state/running
@@ -333,10 +338,13 @@
                                         :pod/running cook-expected-state-dict
                                         :pod/succeeded (handle-pod-completed compute-cluster k8s-actual-state-dict)
                                         ; TODO: Should mark mea culpa retry
-                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state compute-cluster pod-name k8s-actual-state-dict)
+                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
+                                                       compute-cluster pod-name k8s-actual-state-dict)
                                         :pod/waiting (do ; This case is weird.
                                                        ; This breaks our rule of calling pod-has-completed on a non-terminal pod state.
-                                                       (kill-pod-in-weird-state compute-cluster pod-name cook-expected-state-dict k8s-actual-state-dict)
+                                                       (kill-pod-in-weird-state compute-cluster pod-name
+                                                                                cook-expected-state-dict
+                                                                                k8s-actual-state-dict)
                                                        ; TODO: Should mark mea culpa retry
                                                        (handle-pod-completed compute-cluster k8s-actual-state-dict)))
 
@@ -348,7 +356,8 @@
                                         :pod/running (handle-pod-started compute-cluster k8s-actual-state-dict)
                                         :pod/succeeded (handle-pod-completed compute-cluster k8s-actual-state-dict) ; Finished fast.
                                         ; TODO: Should mark mea culpa retry
-                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state compute-cluster pod-name k8s-actual-state-dict)
+                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
+                                                       compute-cluster pod-name k8s-actual-state-dict)
                                         ; Its starting. Can be stuck here. TODO: Stuck state detector to detect being stuck.
                                         :pod/waiting cook-expected-state-dict)
 
@@ -356,7 +365,8 @@
                                       (case pod-synthesized-state-modified
                                         :missing nil
                                         ; We shouldn't hit these unless we get a database rollback.
-                                        :pod/failed (kill-pod-in-weird-state compute-cluster pod-name nil k8s-actual-state-dict)
+                                        :pod/failed (kill-pod-in-weird-state compute-cluster pod-name
+                                                                             nil k8s-actual-state-dict)
                                         ; This can only occur in testing when you're e.g., blowing away the database.
                                         ; It will go through :missing,:missing and then be deleted from the map.
                                         ; TODO: May be evidence of a bug where we process pod changes when we're starting up.
@@ -364,9 +374,11 @@
                                         ; been added to datomic, but hasn't been submitted to k8s yet.
                                         :pod/running (kill-pod api-client cook-expected-state-dict pod)
                                         ; We shouldn't hit these unless we get a database rollback.
-                                        :pod/succeeded (kill-pod-in-weird-state compute-cluster pod-name nil k8s-actual-state-dict)
+                                        :pod/succeeded (kill-pod-in-weird-state compute-cluster pod-name
+                                                                                nil k8s-actual-state-dict)
                                         ; Unlike the other :pod/unknown states, no datomic state to update.
-                                        :pod/unknown (kill-pod-in-weird-state compute-cluster pod-name nil k8s-actual-state-dict)
+                                        :pod/unknown (kill-pod-in-weird-state compute-cluster pod-name
+                                                                              nil k8s-actual-state-dict)
                                         ; This can only occur in testing when you're e.g., blowing away the database.
                                         ; It will go through :missing,:missing and then be deleted from the map.
                                         ; TODO: May be evidence of a bug where we process pod changes when we're starting up.

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -360,6 +360,8 @@
                                         ; This can only occur in testing when you're e.g., blowing away the database.
                                         ; It will go through :missing,:missing and then be deleted from the map.
                                         ; TODO: May be evidence of a bug where we process pod changes when we're starting up.
+                                        ; Currently occurs because kill's can race ahead of launches, we kill something that has
+                                        ; been added to datomic, but hasn't been submitted to k8s yet.
                                         :pod/running (kill-pod api-client cook-expected-state-dict pod)
                                         ; We shouldn't hit these unless we get a database rollback.
                                         :pod/succeeded (kill-pod-in-weird-state compute-cluster pod-name nil k8s-actual-state-dict)
@@ -368,6 +370,8 @@
                                         ; This can only occur in testing when you're e.g., blowing away the database.
                                         ; It will go through :missing,:missing and then be deleted from the map.
                                         ; TODO: May be evidence of a bug where we process pod changes when we're starting up.
+                                        ; Currently occurs because kill's can race ahead of launches, we kill something that has
+                                        ; been added to datomic, but hasn't been submitted to k8s yet.
                                         :pod/waiting (kill-pod api-client cook-expected-state-dict pod)))]
       (when-not (cook-expected-state-equivalent? cook-expected-state-dict new-cook-expected-state-dict)
         (update-or-delete! cook-expected-state-map pod-name new-cook-expected-state-dict)

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -307,6 +307,7 @@
                                         ; TODO: This can also legitimately occur in a
                                         ; normal occurrence if someone submits a kill request on a job that fails to launch.
                                         :missing (do
+                                                   ; TODO: We will review these and may downgrade this to an info later.
                                                    (log/warn "In compute cluster" name ", pod" pod-name "in a weird cook expected state:" cook-expected-state-dict "and k8s actual state" k8s-actual-state-dict)
                                                    ; TODO: Avoid a race. Say a launch occurs, followed by a kill, followed by a watch update.
                                                    ; Before the watch update, we'll think the k8s-actual-state is missing.

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -85,11 +85,10 @@
                        (:cook-expected-state (get @cook-expected-state-map name {}))))
         count-delete-pod (atom 0)]
     (with-redefs [controller/delete-pod  (fn [_ cook-expected-state-dict _] (swap! count-delete-pod inc) cook-expected-state-dict)
-                  controller/log-weird-state (fn [_ _ _ _] :illegal_return_value_should_be_unused)
                   controller/handle-pod-completed (fn [_ _] {:cook-expected-state :cook-expected-state/completed})
                   controller/write-status-to-datomic (fn [_] :illegal_return_value_should_be_unused)]
 
-      (is (= :cook-expected-state/completed (do-process :cook-expected-state/killed :pod/succeeded)))
+      (is (= :cook-expected-state/completed (do-process :cook-expected-state/completed :pod/succeeded)))
       (is (= 1 @count-delete-pod))
       ; Implicitly assume the watch triggers, moving us to next state in kubernetes:
       (is (nil? (do-process :cook-expected-state/completed :missing)))

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -72,6 +72,29 @@
       (is (nil? (do-process :missing :pod/unknown)))
       (is (= :missing (do-process :missing :pod/waiting))))))
 
+(deftest test-completion-protocol
+  (let [name "TestPodName"
+        do-process (fn [cook-expected-state k8s-actual-state]
+                     (let [cook-expected-state-map
+                           (atom {name {:cook-expected-state cook-expected-state}})]
+                       (controller/process
+                         {:api-client nil
+                          :cook-expected-state-map cook-expected-state-map
+                          :k8s-actual-state-map (atom {name {:synthesized-state {:state k8s-actual-state} :pod nil}})}
+                         name)
+                       (:cook-expected-state (get @cook-expected-state-map name {}))))
+        count-delete-pod (atom 0)]
+    (with-redefs [controller/delete-pod  (fn [_ cook-expected-state-dict _] (swap! count-delete-pod inc) cook-expected-state-dict)
+                  controller/log-weird-state (fn [_ _ _ _] :illegal_return_value_should_be_unused)
+                  controller/handle-pod-completed (fn [_ _] {:cook-expected-state :cook-expected-state/completed})
+                  controller/write-status-to-datomic (fn [_] :illegal_return_value_should_be_unused)]
+
+      (is (= :cook-expected-state/completed (do-process :cook-expected-state/killed :pod/succeeded)))
+      (is (= 1 @count-delete-pod))
+      ; Implicitly assume the watch triggers, moving us to next state in kubernetes:
+      (is (nil? (do-process :cook-expected-state/completed :missing)))
+      (is (= 1 @count-delete-pod)))))
+
 (deftest test-handle-pod-completed
   (testing "graceful handling of lack of exit code"
     (let [pod (V1Pod.)


### PR DESCRIPTION
## Changes proposed in this PR

- Fix a small bug in state machine.
- A variety of weird states aren't as weird as we thought and/or are symptomatic of deeper bugs.
- Improve the logging.

In the kubernetes tracking state machine, the old bad code would go:
(completed,succeeded) -> (missing,succeeded) -> (missing,missing), inadvertently deleting its local state first and keeping the kubernetes state.
The correct transitions should go:
(completed, succeeded) -> (completed,missing), (missing,missing).
so we're always tracking the local state.

## Why are we making these changes?
Weird states are supposed to be things that should never occur. So we want less false positives in the log.

