### PR TITLE
Improves log in handle-status-update

### DIFF
--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -69,10 +69,13 @@
                          :task-starting}
                        state)) ; killing an unknown task causes a TASK_LOST message. Break the cycle! Only kill non-terminal tasks
       (do
-
-        (log/warn "Attempting to kill task" task-id
-                  "as instance" instance "with" prior-job-state "and" prior-instance-status
-                  "should've been put down already")
+        (log/info "In compute cluster" (cc/compute-cluster-name compute-cluster)
+                  ", attempting to kill task" task-id "should've been put down already"
+                  {:instance instance
+                   :pool pool-name
+                   :prior-instance-status prior-instance-status
+                   :prior-job-state prior-job-state
+                   :state state})
         (meters/mark! (meters/meter (sched/metric-title "tasks-killed-in-status-update" pool-name)))
         (cc/safe-kill-task compute-cluster task-id))
       (sched/write-status-to-datomic conn pool->fenzo status))


### PR DESCRIPTION
## Changes proposed in this PR

- changing log from `WARN` to `INFO`
- adding more context to the log

## Why are we making these changes?

In the wild, we see this log thousands of times per day, e.g. we receive "task lost" status updates from Mesos due to "health check timed out" and then 2 minutes later Mesos tells us the task is running again. We don't need this to be `WARN`.
