### PR TITLE
Changes 'Failed to get mesos agent state' log from ERROR to INFO

### DIFF
--- a/scheduler/src/cook/mesos/sandbox.clj
+++ b/scheduler/src/cook/mesos/sandbox.clj
@@ -228,7 +228,7 @@
                         (send pending-sync-agent aggregate-pending-sync-hostname host :pending))
                       :success)
                     (catch Exception e
-                      (log/error e "Failed to get mesos agent state on" host)
+                      (log/info e "Failed to get mesos agent state on" host)
                       (send pending-sync-agent aggregate-pending-sync-hostname host :error)
                       :error)))
             cs (swap! mesos-agent-query-cache


### PR DESCRIPTION
## Changes proposed in this PR

- changing the log from `ERROR` to `INFO`

## Why are we making these changes?

In the wild, we see this happen somewhat regularly, and the code is already designed to retry when this fails.
