### PR TITLE
Suppress errors deleting already deleted pods

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -672,7 +672,7 @@
         ;
         ; They actually advise catching the exception and moving on!
         ;
-        (log/info "Caught the https://github.com/kubernetes-client/java/issues/252 exception."))
+        (log/info "Caught the https://github.com/kubernetes-client/java/issues/252 exception deleting" pod-name))
       (catch ApiException e
         (let [code (.getCode e)
               already-deleted? (contains? #{404} code)]


### PR DESCRIPTION
## Changes proposed in this PR

- Suppress raising an error when we try to delete a pod thats not in k8s.

## Why are we making these changes?
Avoids log spam and makes it easier to followup on real problems.

