### PR TITLE
Fix nil default pool

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -37,20 +37,16 @@
  :hostname #config/env "COOK_HOSTNAME"
  :kubernetes {:disallowed-container-paths #{"/mnt/bad"}
               :disallowed-var-names #{"BADVAR"}
-              ;; TODO:
-              ;; The job resource adjustment causes config/default-pool to return nil. Until
-              ;; we fix that, we should run without the sidecar.
-              ;:init-container {:command ["/bin/sh" "-c" "echo sample init container running"]
-              ;                 :image "byrnedo/alpine-curl:latest"}
-              ;:sandbox-fileserver {:command ["fileserver"]
-              ;                     :image "twosigma/cook-fileserver:latest"
-              ;                     :port 23906
-              ;                     :resource-requirements {:cpu-request 0.1
-              ;                                             :cpu-limit 0.1
-              ;                                             :memory-request 128.0
-              ;                                             :memory-limit 128.0}}
-              ;:custom-shell ["/bin/sh" "-c"]
-              }
+              :init-container {:command ["/bin/sh" "-c" "echo sample init container running"]
+                               :image "byrnedo/alpine-curl:latest"}
+              :sandbox-fileserver {:command ["fileserver"]
+                                   :image "twosigma/cook-fileserver:latest"
+                                   :port 23906
+                                   :resource-requirements {:cpu-request 0.1
+                                                           :cpu-limit 0.1
+                                                           :memory-request 128.0
+                                                           :memory-limit 128.0}}
+              :custom-shell ["/bin/sh" "-c"]}
  :log {:file #config/env "COOK_LOG_FILE"
        :levels {"datomic.db" :warn
                 "datomic.kv-cluster" :warn
@@ -66,12 +62,8 @@
  :nrepl {:enabled? true
          :port #config/env-int "COOK_NREPL_PORT"}
  :pools {:default "k8s-gamma"
-         ;; TODO:
-         ;; The job resource adjustment causes config/default-pool to return nil. Until
-         ;; we fix that, we should run without the sidecar.
-         ;:job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
-         ;                          :pool-regex "^k8s-.+"}
-         }
+         :job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
+                                   :pool-regex "^k8s-.+"}}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -131,10 +131,6 @@
       (throw (IllegalArgumentException.
                (str config-string " is not a VMTaskFitnessCalculator"))))))
 
-(defn- resolve-optional-function
-  [function-symbol default-function]
-  (if function-symbol (util/lazy-load-var function-symbol) default-function))
-
 (def config-settings
   "Parses the settings out of a config file"
   (graph/eager-compile
@@ -401,8 +397,7 @@
                 (:job-resource-adjustment pools)
                 (update :job-resource-adjustment
                         #(-> %
-                           (update :pool-regex re-pattern)
-                           (update :adjust-job-resources-fn resolve-optional-function identity)))))
+                           (update :pool-regex re-pattern)))))
 
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
@@ -440,7 +435,7 @@
      :kubernetes (fnk [[:config {kubernetes {}}]]
                    (merge {:default-workdir "/mnt/sandbox"
                            :reconnect-delay-ms 60000}
-                          (update kubernetes :pod-ip->hostname-fn resolve-optional-function identity)))}))
+                          kubernetes))}))
 
 (defn read-config
   "Given a config file path, reads the config and returns the map"

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -477,7 +477,7 @@
   (memoize
     (fn [pool-name]
       (if-let [{:keys [pool-regex adjust-job-resources-fn]} (config/job-resource-adjustments)]
-        (if (re-matches pool-regex pool-name) adjust-job-resources-fn identity)
+        (if (re-matches pool-regex pool-name) (util/lazy-load-var adjust-job-resources-fn) identity)
         identity))))
 
 (defn make-task-request


### PR DESCRIPTION
## Changes proposed in this PR

- don't try to resolve function names when processing the config file

## Why are we making these changes?

The act of resolving function names when processing the config file has side effects. Some of the side effects can be the calling of functions that depend on the config itself. Until we figure out a way to resolve function names without side effects we need to go back to resolving functions at runtime
