### PR TITLE
Improves synthetic pods

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1450,7 +1450,8 @@ def node_pool(nodename):
 
 def max_kubernetes_node_cpus():
     nodes = get_kubernetes_nodes()
-    return max([float(n['status']['capacity']['cpu'])
+    k8s_node_overhead_cpus = 1
+    return max([float(n['status']['capacity']['cpu']) - k8s_node_overhead_cpus
                 for n in nodes])
 
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1450,7 +1450,9 @@ def node_pool(nodename):
 
 def max_kubernetes_node_cpus():
     nodes = get_kubernetes_nodes()
-    k8s_node_overhead_cpus = 1
+    # We need to account for per-node overhead
+    # (capacity not usable by our Cook pods)
+    k8s_node_overhead_cpus = int(os.getenv("COOK_TEST_K8S_NODE_OVERHEAD_CPUS", 0))
     return max([float(n['status']['capacity']['cpu']) - k8s_node_overhead_cpus
                 for n in nodes])
 

--- a/scheduler/bin/help-make-cluster
+++ b/scheduler/bin/help-make-cluster
@@ -36,12 +36,26 @@ $gcloud container clusters get-credentials "$CLUSTERNAME" --zone "$ZONE"
 
 # Make some node-pools --- this takes a while, but it helps guarantee that we have nodes with the appropriate cook-pool taints.
 echo "---- Making extra k8s-alpha and k8s-gamma nodepools for cook pools (please wait 5-10 minutes)"
-$gcloud container node-pools create cook-pool-k8s-gamma --zone "$ZONE" --cluster="$CLUSTERNAME" --disk-size=20gb --machine-type=g1-small \
+$gcloud container node-pools create cook-pool-k8s-gamma \
+       --zone "$ZONE" \
+       --cluster="$CLUSTERNAME" \
+       --disk-size=20gb \
+       --machine-type=g1-small \
        --node-taints=cook-pool=k8s-gamma:NoSchedule \
-       --enable-autoscaling --min-nodes=3 --max-nodes=6
-$gcloud container node-pools create cook-pool-k8s-alpha --zone "$ZONE" --cluster="$CLUSTERNAME" --disk-size=20gb --machine-type=g1-small \
+       --enable-autoscaling \
+       --min-nodes=3 \
+       --max-nodes=6 \
+       --node-labels=cook_pool=k8s-gamma
+$gcloud container node-pools create cook-pool-k8s-alpha \
+       --zone "$ZONE" \
+       --cluster="$CLUSTERNAME" \
+       --disk-size=20gb \
+       --machine-type=g1-small \
        --node-taints=cook-pool=k8s-alpha:NoSchedule \
-       --enable-autoscaling --min-nodes=2 --max-nodes=4
+       --enable-autoscaling \
+       --min-nodes=2 \
+       --max-nodes=4 \
+       --node-labels=cook_pool=k8s-alpha
 
 echo "---- Setting up cook namespace in kubernetes"
 KUBECONFIG=${COOK_KUBECONFIG} kubectl create -f docs/make-kubernetes-namespace.json

--- a/scheduler/bin/help-make-cluster
+++ b/scheduler/bin/help-make-cluster
@@ -10,10 +10,14 @@
 
 set -e
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 PROJECT=$1
 ZONE=$2
 CLUSTERNAME=$3
 COOK_KUBECONFIG=$4
+
+VERSION=1.15.9-gke.9
 
 gcloud="gcloud --project $PROJECT"
 
@@ -33,6 +37,13 @@ echo "---- Setting up gcloud credentials"
 KUBECONFIG=${COOK_KUBECONFIG} $gcloud container clusters get-credentials "$CLUSTERNAME" --zone "$ZONE"
 # Add credentials to default kubeconfig for convenience purposes.
 $gcloud container clusters get-credentials "$CLUSTERNAME" --zone "$ZONE"
+
+echo "---- Upgrading the cluster master version to $VERSION"
+$gcloud container clusters upgrade "$CLUSTERNAME" --cluster-version $VERSION --zone "$ZONE" --quiet --master
+
+echo "---- Setting up cook priority classes in kubernetes"
+KUBECONFIG=${COOK_KUBECONFIG} kubectl create -f "${DIR}/priority-class-cook-workload.yaml"
+KUBECONFIG=${COOK_KUBECONFIG} kubectl create -f "${DIR}/priority-class-synthetic-pod.yaml"
 
 # Make some node-pools --- this takes a while, but it helps guarantee that we have nodes with the appropriate cook-pool taints.
 echo "---- Making extra k8s-alpha and k8s-gamma nodepools for cook pools (please wait 5-10 minutes)"

--- a/scheduler/bin/make-gke-test-clusters
+++ b/scheduler/bin/make-gke-test-clusters
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Usage: ./bin/make-gke-test-clusters <project> <zone> <clustername>
+# Usage: ./bin/make-gke-test-clusters <project> [<zone>] [<clustername>]
 #   Configure two kubernetes clusters for running pool-based integration tests and running pools in general.
 #    NOTE: This script labels any clusters it creates and will DELETE old clusters it created.
 #   <project> is a gcloud project.

--- a/scheduler/bin/priority-class-cook-workload.yaml
+++ b/scheduler/bin/priority-class-cook-workload.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: cook-workload
+value: 1000
+globalDefault: false
+description: "This priority class should be used for Cook scheduled workloads."

--- a/scheduler/bin/priority-class-synthetic-pod.yaml
+++ b/scheduler/bin/priority-class-synthetic-pod.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: synthetic-pod
+value: 1
+globalDefault: false
+description: "This priority class should be used for Cook synthetic pods (trigger autoscaling)."

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -633,7 +633,14 @@
         (.setVolumeMounts container [(workdir-volume-mount-fn true) (sidecar-workdir-volume-mount-fn false)])
         (.addContainersItem pod-spec container)))
 
