### PR TITLE
Makes test_instance_stats_success more reliable

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -672,11 +672,14 @@ class MultiUserCookTest(util.CookTest):
 
     def test_instance_stats_success(self):
         name = str(util.make_temporal_uuid())
-        job_uuid_1, resp = util.submit_job(self.cook_url, command='exit 0', name=name, cpus=0.10, mem=32)
+        job_uuid_1, resp = util.submit_job(self.cook_url, command='exit 0', name=name,
+                                           cpus=0.10, mem=32, max_retries=5)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 1', name=name, cpus=0.11, mem=33)
+        job_uuid_2, resp = util.submit_job(self.cook_url, command='sleep 1', name=name,
+                                           cpus=0.11, mem=33, max_retries=5)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 2', name=name, cpus=0.12, mem=34)
+        job_uuid_3, resp = util.submit_job(self.cook_url, command='sleep 2', name=name,
+                                           cpus=0.12, mem=34, max_retries=5)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
         try:


### PR DESCRIPTION
## Changes proposed in this PR

- adding retries to the job submissions

## Why are we making these changes?

We need to decrease the likelihood that a transient failure like `Mesos executor re-registration timed out` will cause the test to fail.
