### PR TITLE
Avoid NPE when a running job goes completely missing

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -610,6 +610,8 @@
           ; * A job may have additional containers with the name aux-*
           job-status (first (filter (fn [c] (= cook-container-name-for-job (.getName c)))
                                     container-statuses))]
+      ; TODO: When we add logic here that supports detecting pods that have a i-am-being-preempted label, we need to modify
+      ; the controller to set the failure reason to unknown for pods in  :running,:missing.
       (if (some-> pod .getMetadata .getDeletionTimestamp)
         ; If a pod has been ordered deleted, treat it as if it was gone, It's being async removed.
         ; Note that we distinguish between this explicit :missing, and not being there at all when processing

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -179,7 +179,7 @@
   "Calculate the pod status of a completed pod. Factored out so that we can wrap it in an exception handler."
   [compute-cluster pod-name {:keys [synthesized-state pod]} & {:keys [reason]}]
   (let [instance-id (some-> pod .getMetadata .getName)]
-    ; If we have an actual pod here, make sure its got the same name as pod-name.
+    ; If we have an actual pod here, make sure it has the same name as pod-name.
     (when instance-id
       (assert (= instance-id pod-name)))
     (try

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -378,7 +378,7 @@
                                       (case pod-synthesized-state-modified
                                         ; This indicates that something deleted it behind our back
                                         :missing (do
-                                                   (log/error "In compute cluster" name ", something deleted"
+                                                   (log/info "In compute cluster" name ", something deleted"
                                                               pod-name "behind our back")
                                                      ; A :cook-expected-state/running job suddenly disappearing in k8s is
                                                      ; a sign of a preemption, so treat this case as a missed preemption.
@@ -408,8 +408,7 @@
                                                        (log/info "In compute cluster" name ", pod" pod-name
                                                                  "went into waiting while it was expected running")
                                                        (kill-pod api-client cook-expected-state-dict pod)
-                                                       (handle-pod-completed compute-cluster k8s-actual-state-dict
-                                                                             :reason :reason-slave-removed)))
+                                                       (handle-pod-preemption compute-cluster pod-name))
 
                                       :cook-expected-state/starting
                                       (case pod-synthesized-state-modified

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -383,7 +383,7 @@
                                                      ; A :cook-expected-state/running job suddenly disappearing in k8s is
                                                      ; a sign of a preemption, so treat this case as a missed preemption.
                                                      ; TODO: When we have a better story for preemption, we should switch this to
-                                                     ; go through the handle-pod-completed stack. THat needs to be guarded with a null
+                                                     ; go through the handle-pod-completed stack. That needs to be guarded with a null
                                                      ; check because handle-pod-completed cannot handle null pods. So, something like:
                                                      ; (if pod (handle-pod-completed ...) (....write a unknown reason to the pod....))
                                                    (handle-pod-preemption compute-cluster pod-name))

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -107,13 +107,13 @@
     (write-status-to-datomic compute-cluster status)
     {:cook-expected-state :cook-expected-state/completed}))
 
-(defn handle-pod-preemption;
+(defn handle-pod-preemption
   "Marks the corresponding job instance as failed in the database and
   returns the `completed` cook expected state."
   [{:keys [name] :as compute-cluster} pod-name]
   (log/info "In compute cluster" name ", pod" pod-name "preemption has occurred")
   (let [instance-id pod-name
-        status {:reason :reason-executor-preempted
+        status {:reason :reason-slave-removed
                 :state :task-failed
                 :task-id {:value instance-id}}]
     (write-status-to-datomic compute-cluster status)

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [cook.kubernetes.api :as api]
             [cook.kubernetes.controller :as controller]
-            [cook.test.testutil :as tu])
+            [cook.test.testutil :as tu]
+            [cook.compute-cluster :as cc])
   (:import (io.kubernetes.client ApiException)
            (io.kubernetes.client.models V1ObjectMeta V1Pod V1PodStatus)))
 
@@ -98,7 +99,7 @@
         count-kill-pod (atom 0)]
     (with-redefs [controller/kill-pod  (fn [_ cook-expected-state-dict _] (swap! count-kill-pod inc) cook-expected-state-dict)
                   controller/launch-pod (fn [_ cook-expected-state-dict _] cook-expected-state-dict)
-                  controller/handle-pod-completed (fn [_ _] {:cook-expected-state :cook-expected-state/completed})
+                  controller/handle-pod-completed (fn [_ _ _] {:cook-expected-state :cook-expected-state/completed})
                   controller/handle-pod-killed (fn [_ _]
                                                  {:cook-expected-state :cook-expected-state/completed})
                   controller/write-status-to-datomic (fn [_] :illegal_return_value_should_be_unused)
@@ -139,7 +140,7 @@
                        (:cook-expected-state (get @cook-expected-state-map name {}))))
         count-delete-pod (atom 0)]
     (with-redefs [controller/delete-pod  (fn [_ cook-expected-state-dict _] (swap! count-delete-pod inc) cook-expected-state-dict)
-                  controller/handle-pod-completed (fn [_ _] {:cook-expected-state :cook-expected-state/completed})
+                  controller/handle-pod-completed (fn [_ _ _] {:cook-expected-state :cook-expected-state/completed})
                   controller/write-status-to-datomic (fn [_] :illegal_return_value_should_be_unused)]
 
       (is (= :cook-expected-state/completed (do-process :cook-expected-state/completed :pod/succeeded)))
@@ -156,7 +157,7 @@
       (.setStatus pod pod-status)
       (with-redefs [controller/write-status-to-datomic (constantly nil)]
         (is (= {:cook-expected-state :cook-expected-state/completed}
-               (controller/handle-pod-completed nil {:pod pod :synthesized-state {:state :pod/failed}}))))))
+               (controller/handle-pod-completed nil "podA" {:pod pod :synthesized-state {:state :pod/failed}}))))))
 
   (testing "optional reason argument"
     (let [pod (tu/pod-helper "podA" "hostA" {})
@@ -165,6 +166,38 @@
       (with-redefs [controller/write-status-to-datomic (fn [_ status] (reset! reason (:reason status)))
                     controller/container-status->failure-reason (fn [_ _ _ _]
                                                                   (throw (ex-info "Shouldn't get called" {})))]
-        (controller/handle-pod-completed nil {:pod pod :synthesized-state {:state :pod/failed}}
+        (controller/handle-pod-completed nil "podA" {:pod pod :synthesized-state {:state :pod/failed}}
                                          :reason :reason-task-invalid))
-      (is (= :reason-task-invalid @reason)))))
+      (is (= :reason-task-invalid @reason))))
+
+  (testing "throws exception"
+    (let [pod (tu/pod-helper "podA" "hostA" {})
+          reason (atom nil)]
+      (.setStatus pod (V1PodStatus.))
+      (with-redefs [cc/compute-cluster-name (constantly "compute-cluster-name")
+                    controller/write-status-to-datomic (fn [_ status] (reset! reason (:reason status)))
+                    controller/container-status->failure-reason (fn [_ _ _ _]
+                                                                  (throw (ex-info "Got Exception" {})))]
+        (controller/handle-pod-completed nil "podA" {:pod pod :synthesized-state {:state :pod/failed}})
+        (is (= :reason-task-unknown @reason)))))
+
+  (testing "pod mismatch"
+    (let [pod (tu/pod-helper "podA" "hostA" {})
+          reason (atom nil)]
+      (.setStatus pod (V1PodStatus.))
+      (with-redefs [cc/compute-cluster-name (constantly "compute-cluster-name")
+                    controller/write-status-to-datomic (fn [_ status] (reset! reason (:reason status)))]
+        (try
+        (controller/handle-pod-completed nil "podB" {:pod pod :synthesized-state {:state :pod/failed}})
+        ; We expect an AssertionError
+        (is false) ; This line shouldn't execute.
+        (catch AssertionError e)))))
+  (testing "pod is nil"
+    (let [pod nil
+          reason (atom nil)]
+      (with-redefs [cc/compute-cluster-name (constantly "compute-cluster-name")
+                    controller/write-status-to-datomic (fn [_ status] (reset! reason (:reason status)))]
+        (controller/handle-pod-completed nil "podB" {:pod pod :synthesized-state {:state :pod/failed}})
+        (is (= :reason-task-unknown @reason)))))
+
+  )


### PR DESCRIPTION
## Changes proposed in this PR

- Write new logic for the :running,:missing case.

## Why are we making these changes?
In cases where a pod disappears on us completely, we'd get a NPE. This can occur in some cases when GKE preempts a node. This changes the logic into a path that no longer NPE's.