-    (.setNodeName pod-spec hostname)
+    (when hostname
+      ; Why not just set the node name?
+      ; The reason is that setting the node name prevents pod preemption
+      ; (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
+      ; from happening. We want this pod to preempt lower priority pods
+      ; (e.g. synthetic pods).
+      (.setNodeSelector pod-spec {"kubernetes.io/hostname" hostname}))
+
     (.setRestartPolicy pod-spec "Never")
     
     (.addTolerationsItem pod-spec toleration-for-deletion-candidate-of-autoscaler)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -57,6 +57,7 @@
                                              (-> pod
                                                  .getMetadata
                                                  .getCreationTimestamp
+                                                 (or (time/now))
                                                  (time/plus (time/seconds grace-period-seconds))
                                                  (time/after? (time/now)))))
                                          synthetic-pods)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -34,51 +34,6 @@
                  "compute cluster, unable to get node from node name" node-name)
       false)))
 
-(defn compute-num-waiting-synthetic-pods
-  "Given a compute cluster and a collection of pods, returns the number of
-  waiting synthetic pods in the cluster, or 0 if the cluster is not autoscaling"
-  [compute-cluster pods pool-name grace-period-seconds]
-  (if (cc/autoscaling? compute-cluster pool-name)
-    (let [synthetic-pods (filter controller/synthetic-pod->job-uuid pods)
-          waiting-synthetic-pods (filter (fn waiting-and-recent?
-                                           [^V1Pod pod]
-                                           (and
-                                             (or (-> pod
-                                                     .getStatus
-                                                     nil?)
-                                                 (-> pod
-                                                     api/pod->synthesized-pod-state
-                                                     :state
-                                                     (= :pod/waiting)))
-                                             ; We don't want to wait indefinitely because
-                                             ; synthetic pods didn't get scheduled. So, we
-                                             ; only count a synthetic pod as "recent" if it
-                                             ; was created in the last grace-period-seconds.
-                                             (-> pod
-                                                 .getMetadata
-                                                 .getCreationTimestamp
-                                                 (or (time/now))
-                                                 (time/plus (time/seconds grace-period-seconds))
-                                                 (time/after? (time/now)))))
-                                         synthetic-pods)
-          waiting-synthetic-pods-in-pool (filter (fn matching-cook-pool-toleration?
-                                                   [^V1Pod pod]
-                                                   (let [pod-spec (.getSpec pod)
-                                                         tolerations (.getTolerations pod-spec)]
-                                                     (some (fn [^V1Toleration toleration]
-                                                             (and (= (.getKey toleration) "cook-pool")
-                                                                  (= (.getValue toleration) pool-name)))
-                                                           tolerations)))
-                                                 waiting-synthetic-pods)]
-      (log/info "In" (cc/compute-cluster-name compute-cluster)
-                "compute cluster, computed number of waiting synthetic pods"
-                {:grace-period-seconds grace-period-seconds
-                 :num-waiting-synthetic-pods-in-pool (count waiting-synthetic-pods-in-pool)
-                 :pool pool-name
-                 :waiting-synthetic-pods-in-pool (map api/V1Pod->name waiting-synthetic-pods-in-pool)})
-      (count waiting-synthetic-pods-in-pool))
-    0))
-
 (defn total-resource
   "Given a map from node-name->resource-keyword->amount and a resource-keyword,
   returns the total amount of that resource for all nodes."
@@ -247,6 +202,12 @@
   (let [starting-pods (controller/starting-namespaced-pod-name->pod compute-cluster)]
     (-> pods (merge starting-pods) vals)))
 
