### PR TITLE
don't fail test when init script is used

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -408,7 +408,11 @@ class CookTest(util.CookTest):
             self.assertEqual(resp.content, str.encode(f"submitted jobs {job_uuid}"))
             job = util.load_job(self.cook_url, job_uuid)
             util.wait_for_job(self.cook_url, job_uuid, 'completed')
-            util.wait_for_instance(self.cook_url, job_uuid, status='success')
+            settings_dict = util.settings(self.cook_url)
+            if settings_dict['kubernetes'] and settings_dict['kubernetes']['custom-shell']:
+                util.wait_for_instance(self.cook_url, job_uuid)
+            else:
+                util.wait_for_instance(self.cook_url, job_uuid, status='success')
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -409,7 +409,7 @@ class CookTest(util.CookTest):
             job = util.load_job(self.cook_url, job_uuid)
             util.wait_for_job(self.cook_url, job_uuid, 'completed')
             settings_dict = util.settings(self.cook_url)
-            if settings_dict['kubernetes'] and settings_dict['kubernetes']['custom-shell']:
+            if 'kubernetes' in settings_dict and 'custom-shell' in settings_dict['kubernetes']:
                 util.wait_for_instance(self.cook_url, job_uuid)
             else:
                 util.wait_for_instance(self.cook_url, job_uuid, status='success')

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -409,6 +409,8 @@ class CookTest(util.CookTest):
             job = util.load_job(self.cook_url, job_uuid)
             util.wait_for_job(self.cook_url, job_uuid, 'completed')
             settings_dict = util.settings(self.cook_url)
+            # This test provides a non-writeable workdir, so we're adding this temporary change until we separate
+            # the sandbox and workdir.
             if 'kubernetes' in settings_dict and 'custom-shell' in settings_dict['kubernetes']:
                 util.wait_for_instance(self.cook_url, job_uuid)
             else:


### PR DESCRIPTION
## Changes proposed in this PR

- Don't fail test when pod exits non-zero in the test_workdir_volume_overlap test and the cook init script is used

## Why are we making these changes?

The test_workdir_volume_overlap test uses a non-writable workdir which causes the cook init script to exit non-zero
