### PR TITLE
Retry k8s startup forever

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -151,12 +151,12 @@
                              (filter (fn [[_ task-ent]] (some? task-ent)))
                              (into {}))
         all-task-id->task (merge extra-tasks-id->task running-task-id->task)]
-    (log/info "Initialized tasks on startup: "
-              (count all-tasks-ids-in-pods) " tasks in pods and "
-              (count running-task-id->task) " running tasks in this compute cluster in datomic. "
-              "We need to load an extra "
-              (count extra-tasks-id->task) " pods that aren't running in datomic. "
-              "For a total expected state size of "
+    (log/info "Initialized tasks on startup:"
+              (count all-tasks-ids-in-pods) "tasks in pods and"
+              (count running-task-id->task) "running tasks in compute cluster" compute-cluster-name "in datomic. "
+              "We need to load an extra"
+              (count extra-tasks-id->task) "pods that aren't running in datomic. "
+              "For a total expected state size of"
               (count all-task-id->task) "tasks in cook expected state.")
     (doseq [[k v] all-task-id->task]
       (log/debug "Setting cook expected state for " k " ---> " (task-ent->cook-expected-state v)))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -132,7 +132,7 @@
   all running tasks entities (via (->> (cook.tools/get-running-task-ents)."
   [conn api-client compute-cluster-name running-tasks-ents]
   (let [db (d/db conn)
-        [_ pod-name->pod] (api/get-all-pods-in-kubernetes api-client)
+        [_ pod-name->pod] (api/try-forever-get-all-pods-in-kubernetes compute-cluster-name api-client)
         all-tasks-ids-in-pods (into #{} (keys pod-name->pod))
         _ (log/debug "All tasks in pods (for initializing cook expected state): " all-tasks-ids-in-pods)
         running-tasks-in-cc-ents (filter


### PR DESCRIPTION
## Changes proposed in this PR

- Retry k8s startup forever.
- Some minor logging improvements. 

## Why are we making these changes?
The kubernetes watches used to retry forever, but the initial cluster setup would not retry. It needs to 
enumerate the pods in k8s in order to determine what state to load from datomic. 


