### PR TITLE
Changes 'dropped item from tx-report-mult' log to INFO

### DIFF
--- a/scheduler/src/cook/datomic.clj
+++ b/scheduler/src/cook/datomic.clj
@@ -66,7 +66,7 @@
                                ;; The value for :default is eagerly evaluated, unlike for other clauses
                                :default :dropped
                                :priority true)
-                         :dropped (log/error "dropped item from tx-report-mult--maybe there's a slow consumer?")
+                         :dropped (log/info "dropped item from tx-report-mult--maybe there's a slow consumer?")
                          nil))
                      (catch InterruptedException _ nil)))
                  (catch Exception e


### PR DESCRIPTION
## Changes proposed in this PR

- changing the log level from `ERROR` to `INFO`

## Why are we making these changes?

Cook can log this thousands of times on startup. `ERROR` is excessive.
