### PR TITLE
Adds running reason for k8s instances

### DIFF
--- a/scheduler/docs/reason-code
+++ b/scheduler/docs/reason-code
@@ -3,6 +3,7 @@
 01001: Killed by user (Not Implemented)
 01002: Preempted by rebalancer
 01003: REASON_CONTAINER_PREEMPTED
+01005: Running
 
 02xxx: Job Misconfiguration
 02000: REASON_CONTAINER_LIMITATION

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -232,7 +232,8 @@
   (let [instance-id (-> pod .getMetadata .getName)
         ; We leak mesos terminology here ('task') because of backward compatibility.
         status {:task-id {:value instance-id}
-                :state :task-running}]
+                :state :task-running
+                :reason :reason-running}]
     (write-status-to-datomic compute-cluster status)
     {:cook-expected-state :cook-expected-state/running}))
 

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -1212,6 +1212,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :reason/name :mesos-container-preempted
     :reason/mea-culpa? false
     :reason/mesos-reason :reason-executor-preempted}
+   {:db/id (d/tempid :db.part/user)
+    :reason/code 1005
+    :reason/string "Running"
+    :reason/name :running
+    :reason/mea-culpa? false
+    :reason/mesos-reason :reason-running}
 
    {:db/id (d/tempid :db.part/user)
     :reason/code 2000

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -30,8 +30,6 @@
                                                            cook-expected-state-dict)
                                    controller/kill-pod (fn [_ cook-expected-state-dict _]
                                                          cook-expected-state-dict)
-                                   controller/handle-pod-started (fn [_ _]
-                                                                   {:cook-expected-state :cook-expected-state/running})
                                    controller/handle-pod-killed (fn [_ _]
                                                                   {:cook-expected-state :cook-expected-state/completed})
                                    controller/write-status-to-datomic (fn [_ status]
@@ -78,6 +76,7 @@
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/starting :pod/succeeded)))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/starting :pod/failed)))
     (is (= :cook-expected-state/running (do-process :cook-expected-state/starting :pod/running)))
+    (is (= :reason-running @reason))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/starting :pod/unknown)))
     (is (= :cook-expected-state/starting (do-process :cook-expected-state/starting :pod/waiting)))
 

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1479,10 +1479,12 @@
                   (is (= (assoc (expected-job-map job)
                            :container (assoc-in docker-container
                                                 [:docker :parameters]
-                                                [{:key "tee" :value "tie"}
-                                                 {:key "fee" :value "fie"}
-                                                 {:key "user" :value "1234:2345"}]))
-                         (dissoc (api/fetch-job-map (db conn) uuid) :submit_time)))))
+                                                (frequencies [{:key "tee" :value "tie"}
+                                                              {:key "fee" :value "fie"}
+                                                              {:key "user" :value "1234:2345"}])))
+                         (-> (api/fetch-job-map (db conn) uuid)
+                             (dissoc :submit_time)
+                             (update-in [:container :docker :parameters] frequencies))))))
 
               (testing "user parameter absent"
                 (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1494,10 +1496,12 @@
                   (is (= (assoc (expected-job-map job)
                            :container (assoc-in docker-container
                                                 [:docker :parameters]
-                                                [{:key "tee" :value "tie"}
-                                                 {:key "fee" :value "fie"}
-                                                 {:key "user" :value "1234:2345"}]))
-                         (dissoc (api/fetch-job-map (db conn) uuid) :submit_time))))))))))
+                                                (frequencies [{:key "tee" :value "tie"}
+                                                              {:key "fee" :value "fie"}
+                                                              {:key "user" :value "1234:2345"}])))
+                         (-> (api/fetch-job-map (db conn) uuid)
+                             (dissoc :submit_time)
+                             (update-in [:container :docker :parameters] frequencies)))))))))))
 
     (testing "returns unsupported for multiple compute clusters"
       (with-redefs [config/compute-clusters (constantly [{:factory-fn 'cook.mesos.mesos-compute-cluster/factory-fn

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1477,9 +1477,9 @@
                   (is (= (assoc (expected-job-map job)
                            :container (assoc-in docker-container
                                                 [:docker :parameters]
-                                                [{:key "user" :value "1234:2345"}
-                                                 {:key "tee" :value "tie"}
-                                                 {:key "fee" :value "fie"}]))
+                                                [{:key "tee" :value "tie"}
+                                                 {:key "fee" :value "fie"}
+                                                 {:key "user" :value "1234:2345"}]))
                          (dissoc (api/fetch-job-map (db conn) uuid) :submit_time)))))
 
               (testing "user parameter absent"
@@ -1492,9 +1492,9 @@
                   (is (= (assoc (expected-job-map job)
                            :container (assoc-in docker-container
                                                 [:docker :parameters]
-                                                [{:key "user" :value "1234:2345"}
-                                                 {:key "tee" :value "tie"}
-                                                 {:key "fee" :value "fie"}]))
+                                                [{:key "tee" :value "tie"}
+                                                 {:key "fee" :value "fie"}
+                                                 {:key "user" :value "1234:2345"}]))
                          (dissoc (api/fetch-job-map (db conn) uuid) :submit_time))))))))))
 
     (testing "returns unsupported for multiple compute clusters"


### PR DESCRIPTION
## Changes proposed in this PR

- adding a "running" reason
- setting the `:reason` to this new reason for k8s instances

## Why are we making these changes?

The `write-status-to-datomic` code in the scheduler expects a non-`nil` reason, and when it gets `nil` (without this patch), it logs a warning and uses the `:mesos-unknown` reason, which is not what we want.