### PR TITLE
Fix a race where cook scheduler can kill a task then later launch a t…

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -20,7 +20,8 @@
 
 ; There's an ugly race where the core cook scheduler can kill a job before it tries to launch it.
 ; What happens is:
-;   1. In launch-matched-tasks, we write instance objects to datomic for everything that matches, we have not submitted these to the compute cluster backends yet.
+;   1. In launch-matched-tasks, we write instance objects to datomic for everything that matches,
+;      we have not submitted these to the compute cluster backends yet.
 ;   2. A kill command arrives to kill the job. The job is put into completed.
 ;   3. The monitor-tx-queue happens to notice the job just completed. It sees the instance written in step 1.
 ;   4. We submit a kill-task to the compute cluster backend.

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -21,8 +21,8 @@
 ; There's an ugly race where the core cook scheduler can kill a job before it tries to launch it.
 ; What happens is:
 ;   1. In launch-matched-tasks, we write instance objects to datomic for everything that matches, we have not submitted these to the compute cluster backends yet.
-;   2. A kill command arrives to kill the job. THe job is put into completed.
-;   3. This monitor-tx-queue happens to notice the job just completed. It sees the instance written in step 1.
+;   2. A kill command arrives to kill the job. The job is put into completed.
+;   3. The monitor-tx-queue happens to notice the job just completed. It sees the instance written in step 1.
 ;   4. We submit a kill-task to the compute cluster backend.
 ;   5. Kill task processes. There's not much to do, as there's no task to kill.
 ;   6. launch-matched-tasks now visits the task and submits it to the compute cluster backend.
@@ -148,4 +148,3 @@
                                 (map (fn [{:keys [config]}] (:compute-cluster-name config)))
                                 first)]
     (compute-cluster-name->ComputeCluster first-cluster-name)))
