### PR TITLE
Makes log in logging-exception-handler be INFO level

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2956,12 +2956,12 @@
       in-str)))
 
 (defn- logging-exception-handler
-  "Wraps `base-handler` with an additional `log/error` call which logs the request and exception"
+  "Wraps `base-handler` with an additional `log/info` call which logs the request and exception"
   [base-handler]
   (fn logging-exception-handler [ex data req]
-    (log/error ex "Error when processing request"
-               (-> (dissoc req ::c-mw/options :body :ctrl :request-time :servlet-request :ssl-client-cert)
-                   (update-in [:headers] (fn [headers] (pc/map-vals (fn [value] (truncate value 80)) headers)))))
+    (log/info ex "Error when processing request"
+              (-> (dissoc req ::c-mw/options :body :ctrl :request-time :servlet-request :ssl-client-cert)
+                  (update-in [:headers] (fn [headers] (pc/map-vals (fn [value] (truncate value 80)) headers)))))
     (base-handler ex data req)))
 
 ;;


### PR DESCRIPTION
## Changes proposed in this PR

- changing the log level from `ERROR` to `INFO`

## Why are we making these changes?

These logs are expected to happen regularly, for example when request validation fails. `ERROR` is excessive.
