### PR TITLE
Add support to blacklist nodes in kubernetes that have certain labels

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -19,11 +19,13 @@
  :compute-clusters [{:factory-fn cook.kubernetes.compute-cluster/factory-fn
                      :config {:compute-cluster-name "gke-1"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
-                              :config-file "../scheduler/.cook_kubeconfig_1"}}
+                              :config-file "../scheduler/.cook_kubeconfig_1"
+                              :blacklist-labels ["blacklist-nodes-with-this-label-key"]}}
                     {:factory-fn cook.kubernetes.compute-cluster/factory-fn
                      :config {:compute-cluster-name "gke-2"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
-                              :config-file "../scheduler/.cook_kubeconfig_2"}}]
+                              :config-file "../scheduler/.cook_kubeconfig_2"
+                              :blacklist-labels ["blacklist-nodes-with-this-label-key-1" "blacklist-nodes-with-this-label-key-2"]}}]
  :cors-origins ["https?://cors.example.com"]
  :database {:datomic-uri #config/env "COOK_DATOMIC_URI"}
  :plugins {:job-submission-validator {:batch-timeout-seconds 40

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -20,12 +20,12 @@
                      :config {:compute-cluster-name "gke-1"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_1"
-                              :blacklist-labels ["blacklist-nodes-with-this-label-key"]}}
+                              :node-blocklist-labels ["blocklist-nodes-with-this-label-key"]}}
                     {:factory-fn cook.kubernetes.compute-cluster/factory-fn
                      :config {:compute-cluster-name "gke-2"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_2"
-                              :blacklist-labels ["blacklist-nodes-with-this-label-key-1" "blacklist-nodes-with-this-label-key-2"]}}]
+                              :node-blocklist-labels ["blocklist-nodes-with-this-label-key-1" "blocklist-nodes-with-this-label-key-2"]}}]
  :cors-origins ["https?://cors.example.com"]
  :database {:datomic-uri #config/env "COOK_DATOMIC_URI"}
  :plugins {:job-submission-validator {:batch-timeout-seconds 40

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -241,22 +241,28 @@
     (-> node-name->pods (get node-name []) count)))
 
 (defn node-schedulable?
-  "Can we schedule on a node. For now, yes, unless there are other taints on it. TODO: Incorporate other node-health measures here."
-  [^V1Node node pod-count-capacity pods]
+  "Can we schedule on a node. For now, yes, unless there are other taints on it. TODO: Incorporate other node-health measures here.
+   If blacklist-labels is not nil, a node is unschedulable if it contains any label in that list."
+  [^V1Node node pod-count-capacity pods blacklist-labels]
   (if (nil? node)
     false
     (let [taints-on-node (or (some-> node .getSpec .getTaints) [])
           other-taints (remove #(= "cook-pool" (.getKey %)) taints-on-node)
-          schedulable (zero? (count other-taints))
           node-name (some-> node .getMetadata .getName)
           pods-on-node (num-pods-on-node node-name pods)
-          below-pod-count-capacity (< pods-on-node pod-count-capacity)]
-      (when-not schedulable
-        (log/info "Filtering out" node-name "because it has taints" other-taints))
-      (when-not below-pod-count-capacity
-        (log/info "Filtering out" node-name "because it is at or above its pod count capacity of"
-                  pod-count-capacity "(" pods-on-node ")"))
-      (and schedulable below-pod-count-capacity))))
+          labels-on-node (or (some-> node .getMetadata .getLabels) {})
+          matching-blacklist-labels (some #(get labels-on-node %) blacklist-labels)]
+      (cond  (seq other-taints) (do
+                                  (log/info "Filtering out" node-name "because it has taints" other-taints)
+                                  false)
+             (>= pods-on-node pod-count-capacity) (do
+                                                    (log/info "Filtering out" node-name "because it is at or above its pod count capacity of"
+                                                              pod-count-capacity "(" pods-on-node ")")
+                                                    false)
+             (seq matching-blacklist-labels) (do
+                                               (log/info "Filtering out" node-name "because it has blacklist labels" matching-blacklist-labels)
+                                               false)
+             :else true))))
 
 (defn get-capacity
   "Given a map from node-name to node, generate a map from node-name->resource-type-><capacity>"

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -23,9 +23,9 @@
 
 (defn schedulable-node-filter
   "Is a node schedulable?"
-  [node-name->node [node-name _] {:keys [blacklist-labels] :as compute-cluster} pods]
+  [node-name->node [node-name _] {:keys [node-blocklist-labels] :as compute-cluster} pods]
   (if-let [^V1Node node (node-name->node node-name)]
-    (api/node-schedulable? node (cc/max-tasks-per-host compute-cluster) pods blacklist-labels)
+    (api/node-schedulable? node (cc/max-tasks-per-host compute-cluster) pods node-blocklist-labels)
     (do
       (log/error "In" (cc/compute-cluster-name compute-cluster)
                  "compute cluster, unable to get node from node name" node-name)
@@ -179,7 +179,7 @@
 (defrecord KubernetesComputeCluster [^ApiClient api-client name entity-id match-trigger-chan exit-code-syncer-state
                                      all-pods-atom current-nodes-atom cook-expected-state-map k8s-actual-state-map
                                      pool->fenzo-atom namespace-config scan-frequency-seconds-config max-pods-per-node
-                                     blacklist-labels]
+                                     node-blocklist-labels]
   cc/ComputeCluster
   (launch-tasks [this offers task-metadata-seq]
     (doseq [task-metadata task-metadata-seq]
@@ -341,13 +341,13 @@
            namespace
            scan-frequency-seconds
            max-pods-per-node
-           blacklist-labels]
+           node-blocklist-labels]
     :or {bearer-token-refresh-seconds 300
          namespace {:kind :static
                     :namespace "cook"}
          scan-frequency-seconds 120
          max-pods-per-node 32
-         blacklist-labels (list)}}
+         node-blocklist-labels (list)}}
    {:keys [exit-code-syncer-state
            trigger-chans]}]
   (let [conn cook.datomic/conn
@@ -362,6 +362,6 @@
                                                     namespace
                                                     scan-frequency-seconds
                                                     max-pods-per-node
-                                                    blacklist-labels)]
+                                                    node-blocklist-labels)]
     (cc/register-compute-cluster! compute-cluster)
     compute-cluster))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -43,7 +43,7 @@
       (testing "static namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                              {:kind :static :namespace "cook"} nil nil)
+                                                              {:kind :static :namespace "cook"} nil nil nil)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -58,7 +58,7 @@
       (testing "per-user namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                              {:kind :per-user} nil nil)
+                                                              {:kind :per-user} nil nil nil)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -75,7 +75,7 @@
     (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")
           compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
                                                           (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                          {:kind :static :namespace "cook"} nil 3)
+                                                          {:kind :static :namespace "cook"} nil 3 nil)
           node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 nil)
                            "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 nil)
                            "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil)


### PR DESCRIPTION


## Changes proposed in this PR

- Add support to blacklist nodes in kubernetes that have certain labels. Nodes with these labels will not be used for scheduling. These labels can be dynamically added and removed.

## Why are we making these changes?
So we can defer using nodes until they're fully initialized. 