+(defn synthetic-pod->job-uuid
+  "If the given pod is a synthetic pod for autoscaling, returns the job uuid
+  that the pod corresponds to (stored in a pod label). Otherwise, returns nil."
+  [^V1Pod pod]
+  (some-> pod .getMetadata .getLabels (.get api/cook-synthetic-pod-job-uuid-label)))
+
 (defrecord KubernetesComputeCluster [^ApiClient api-client name entity-id match-trigger-chan exit-code-syncer-state
                                      all-pods-atom current-nodes-atom cook-expected-state-map k8s-actual-state-map
                                      pool->fenzo-atom namespace-config scan-frequency-seconds-config max-pods-per-node
@@ -309,31 +270,19 @@
 
   (pending-offers [this pool-name]
     (let [pods (add-starting-pods this @all-pods-atom)
-          synthetic-pod-grace-period-seconds (-> synthetic-pods-config :grace-period-seconds (or 180))
-          num-waiting-synthetic-pods (compute-num-waiting-synthetic-pods this pods pool-name
-                                                                         synthetic-pod-grace-period-seconds)
-          nodes @current-nodes-atom]
-      (log/info "In" name "compute cluster, got asked for pending offers for pool" pool-name
-                {:nodes (count nodes)
-                 :synthetic-pods num-waiting-synthetic-pods
-                 :total-pods (count pods)})
-      (if (pos? num-waiting-synthetic-pods)
-        (do
-          ; If there are waiting synthetic pods for the given pool in the cluster, we should let
-          ; them get scheduled before we generate offers. Otherwise, we will be racing against the
-          ; k8s scheduler scheduling those synthetic pods, and we will often lose, resulting in
-          ; Failed instances for no good reason.
-          (log/info "In" name "compute cluster, skipping offer generation for pool" pool-name
-                    "because there are" num-waiting-synthetic-pods
-                    "waiting synthetic pod(s) in that pool")
-          [])
-        (let [offers-all-pools (generate-offers this nodes pods)
-              ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
-              ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
-              offers-this-pool (get offers-all-pools pool-name)]
-          (log/info "In" name "compute cluster, generated" (count offers-this-pool) "offers for pool" pool-name
-                    (into [] (map #(into {} (select-keys % [:hostname :resources])) offers-this-pool)))
-          offers-this-pool))))
+          nodes @current-nodes-atom
+          offers-all-pools (generate-offers this nodes pods)
+          ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
+          ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
+          offers-this-pool (get offers-all-pools pool-name)
+          offers-this-pool-for-logging (into []
+                                             (map #(into {} (select-keys % [:hostname :resources]))
+                                                  offers-this-pool))]
+      (log/info "In" name "compute cluster, generated" (count offers-this-pool) "offers for pool" pool-name
+                {:num-total-nodes-in-compute-cluster (count nodes)
+                 :num-total-pods-in-compute-cluster (count pods)
+                 :offers-this-pool offers-this-pool-for-logging})
+      offers-this-pool))
 
   (restore-offers [this pool-name offers])
 
@@ -346,7 +295,7 @@
               (str "In " name " compute cluster, request to autoscale despite invalid / missing config"))
       (let [outstanding-synthetic-pods (->> @all-pods-atom
                                             (add-starting-pods this)
-                                            (filter controller/synthetic-pod->job-uuid))
+                                            (filter synthetic-pod->job-uuid))
             num-synthetic-pods (count outstanding-synthetic-pods)
             {:keys [image user command max-pods-outstanding] :or {command "exit 0"}} synthetic-pods-config]
         (log/info "In" name "compute cluster, there are" num-synthetic-pods
@@ -356,13 +305,15 @@
           (let [using-pools? (config/default-pool)
                 synthetic-task-pool-name (when using-pools? pool-name)
                 new-task-requests (remove (fn [{{:keys [job/uuid]} :job}]
-                                            (some #(= (str uuid) (controller/synthetic-pod->job-uuid %))
+                                            (some #(= (str uuid) (synthetic-pod->job-uuid %))
                                                   outstanding-synthetic-pods))
                                           task-requests)
                 task-metadata-seq (->>
                                     new-task-requests
                                     (map (fn [{{:keys [job/uuid] :as job} :job}]
-                                           {:task-id (str "synthetic-" pool-name "-" (d/squuid))
+                                           {:task-id (str api/cook-synthetic-pod-name-prefix "-"
+                                                          pool-name "-"
+                                                          uuid)
                                             :command {:user user :value command}
                                             :container {:docker {:image image}}
                                             :task-request {:scalar-requests (walk/stringify-keys
@@ -371,7 +322,14 @@
                                             ; We need to label the synthetic pods so that we
                                             ; can opt them out of some of the normal plumbing,
                                             ; like mapping status back to a job instance
-                                            :pod-labels {api/cook-synthetic-pod-job-uuid-label (str uuid)}}))
+                                            :pod-labels {api/cook-synthetic-pod-job-uuid-label (str uuid)}
+                                            ; We need to give synthetic pods a lower priority than
+                                            ; actual job pods so that the job pods can preempt them
+                                            ; (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/);
+                                            ; if we don't do this, we run the risk of job pods
+                                            ; encountering failures when they lose scheduling races
+                                            ; against pending synthetic pods
+                                            :pod-priority-class api/cook-synthetic-pod-priority-class}))
                                     (take (- max-pods-outstanding num-synthetic-pods)))]
             (log/info "In" name "compute cluster, launching" (count task-metadata-seq) "synthetic pod(s) for"
                       (count new-task-requests) "new un-matched task(s) in" synthetic-task-pool-name "pool"

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -70,12 +70,12 @@
                                                                   (= (.getValue toleration) pool-name)))
                                                            tolerations)))
                                                  waiting-synthetic-pods)]
