### PR TITLE
Makes test_configurable_progress_update_submit more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -613,7 +613,7 @@ class CookTest(util.CookTest):
     def test_configurable_progress_update_submit(self):
         job_executor_type = util.get_job_executor_type()
         command = 'echo "message: 25 Twenty-five percent" > progress_file.txt; sleep 1; exit 0'
-        job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=job_executor_type, max_runtime=60000,
+        job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=job_executor_type,
                                          progress_output_file='progress_file.txt',
                                          progress_regex_string='message: (\\d*) (.*)')
         self.assertEqual(201, resp.status_code, msg=resp.content)


### PR DESCRIPTION
## Changes proposed in this PR

- removing the `max_runtime` from the job spec

## Why are we making these changes?

If we get "unlucky", the lingering task killer will kill the job before progress is reported.
