### PR TITLE
Uses 'Normal exit' reason for successful k8s instances

### DIFF
--- a/scheduler/docs/reason-code
+++ b/scheduler/docs/reason-code
@@ -1,5 +1,5 @@
 01xxx: Normal
-01000: Normal exit (Not Implemented)
+01000: Normal exit
 01001: Killed by user (Not Implemented)
 01002: Preempted by rebalancer
 01003: REASON_CONTAINER_PREEMPTED

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -193,10 +193,9 @@
                            :task-finished
                            :task-failed)
               reason (or reason 
-                         (if succeeded?
-                           :reason-normal-exit
-                           (container-status->failure-reason compute-cluster pod-name
-                                                             pod-status job-container-status)))
+                         (when succeeded? :reason-normal-exit)
+                         (container-status->failure-reason compute-cluster pod-name
+                                                           pod-status job-container-status))
               status {:task-id {:value pod-name}
                       :state task-state
                       :reason reason}

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -188,14 +188,18 @@
         (let [pod-status (.getStatus pod)
               ^V1ContainerStatus job-container-status (get-job-container-status pod-status)
               ; We leak mesos terminology here ('task') because of backward compatibility.
-              task-state (if (= (:state synthesized-state) :pod/succeeded)
+              succeeded? (= (:state synthesized-state) :pod/succeeded)
+              task-state (if succeeded?
                            :task-finished
                            :task-failed)
+              reason (if succeeded?
+                       :reason-normal-exit
+                       (or reason
+                           (container-status->failure-reason compute-cluster pod-name
+                                                             pod-status job-container-status)))
               status {:task-id {:value pod-name}
                       :state task-state
-                      :reason (or reason
-                                  (container-status->failure-reason compute-cluster pod-name
-                                                                    pod-status job-container-status))}
+                      :reason reason}
               exit-code (some-> job-container-status .getState .getTerminated .getExitCode)]
           {:status status :exit-code exit-code})
         ; We didn't have a pod, so we have to generate a status, without it.

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -192,9 +192,9 @@
               task-state (if succeeded?
                            :task-finished
                            :task-failed)
-              reason (if succeeded?
-                       :reason-normal-exit
-                       (or reason
+              reason (or reason 
+                         (if succeeded?
+                           :reason-normal-exit
                            (container-status->failure-reason compute-cluster pod-name
                                                              pod-status job-container-status)))
               status {:task-id {:value pod-name}

--- a/scheduler/src/cook/mesos/reason.clj
+++ b/scheduler/src/cook/mesos/reason.clj
@@ -26,11 +26,11 @@
   (:reason/string (reason-code->reason-entity db reason-code)))
 
 (defn mesos-reason->cook-reason-entity-id
-  [db mesos-reason]
+  [db task-id mesos-reason]
   (if-let [reason-entity-id (:db/id (d/entity db [:reason/mesos-reason mesos-reason]))]
     reason-entity-id
     (do
-      (log/warn "Unknown mesos reason: " mesos-reason)
+      (log/warn "Unknown mesos reason:" mesos-reason "for task" task-id)
       (:db/id (d/entity db [:reason/name :mesos-unknown])))))
 
 (defn instance-entity->reason-entity

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -1196,6 +1196,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
 
 (def reason-entities
   [{:db/id (d/tempid :db.part/user)
+    :reason/code 1000
+    :reason/string "Normal exit"
+    :reason/name :normal-exit
+    :reason/mea-culpa? false
+    :reason/mesos-reason :reason-normal-exit}
+   {:db/id (d/tempid :db.part/user)
     :reason/code 1002
     :reason/string "Preempted by rebalancer"
     :reason/mea-culpa? true

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -65,6 +65,7 @@
 
     (is (nil? (do-process :cook-expected-state/running :missing)))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/succeeded)))
+    (is (= :reason-normal-exit @reason))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/failed)))
     (is (= :cook-expected-state/running (do-process :cook-expected-state/running :pod/running)))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/unknown)))


### PR DESCRIPTION
## Changes proposed in this PR

- adding the "Normal exit" reason (documented but never implemented until now)
- using the "Normal exit" reason when a k8s instance succeeds
- adding the `task-id` to the log when an unknown reason is passed to `mesos-reason->cook-reason-entity-id`

## Why are we making these changes?

Without the first two changes, we're doing the following on every successful pod:

1. Calling `container-status->failure-reason` for no good reason
1. Logging warnings unnecessarily

The addition of `task-id` to the log is to make the log more useful for troubleshooting.