-      ; TODO(DPO): Change this to debug
       (log/info "In" (cc/compute-cluster-name compute-cluster)
                 "compute cluster, computed number of waiting synthetic pods"
                 {:grace-period-seconds grace-period-seconds
+                 :num-waiting-synthetic-pods-in-pool (count waiting-synthetic-pods-in-pool)
                  :pool pool-name
-                 :waiting-synthetic-pods-in-pool waiting-synthetic-pods-in-pool})
+                 :waiting-synthetic-pods-in-pool (map api/V1Pod->name waiting-synthetic-pods-in-pool)})
       (count waiting-synthetic-pods-in-pool))
     0))
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -70,6 +70,12 @@
                                                                   (= (.getValue toleration) pool-name)))
                                                            tolerations)))
                                                  waiting-synthetic-pods)]
+      ; TODO(DPO): Change this to debug
+      (log/info "In" (cc/compute-cluster-name compute-cluster)
+                "compute cluster, computed number of waiting synthetic pods"
+                {:grace-period-seconds grace-period-seconds
+                 :pool pool-name
+                 :waiting-synthetic-pods-in-pool waiting-synthetic-pods-in-pool})
       (count waiting-synthetic-pods-in-pool))
     0))
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -335,9 +335,10 @@
                              ; encountering failures when they lose scheduling races
                              ; against pending synthetic pods
                              :pod-priority-class api/cook-synthetic-pod-priority-class
