### PR TITLE
Fix a race where we don't kill a pod thats been sent to kubernetes because the watch hasn't returned yet.

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -590,7 +590,7 @@
                                     container-statuses))]
       (if (some-> pod .getMetadata .getDeletionTimestamp)
         ; If a pod has been ordered deleted, treat it as if it was gone, It's being async removed.
-        ; Note that we distinguish between this explicit :missing, and not being there at all, when processing
+        ; Note that we distinguish between this explicit :missing, and not being there at all when processing
         ; (:cook-expected-state/killed, :missing) in cook.kubernetes.controller/process
         {:state :missing :reason "Pod was explicitly deleted"}
         ; If pod isn't being async removed, then look at the containers inside it.

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -590,6 +590,8 @@
                                     container-statuses))]
       (if (some-> pod .getMetadata .getDeletionTimestamp)
         ; If a pod has been ordered deleted, treat it as if it was gone, It's being async removed.
+        ; Note that we distinguish between this explicit :missing, and not being there at all, when processing
+        ; (:cook-expected-state/killed, :missing) in cook.kubernetes.controller/process
         {:state :missing :reason "Pod was explicitly deleted"}
         ; If pod isn't being async removed, then look at the containers inside it.
         (if job-status

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -323,7 +323,7 @@
                                         ; If we did nothing, we'd log this as a weird state, then when the watch
                                         ; shows up, we'd see (:missing, :starting) and log that as a weird state too.
                                         ;
-                                        ; So, a better approach. If we detect a :missing,:killed, then we opportunistically
+                                        ; So, a better approach. If we detect a (:killed, :missing), then we opportunistically
                                         ; try to kill the pod. This is why update-cook-expected-state saves :launch-pod,
                                         ; so its available here.
                                         (if-let [pod (some-> cook-expected-state-dict :launch-pod :pod)]
@@ -333,7 +333,7 @@
                                             ; We treat a deleting pod in kubernetes the same as a missing pod when coming up with a synthesized state.
                                             ; That's good for (almost) all parts of the system. However,
                                             ; If it is legitimately missing, then something weird is going on. If it is
-                                            ; deleting, that's an expected state. So, lets be selective with our logging.
+                                            ; deleting, that's an expected state. So, let's be selective with our logging.
                                             (if (= (:state synthesized-state) :missing)
                                               (log/info "In compute cluster" name ", pod" pod-name
                                                         "was killed with cook expected state"

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -330,7 +330,10 @@
                                           (do
                                             (log/info "In compute cluster" name ", opportunistically killing" pod-name
                                                       "because of potential race where kill arrives before the watch responds to the launch")
-                                            (kill-pod api-client :ignored pod))
+                                            (kill-pod api-client :ignored pod)
+                                            ; This is needed to make sure if we take the opportunistic kill, we make
+                                            ; sure to write the status to datomic. Recall we're in kubernetes state missing.
+                                            (handle-pod-killed compute-cluster pod-name))
                                           (do
                                             ; We treat a deleting pod in kubernetes the same as a missing pod when coming up with a synthesized state.
                                             ; That's good for (almost) all parts of the system. However,

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -317,7 +317,7 @@
                                       (case pod-synthesized-state-modified
                                         :missing
                                         ; There's a race where we can launch then kill, when the kill arrives after
-                                        ; the launch, but before the watch updates k8s-actual-state-dict.
+                                        ; the launch, but before the watch updates k8s-actual-state.
                                         ; (k8s-actual-state isn't the actual state, because of this watch lag)
                                         ; When that happens, we will have an actual state of :missing.
                                         ; If we did nothing, we'd log this as a weird state, then when the watch
@@ -331,9 +331,9 @@
                                               (kill-pod api-client :ignored pod))
                                           (do
                                             ; We treat a deleting pod in kubernetes the same as a missing pod when coming up with a synthesized state.
-                                            ; Thats good for (almost) all parts of the system. However,
+                                            ; That's good for (almost) all parts of the system. However,
                                             ; If it is legitimately missing, then something weird is going on. If it is
-                                            ; deleting, thats an expected state. So, lets be selective with our logging.
+                                            ; deleting, that's an expected state. So, lets be selective with our logging.
                                             (if (= (:state synthesized-state) :missing)
                                               (log/info "In compute cluster" name ", pod" pod-name
                                                         "was killed with cook expected state"
@@ -342,10 +342,10 @@
                                                         (prepare-k8s-actual-state-dict-for-logging k8s-actual-state-dict))
                                               (log-weird-state compute-cluster pod-name
                                                                cook-expected-state-dict k8s-actual-state-dict))
-                                              (handle-pod-killed compute-cluster pod-name)))
-                                          :pod/failed (handle-pod-completed compute-cluster k8s-actual-state-dict)
-                                          :pod/running (kill-pod api-client cook-expected-state-dict pod)
-                                          ; There was a race and it completed normally before being it was killed.
+                                            (handle-pod-killed compute-cluster pod-name)))
+                                        :pod/failed (handle-pod-completed compute-cluster k8s-actual-state-dict)
+                                        :pod/running (kill-pod api-client cook-expected-state-dict pod)
+                                        ; There was a race and it completed normally before being it was killed.
                                         :pod/succeeded (handle-pod-completed compute-cluster k8s-actual-state-dict)
                                         ; TODO: Should mark mea culpa retry
                                         :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -107,7 +107,7 @@
     {:cook-expected-state :cook-expected-state/completed}))
 
 (defn launch-pod
-  [compute-cluster api-client cook-expected-state-dict pod-name]
+  [{:keys [api-client] :as compute-cluster} cook-expected-state-dict pod-name]
   (if (api/launch-pod api-client cook-expected-state-dict pod-name)
     cook-expected-state-dict
     (handle-pod-submission-failed compute-cluster pod-name)))
@@ -378,7 +378,7 @@
 
                                       :cook-expected-state/starting
                                       (case pod-synthesized-state-modified
-                                        :missing (launch-pod compute-cluster api-client
+                                        :missing (launch-pod compute-cluster
                                                              cook-expected-state-dict pod-name)
                                         ; TODO: May need to mark mea culpa retry
                                         :pod/failed (handle-pod-completed compute-cluster k8s-actual-state-dict) ; Finished or failed fast.

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -327,8 +327,10 @@
                                         ; try to kill the pod. This is why update-cook-expected-state saves :launch-pod,
                                         ; so its available here.
                                         (if-let [pod (some-> cook-expected-state-dict :launch-pod :pod)]
-                                          (do (log/info "In compute cluster" name ", opportunistically killing" pod-name "because of potential race where kill arrives before the watch responds to the launch")
-                                              (kill-pod api-client :ignored pod))
+                                          (do
+                                            (log/info "In compute cluster" name ", opportunistically killing" pod-name
+                                                      "because of potential race where kill arrives before the watch responds to the launch")
+                                            (kill-pod api-client :ignored pod))
                                           (do
                                             ; We treat a deleting pod in kubernetes the same as a missing pod when coming up with a synthesized state.
                                             ; That's good for (almost) all parts of the system. However,

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -98,9 +98,7 @@
         count-kill-pod (atom 0)]
     (with-redefs [controller/kill-pod  (fn [_ cook-expected-state-dict _] (swap! count-kill-pod inc) cook-expected-state-dict)
                   controller/launch-pod (fn [_ cook-expected-state-dict] cook-expected-state-dict)
-                  controller/log-weird-state (fn [_ _ _ _] :illegal_return_value_should_be_unused)
                   controller/handle-pod-completed (fn [_ _] {:cook-expected-state :cook-expected-state/completed})
-                  ;controller/handle-pod-killed (fn [_ _] {:cook-expected-state :cook-expected-state/completed})
                   controller/write-status-to-datomic (fn [_] :illegal_return_value_should_be_unused)
                   controller/prepare-k8s-actual-state-dict-for-logging identity]
 

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -97,7 +97,7 @@
                                       (:cook-expected-state (get @cook-expected-state-map pod-name {})))
         count-kill-pod (atom 0)]
     (with-redefs [controller/kill-pod  (fn [_ cook-expected-state-dict _] (swap! count-kill-pod inc) cook-expected-state-dict)
-                  controller/launch-pod (fn [_ cook-expected-state-dict] cook-expected-state-dict)
+                  controller/launch-pod (fn [_ cook-expected-state-dict _] cook-expected-state-dict)
                   controller/handle-pod-completed (fn [_ _] {:cook-expected-state :cook-expected-state/completed})
                   controller/write-status-to-datomic (fn [_] :illegal_return_value_should_be_unused)
                   controller/prepare-k8s-actual-state-dict-for-logging identity]

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -99,6 +99,8 @@
     (with-redefs [controller/kill-pod  (fn [_ cook-expected-state-dict _] (swap! count-kill-pod inc) cook-expected-state-dict)
                   controller/launch-pod (fn [_ cook-expected-state-dict _] cook-expected-state-dict)
                   controller/handle-pod-completed (fn [_ _] {:cook-expected-state :cook-expected-state/completed})
+                  controller/handle-pod-killed (fn [_ _]
+                                                 {:cook-expected-state :cook-expected-state/completed})
                   controller/write-status-to-datomic (fn [_] :illegal_return_value_should_be_unused)
                   controller/prepare-k8s-actual-state-dict-for-logging identity]
 


### PR DESCRIPTION
## Changes proposed in this PR

- When we're in the state where we have a starting pod, and kill it, we may think the pod's not on kubernetes because the watch is stale, so we'll not kill it. In this change, we kill the pod. 
- We also log when remaining weirder corner cases occur.

## Why are we making these changes?
Makes the cook log look less scary and suppresses it mentioning about weird states. 
