### PR TITLE
Makes test_set_retries_to_attempts_conflict more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2544,9 +2544,10 @@ class CookTest(util.CookTest):
         self.assertFalse(job_uuids[1] in error, resp.content)
 
     def test_set_retries_to_attempts_conflict(self):
-        uuid, resp = util.submit_job(self.cook_url, command='sleep 30', max_retries=5, disable_mea_culpa_retries=True)
-        util.wait_until(lambda: util.load_job(self.cook_url, uuid),
-                        lambda j: (len(j['instances']) >= 1) and any([i['status'] == 'running' for i in j['instances']]))
+        sleep_command = f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'
+        uuid, resp = util.submit_job(self.cook_url, command=sleep_command,
+                                     max_retries=5, disable_mea_culpa_retries=True)
+        util.wait_for_running_instance(self.cook_url, uuid)
         util.kill_jobs(self.cook_url, [uuid])
 
         def instances_complete(job):

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -613,7 +613,7 @@ class CookTest(util.CookTest):
     def test_configurable_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type()
         command = 'echo "message: 25 Twenty-five percent" > progress_file.txt; sleep 1; exit 0'
-        job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=job_executor_type, max_runtime=60000,
+        job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=job_executor_type,
                                          progress_output_file='progress_file.txt',
                                          progress_regex_string='message: (\\d*) (.*)')
         self.assertEqual(201, resp.status_code, msg=resp.content)


### PR DESCRIPTION
## Changes proposed in this PR

- `sleep`ing for the duration of the test instead of 30 seconds
- using `util.wait_for_running_instance`

## Why are we making these changes?

The 30 second sleep can race with the kill, and if the job completes successfully, the `wait_until`-failed-instance will never succeed.
 