-                             ; We don't want to add in the sidecar, because we don't need it
-                             ; for synthetic pods and all it will do is slow things down.
-                             :pod-supports-sidecar? false}))
+                             ; We don't want to add in the cook-init cruft or the cook sidecar, because we
+                             ; don't need them for synthetic pods and all they will do is slow things down.
+                             :pod-supports-cook-init? false
+                             :pod-supports-cook-sidecar? false}))
                      (take (- max-pods-outstanding num-synthetic-pods)))]
             (log/info "In" name "compute cluster, launching" (count task-metadata-seq) "synthetic pod(s) for"
                       (count new-task-requests) "new un-matched task(s) in" synthetic-task-pool-name "pool"

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -68,7 +68,8 @@
     (-> k8s-actual-state-dict
         (update-in [:synthesized-state :state] #(or % :missing))
         (dissoc :pod)
-        (assoc :pod-status (some-> pod .getStatus)))
+        (assoc :pod-status (some-> pod .getStatus))
+        (assoc :node-name (some-> pod .getSpec .getNodeName)))
     (catch Throwable t
       (log/error t "Error preparing k8s actual state for logging:" k8s-actual-state-dict)
       k8s-actual-state-dict)))

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -68,8 +68,9 @@
     (-> k8s-actual-state-dict
         (update-in [:synthesized-state :state] #(or % :missing))
         (dissoc :pod)
-        (assoc :pod-status (some-> pod .getStatus))
-        (assoc :node-name (api/pod->node-name pod)))
+        (assoc 
+          :node-name (api/pod->node-name pod)
+          :pod-status (some-> pod .getStatus)))
     (catch Throwable t
       (log/error t "Error preparing k8s actual state for logging:" k8s-actual-state-dict)
       k8s-actual-state-dict)))

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -69,7 +69,7 @@
         (update-in [:synthesized-state :state] #(or % :missing))
         (dissoc :pod)
         (assoc :pod-status (some-> pod .getStatus))
-        (assoc :node-name (some-> pod .getSpec .getNodeName)))
+        (assoc :node-name (api/pod->node-name pod)))
     (catch Throwable t
       (log/error t "Error preparing k8s actual state for logging:" k8s-actual-state-dict)
       k8s-actual-state-dict)))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -857,7 +857,7 @@
                      :num-failures (count failures)
                      :num-matches (count matches)
                      :num-offers (count offers)
-                     :pool->num-pending-jobs (pc/map-vals count pool-name)})
+                     :pool->num-pending-jobs (pc/map-vals count pool-name->pending-jobs-atom)})
 
           (fenzo/record-placement-failures! conn failures)
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -851,6 +851,14 @@
               first-considerable-job-resources (-> considerable-jobs first tools/job-ent->resources)
               matched-considerable-jobs-head? (contains? matched-job-uuids (-> considerable-jobs first :job/uuid))]
 
+          (log/info "In" pool-name "pool, handling resource offers"
+                    {:matched-considerable-jobs-head? matched-considerable-jobs-head?
+                     :num-considerable num-considerable
+                     :num-failures (count failures)
+                     :num-matches (count matches)
+                     :num-offers (count offers)
+                     :pool->num-pending-jobs (pc/map-vals count pool-name)})
+
           (fenzo/record-placement-failures! conn failures)
 
           (reset! offer-stash offers-scheduled)

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -885,6 +885,9 @@
                     (launch-matched-tasks! matches conn db fenzo mesos-run-as-user pool-name)
                     (update-host-reservations! rebalancer-reservation-atom matched-job-uuids)
                     matched-considerable-jobs-head?))]