-

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -705,55 +705,58 @@
   (let [matches (map #(update-match-with-task-metadata-seq % db mesos-run-as-user) matches)
         task-txns (matches->task-txns matches)]
     (log/info "In" pool-name "pool, writing tasks" task-txns)
-    ;; Note that this transaction can fail if a job was scheduled
-    ;; during a race. If that happens, then other jobs that should
-    ;; be scheduled will not be eligible for rescheduling until
-    ;; the pending-jobs atom is repopulated
     (timers/time!
-      (timers/timer (metric-title "handle-resource-offer!-transact-task-duration" pool-name))
-      (datomic/transact
-        conn
-        (reduce into [] task-txns)
-        (fn [e]
-          (log/warn e
-                    "In" pool-name "pool, transaction timed out, so these tasks might be present"
-                    "in Datomic without actually having been launched in Mesos"
-                    matches)
-          (throw e))))
-    (log/info "In" pool-name "pool, launching" (count task-txns) "tasks")
-    (ratelimit/spend! ratelimit/global-job-launch-rate-limiter ratelimit/global-job-launch-rate-limiter-key (count task-txns))
-    ;; This launch-tasks MUST happen after the above transaction in
-    ;; order to allow a transaction failure (due to failed preconditions)
-    ;; to block the launch
-    (let [num-offers-matched (->> matches
-                                  (mapcat (comp :id :offer :leases))
-                                  (distinct)
-                                  (count))]
-      (meters/mark! scheduler-offer-matched num-offers-matched)
-      (histograms/update! number-offers-matched num-offers-matched))
-    (meters/mark! (meters/meter (metric-title "matched-tasks" pool-name)) (count task-txns))
-    (timers/time!
-      (timers/timer (metric-title "handle-resource-offer!-mesos-submit-duration" pool-name))
-      ;; Iterates over offers (each offer can match to multiple tasks)
-      (doseq [{:keys [leases task-metadata-seq]} matches
-              :let [all-offers (mapv :offer leases)]]
-        (doseq [[compute-cluster offers] (group-by :compute-cluster all-offers)
-                :let [compute-cluster-name (cc/compute-cluster-name compute-cluster)]]
-          (try
-            (cc/launch-tasks compute-cluster offers task-metadata-seq)
-            (log/info "In" pool-name "pool, launching" (count offers)
-                      "offers for" compute-cluster-name "compute cluster")
-            (doseq [{:keys [hostname task-request] :as meta} task-metadata-seq]
-              ; Iterate over the tasks we matched
-              (let [user (get-in task-request [:job :job/user])]
-                (ratelimit/spend! ratelimit/job-launch-rate-limiter user 1))
-              (locking fenzo
-                (.. fenzo
-                    (getTaskAssigner)
-                    (call task-request hostname))))
-            (catch Throwable t
-              (log/error t "In" pool-name "pool, error launching tasks for"
-                         compute-cluster-name "compute cluster"))))))))
+      (timers/timer (metric-title "launch-matched-tasks-all-duration" pool-name))
+      (locking cc/kill-lock-object
+        ;; Note that this transaction can fail if a job was scheduled
+        ;; during a race. If that happens, then other jobs that should
+        ;; be scheduled will not be eligible for rescheduling until
+        ;; the pending-jobs atom is repopulated
+        (timers/time!
+          (timers/timer (metric-title "handle-resource-offer!-transact-task-duration" pool-name))
+          (datomic/transact
+            conn
+            (reduce into [] task-txns)
+            (fn [e]
+              (log/warn e
+                        "In" pool-name "pool, transaction timed out, so these tasks might be present"
+                        "in Datomic without actually having been launched in Mesos"
+                        matches)
+              (throw e))))
+        (log/info "In" pool-name "pool, launching" (count task-txns) "tasks")
+        (ratelimit/spend! ratelimit/global-job-launch-rate-limiter ratelimit/global-job-launch-rate-limiter-key (count task-txns))
+        ;; This launch-tasks MUST happen after the above transaction in
+        ;; order to allow a transaction failure (due to failed preconditions)
+        ;; to block the launch
+        (let [num-offers-matched (->> matches
+                                      (mapcat (comp :id :offer :leases))
+                                      (distinct)
+                                      (count))]
+          (meters/mark! scheduler-offer-matched num-offers-matched)
+          (histograms/update! number-offers-matched num-offers-matched))
+        (meters/mark! (meters/meter (metric-title "matched-tasks" pool-name)) (count task-txns))
+        (timers/time!
+          (timers/timer (metric-title "handle-resource-offer!-mesos-submit-duration" pool-name))
+          ;; Iterates over offers (each offer can match to multiple tasks)
+          (doseq [{:keys [leases task-metadata-seq]} matches
+                  :let [all-offers (mapv :offer leases)]]
+            (doseq [[compute-cluster offers] (group-by :compute-cluster all-offers)
+                    :let [compute-cluster-name (cc/compute-cluster-name compute-cluster)]]
+              (try
+                (cc/launch-tasks compute-cluster offers task-metadata-seq)
+                (log/info "In" pool-name "pool, launching" (count offers)
+                          "offers for" compute-cluster-name "compute cluster")
+                (doseq [{:keys [hostname task-request] :as meta} task-metadata-seq]
+                  ; Iterate over the tasks we matched
+                  (let [user (get-in task-request [:job :job/user])]
+                    (ratelimit/spend! ratelimit/job-launch-rate-limiter user 1))
+                  (locking fenzo
+                    (.. fenzo
+                        (getTaskAssigner)
+                        (call task-request hostname))))
+                (catch Throwable t
+                  (log/error t "In" pool-name "pool, error launching tasks for"
+                             compute-cluster-name "compute cluster"))))))))))
 
 (defn update-host-reservations!
   "Updates the rebalancer-reservation-atom with the result of the match cycle.


### PR DESCRIPTION
## Changes proposed in this PR

- We add a lock around launch-task in the scheduler and kill-task in compute cluster to avoid cook sending a nonsensical kill-task followed by launch task on the same task. 

## Why are we making these changes?

This bug means that Cook can leave behind an orphaned k8s-pod (or, very likely, mesos task) running to completion, unmonitored. 
