### PR TITLE
Handles pod submission failures

### DIFF
--- a/scheduler/docs/kubernetes-state.dot
+++ b/scheduler/docs/kubernetes-state.dot
@@ -4,7 +4,8 @@
 digraph g {
         Starting -> Starting [label=":waiting\n:missing"]
         Starting -> Running [label=":running"]
-        Starting -> Completed [label=":succeeded\n:failed\n:unknown"]
+        // (Starting, missing) -> Completed happens for some failed pod submissions
+        Starting -> Completed [label=":succeeded\n:failed\n:unknown\n:missing"]
 
         Running -> Running [label=":running"]
         Running -> Completed [label=":waiting\n:succeeded\n:failed\n:unknown\n:missing"]

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -674,7 +674,13 @@
         ))))
 
 (defn launch-pod
-  "Given a V1Pod, launch it."
+  "Attempts to submit the given pod to k8s. If pod submission fails, we inspect the
+  response code to determine whether or not this is a bad pod spec (e.g. the
+  namespace doesn't exist on the cluster or there is an invalid environment
+  variable name), or whether the failure is something less offensive (like a 409
+  conflict error because we've attempted to re-submit a pod that the watch has not
+  yet notified us exists). The function returns false if we should consider the
+  launch operation failed."
   [api-client {:keys [launch-pod]} pod-name]
   (if launch-pod
     (let [{:keys [pod]} launch-pod

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -690,7 +690,7 @@
         true
         (catch ApiException e
           (let [code (.getCode e)
-                bad-pod-spec? (= code 422)]
+                bad-pod-spec? (some #{code} [404 422])]
             (log/info e "Error submitting pod with name" pod-name "in namespace" namespace
                       ", code:" code ", response body:" (.getResponseBody e))
             (not bad-pod-spec?)))))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -673,6 +673,11 @@
         ;
         ))))
 
+(defn create-namespaced-pod
+  "Delegates to the k8s API .createNamespacedPod function"
+  [api namespace pod]
+  (.createNamespacedPod api namespace pod nil nil nil))
+
 (defn launch-pod
   "Attempts to submit the given pod to k8s. If pod submission fails, we inspect the
   response code to determine whether or not this is a bad pod spec (e.g. the
@@ -692,7 +697,7 @@
                    "does not match pod name argument (" pod-name ")"))
       (log/info "Launching pod with name" pod-name "in namespace" namespace ":" (Yaml/dump pod))
       (try
-        (.createNamespacedPod api namespace pod nil nil nil)
+        (create-namespaced-pod api namespace pod)
         true
         (catch ApiException e
           (let [code (.getCode e)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -679,11 +679,11 @@
   (if launch-pod
     (let [{:keys [pod]} launch-pod
           pod-name-from-pod (-> pod .getMetadata .getName)
-          (assert (= pod-name-from-pod pod-name)
-                  (str "Pod name from pod (" pod-name-from-pod ") "
-                       "does not match pod name argument (" pod-name ")"))
           namespace (-> pod .getMetadata .getNamespace)
           api (CoreV1Api. api-client)]
+      (assert (= pod-name-from-pod pod-name)
+              (str "Pod name from pod (" pod-name-from-pod ") "
+                   "does not match pod name argument (" pod-name ")"))
       (log/info "Launching pod with name" pod-name "in namespace" namespace ":" (Yaml/dump pod))
       (try
         (.createNamespacedPod api namespace pod nil nil nil)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -690,7 +690,7 @@
         true
         (catch ApiException e
           (let [code (.getCode e)
-                bad-pod-spec? (some #{code} [404 422])]
+                bad-pod-spec? (contains? #{404 422} code)]
             (log/info e "Error submitting pod with name" pod-name "in namespace" namespace
                       ", code:" code ", response body:" (.getResponseBody e))
             (not bad-pod-spec?)))))

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -95,7 +95,8 @@
                                      mesos-status))
 
 (defn handle-pod-submission-failed
-  "TODO(DPO)"
+  "Marks the corresponding job instance as failed in the database and
+  returns the `completed` cook expected state"
   [{:keys [name] :as compute-cluster} pod-name]
   (log/info "In compute cluster" name ", pod" pod-name "submission failed")
   (let [instance-id pod-name

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -100,9 +100,9 @@
   [{:keys [name] :as compute-cluster} pod-name]
   (log/info "In compute cluster" name ", pod" pod-name "submission failed")
   (let [instance-id pod-name
-        status {:task-id {:value instance-id}
+        status {:reason :reason-task-invalid
                 :state :task-failed
-                :reason :reason-task-invalid}]
+                :task-id {:value instance-id}}]
     (write-status-to-datomic compute-cluster status)
     {:cook-expected-state :cook-expected-state/completed}))
 

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -87,11 +87,35 @@
   (log-weird-state compute-cluster pod-name cook-expected-state-dict k8s-actual-state-dict)
   (kill-pod api-client cook-expected-state-dict pod))
 
+(defn write-status-to-datomic
+  "Helper function for calling scheduler/write-status-to-datomic"
+  [compute-cluster mesos-status]
+  (scheduler/write-status-to-datomic datomic/conn
+                                     @(:pool->fenzo-atom compute-cluster)
+                                     mesos-status))
+
+(defn handle-pod-submission-failed
+  "TODO(DPO)"
+  [{:keys [name] :as compute-cluster} pod-name]
+  (log/info "In compute cluster" name ", pod" pod-name "submission failed")
+  (let [instance-id pod-name
+        status {:task-id {:value instance-id}
+                :state :task-failed
+                :reason :reason-task-invalid}]
+    (write-status-to-datomic compute-cluster status)
+    {:cook-expected-state :cook-expected-state/completed}))
+
 (defn launch-pod
-  [api-client cook-expected-state-dict]
-  (api/launch-pod api-client cook-expected-state-dict)
-  ; TODO: Should detect if we don't have a :launch-pod key and force a mea culpa retry and :cook-expected-state/killed so that we retry.
-  cook-expected-state-dict)
+  [compute-cluster api-client {:keys [launch-pod] :as cook-expected-state-dict}]
+  (if (api/launch-pod api-client cook-expected-state-dict)
+    ; TODO:
+    ; Should detect if we don't have a :launch-pod key and
+    ; force a mea culpa retry and :cook-expected-state/killed
+    ; so that we retry.
+    cook-expected-state-dict
+    (let [{:keys [pod]} launch-pod
+          pod-name (-> pod .getMetadata .getName)]
+      (handle-pod-submission-failed compute-cluster pod-name))))
 
 (defn update-or-delete!
   "Given a map atom, key, and value, if the value is not nil, set the key to the value in the map.
@@ -124,13 +148,6 @@
         (log/warn "In compute cluster" name ", unable to determine failure reason for" instance-id
                   {:pod-status pod-status :container-status container-status})
         :unknown))))
-
-(defn write-status-to-datomic
-  "Helper function for calling scheduler/write-status-to-datomic"
-  [compute-cluster mesos-status]
-  (scheduler/write-status-to-datomic datomic/conn
-                                     @(:pool->fenzo-atom compute-cluster)
-                                     mesos-status))
 
 (defn- get-job-container-status
   "Extract the container status for the main cook job container (defined in api/cook-container-name-for-job).
@@ -210,7 +227,6 @@
     (write-status-to-datomic compute-cluster status)
     (sandbox/aggregate-exit-code (:exit-code-syncer-state compute-cluster) instance-id 143)
     {:cook-expected-state :cook-expected-state/completed}))
-
 
 (defn handle-pod-completed-and-kill-pod-in-weird-state
   "Writes the completed state to datomic and deletes the pod in kubernetes.
@@ -343,7 +359,7 @@
 
                                       :cook-expected-state/starting
                                       (case pod-synthesized-state-modified
-                                        :missing (launch-pod api-client cook-expected-state-dict)
+                                        :missing (launch-pod compute-cluster api-client cook-expected-state-dict)
                                         ; TODO: May need to mark mea culpa retry
                                         :pod/failed (handle-pod-completed compute-cluster k8s-actual-state-dict) ; Finished or failed fast.
                                         :pod/running (handle-pod-started compute-cluster k8s-actual-state-dict)

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -37,7 +37,7 @@
                                               tu/make-task-request
                                               tu/make-task-assignment-result)))
         launched-pod-atom (atom nil)]
