### PR TITLE
Adds test and logging for default pool

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3096,3 +3096,13 @@ class CookTest(util.CookTest):
         self.assertEqual(1, len(job['instances']))
         self.assertEqual('failed', job['instances'][0]['status'], job)
         self.assertEqual('Invalid task', job['instances'][0]['reason_string'], job)
+
+    def test_submit_pool_unspecified(self):
+        job_uuid, resp = util.submit_job(self.cook_url, pool=util.POOL_UNSPECIFIED)
+        self.assertEqual(resp.status_code, 201, resp.content)
+        job = util.wait_for_job_in_statuses(self.cook_url, job_uuid, ['completed'])
+        self.logger.info(json.dumps(job, indent=2))
+        self.assertNotIn('pool', job, job)
+        self.assertEqual('success', job['state'], job)
+        self.assertLessEqual(1, len(job['instances']))
+        self.assertIn('success', [i['status'] for i in job['instances']], job)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -97,7 +97,7 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 
     @pytest.mark.travis_skip
-    @unittest.skipIf(util.using_kubernetes() and 'sandbox-filesªªerver' not in util.kubernetes_settings(),
+    @unittest.skipIf(util.using_kubernetes() and 'sandbox-fileserver' not in util.kubernetes_settings(),
                      'This test requires the fileserver to be configured when running in Kubernetes')
     def test_output_url(self):
         job_executor_type = util.get_job_executor_type()

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -97,6 +97,8 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 
     @pytest.mark.travis_skip
+    @unittest.skipIf(util.using_kubernetes() and 'sandbox-filesªªerver' not in util.kubernetes_settings(),
+                     'This test requires the fileserver to be configured when running in Kubernetes')
     def test_output_url(self):
         job_executor_type = util.get_job_executor_type()
         job_uuid, resp = util.submit_job(self.cook_url,

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1793,3 +1793,9 @@ def make_failed_job(cook_url, **kwargs):
         return job
 
     return wait_until(__make_failed_job, lambda _: True)
+
+
+@functools.lru_cache()
+def kubernetes_settings():
+    cook_url = retrieve_cook_url()
+    return settings(cook_url)['kubernetes']

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -44,6 +44,11 @@ EPHEMERAL_HOSTS_SKIP_REASON = 'If the cluster under test has ephemeral hosts, th
                               'the process responsible for launching hosts to launch hosts that ' \
                               'never get used'
 
+# We need a way for tests to explicitly specify
+# that they don't want to specify a pool for a
+# particular job submission
+POOL_UNSPECIFIED = 'COOK_TEST_POOL_UNSPECIFIED'
+
 
 def continuous_integration():
     """Returns true if the CONTINUOUS_INTEGRATION environment variable is set, as done by Travis-CI."""
@@ -543,7 +548,9 @@ def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, log_requ
     jobs = [full_spec(j) for j in job_specs]
     request_body = {'jobs': jobs}
     default_pool = default_submit_pool()
-    if pool:
+    if pool == POOL_UNSPECIFIED:
+        logger.info('Submitting with no explicit pool (via POOL_UNSPECIFIED)')
+    elif pool:
         logger.info(f'Submitting explicitly to the {pool} pool')
         request_body['pool'] = pool
     elif 'x-cook-pool' in headers:

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -35,16 +35,19 @@
  :hostname #config/env "COOK_HOSTNAME"
  :kubernetes {:disallowed-container-paths #{"/mnt/bad"}
               :disallowed-var-names #{"BADVAR"}
-              :init-container {:command ["/bin/sh" "-c" "echo sample init container running"]
-                               :image "byrnedo/alpine-curl:latest"}
-              :sandbox-fileserver {:command ["fileserver"]
-                                   :image "twosigma/cook-fileserver:latest"
-                                   :port 23906
-                                   :resource-requirements {:cpu-request 0.1
-                                                           :cpu-limit 0.1
-                                                           :memory-request 128.0
-                                                           :memory-limit 128.0}}
-              :custom-shell ["/bin/sh" "-c"]}
+              ;; The job resource adjustment causes config/default-pool to return nil. Until
+              ;; we fix that, we should run without the sidecar.
+              ;:init-container {:command ["/bin/sh" "-c" "echo sample init container running"]
+              ;                 :image "byrnedo/alpine-curl:latest"}
+              ;:sandbox-fileserver {:command ["fileserver"]
+              ;                     :image "twosigma/cook-fileserver:latest"
+              ;                     :port 23906
+              ;                     :resource-requirements {:cpu-request 0.1
+              ;                                             :cpu-limit 0.1
+              ;                                             :memory-request 128.0
+              ;                                             :memory-limit 128.0}}
+              ;:custom-shell ["/bin/sh" "-c"]
+              }
  :log {:file #config/env "COOK_LOG_FILE"
        :levels {"datomic.db" :warn
                 "datomic.kv-cluster" :warn
@@ -60,8 +63,11 @@
  :nrepl {:enabled? true
          :port #config/env-int "COOK_NREPL_PORT"}
  :pools {:default "k8s-gamma"
-         :job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
-                                   :pool-regex "^k8s-.+"}}
+         ;; The job resource adjustment causes config/default-pool to return nil. Until
+         ;; we fix that, we should run without the sidecar.
+         ;:job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
+         ;                          :pool-regex "^k8s-.+"}
+         }
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -35,6 +35,7 @@
  :hostname #config/env "COOK_HOSTNAME"
  :kubernetes {:disallowed-container-paths #{"/mnt/bad"}
               :disallowed-var-names #{"BADVAR"}
+              ;; TODO:
               ;; The job resource adjustment causes config/default-pool to return nil. Until
               ;; we fix that, we should run without the sidecar.
               ;:init-container {:command ["/bin/sh" "-c" "echo sample init container running"]
@@ -63,6 +64,7 @@
  :nrepl {:enabled? true
          :port #config/env-int "COOK_NREPL_PORT"}
  :pools {:default "k8s-gamma"
+         ;; TODO:
          ;; The job resource adjustment causes config/default-pool to return nil. Until
          ;; we fix that, we should run without the sidecar.
          ;:job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -475,7 +475,7 @@
       (log/info "Configured logging")
       (log/info "Cook" @util/version "( commit" @util/commit ")")
       (let [settings {:settings (config-settings literal-config)}]
-        (log/info "Interpreted settings")
+        (log/info "Interpreted settings:" settings)
         settings))
     (catch Throwable t
       (log/error t "Failed to initialize settings")

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -91,6 +91,7 @@
        (map first)))
 
 (let [default-pool (config/default-pool)
+      _ (log/info "The config/default-pool is" default-pool)
       miss-fn (fn [{:keys [job/pool]}]
                 (or (:pool/name pool) default-pool "no-pool"))]
   (defn job->pool-name


### PR DESCRIPTION
## Changes proposed in this PR

- adding an integration test that explicitly submits with no pool specified
- commenting out the sidecar configuration
- adding some logs for settings and for `(config/default-pool)`

## Why are we making these changes?

For some reason, when the `:job-resource-adjustment` config is present, `(config/default-pool)` returns `nil`, which is bad. The test will help us catch issues like this in the future.

Fixing the issue will come in a later patch (@nsinkov has identified the cause).
