### PR TITLE
Deflake test_progress_update_rest

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -718,9 +718,14 @@ class CookTest(util.CookTest):
         self.assertEqual(201, resp.status_code, msg=resp.content)
         instance = util.wait_for_instance(self.cook_url, job_uuid)
         instance_uuid = instance['task_id']
+        publish_interval_ms = util.get_publish_interval_ms(self.cook_url)
+        progress_wait_timeout_ms = 10 * publish_interval_ms
+        progress_wait_interval_ms = min(1000, publish_interval_ms // 2)
         def wait_until_instance(predicate):
             util.wait_until(lambda: util.load_instance(self.cook_url, instance_uuid),
-                            predicate, max_wait_ms=10000)
+                            predicate,
+                            max_wait_ms=progress_wait_timeout_ms,
+                            wait_interval_ms=progress_wait_interval_ms)
         # send progress percentage update
         util.send_progress_update(self.cook_url, instance_uuid, sequence=100, percent=10)
         wait_until_instance(lambda i: i['progress'] == 10)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1041,10 +1041,14 @@ def wait_for_instance(cook_url, job_uuid, max_wait_ms=DEFAULT_TIMEOUT_MS, wait_i
     return instance
 
 
-def sleep_for_publish_interval(cook_url):
-    # allow enough time for progress and sandbox updates to be submitted
+def get_publish_interval_ms(cook_url):
+    """Get the progress publisher's interval (in milliseconds)"""
     cook_settings = settings(cook_url)
-    progress_publish_interval_ms = get_in(cook_settings, 'progress', 'publish-interval-ms')
+    return get_in(cook_settings, 'progress', 'publish-interval-ms')
+
+
+def sleep_for_publish_interval(cook_url):
+    progress_publish_interval_ms = get_publish_interval_ms(cook_url)
     wait_publish_interval_ms = min(3 * progress_publish_interval_ms, 20000)
     time.sleep(wait_publish_interval_ms / 1000.0)
 

--- a/scheduler/src/cook/progress.clj
+++ b/scheduler/src/cook/progress.clj
@@ -82,7 +82,7 @@
   (let [progress-aggregator-chan (async/chan (async/sliding-buffer pending-threshold))
         sequence-cache-store (-> {}
                                  (cache/lru-cache-factory :threshold sequence-cache-threshold)
-                                 (cache/ttl-cache-factory :ttl (* 2 publish-interval-ms))
+                                 (cache/ttl-cache-factory :ttl (* 10 publish-interval-ms))
                                  atom)
         progress-aggregator-fn (fn progress-aggregator-fn [instance-id->progress-state data]
                                  (progress-aggregator pending-threshold sequence-cache-store instance-id->progress-state data))


### PR DESCRIPTION
## Changes proposed in this PR

- Increase progress aggregator's sequence-number cache's TTL
- Improve test_progress_update_rest wait intervals

## Why are we making these changes?

Increasing the cache TTL should help avoid flakes in the test_progress_update_rest
integration test where out-of-sequence progress updates are not ignored.

The wait/retry intervals in this test should be a function of the
progress reporter's publish interval, not hard-coded.