### PR TITLE
Name test jobs with their caller function to better identify them.

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2370,12 +2370,12 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, job_uuids)
 
     def test_submit_with_no_name(self):
-        # We need to manually set the 'uuid' to avoid having the
-        # job name automatically set by the submit_job function
+        # The code specialcases name=None and removes it before submitting.
         job_with_no_name = {'uuid': str(util.make_temporal_uuid()),
                             'command': 'ls',
                             'cpus': 0.1,
                             'mem': 16,
+                            'name' : None,
                             'max-retries': 1}
         job_uuid, resp = util.submit_job(self.cook_url, **job_with_no_name)
         self.assertEqual(resp.status_code, 201, msg=resp.content)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2370,7 +2370,7 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, job_uuids)
 
     def test_submit_with_no_name(self):
-        # The code specialcases name=None and removes it before submitting.
+        # The job submission code special-cases name=None and removes it before submitting.
         job_with_no_name = {'uuid': str(util.make_temporal_uuid()),
                             'command': 'ls',
                             'cpus': 0.1,

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -50,6 +50,8 @@ EPHEMERAL_HOSTS_SKIP_REASON = 'If the cluster under test has ephemeral hosts, th
 # particular job submission
 POOL_UNSPECIFIED = 'COOK_TEST_POOL_UNSPECIFIED'
 
+# The default name prefix for default jobs
+DEFAULT_JOB_NAME_PREFIX = "default_job-"
 
 def continuous_integration():
     """Returns true if the CONTINUOUS_INTEGRATION environment variable is set, as done by Travis-CI."""
@@ -474,7 +476,7 @@ def minimal_job(**kwargs):
         'cpus': get_default_cpus(),
         'max_retries': 1,
         'mem': int(os.getenv('COOK_DEFAULT_JOB_MEM_MB', 32)),
-        'name': ('default_test_job-'+get_caller()),
+        'name': (DEFAULT_JOB_NAME_PREFIX + get_caller()),
         'priority': 1,
         'uuid': str(make_temporal_uuid())
     }
@@ -554,9 +556,10 @@ def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, log_requ
     if isinstance(job_specs, dict):
         job_specs = [job_specs] * clones
     caller = get_caller()
+
     def full_spec(spec):
         if 'name' not in spec:
-            spec['name']="default_job-"+caller
+            spec['name'] = DEFAULT_JOB_NAME_PREFIX + caller
         if 'uuid' not in spec:
             return minimal_job(**spec)
         else:
@@ -635,7 +638,7 @@ def submit_job(cook_url, pool=None, headers=None, **kwargs):
     if headers is None:
         headers = {}
     if 'name' not in kwargs:
-        kwargs['name']="default_job-"+get_caller()
+        kwargs['name'] = DEFAULT_JOB_NAME_PREFIX + get_caller()
     uuids, resp = submit_jobs(cook_url, job_specs=[kwargs], pool=pool, headers=headers)
     return uuids[0], resp
 


### PR DESCRIPTION
## Changes proposed in this PR

- Most jobs are annotated with which integration test created them. 

## Why are we making these changes?

Many/most of our test jobs have the same name, this can make it hard to trace where a test job came from (when the underlying integration test passes). Try to auto-pick a name variant to make it easier to do this tracing.

