### PR TITLE
Initializes pool->fenzo atom earlier

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -206,8 +206,15 @@
     ; so we launch within a future so that our caller can continue initializing other clusters.
     (future
       (try
-        ; Initialize the pod watch path.
         (log/info "Initializing Kubernetes compute cluster" name)
+
+        ; We need to reset! the pool->fenzo atom before initializing the
+        ; watches, because otherwise, we will start to see and handle events
+        ; for pods, but we won't be able to update the corresponding Fenzo
+        ; instance (e.g. unassigning a completed task from its host)
+        (reset! pool->fenzo-atom pool->fenzo)
+
+        ; Initialize the pod watch path.
         (let [conn cook.datomic/conn
               cook-pod-callback (make-cook-pod-watch-callback this)]
           ; We set cook expected state first because initialize-pod-watch sets (and invokes callbacks on and reacts to) the
@@ -221,8 +228,6 @@
 
         ; Initialize the node watch path.
         (api/initialize-node-watch api-client name current-nodes-atom)
-
-        (reset! pool->fenzo-atom pool->fenzo)
         (catch Throwable e
           (log/error e "Failed to bring up compute cluster" name)
           (throw e))))


### PR DESCRIPTION
## Changes proposed in this PR

- `reset!`ing the `pool->fenzo-atom` before initializing the watches

## Why are we making these changes?

Otherwise, we will start to see and handle events for pods, but we won't be able to update the corresponding Fenzo instance (e.g. un-assigning a completed task from its host).

Observed this log during the compute cluster initialization:

https://github.com/twosigma/Cook/blob/d4ceb8aec493c84cdf93e887642713059d1fab92/scheduler/src/cook/scheduler/scheduler.clj#L264-L265