### PR TITLE
Makes test_multiple_rapid_progress_updates_submit more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -679,10 +679,9 @@ class CookTest(util.CookTest):
 
         items = list(range(1, 100, 4)) + list(range(99, 40, -4)) + list(range(40, 81, 2))
         command = ''.join([f'{progress_string(a)} && ' for a in items]) + 'echo "Done" && sleep 10 && exit 0'
-        job_uuid, resp = util.submit_job(self.cook_url, command=command,
-                                         executor=job_executor_type, max_runtime=60000)
+        job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=job_executor_type)
         self.assertEqual(201, resp.status_code, msg=resp.content)
-        time.sleep(10) # since the job sleeps for 10 seconds, it won't be done for at least 10 seconds
+        time.sleep(10)  # since the job sleeps for 10 seconds, it won't be done for at least 10 seconds
         util.wait_for_job(self.cook_url, job_uuid, 'completed')
         instance = util.wait_for_instance_with_progress(self.cook_url, job_uuid, 80)
         message = json.dumps(instance, sort_keys=True)


### PR DESCRIPTION
## Changes proposed in this PR

- removing `max_runtime` from the job spec
- fixing a formatting issue

## Why are we making these changes?

In environments with a small interval for the lingering task killer (e.g. 1 minute), Cook can kill the task with `Task max runtime exceeded` before the progress update is published.