-    (with-redefs [api/launch-pod (fn [api {:keys [launch-pod]}]
+    (with-redefs [api/launch-pod (fn [_ {:keys [launch-pod]} _]
                                    (reset! launched-pod-atom launch-pod))
                   api/make-security-context (constantly (V1PodSecurityContext.))]
       (testing "static namespace"
@@ -71,7 +71,7 @@
 
 (deftest test-generate-offers
   (tu/setup)
-  (with-redefs [api/launch-pod (constantly nil)]
+  (with-redefs [api/launch-pod (constantly true)]
     (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")
           compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                           (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -30,7 +30,7 @@
                        (:cook-expected-state (get @cook-expected-state-map name {}))))]
     (with-redefs [controller/delete-pod  (fn [_ cook-expected-state-dict _] cook-expected-state-dict)
                   controller/kill-pod  (fn [_ cook-expected-state-dict _] cook-expected-state-dict)
-                  controller/launch-pod (fn [_ cook-expected-state-dict] cook-expected-state-dict)
+                  controller/launch-pod (fn [_ _ cook-expected-state-dict _] cook-expected-state-dict)
                   controller/log-weird-state (fn [_ _ _ _] :illegal_return_value_should_be_unused)
                   controller/handle-pod-completed (fn [_ _] {:cook-expected-state :cook-expected-state/completed})
                   controller/handle-pod-started (fn [_ _] {:cook-expected-state :cook-expected-state/running})


### PR DESCRIPTION
## Changes proposed in this PR

When a pod submission fails in a way we know is permanent, mark the instance as Failed in the database and transition from (starting, missing) to (completed, missing) in the k8s state machine.

The `:missing` edge from `Starting` to `Completed` is new:

![image](https://user-images.githubusercontent.com/444778/73497612-cea4c080-4380-11ea-995d-1770f83b1a85.png)

## Why are we making these changes?

This is a "fast fail" for invalid pods, so that their jobs don't stay in the Running state forever.

## Integration test run

```
$ COOK_TEST_DEFAULT_SUBMIT_POOL=k8s-alpha COOK_TEST_COMPUTE_CLUSTER_TYPE=kubernetes pytest -k test_pod_submission_failed -n1
=============================================================================================================================== test session starts ===============================================================================================================================
platform linux -- Python 3.6.8, pytest-5.2.0, py-1.8.0, pluggy-0.13.0 -- /home/dpo/source/Cook/venv/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/dpo/source/Cook/integration, inifile: setup.cfg
plugins: xdist-1.30.0, timeout-1.3.3, forked-1.0.2
timeout: 1200.0s
timeout method: thread
timeout func_only: False
[gw0] linux Python 3.6.8 cwd: /home/dpo/source/Cook/integration
[gw0] Python 3.6.8 (default, Aug 20 2019, 17:12:48)  -- [GCC 8.3.0]
gw0 [1]
scheduling tests via LoadScheduling

tests/cook/test_basic.py::CookTest::test_pod_submission_failed 
[gw0] [100%] PASSED tests/cook/test_basic.py::CookTest::test_pod_submission_failed 

============================================================================================================================ slowest 25 test durations ============================================================================================================================
6.04s call     tests/cook/test_basic.py::CookTest::test_pod_submission_failed

(0.00 durations hidden.  Use -vv to show these durations.)
================================================================================================================================ 1 passed in 7.07s ================================================================================================================================
```

## Example from log

```
2020-01-30 14:33:08,791 INFO  cook.kubernetes.api [async-thread-macro-5] - Launching pod with name 5e333d84-ba6b-412f-b7f5-85ead27db93f in namespace cook : metadata:
  name: 5e333d84-ba6b-412f-b7f5-85ead27db93f
    - {name: COOK_INSTANCE_UUID, value: 5e333d84-ba6b-412f-b7f5-85ead27db93f}
2020-01-30 14:33:08,863 INFO  cook.kubernetes.api [async-thread-macro-5] - Error submitting pod with name 5e333d84-ba6b-412f-b7f5-85ead27db93f in namespace cook , code: 422 , response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod \"5e333d84-ba6b-412f-b7f5-85ead27db93f\" is invalid: [spec.containers[0].image: Required value, spec.containers[0].env[0].name: Invalid value: \"1\": a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit (e.g. 'my.env-name',  or 'MY_ENV.NAME',  or 'MyEnvName1', regex used for validation is '[-._a-zA-Z][-._a-zA-Z0-9]*')]","reason":"Invalid","details":{"name":"5e333d84-ba6b-412f-b7f5-85ead27db93f","kind":"Pod","causes":[{"reason":"FieldValueRequired","message":"Required value","field":"spec.containers[0].image"},{"reason":"FieldValueInvalid","message":"Invalid value: \"1\": a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit (e.g. 'my.env-name',  or 'MY_ENV.NAME',  or 'MyEnvName1', regex used for validation is '[-._a-zA-Z][-._a-zA-Z0-9]*')","field":"spec.containers[0].env[0].name"}]},"code":422}
2020-01-30 14:33:08,864 INFO  cook.kubernetes.controller [async-thread-macro-5] - In compute cluster gke-1 , pod 5e333d84-ba6b-412f-b7f5-85ead27db93f submission failed
2020-01-30 14:33:08,864 INFO  cook.scheduler.scheduler [async-thread-macro-5] - Mesos status is: {:task-id {:value 5e333d84-ba6b-412f-b7f5-85ead27db93f}, :state :task-failed, :reason :reason-task-invalid}
2020-01-30 14:33:08,867 DEBUG cook.scheduler.scheduler [async-thread-macro-5] - In k8s-alpha pool, unassigning task 5e333d84-ba6b-412f-b7f5-85ead27db93f from gke-dpo-test-cluster-cook-pool-k8s-al-4564d500-w0c9
2020-01-30 14:33:08,868 INFO  cook.kubernetes.controller [async-thread-macro-5] - In compute cluster gke-1 , processing pod 5e333d84-ba6b-412f-b7f5-85ead27db93f after cook-expected-state-change
2020-01-30 14:33:08,868 INFO  cook.kubernetes.controller [async-thread-macro-5] - In compute cluster gke-1 , processing pod 5e333d84-ba6b-412f-b7f5-85ead27db93f ; cook-expected: {:cook-expected-state :cook-expected-state/completed} , k8s-actual: {:synthesized-state {:state :missing}, :pod-status nil}
2020-01-30 14:33:08,868 INFO  cook.kubernetes.controller [async-thread-macro-5] - In compute cluster gke-1 , processing pod 5e333d84-ba6b-412f-b7f5-85ead27db93f after cook-expected-state-change
2020-01-30 14:33:08,868 INFO  cook.kubernetes.controller [async-thread-macro-5] - In compute cluster gke-1 , processing pod 5e333d84-ba6b-412f-b7f5-85ead27db93f ; cook-expected: nil , k8s-actual: {:synthesized-state {:state :missing}, :pod-status nil}
```