### PR TITLE
Fixes timeout for test_straggler_handling

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1443,7 +1443,8 @@ class CookTest(util.CookTest):
     @pytest.mark.xfail
     # The test timeout needs to be a little more than 2 times the timeout
     # interval to allow at least two runs of the straggler handler
-    @pytest.mark.timeout((2 * util.timeout_interval_minutes() * 60) + 60)
+    @pytest.mark.timeout(max((2 * util.timeout_interval_minutes() * 60) + 60,
+                             util.DEFAULT_TEST_TIMEOUT_SECS))
     def test_straggler_handling(self):
         straggler_handling = {
             'type': 'quantile-deviation',


### PR DESCRIPTION
## Changes proposed in this PR

- taking the max of (timeout-interval-based timeout, default timeout)

## Why are we making these changes?

Even though the test is marked `xfail`, if it times out, the test run fails. In environments with a low timeout-interval, e.g. 1 minute, we may need the longer default timeout.
