### PR TITLE
Downgrade this ERROR to an INFO. This exclusively is 'job can't start.

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -822,7 +822,7 @@
               matched-considerable-jobs-head?)))
         (catch Throwable t
           (meters/mark! handle-resource-offer!-errors)
-          (log/error t "In" pool-name "pool, error in match:" (ex-data t))
+          (log/info t "In" pool-name "pool, error in match:" (ex-data t))
           (when-let [offers @offer-stash]
             ; Group the set of all offers by compute cluster and route them to that compute cluster for restoring.
             (doseq [[compute-cluster offer-subset] (group-by :compute-cluster offers)]


### PR DESCRIPTION
## Changes proposed in this PR

- Downgrade from ERROR to INFO.

## Why are we making these changes?
Its a symptom of an innocous error, a kill/launch race where a user kills a job shortly before it launches. Doing this cuts the number of logged errors by 50x. 


