### PR TITLE
Use scalar-requests for job container resources

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -439,8 +439,10 @@
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."
   [namespace compute-cluster-name {:keys [task-id command container task-request hostname]}]
-  (let [{:keys [resources job]} task-request
-        {:keys [mem cpus]} resources
+  (let [{:keys [scalar-requests job]} task-request
+        ;; NOTE: The scheduler's adjust-job-resources-for-pool-fn may modify :resources,
+        ;; whereas :scalar-requests always contains the unmodified job resource values.
+        {:strs [mem cpus]} scalar-requests
         {:keys [docker volumes]} container
         {:keys [image parameters]} docker
         pod (V1Pod.)

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -63,8 +63,12 @@
                                      :user (System/getProperty "user.name")}
                            :container {:type :docker
                                        :docker {:image "alpine:latest"}}
-                           :task-request {:resources {:mem 512
-                                                      :cpus 1.0}}
+                           ;; assume this task requested {cpu:1.0,mem:512} for the job's container
+                           ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
+                           :task-request {:resources {:mem 576
+                                                      :cpus 1.1}
+                                          :scalar-requests {"mem" 512
+                                                            "cpus" 1.0}}
                            :hostname "kubehost"}
             pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)]
         (is (= "my-task" (-> pod .getMetadata .getName)))
@@ -115,8 +119,12 @@
                                      :docker {:image "alpine:latest"
                                               :parameters [{:key "user"
                                                             :value "100:10"}]}}
-                         :task-request {:resources {:mem 512
-                                                    :cpus 1.0}}
+                         ;; assume this task requested {cpu:1.0,mem:512} for the job's container
+                         ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
+                         :task-request {:resources {:mem 576
+                                                    :cpus 1.1}
+                                        :scalar-requests {"mem" 512
+                                                          "cpus" 1.0}}
                          :hostname "kubehost"}
           pod (api/task-metadata->pod "cook" "test-cluster" task-metadata)]
       (is (= 100 (-> pod .getSpec .getSecurityContext .getRunAsUser)))


### PR DESCRIPTION
## Changes proposed in this PR

Use scalar-requests for job container resources when constructing k8s pod specs.

## Why are we making these changes?

Fixes a bug where the sidecar's resources were added into the main job
container's resource requests and limits, in addition to specifying
those resources in the sidecar's container.

## Additional details

<details>

<summary>
I dumped the value of <code>task-request</code> at the start of <code>task-metadata->pod</code>, which is when I noticed the difference between its <code>:resources</code> and <code>:scalar-requests</code> members.
</summary>

```clojure
;; 2020-01-29 20:13:56,944 INFO  cook.kubernetes.api [async-thread-macro-4] - TASK FOR POD:
{:job
 {:job/pool
  {:pool/name "k8s-gamma",
   :pool/purpose "This is a pool for testing purposes",
   :pool/state :pool.state/active,
   :pool/dru-mode :pool.dru-mode/default},
  :job/commit-latch
  {:commit-latch/committed? true,
   :commit-latch/uuid #uuid "5e323bdc-1fcb-4f0d-a7b5-88923495ce2f"},
  :job/submit-time #inst "2020-01-30T02:13:48.172-00:00",
  :job/custom-executor false,
  :job/application
  {:application/name "cook-scheduler-cli",
   :application/version "2.15.0"},
  :job/container
  {:container/type "DOCKER",
   :container/docker
   {:docker/image "python:3.7-alpine",
    :docker/parameters
    #{{:docker.param/key "user", :docker.param/value "1001:1001"}},
    :docker/network "HOST",
    :docker/force-pull-image false}},
  :job/state :job.state/waiting,
  :job/name "nickv_job",
  :job/command "echo Hello > stdout ; sleep 1",
  :job/max-retries 1,
  :job/resource
  #{{:resource/type :resource.type/cpus, :resource/amount 0.1}
    {:resource/type :resource.type/mem, :resource/amount 32.0}},
  :job/uuid #uuid "20012920-354d-4e68-ba62-f3af0e34453c",
  :job/user "nickv",
  :job/disable-mea-culpa-retries false},
 :resources {:ports 0, :cpus 0.2, :mem 160.0},
 :task-id "5e323be4-ad4e-4a6f-9d21-48e57fa4edce",
 :assigned-resources #<Atom@3ab89dfb: nil>,
 :guuid->considerable-cotask-ids #object[cook.tools$make_guuid__GT_considerable_cotask_ids$fn__30141 0x22d7c0a4 "cook.tools$make_guuid__GT_considerable_cotask_ids$fn__30141@22d7c0a4"],
 :constraints (#object[cook.scheduler.constraints$fenzoize_job_constraint$reify__38566 0x4c13a933 "cook.scheduler.constraints$fenzoize_job_constraint$reify__38566@4c13a933"]
               #object[cook.scheduler.constraints$build_max_tasks_per_host_constraint$reify__38563 0x995a528 "cook.scheduler.constraints$build_max_tasks_per_host_constraint$reify__38563@995a528"]
               #object[cook.scheduler.constraints$build_launch_max_tasks_constraint$reify__38560 0x773cb6a4 "cook.scheduler.constraints$build_launch_max_tasks_constraint$reify__38560@773cb6a4"]
               #object[cook.scheduler.constraints$fenzoize_job_constraint$reify__38566 0x6b729a07 "cook.scheduler.constraints$fenzoize_job_constraint$reify__38566@6b729a07"]
               #object[cook.scheduler.constraints$fenzoize_job_constraint$reify__38566 0x3af9fc6b "cook.scheduler.constraints$fenzoize_job_constraint$reify__38566@3af9fc6b"]
               #object[cook.scheduler.constraints$fenzoize_job_constraint$reify__38566 0x1ee1b2f9 "cook.scheduler.constraints$fenzoize_job_constraint$reify__38566@1ee1b2f9"]),
 :needs-gpus? false,
 :scalar-requests {"cpus" 0.1, "mem" 32.0}}
```

</details>

I've included below the relevant output from `kubectl describe pod` before and after this patch for comparison.

Job submission command:
```
cs submit --pool=k8s-gamma --cpus=0.1 --mem=32 --docker-image=python:3.7-alpine sleep 300
```

Sidecar container details:
```
    aux-cook-sandbox-file-server-container:
      Limits:
        cpu:     100m
        memory:  128M
      Requests:
        cpu:      100m
        memory:   128M
```

Resulting pod's main job container before this patch:
```
    required-cook-job-container:
      Limits:
        cpu:     200m
        memory:  160M
      Requests:
        cpu:     200m
        memory:  160M
```

Resulting pod's main job container after this patch:
```
    required-cook-job-container:
      Limits:
        cpu:     100m
        memory:  32M
      Requests:
        cpu:     100m
        memory:  32M
```