### PR TITLE
Fast fail when we get a bad request response from k8s

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -733,7 +733,7 @@
         true
         (catch ApiException e
           (let [code (.getCode e)
-                bad-pod-spec? (contains? #{404 422} code)]
+                bad-pod-spec? (contains? #{400 404 422} code)]
             (log/info e "Error submitting pod with name" pod-name "in namespace" namespace
                       ", code:" code ", response body:" (.getResponseBody e))
             (not bad-pod-spec?)))))


### PR DESCRIPTION
## Changes proposed in this PR

- Fast fail when we get a bad request response from k8s

## Why are we making these changes?
If we submit a broken configuration, no need to let it get stuck. 

