### PR TITLE
Adds timeout to test metrics POST request

### DIFF
--- a/integration/tests/conftest.py
+++ b/integration/tests/conftest.py
@@ -70,8 +70,9 @@ if 'TEST_METRICS_URL' in os.environ:
                 'runtime-milliseconds': (end - start) * 1000,
                 'expected-to-fail': xfail_mark is not None and xfail_mark.name == 'xfail'
             }
-            logging.info(f'Updating test metrics: {json.dumps(metrics, indent=2)}')
-            resp = util.session.post(f'{elastic_search_url}/{index}/test-result', json=metrics)
+            timeout = os.getenv('TEST_METRICS_POST_TIMEOUT_SECONDS', 10)
+            logging.info(f'Updating test metrics (timeout = {timeout} seconds): {json.dumps(metrics, indent=2)}')
+            resp = util.session.post(f'{elastic_search_url}/{index}/test-result', json=metrics, timeout=timeout)
             logging.info(f'Response from updating test metrics: {resp.text}')
         except:
             logging.exception('Encountered exception while recording test metrics')


### PR DESCRIPTION
## Changes proposed in this PR

- setting a configurable timeout on the POST for test metrics

## Why are we making these changes?

We've seen cases where tests timeout in pytest because the test metrics request hangs.