### PR TITLE
Avoid NPE in sandbox calculation when compute cluster is not found.

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -137,7 +137,7 @@
     nil))
 
 (defn compute-cluster-name->ComputeCluster
-  "From the name of a compute cluster, return the object. Throws if not found. Does not return nil."
+  "From the name of a compute cluster, return the object. May return nil if not found."
   [compute-cluster-name]
   (let [result (get @cluster-name->compute-cluster-atom compute-cluster-name)]
     (when-not result

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -986,11 +986,11 @@
   "Gets a URL to query the sandbox directory of the task.
    Users will need to add the file path & offset to their query.
    Refer to the 'Using the output_url' section in docs/scheduler-rest-api.adoc for further details.
-   Delegates to the compute cluster implimentation."
+   Delegates to the compute cluster implementation."
   [instance-entity]
   (if-let [sandbox-url (:instance/sandbox-url instance-entity)]
     sandbox-url
-    (let [compute-cluster (task/task-ent->ComputeCluster instance-entity)]
+    (when-let [compute-cluster (task/task-ent->ComputeCluster instance-entity)]
       (cc/retrieve-sandbox-url-path compute-cluster instance-entity))))
 
 (defn compute-cluster-entity->map

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -990,8 +990,9 @@
   [instance-entity]
   (if-let [sandbox-url (:instance/sandbox-url instance-entity)]
     sandbox-url
-    (when-let [compute-cluster (task/task-ent->ComputeCluster instance-entity)]
-      (cc/retrieve-sandbox-url-path compute-cluster instance-entity))))
+    (if-let [compute-cluster (task/task-ent->ComputeCluster instance-entity)]
+      (cc/retrieve-sandbox-url-path compute-cluster instance-entity)
+      (log/error "Unable to get sandbox URL for" instance-entity "whose compute cluster resolves to nil"))))
 
 (defn compute-cluster-entity->map
   "Attached to the the instance object when we send it in API responses"

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -34,6 +34,7 @@
             [cook.plugins.file :as file-plugin]
             [cook.plugins.submission :as submission-plugin]
             [cook.rate-limit :as rate-limit]
+            [cook.task :as task]
             [cook.test.testutil :refer [create-dummy-instance
                                         create-dummy-job
                                         create-dummy-job-with-instances
@@ -1615,7 +1616,9 @@
 
 (deftest test-retrieve-sandbox-url-path
   (let [agent-hostname "www.mesos-agent-com"]
-    (with-redefs [cc/retrieve-sandbox-url-path (fn [_ {:keys [instance/hostname instance/sandbox-directory instance/task-id]}]
+    ; We have a special gate that the compute cluster isn't nil, so have this return something not nil.
+    (with-redefs [task/task-ent->ComputeCluster (constantly "JustHasToBeNonNil-ComputeCluster")
+                  cc/retrieve-sandbox-url-path (fn [_ {:keys [instance/hostname instance/sandbox-directory instance/task-id]}]
                                                  (when (and hostname sandbox-directory)
                                                    (str "http://" hostname ":5051" "/" task-id "/files/read.json?path=" sandbox-directory)))]
       (testing "retrieve-sandbox-url-path"


### PR DESCRIPTION
## Changes proposed in this PR

- Avoid NPE in sandbox calculation when compute cluster is not found.
- Fix a couple of comments.

## Why are we making these changes?
NPE is bad.

