### PR TITLE
Adds mapping for REASON_TASK_KILLED_DURING_LAUNCH

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1128,11 +1128,11 @@ def dummy_ls_entries(_, __, ___):
     def __wait_for_progress_message(self, uuids):
         return util.wait_until(lambda: cli.show_jobs(uuids, self.cook_url)[1][0],
                                lambda j: next(
-                                   i for i in job['instances'] if 'progress' in i and 'progress_message' in i))
+                                   i for i in j['instances'] if 'progress' in i and 'progress_message' in i))
 
     def __wait_for_exit_code(self, uuids):
         return util.wait_until(lambda: cli.show_jobs(uuids, self.cook_url)[1][0],
-                               lambda j: next(i for i in job['instances'] if 'exit_code' in i))
+                               lambda j: next(i for i in j['instances'] if 'exit_code' in i))
 
     def __wait_for_executor_completion_message(self, uuids):
         def query():

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1126,13 +1126,16 @@ def dummy_ls_entries(_, __, ___):
                 self.assertEqual(1, entry2['size'])
 
     def __wait_for_progress_message(self, uuids):
-        return util.wait_until(lambda: cli.show_jobs(uuids, self.cook_url)[1][0],
-                               lambda j: next(
-                                   i for i in j['instances'] if 'progress' in i and 'progress_message' in i))
+        return util.wait_until(
+            lambda: next(i for i in cli.show_jobs(uuids, self.cook_url)[1][0]['instances'] 
+                         if 'progress' in i and 'progress_message' in i),
+            lambda i: True)
 
     def __wait_for_exit_code(self, uuids):
-        return util.wait_until(lambda: cli.show_jobs(uuids, self.cook_url)[1][0],
-                               lambda j: next(i for i in j['instances'] if 'exit_code' in i))
+        return util.wait_until(
+            lambda: next(i for i in cli.show_jobs(uuids, self.cook_url)[1][0]['instances'] 
+                         if 'exit_code' in i),
+            lambda i: True)
 
     def __wait_for_executor_completion_message(self, uuids):
         def query():

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1126,12 +1126,13 @@ def dummy_ls_entries(_, __, ___):
                 self.assertEqual(1, entry2['size'])
 
     def __wait_for_progress_message(self, uuids):
-        return util.wait_until(lambda: cli.show_jobs(uuids, self.cook_url)[1][0]['instances'][0],
-                               lambda i: 'progress' in i and 'progress_message' in i)
+        return util.wait_until(lambda: cli.show_jobs(uuids, self.cook_url)[1][0],
+                               lambda j: next(
+                                   i for i in job['instances'] if 'progress' in i and 'progress_message' in i))
 
     def __wait_for_exit_code(self, uuids):
-        return util.wait_until(lambda: cli.show_jobs(uuids, self.cook_url)[1][0]['instances'][0],
-                               lambda i: 'exit_code' in i)
+        return util.wait_until(lambda: cli.show_jobs(uuids, self.cook_url)[1][0],
+                               lambda j: next(i for i in job['instances'] if 'exit_code' in i))
 
     def __wait_for_executor_completion_message(self, uuids):
         def query():

--- a/scheduler/docs/reason-code
+++ b/scheduler/docs/reason-code
@@ -3,6 +3,7 @@
 01001: Killed by user (Not Implemented)
 01002: Preempted by rebalancer
 01003: REASON_CONTAINER_PREEMPTED
+01004: REASON_TASK_KILLED_DURING_LAUNCH
 
 02xxx: Job Misconfiguration
 02000: REASON_CONTAINER_LIMITATION

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -34,7 +34,7 @@
             [plumbing.core :as pc]
             [metrics.counters :as counters])
   (:import (java.net URLEncoder)
-           org.apache.mesos.Protos$TaskStatus$Reason))
+           (org.apache.mesos Protos$TaskStatus$Reason)))
 
 (meters/defmeter [cook-mesos scheduler mesos-error])
 (meters/defmeter [cook-mesos scheduler handle-framework-message-rate])
@@ -78,7 +78,8 @@
         (cc/safe-kill-task compute-cluster task-id))
       ; Mesomatic doesn't have a mapping for REASON_TASK_KILLED_DURING_LAUNCH
       ; (http://mesos.apache.org/documentation/latest/task-state-reasons/#for-state-task_killed),
-      ; so we're rolling our own mapping for it here.
+      ; so we're rolling our own mapping for it here. There is an open issue with Mesomatic:
+      ; https://github.com/clojusc/mesomatic/issues/53
       (let [status' (cond-> status
                       (= reason Protos$TaskStatus$Reason/REASON_TASK_KILLED_DURING_LAUNCH)
                       (assoc :reason :reason-killed-during-launch))]

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -33,7 +33,8 @@
             [metrics.meters :as meters]
             [plumbing.core :as pc]
             [metrics.counters :as counters])
-  (:import (java.net URLEncoder)))
+  (:import (java.net URLEncoder)
+           org.apache.mesos.Protos$TaskStatus$Reason))
 
 (meters/defmeter [cook-mesos scheduler mesos-error])
 (meters/defmeter [cook-mesos scheduler handle-framework-message-rate])