+            ;; This call needs to happen *after* launch-matched-tasks!
+            ;; in order to avoid autoscaling tasks taking up available
+            ;; capacity that was already matched for real Cook tasks.
             (trigger-autoscaling! failures pool-name compute-clusters)
             matched-head-or-no-matches?))
         (catch Throwable t

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -527,7 +527,8 @@
    Returns {:matches (list of tasks that got matched to the offer)
             :failures (list of unmatched tasks, and why they weren't matched)}"
   [db ^TaskScheduler fenzo considerable offers rebalancer-reservation-atom pool-name]
-  (log/info "In" pool-name "pool, matching" (count offers) "offers to" (count considerable) "jobs with fenzo")
+  (log/info "In" pool-name "pool, matching" (count offers) "offers to"
+            (count considerable) "considerable jobs with fenzo")
   (log/debug "In" pool-name "pool, tasks to scheduleOnce" considerable)
   (dl/update-cost-staleness-metric considerable)
   (let [t (System/currentTimeMillis)
@@ -853,7 +854,8 @@
 
           (log/info "In" pool-name "pool, handling resource offers"
                     {:matched-considerable-jobs-head? matched-considerable-jobs-head?
-                     :num-considerable num-considerable
+                     :num-considerable-jobs (count considerable-jobs)
+                     :num-considerable-setting num-considerable
                      :num-failures (count failures)
                      :num-matches (count matches)
                      :num-offers (count offers)

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -857,7 +857,7 @@
                      :num-failures (count failures)
                      :num-matches (count matches)
                      :num-offers (count offers)
-                     :pool->num-pending-jobs (pc/map-vals count pool-name->pending-jobs-atom)})
+                     :num-pending-jobs (count pending-jobs)})
 
           (fenzo/record-placement-failures! conn failures)
 

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -496,6 +496,18 @@
     (.setSpec pod spec)
     pod))
 
+(defn synthetic-pod-helper
+  "Makes a synthetic pod for unit tests"
+  [job-uuid pool-name creation-timestamp]
+  (let [^V1Pod outstanding-synthetic-pod (pod-helper "podA" "nodeA")
+        ^V1ObjectMeta pod-metadata (.getMetadata outstanding-synthetic-pod)]
+    (.setLabels pod-metadata {kapi/cook-synthetic-pod-job-uuid-label job-uuid})
+    (.setCreationTimestamp pod-metadata creation-timestamp)
+    (-> outstanding-synthetic-pod
+        .getSpec
+        (.addTolerationsItem (kapi/toleration-for-pool pool-name)))
+    outstanding-synthetic-pod))
+
 (defn node-helper [node-name cpus mem pool]
   "Make a fake node for kubernetes unit tests"
   (let [node (V1Node.)

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -76,7 +76,7 @@
         (is (= "my-task" (-> pod .getMetadata .getName)))
         (is (= "cook" (-> pod .getMetadata .getNamespace)))
         (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
-        (is (= "kubehost" (-> pod .getSpec .getNodeSelector (get "kubernetes.io/hostname"))))
+        (is (= "kubehost" (-> pod .getSpec .getNodeSelector (get api/k8s-hostname-label))))
         (is (= 1 (count (-> pod .getSpec .getContainers))))
         (is (= {api/cook-pod-label "testing-cluster"} (-> pod .getMetadata .getLabels)))
         (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))
@@ -155,8 +155,8 @@
           ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
           ^V1PodSpec pod-spec (.getSpec pod)
           node-selector (.getNodeSelector pod-spec)]
-      (is (contains? node-selector "kubernetes.io/hostname"))
-      (is (= hostname (get node-selector "kubernetes.io/hostname"))))))
+      (is (contains? node-selector api/k8s-hostname-label))
+      (is (= hostname (get node-selector api/k8s-hostname-label))))))
 
 (deftest test-make-volumes
   (testing "defaults for minimal volume"

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -4,7 +4,9 @@
             [cook.kubernetes.api :as api]
             [cook.test.testutil :as tu]
             [datomic.api :as d])
-  (:import (io.kubernetes.client.models V1Container V1EnvVar V1Pod V1PodStatus V1ContainerStatus V1ContainerState V1ContainerStateWaiting V1VolumeMount V1Volume V1NodeSpec V1Node V1ObjectMeta V1Taint)))
+  (:import (io.kubernetes.client.models V1Container V1ContainerState V1ContainerStateWaiting V1ContainerStatus
+                                        V1EnvVar V1Node V1NodeSelectorRequirement V1NodeSpec V1ObjectMeta V1Pod
+                                        V1PodStatus V1Taint V1Volume V1VolumeMount)))
 
 (deftest test-get-consumption
   (testing "correctly computes consumption for a single pod"
@@ -128,7 +130,29 @@
                          :hostname "kubehost"}
           pod (api/task-metadata->pod "cook" "test-cluster" task-metadata)]
       (is (= 100 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
-      (is (= 10 (-> pod .getSpec .getSecurityContext .getRunAsGroup))))))
+      (is (= 10 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))))
+
+  (testing "node affinity"
+    (let [pool-name "test-pool"
+          task-metadata {:container {:docker {:parameters [{:key "user"
+                                                            :value "100:10"}]}}
+                         :task-request {:job {:job/pool {:pool/name pool-name}}
+                                        :scalar-requests {"mem" 512
+                                                          "cpus" 1.0}}}
+          ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
+          ^V1NodeSelectorRequirement node-selector-requirement (-> pod
+                                                                   .getSpec
+                                                                   .getAffinity
+                                                                   .getNodeAffinity
+                                                                   .getRequiredDuringSchedulingIgnoredDuringExecution
+                                                                   .getNodeSelectorTerms
+                                                                   first
+                                                                   .getMatchExpressions
+                                                                   first)]
+      (is (= "cook_pool" (.getKey node-selector-requirement)))
+      (is (= "In" (.getOperator node-selector-requirement)))
+      (is (= 1 (-> node-selector-requirement .getValues count)))
+      (is (= pool-name (-> node-selector-requirement .getValues first))))))
 
 (deftest test-make-volumes
   (testing "defaults for minimal volume"

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -88,8 +88,8 @@
           job-ent-1 (d/entity db j1)
           job-ent-2 (d/entity db j2)
           task-1 (tu/make-task-metadata job-ent-1 db compute-cluster)
-          _ (cc/launch-tasks compute-cluster nil [task-1
-                                                  (tu/make-task-metadata job-ent-2 db compute-cluster)])
+          task-2 (tu/make-task-metadata job-ent-2 db compute-cluster)
+          _ (cc/launch-tasks compute-cluster nil [task-1 task-2])
           task-1-id (-> task-1 :task-request :task-id)
           pod-name->pod {{:namespace "cook" :name "podA"} (tu/pod-helper "podA" "nodeA"
                                                                          {:cpus 0.25 :mem 250.0}
@@ -100,7 +100,8 @@
                                                                          {:cpus 1.0 :mem 1100.0})
                          {:namespace "cook" :name task-1-id} (tu/pod-helper task-1-id "my.fake.host"
                                                                             {:cpus 0.1 :mem 10.0})}
-          all-offers (kcc/generate-offers compute-cluster node-name->node (kcc/add-starting-pods compute-cluster pod-name->pod))
+          all-offers (kcc/generate-offers compute-cluster node-name->node
+                                          (kcc/add-starting-pods compute-cluster pod-name->pod))
           offers (get all-offers "no-pool")]
       (is (= 4 (count offers)))
       (let [offer (first (filter #(= "nodeA" (:hostname %))
@@ -151,5 +152,5 @@
                                    (swap! launched-pods-atom conj cook-expected-state-dict))]
       (cc/autoscale! compute-cluster pool-name task-requests))
     (is (= 2 (count @launched-pods-atom)))
-    (is (= job-uuid-2 (-> @launched-pods-atom (nth 0) :launch-pod :pod controller/synthetic-pod->job-uuid)))
-    (is (= job-uuid-3 (-> @launched-pods-atom (nth 1) :launch-pod :pod controller/synthetic-pod->job-uuid)))))
+    (is (= job-uuid-2 (-> @launched-pods-atom (nth 0) :launch-pod :pod kcc/synthetic-pod->job-uuid)))
+    (is (= job-uuid-3 (-> @launched-pods-atom (nth 1) :launch-pod :pod kcc/synthetic-pod->job-uuid)))))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -153,27 +153,3 @@
     (is (= 2 (count @launched-pods-atom)))
     (is (= job-uuid-2 (-> @launched-pods-atom (nth 0) :launch-pod :pod controller/synthetic-pod->job-uuid)))
     (is (= job-uuid-3 (-> @launched-pods-atom (nth 1) :launch-pod :pod controller/synthetic-pod->job-uuid)))))
