### PR TITLE
Upgrade org.clojure/core.cache to 0.8.2

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -33,7 +33,7 @@
                  [listora/ring-congestion "0.1.2"]
                  [lonocloud/synthread "1.0.4"]
                  [org.clojure/tools.namespace "0.2.4"]
-                 [org.clojure/core.cache "0.6.4"]
+                 [org.clojure/core.cache "0.8.2"]
                  [org.clojure/core.memoize "0.5.8"]
                  [clj-time "0.12.0"]
                  [org.clojure/core.async "0.3.442" :exclusions [org.clojure/tools.reader]]


### PR DESCRIPTION
## Changes proposed in this PR

Upgrade org.clojure/core.cache to 0.8.2

## Why are we making these changes?

We've encountered problems with our ttl+lru cache for progress
reporting, and that bug was fixed in release 0.7.0. Upgrading to the
latest stable version (2019-09-30) for additional bug fixes.