@@ -54,7 +55,7 @@
 (defn handle-status-update
   "Handles a status update from mesos. When a task/job is in an inconsistent state it may kill the task. It also writes the
   status back to datomic."
-  [conn compute-cluster sync-agent-sandboxes-fn pool->fenzo {:keys [state] :as status}]
+  [conn compute-cluster sync-agent-sandboxes-fn pool->fenzo {:keys [reason state] :as status}]
   (let [task-id (-> status :task-id :value)
         instance (d/entity (d/db conn) [:instance/task-id task-id])
         prior-job-state (:job/state (:job/_instance instance))
@@ -75,7 +76,13 @@
                   "should've been put down already")
         (meters/mark! (meters/meter (sched/metric-title "tasks-killed-in-status-update" pool-name)))
         (cc/safe-kill-task compute-cluster task-id))
-      (sched/write-status-to-datomic conn pool->fenzo status))
+      ; Mesomatic doesn't have a mapping for REASON_TASK_KILLED_DURING_LAUNCH
+      ; (http://mesos.apache.org/documentation/latest/task-state-reasons/#for-state-task_killed),
+      ; so we're rolling our own mapping for it here.
+      (let [status' (cond-> status
+                      (= reason Protos$TaskStatus$Reason/REASON_TASK_KILLED_DURING_LAUNCH)
+                      (assoc :reason :reason-killed-during-launch))]
+        (sched/write-status-to-datomic conn pool->fenzo status')))
     (conditionally-sync-sandbox conn task-id (:state status) sync-agent-sandboxes-fn)))
 
 (defn create-mesos-scheduler

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -1212,6 +1212,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :reason/name :mesos-container-preempted
     :reason/mea-culpa? false
     :reason/mesos-reason :reason-executor-preempted}
+   {:db/id (d/tempid :db.part/user)
+    :reason/code 1004
+    :reason/string "Killed during launch"
+    :reason/name :killed-during-launch
+    :reason/mea-culpa? false
+    :reason/mesos-reason :reason-killed-during-launch}
 
    {:db/id (d/tempid :db.part/user)
     :reason/code 2000

--- a/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
+++ b/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
@@ -13,7 +13,7 @@
             [mesomatic.scheduler :as msched]
             [plumbing.core :as pc])
   (:import (java.util.concurrent CountDownLatch TimeUnit)
-           org.apache.mesos.Protos$TaskStatus$Reason))
+           (org.apache.mesos Protos$TaskStatus$Reason)))
 
 (deftest test-in-order-status-update-processing
   (let [status-store (atom {})

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -39,7 +39,8 @@
                                         create-dummy-job-with-instances
                                         create-pool
                                         flush-caches!
-                                        restore-fresh-database!] :as testutil]
+                                        restore-fresh-database!
+                                        setup] :as testutil]
             [datomic.api :as d :refer [q db]]
             [mesomatic.scheduler :as msched]
             [schema.core :as s])
@@ -1283,6 +1284,7 @@
    :user "user"})
 
 (deftest test-create-jobs!
+  (setup)
   (cook.test.testutil/flush-caches!)
 
   (let [expected-job-map
@@ -1477,9 +1479,9 @@
                   (is (= (assoc (expected-job-map job)
                            :container (assoc-in docker-container
                                                 [:docker :parameters]
-                                                [{:key "user" :value "1234:2345"}
-                                                 {:key "tee" :value "tie"}
-                                                 {:key "fee" :value "fie"}]))
+                                                [{:key "tee" :value "tie"}
+                                                 {:key "fee" :value "fie"}
+                                                 {:key "user" :value "1234:2345"}]))
                          (dissoc (api/fetch-job-map (db conn) uuid) :submit_time)))))
 
               (testing "user parameter absent"
@@ -1492,9 +1494,9 @@
                   (is (= (assoc (expected-job-map job)
                            :container (assoc-in docker-container
                                                 [:docker :parameters]
-                                                [{:key "user" :value "1234:2345"}
-                                                 {:key "tee" :value "tie"}
-                                                 {:key "fee" :value "fie"}]))
+                                                [{:key "tee" :value "tie"}
+                                                 {:key "fee" :value "fie"}
+                                                 {:key "user" :value "1234:2345"}]))
                          (dissoc (api/fetch-job-map (db conn) uuid) :submit_time))))))))))
 
     (testing "returns unsupported for multiple compute clusters"


### PR DESCRIPTION
## Changes proposed in this PR

- adding a mapping for this status reason from Mesos

## Why are we making these changes?

Mesomatic doesn't have a mapping for [`REASON_TASK_KILLED_DURING_LAUNCH`](http://mesos.apache.org/documentation/latest/task-state-reasons/#for-state-task_killed), so we're rolling our own mapping for it here.

This avoids tons of "Unknown mesos reason" warning logs.


### Related Issue: https://github.com/clojusc/mesomatic/issues/53