-
-(deftest test-compute-num-waiting-synthetic-pods
-  (let [pool-name "test-pool"
-        job-uuid (str (UUID/randomUUID))
-        compute-cluster (tu/make-kubernetes-compute-cluster {} #{pool-name})
-        grace-period-seconds 180]
-
-    (testing "handles nil creation timestamp gracefully"
-      (is (= 1 (kcc/compute-num-waiting-synthetic-pods compute-cluster
-                                                       [(tu/synthetic-pod-helper job-uuid pool-name nil)]
-                                                       pool-name
-                                                       grace-period-seconds))))
-
-    (testing "ancient pod doesn't count as 'waiting'"
-      (is (= 0 (kcc/compute-num-waiting-synthetic-pods compute-cluster
-                                                       [(tu/synthetic-pod-helper job-uuid pool-name (t/epoch))]
-                                                       pool-name
-                                                       grace-period-seconds))))
-
-    (testing "recent pod does count as 'waiting'"
-      (is (= 1 (kcc/compute-num-waiting-synthetic-pods compute-cluster
-                                                       [(tu/synthetic-pod-helper job-uuid pool-name (t/now))]
-                                                       pool-name
-                                                       grace-period-seconds))))))


### PR DESCRIPTION
## Changes proposed in this PR

There are a few different changes all related to improving the way synthetic pods work. The main change is introducing priority classes for Cook job pods and synthetic pods.

## Why are we making these changes?

The priority classes allow the job pods to preempt the synthetic pods and avoid instance failures due to pending synthetic pods racing with the job pods when new capacity becomes available.

I've marked significant changes in this PR with a comment explaining the "why".
