### PR TITLE
don't resolve the sandbox directory when ssh'ing kubernetes

### DIFF
--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -243,7 +243,7 @@ def __get_latest_instance(job):
     raise CookRetriableException(f'Job {job["uuid"]} currently has no instances.')
 
 
-def query_unique_and_run(clusters, entity_ref, command_fn, wait=False, resove_sandbox_directory=True):
+def query_unique_and_run(clusters, entity_ref, command_fn, wait=False, resolve_sandbox_directory=True):
     """Calls query_unique and then calls the given command_fn on the resulting job instance"""
 
     def query_unique_and_run():
@@ -251,12 +251,12 @@ def query_unique_and_run(clusters, entity_ref, command_fn, wait=False, resove_sa
         if query_result['type'] == Types.JOB:
             job = query_result['data']
             instance = __get_latest_instance(job)
-            directory = mesos.retrieve_instance_sandbox_directory(instance, job) if resove_sandbox_directory \
+            directory = mesos.retrieve_instance_sandbox_directory(instance, job) if resolve_sandbox_directory \
                 else partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job)
             command_fn(instance, directory, query_result['cluster'])
         elif query_result['type'] == Types.INSTANCE:
             instance, job = query_result['data']
-            directory = mesos.retrieve_instance_sandbox_directory(instance, job) if resove_sandbox_directory \
+            directory = mesos.retrieve_instance_sandbox_directory(instance, job) if resolve_sandbox_directory \
                 else partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job)
             command_fn(instance, directory, query_result['cluster'])
         else:

--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -243,7 +243,7 @@ def __get_latest_instance(job):
     raise CookRetriableException(f'Job {job["uuid"]} currently has no instances.')
 
 
-def query_unique_and_run(clusters, entity_ref, command_fn, wait=False, do_not_resove_sandbox_directory=False):
+def query_unique_and_run(clusters, entity_ref, command_fn, wait=False, resove_sandbox_directory=True):
     """Calls query_unique and then calls the given command_fn on the resulting job instance"""
 
     def query_unique_and_run():
@@ -251,13 +251,13 @@ def query_unique_and_run(clusters, entity_ref, command_fn, wait=False, do_not_re
         if query_result['type'] == Types.JOB:
             job = query_result['data']
             instance = __get_latest_instance(job)
-            directory = partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job)\
-                if do_not_resove_sandbox_directory else mesos.retrieve_instance_sandbox_directory(instance, job)
+            directory = mesos.retrieve_instance_sandbox_directory(instance, job) if resove_sandbox_directory \
+                else partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job)
             command_fn(instance, directory, query_result['cluster'])
         elif query_result['type'] == Types.INSTANCE:
             instance, job = query_result['data']
-            directory = partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job) \
-                if do_not_resove_sandbox_directory else mesos.retrieve_instance_sandbox_directory(instance, job)
+            directory = mesos.retrieve_instance_sandbox_directory(instance, job) if resove_sandbox_directory \
+                else partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job)
             command_fn(instance, directory, query_result['cluster'])
         else:
             # This should not happen, because query_unique should

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -33,7 +33,7 @@ def ssh_to_instance(instance, sandbox_dir_fn, cluster):
         logging.info(f'using ssh command: {command}')
         hostname = instance['hostname']
         print_info(f'Executing ssh to {terminal.bold(hostname)}.')
-        os.execlp(command, 'ssh', '-t', hostname, f'cd "{sandbox_dir()}" ; bash')
+        os.execlp(command, 'ssh', '-t', hostname, f'cd "{sandbox_dir}" ; bash')
 
 
 def ssh(clusters, args, _):

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -44,7 +44,7 @@ def ssh(clusters, args, _):
         # argparse should prevent this, but we'll be defensive anyway
         raise Exception(f'You can only provide a single uuid.')
 
-    query_unique_and_run(clusters_of_interest, entity_refs[0], ssh_to_instance, resove_sandbox_directory=False)
+    query_unique_and_run(clusters_of_interest, entity_refs[0], ssh_to_instance, resolve_sandbox_directory=False)
 
 
 def register(add_parser, _):

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -44,7 +44,7 @@ def ssh(clusters, args, _):
         # argparse should prevent this, but we'll be defensive anyway
         raise Exception(f'You can only provide a single uuid.')
 
-    query_unique_and_run(clusters_of_interest, entity_refs[0], ssh_to_instance, do_not_resove_sandbox_directory=True)
+    query_unique_and_run(clusters_of_interest, entity_refs[0], ssh_to_instance, resove_sandbox_directory=False)
 
 
 def register(add_parser, _):

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -688,7 +688,7 @@ class CookCliTest(util.CookTest):
         env['CS_SSH'] = 'echo'
         cp = cli.ssh(uuids[0], self.cook_url, env=env)
         stdout = cli.stdout(cp)
-        self.assertEqual(0, cp.returncode, cli.decode(cp.stderr))
+        self.assertEqual(0, cp.returncode, cli.output(cp))
         self.assertIn(f'Attempting ssh for job instance {instance["task_id"]}', stdout)
         self.assertIn('Executing ssh', stdout)
         self.assertIn(hostname, stdout)
@@ -740,7 +740,7 @@ class CookCliTest(util.CookTest):
         env['CS_SSH'] = 'echo'
         cp = cli.ssh(instance['task_id'], self.cook_url, env=env)
         stdout = cli.stdout(cp)
-        self.assertEqual(0, cp.returncode, cli.decode(cp.stderr))
+        self.assertEqual(0, cp.returncode, cli.output(cp))
         self.assertIn('Executing ssh', stdout)
         self.assertIn(hostname, stdout)
         self.assertIn(f'-t {hostname} cd', stdout)


### PR DESCRIPTION
## Changes proposed in this PR

- don't look up sandbox directory when ssh'ing kubernetes

## Why are we making these changes?

looking up the sandbox directory when ssh'ing kubernetes is not needed and will fail when there is no ouput_url. There will not be an ouput_url when the fileserver sidecar is not enabled. But a user should still be able to ssh into their pod
