### PR TITLE
Adds k8s metrics

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -3,11 +3,14 @@
             [cook.config :as config]
             [cook.datomic :as datomic]
             [cook.kubernetes.api :as api]
+            [cook.kubernetes.metrics :as metrics]
             [cook.mesos.sandbox :as sandbox]
             [cook.scheduler.scheduler :as scheduler]
             [cook.util :as util]
             [clojure.string :as str]
-            [clojure.tools.logging :as log])
+            [clojure.tools.logging :as log]
+            [metrics.counters :as counters]
+            [metrics.timers :as timers])
   (:import (clojure.lang IAtom)
            (io.kubernetes.client.models V1Pod V1ContainerStatus V1PodStatus)
            (java.net URLEncoder)))
@@ -23,11 +26,17 @@
   ; TODO: Should do lock sharding based on hash of pod-name.
   lock-object)
 
+(defn canonicalize-cook-expected-state
+  "Canonicalize the expected states before comparing if they're equivalent"
+  [cook-expected-state]
+  (dissoc cook-expected-state :waiting-metric-timer :running-metric-timer))
+
 (defn cook-expected-state-equivalent?
   "Is the old and new state equivalent?"
   [old-state new-state]
-  (= old-state new-state); TODO
-  )
+  (=
+    (canonicalize-cook-expected-state old-state)
+    (canonicalize-cook-expected-state new-state)))
 
 (defn k8s-actual-state-equivalent?
   "Is the old and new state equivalent?"
@@ -42,8 +51,8 @@
   Delete is used for completed pods that we're done with.
   Kill is used for possibly running pods we want to kill so that they fail.
   Returns the cook-expected-state-dict passed in."
-  [api-client cook-expected-state-dict pod]
-  (api/delete-pod api-client pod)
+  [api-client compute-cluster-name cook-expected-state-dict pod]
+  (api/delete-pod api-client compute-cluster-name pod)
   cook-expected-state-dict)
 
 (defn kill-pod
@@ -51,16 +60,24 @@
   Delete is used for completed pods that we're done with.
   Kill is used for possibly running pods we want to kill so that they fail.
   Returns the cook-expected-state-dict passed in."
-  [api-client cook-expected-state-dict pod]
-  (api/delete-pod api-client pod)
+  [api-client compute-cluster-name cook-expected-state-dict pod]
+  (api/delete-pod api-client compute-cluster-name pod)
   cook-expected-state-dict)
 
 (defn prepare-cook-expected-state-dict-for-logging
   ".toString on a pod is incredibly large. Make a version thats been elided."
   [cook-expected-state-dict]
-  (if (:launch-pod cook-expected-state-dict)
-    (assoc cook-expected-state-dict :launch-pod [:elided-for-brevity])
-    cook-expected-state-dict))
+  (let [stripped-cook-expected-state-dict
+        (try
+          (-> cook-expected-state-dict
+              (dissoc :waiting-metric-timer)
+              (dissoc :running-metric-timer))
+          (catch Throwable t
+            (log/error t "Error preparing cook expected state for logging:" cook-expected-state-dict)
+            cook-expected-state-dict))]
+    (if (:launch-pod stripped-cook-expected-state-dict)
+      (assoc stripped-cook-expected-state-dict :launch-pod [:elided-for-brevity])
+      stripped-cook-expected-state-dict)))
 
 (defn prepare-k8s-actual-state-dict-for-logging
   [{:keys [pod] :as k8s-actual-state-dict}]
@@ -87,9 +104,9 @@
   "We're in a weird state that shouldn't occur with any of the normal expected races. This shouldn't occur. However,
   we're going to pessimistically assume that anything that could happen will, whether it should or not. Returns
   the cook-expected-state-dict passed in."
-  [{:keys [api-client] :as compute-cluster} pod-name cook-expected-state-dict {:keys [pod] :as k8s-actual-state-dict}]
+  [{:keys [api-client name] :as compute-cluster} pod-name cook-expected-state-dict {:keys [pod] :as k8s-actual-state-dict}]
   (log-weird-state compute-cluster pod-name cook-expected-state-dict k8s-actual-state-dict)
-  (kill-pod api-client cook-expected-state-dict pod))
+  (kill-pod api-client name cook-expected-state-dict pod))
 
 (defn write-status-to-datomic
   "Helper function for calling scheduler/write-status-to-datomic"
@@ -129,9 +146,13 @@
     {:cook-expected-state :cook-expected-state/completed}))
 
 (defn launch-pod
-  [{:keys [api-client] :as compute-cluster} cook-expected-state-dict pod-name]
-  (if (api/launch-pod api-client cook-expected-state-dict pod-name)
-    cook-expected-state-dict
+  [{:keys [api-client name] :as compute-cluster} cook-expected-state-dict pod-name]
+  (if (api/launch-pod api-client name cook-expected-state-dict pod-name)
+    ; These metrics only measure the happy paths to avoid wide variations from error rates changing.
+    ; k8s-response-time-until-waiting helps us characterize watch latency
+    (merge {:waiting-metric-timer (timers/start (metrics/timer "k8s-response-time-until-waiting" name))
+            :running-metric-timer (timers/start (metrics/timer "k8s-response-time-until-running" name))}
+           cook-expected-state-dict)
     (handle-pod-submission-failed compute-cluster pod-name)))
 
 (defn update-or-delete!
@@ -237,7 +258,7 @@
 
 (defn handle-pod-started
   "A pod has started. So now we need to update the status in datomic."
-  [compute-cluster pod-name]
+  [compute-cluster {:keys [running-metric-timer]} pod-name]
   (when-not (synthetic-pod? pod-name)
     (let [instance-id pod-name
           ; We leak mesos terminology here ('task') because of backward compatibility.
@@ -245,6 +266,9 @@
                   :state :task-running
                   :reason :reason-running}]
       (write-status-to-datomic compute-cluster status)))
+  ; Track the time until running, if available.
+  (when running-metric-timer (timers/stop running-metric-timer))
+  ; At this point, we don't care about the launch pod or the metric timers, so toss their dictionary away.
   {:cook-expected-state :cook-expected-state/running})
 
 (def get-pod-ip->hostname-fn
@@ -298,256 +322,270 @@
   "Visit this pod-name, processing the new level-state. Returns the new cook expected state. Returns
   empty dictionary to indicate that the result should be deleted. NOTE: Must be invoked with the lock."
   [{:keys [api-client k8s-actual-state-map cook-expected-state-map name] :as compute-cluster} ^String pod-name]
-  (loop [{:keys [cook-expected-state] :as cook-expected-state-dict} (get @cook-expected-state-map pod-name)
-         {:keys [synthesized-state pod] :as k8s-actual-state-dict} (get @k8s-actual-state-map pod-name)]
-    (log/info "In compute cluster" name ", processing pod" pod-name ";"
-              "cook-expected:" (prepare-cook-expected-state-dict-for-logging cook-expected-state-dict) ","
-              "k8s-actual:" (prepare-k8s-actual-state-dict-for-logging k8s-actual-state-dict))
-    ; We should have the cross product of
-    ;      :cook-expected-state/starting :cook-expected-state/running :cook-expected-state/completed :cook-expected-state/killed :missing
-    ; and
-    ;      :pod/waiting :pod/running :pod/succeeded :pod/failed :pod/unknown :missing
-    ;
-    ; for a total of 30 states.
-    ;
-    ; The only terminal expected states are :cook-expected-state/completed and :missing
-    ; The only terminal pod states are :pod/succeeded :pod/failed and :missing. We also treat :pod/unknown as a terminal state.
-    ;
-    ; We don't know if :pod/unknown is a terminal state for kubernetes. We treat it as a terminal state as far
-    ; as the state machine is concerned, and force a retry at the cook level.
-    ;
-    ; If you ignore the reloading on startup, the initial state is set at (:cook-expected-state/starting, :missing) when we first add a pod to launch.
-    ; The final state is (:missing, :missing)
-    ;
-    ; We use :cook-expected-state/killed to represent a user-chosen kill. If we're doing a state-machine-induced kill (because something
-    ; went wrong) it should occur by deleting the pod, so we go, e.g.,  (:running,:waiting) (an illegal state) to (:running,:missing)
-    ; to (:completed, :missing), to (:missing,missing) to deleted. We will put a flag in the cook expected state dictionary
-    ; when we delete to indicate the provenance (e.g., induced because of a weird state)
-    ;
-    ; Invariants:
-    ;   handle-pod-completed/handle-pod-killed/handle-pod-started: These are callbacks invoked when kubernetes has moved
-    ;       to a new state. They handle writeback to datomic only. handle-pod-killed is called in all of the weird
-    ;       kubernetes states that are not expected to occur, while handle-pod-completed is invoked in all of the
-    ;       normal exit states (including exit-with-failure). I.e., these MUST only be invoked if cook expected state is not
-    ;       in a terminal state. These functions return new cook-expected-state-dict's so should be invoked last in almost
-    ;       all cases. (However, in a few cases, (delete-pod ? ?) can be invoked afterwards. It deletes the key from
-    ;       the cook expected state completely. Should only be invoked if we're in a :missing cook-expected-state.)
-    ;
-    ;   log-weird-state can be called at any time to indicate we're in a weird state and extra logging is warranted.
-    ;
-    ;   We always end with one of handle-pod-completed/handle-pod-killed/handle-pod-started or delete-pod.
-    ;
-    ;   We always update datomic first (with pod-has-* pod-was-*), etc, then we update kubernetes so we can handle restarts.
-    ;
-    ;   (delete-pod ? ?) is only valid when the kubernetes pod is in a terminal-state.
-    ;
-    ;   Note that we have release semantics. We could fail to process any operation. This means that, where relevant, we
-    ;     first write to datomic, then change into the next step. We thus show some intermediate states in the machine
-    ;     that seem like they could be skipped.
-    ;
-    ;   In the (:completed,*) states, we delete from datomic, transitioning into (:completed,:missing) and thence to (:missing, :missing)
-    ;     when we're in a terminal pod state.
-    ;
-    ;   We delete a pod if and only if the pod is in a terminal (or unknown) state.
-    ; In some cases, we may mark mea culpa retries (if e.g., the node got reclaimed, so the pod got killed). In weird cases, we always need to mark mea culpa retries.
-    (let
-      [pod-synthesized-state-modified (or (:state synthesized-state) :missing)
-       new-cook-expected-state-dict (case (or cook-expected-state :missing)
-                                      :cook-expected-state/completed
-                                      (case pod-synthesized-state-modified
-                                        ; Cause this entry to be deleted by update-or-delete! called later down.
-                                        :missing nil
-                                        ; The writeback to datomic has occurred, so there's nothing to do except to delete the pod from kubernetes
-                                        ; and remove it from our tracking.
-                                        :pod/failed (delete-pod api-client cook-expected-state-dict pod)
-                                        ; Who resurrected this pod? Where did it come from? Do we have two instances of cook?
-                                        :pod/running (kill-pod-in-weird-state compute-cluster pod-name
-                                                                              cook-expected-state-dict
-                                                                              k8s-actual-state-dict)
-                                        ; The writeback to datomic has occurred, so there's nothing to do except to delete the pod from kubernetes
-                                        ; and remove it from our tracking.
-                                        :pod/succeeded (delete-pod api-client cook-expected-state-dict pod)
-                                        ; TODO: Should mark mea culpa retry
-                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
-                                                       compute-cluster pod-name k8s-actual-state-dict)
-                                        ; Who resurrected this pod? Where did it come from? Do we have two instances of cook?
-                                        :pod/waiting (kill-pod-in-weird-state compute-cluster pod-name
-                                                                              cook-expected-state-dict
-                                                                              k8s-actual-state-dict))
+  (timers/time! (metrics/timer "controller-process" name)
+    (loop [{:keys [cook-expected-state waiting-metric-timer] :as cook-expected-state-dict} (get @cook-expected-state-map pod-name)
+           {:keys [synthesized-state pod] :as k8s-actual-state-dict} (get @k8s-actual-state-map pod-name)]
+      (log/info "In compute cluster" name ", processing pod" pod-name ";"
+                "cook-expected:" (prepare-cook-expected-state-dict-for-logging cook-expected-state-dict) ","
+                "k8s-actual:" (prepare-k8s-actual-state-dict-for-logging k8s-actual-state-dict))
+      ; We should have the cross product of
+      ;      :cook-expected-state/starting :cook-expected-state/running :cook-expected-state/completed :cook-expected-state/killed :missing
+      ; and
+      ;      :pod/waiting :pod/running :pod/succeeded :pod/failed :pod/unknown :missing
+      ;
+      ; for a total of 30 states.
+      ;
+      ; The only terminal expected states are :cook-expected-state/completed and :missing
+      ; The only terminal pod states are :pod/succeeded :pod/failed and :missing. We also treat :pod/unknown as a terminal state.
+      ;
+      ; We don't know if :pod/unknown is a terminal state for kubernetes. We treat it as a terminal state as far
+      ; as the state machine is concerned, and force a retry at the cook level.
+      ;
+      ; If you ignore the reloading on startup, the initial state is set at (:cook-expected-state/starting, :missing) when we first add a pod to launch.
+      ; The final state is (:missing, :missing)
+      ;
+      ; We use :cook-expected-state/killed to represent a user-chosen kill. If we're doing a state-machine-induced kill (because something
+      ; went wrong) it should occur by deleting the pod, so we go, e.g.,  (:running,:waiting) (an illegal state) to (:running,:missing)
+      ; to (:completed, :missing), to (:missing,missing) to deleted. We will put a flag in the cook expected state dictionary
+      ; when we delete to indicate the provenance (e.g., induced because of a weird state)
+      ;
+      ; Invariants:
+      ;   handle-pod-completed/handle-pod-killed/handle-pod-started: These are callbacks invoked when kubernetes has moved
+      ;       to a new state. They handle writeback to datomic only. handle-pod-killed is called in all of the weird
+      ;       kubernetes states that are not expected to occur, while handle-pod-completed is invoked in all of the
+      ;       normal exit states (including exit-with-failure). I.e., these MUST only be invoked if cook expected state is not
+      ;       in a terminal state. These functions return new cook-expected-state-dict's so should be invoked last in almost
+      ;       all cases. (However, in a few cases, (delete-pod ? ?) can be invoked afterwards. It deletes the key from
+      ;       the cook expected state completely. Should only be invoked if we're in a :missing cook-expected-state.)
+      ;
+      ;   log-weird-state can be called at any time to indicate we're in a weird state and extra logging is warranted.
+      ;
+      ;   We always end with one of handle-pod-completed/handle-pod-killed/handle-pod-started or delete-pod.
+      ;
+      ;   We always update datomic first (with pod-has-* pod-was-*), etc, then we update kubernetes so we can handle restarts.
+      ;
+      ;   (delete-pod ? ?) is only valid when the kubernetes pod is in a terminal-state.
+      ;
+      ;   Note that we have release semantics. We could fail to process any operation. This means that, where relevant, we
+      ;     first write to datomic, then change into the next step. We thus show some intermediate states in the machine
+      ;     that seem like they could be skipped.
+      ;
+      ;   In the (:completed,*) states, we delete from datomic, transitioning into (:completed,:missing) and thence to (:missing, :missing)
+      ;     when we're in a terminal pod state.
+      ;
+      ;   We delete a pod if and only if the pod is in a terminal (or unknown) state.
+      ; In some cases, we may mark mea culpa retries (if e.g., the node got reclaimed, so the pod got killed). In weird cases, we always need to mark mea culpa retries.
+      (let
+        [pod-synthesized-state-modified (or (:state synthesized-state) :missing)
+         new-cook-expected-state-dict (case (or cook-expected-state :missing)
+                                        :cook-expected-state/completed
+                                        (case pod-synthesized-state-modified
+                                          ; Cause this entry to be deleted by update-or-delete! called later down.
+                                          :missing nil
+                                          ; The writeback to datomic has occurred, so there's nothing to do except to delete the pod from kubernetes
+                                          ; and remove it from our tracking.
+                                          :pod/failed (delete-pod api-client name cook-expected-state-dict pod)
+                                          ; Who resurrected this pod? Where did it come from? Do we have two instances of cook?
+                                          :pod/running (kill-pod-in-weird-state compute-cluster pod-name
+                                                                                cook-expected-state-dict
+                                                                                k8s-actual-state-dict)
+                                          ; The writeback to datomic has occurred, so there's nothing to do except to delete the pod from kubernetes
+                                          ; and remove it from our tracking.
+                                          :pod/succeeded (delete-pod api-client name cook-expected-state-dict pod)
+                                          ; TODO: Should mark mea culpa retry
+                                          :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
+                                                         compute-cluster pod-name k8s-actual-state-dict)
+                                          ; Who resurrected this pod? Where did it come from? Do we have two instances of cook?
+                                          :pod/waiting (kill-pod-in-weird-state compute-cluster pod-name
+                                                                                cook-expected-state-dict
+                                                                                k8s-actual-state-dict))
 
-                                      :cook-expected-state/killed
-                                      (case pod-synthesized-state-modified
-                                        :missing
-                                        ; There's a race where we can launch then kill, when the kill arrives after
-                                        ; the launch, but before the watch updates k8s-actual-state.
-                                        ; (k8s-actual-state isn't the actual state, because of this watch lag)
-                                        ; When that happens, we will have an actual state of :missing.
-                                        ; If we did nothing, we'd log this as a weird state, then when the watch
-                                        ; shows up, we'd see (:missing, :starting) and log that as a weird state too.
-                                        ;
-                                        ; So, a better approach. If we detect a (:killed, :missing), then we opportunistically
-                                        ; try to kill the pod. This is why update-cook-expected-state saves :launch-pod,
-                                        ; so its available here.
-                                        (if-let [pod (some-> cook-expected-state-dict :launch-pod :pod)]
-                                          (do
-                                            (log/info "In compute cluster" name ", opportunistically killing" pod-name
-                                                      "because of potential race where kill arrives before the watch responds to the launch")
-                                            (kill-pod api-client :ignored pod)
-                                            ; This is needed to make sure if we take the opportunistic kill, we make
-                                            ; sure to write the status to datomic. Recall we're in kubernetes state missing.
-                                            (handle-pod-killed compute-cluster pod-name))
-                                          (do
-                                            ; We treat a deleting pod in kubernetes the same as a missing pod when coming up with a synthesized state.
-                                            ; That's good for (almost) all parts of the system. However,
-                                            ; If it is legitimately missing, then something weird is going on. If it is
-                                            ; deleting, that's an expected state. So, let's be selective with our logging.
-                                            (if (= (:state synthesized-state) :missing)
-                                              (log/info "In compute cluster" name ", pod" pod-name
-                                                        "was killed with cook expected state"
-                                                        (prepare-cook-expected-state-dict-for-logging cook-expected-state-dict)
-                                                        "and k8s actual state"
-                                                        (prepare-k8s-actual-state-dict-for-logging k8s-actual-state-dict))
-                                              (log-weird-state compute-cluster pod-name
-                                                               cook-expected-state-dict k8s-actual-state-dict))
-                                            (handle-pod-killed compute-cluster pod-name)))
-                                        :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
-                                        :pod/running (kill-pod api-client cook-expected-state-dict pod)
-                                        ; There was a race and it completed normally before being it was killed.
-                                        :pod/succeeded (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
-                                        ; TODO: Should mark mea culpa retry
-                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
-                                                       compute-cluster pod-name k8s-actual-state-dict)
-                                        :pod/waiting (kill-pod api-client cook-expected-state-dict pod))
+                                        :cook-expected-state/killed
+                                        (case pod-synthesized-state-modified
+                                          :missing
+                                          ; There's a race where we can launch then kill, when the kill arrives after
+                                          ; the launch, but before the watch updates k8s-actual-state.
+                                          ; (k8s-actual-state isn't the actual state, because of this watch lag)
+                                          ; When that happens, we will have an actual state of :missing.
+                                          ; If we did nothing, we'd log this as a weird state, then when the watch
+                                          ; shows up, we'd see (:missing, :starting) and log that as a weird state too.
+                                          ;
+                                          ; So, a better approach. If we detect a (:killed, :missing), then we opportunistically
+                                          ; try to kill the pod. This is why update-cook-expected-state saves :launch-pod,
+                                          ; so its available here.
+                                          (if-let [pod (some-> cook-expected-state-dict :launch-pod :pod)]
+                                            (do
+                                              (log/info "In compute cluster" name ", opportunistically killing" pod-name
+                                                        "because of potential race where kill arrives before the watch responds to the launch")
+                                              (kill-pod api-client name :ignored pod)
+                                              ; This is needed to make sure if we take the opportunistic kill, we make
+                                              ; sure to write the status to datomic. Recall we're in kubernetes state missing.
+                                              (handle-pod-killed compute-cluster pod-name))
+                                            (do
+                                              ; We treat a deleting pod in kubernetes the same as a missing pod when coming up with a synthesized state.
+                                              ; That's good for (almost) all parts of the system. However,
+                                              ; If it is legitimately missing, then something weird is going on. If it is
+                                              ; deleting, that's an expected state. So, let's be selective with our logging.
+                                              (if (= (:state synthesized-state) :missing)
+                                                (log/info "In compute cluster" name ", pod" pod-name
+                                                          "was killed with cook expected state"
+                                                          (prepare-cook-expected-state-dict-for-logging cook-expected-state-dict)
+                                                          "and k8s actual state"
+                                                          (prepare-k8s-actual-state-dict-for-logging k8s-actual-state-dict))
+                                                (log-weird-state compute-cluster pod-name
+                                                                 cook-expected-state-dict k8s-actual-state-dict))
+                                              (handle-pod-killed compute-cluster pod-name)))
+                                          :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
+                                          :pod/running (kill-pod api-client name cook-expected-state-dict pod)
+                                          ; There was a race and it completed normally before being it was killed.
+                                          :pod/succeeded (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
+                                          ; TODO: Should mark mea culpa retry
+                                          :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
+                                                         compute-cluster pod-name k8s-actual-state-dict)
+                                          :pod/waiting (kill-pod api-client name cook-expected-state-dict pod))
 
-                                      :cook-expected-state/running
-                                      (case pod-synthesized-state-modified
-                                        ; This indicates that something deleted it behind our back
-                                        :missing (do
-                                                   (log/info "In compute cluster" name ", something deleted"
-                                                              pod-name "behind our back")
+                                        :cook-expected-state/running
+                                        (case pod-synthesized-state-modified
+                                          ; This indicates that something deleted it behind our back
+                                          :missing (do
+                                                     (log/info "In compute cluster" name ", something deleted"
+                                                               pod-name "behind our back")
                                                      ; A :cook-expected-state/running job suddenly disappearing in k8s is
                                                      ; a sign of a preemption, so treat this case as a missed preemption.
                                                      ; TODO: When we have a better story for preemption, we should switch this to
                                                      ; go through the handle-pod-completed stack. That needs to be guarded with a null
                                                      ; check because handle-pod-completed cannot handle null pods. So, something like:
                                                      ; (if pod (handle-pod-completed ...) (....write a unknown reason to the pod....))
-                                                   (handle-pod-preemption compute-cluster pod-name))
-                                        ; TODO: May need to mark mea culpa retry
-                                        :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
-                                        :pod/running cook-expected-state-dict
-                                        :pod/succeeded (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
-                                        ; TODO: Should mark mea culpa retry
-                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
-                                                       compute-cluster pod-name k8s-actual-state-dict)
-                                        ; This is a sign that our pod was moved to a new node.
-                                        ;
-                                        ; For example, on GKE preemptible VMs:
-                                        ;  "there is no guarantee that Pods running on preemptible VMs
-                                        ;   can always shutdown gracefully. It may take several minutes
-                                        ;   for GKE to detect that the node was preempted and that the
-                                        ;   Pods are no longer running, which will delay the rescheduling
-                                        ;   of the Pods to a new node."
-                                        ;
-                                        ; (https://cloud.google.com/kubernetes-engine/docs/how-to/preemptible-vms#best_practices)
-                                        :pod/waiting (do
-                                                       (log/info "In compute cluster" name ", pod" pod-name
-                                                                 "went into waiting while it was expected running")
-                                                       (kill-pod api-client cook-expected-state-dict pod)
-                                                       (handle-pod-preemption compute-cluster pod-name)))
+                                                     (handle-pod-preemption compute-cluster pod-name))
+                                          ; TODO: May need to mark mea culpa retry
+                                          :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
+                                          :pod/running cook-expected-state-dict
+                                          :pod/succeeded (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
+                                          ; TODO: Should mark mea culpa retry
+                                          :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
+                                                         compute-cluster pod-name k8s-actual-state-dict)
+                                          ; This is a sign that our pod was moved to a new node.
+                                          ;
+                                          ; For example, on GKE preemptible VMs:
+                                          ;  "there is no guarantee that Pods running on preemptible VMs
+                                          ;   can always shutdown gracefully. It may take several minutes
+                                          ;   for GKE to detect that the node was preempted and that the
+                                          ;   Pods are no longer running, which will delay the rescheduling
+                                          ;   of the Pods to a new node."
+                                          ;
+                                          ; (https://cloud.google.com/kubernetes-engine/docs/how-to/preemptible-vms#best_practices)
+                                          :pod/waiting (do
+                                                         (log/info "In compute cluster" name ", pod" pod-name
+                                                                   "went into waiting while it was expected running")
+                                                         (kill-pod api-client name cook-expected-state-dict pod)
+                                                         (handle-pod-preemption compute-cluster pod-name)))
 
-                                      :cook-expected-state/starting
-                                      (case pod-synthesized-state-modified
+                                        :cook-expected-state/starting
+                                        (case pod-synthesized-state-modified
                                         :missing (if (:pod-deleted? synthesized-state)
                                                    (do
                                                      (log/info "In compute cluster" name ", pod" pod-name
                                                                "was deleted while it was expected starting")
                                                      (handle-pod-killed compute-cluster pod-name))
                                                    (launch-pod compute-cluster cook-expected-state-dict pod-name))
-                                        ; TODO: May need to mark mea culpa retry
-                                        :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict) ; Finished or failed fast.
-                                        :pod/running (handle-pod-started compute-cluster pod-name)
-                                        :pod/succeeded (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict) ; Finished fast.
-                                        ; TODO: Should mark mea culpa retry
-                                        :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
-                                                       compute-cluster pod-name k8s-actual-state-dict)
-                                        ; Its starting. Can be stuck here. TODO: Stuck state detector to detect being stuck.
-                                        :pod/waiting cook-expected-state-dict)
+                                          ; TODO: May need to mark mea culpa retry
+                                          :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict) ; Finished or failed fast.
+                                        :pod/running (handle-pod-started compute-cluster cook-expected-state-dict pod-name)
+                                          :pod/succeeded (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict) ; Finished fast.
+                                          ; TODO: Should mark mea culpa retry
+                                          :pod/unknown (handle-pod-completed-and-kill-pod-in-weird-state
+                                                         compute-cluster pod-name k8s-actual-state-dict)
+                                          ; Its starting. Can be stuck here. TODO: Stuck state detector to detect being stuck.
+                                          :pod/waiting (do
+                                                         (when waiting-metric-timer (timers/stop waiting-metric-timer))
+                                                         ; Delete the timer so we only track the first time.
+                                                         (dissoc cook-expected-state-dict waiting-metric-timer)))
 
-                                      :missing
-                                      (case pod-synthesized-state-modified
-                                        :missing nil
-                                        ; We shouldn't hit these unless we get a database rollback.
-                                        :pod/failed (kill-pod-in-weird-state compute-cluster pod-name
-                                                                             nil k8s-actual-state-dict)
-                                        ; This can occur in testing when you're e.g., blowing away the database.
-                                        ; It will go through :missing,:missing and then be deleted from the map.
-                                        ; TODO: May be evidence of a bug where we process pod changes when we're starting up.
-                                        ; Currently occurs because kill's can race ahead of launches, we kill something that has
-                                        ; been added to datomic, but hasn't been submitted to k8s yet.
-                                        :pod/running (kill-pod api-client cook-expected-state-dict pod)
-                                        ; We shouldn't hit these unless we get a database rollback.
-                                        :pod/succeeded (kill-pod-in-weird-state compute-cluster pod-name
+                                        :missing
+                                        (case pod-synthesized-state-modified
+                                          :missing nil
+                                          ; We shouldn't hit these unless we get a database rollback.
+                                          :pod/failed (kill-pod-in-weird-state compute-cluster pod-name
+                                                                               nil k8s-actual-state-dict)
+                                          ; This can occur in testing when you're e.g., blowing away the database.
+                                          ; It will go through :missing,:missing and then be deleted from the map.
+                                          ; TODO: May be evidence of a bug where we process pod changes when we're starting up.
+                                          ; Currently occurs because kill's can race ahead of launches, we kill something that has
+                                          ; been added to datomic, but hasn't been submitted to k8s yet.
+                                          :pod/running (kill-pod api-client name cook-expected-state-dict pod)
+                                          ; We shouldn't hit these unless we get a database rollback.
+                                          :pod/succeeded (kill-pod-in-weird-state compute-cluster pod-name
+                                                                                  nil k8s-actual-state-dict)
+                                          ; Unlike the other :pod/unknown states, no datomic state to update.
+                                          :pod/unknown (kill-pod-in-weird-state compute-cluster pod-name
                                                                                 nil k8s-actual-state-dict)
-                                        ; Unlike the other :pod/unknown states, no datomic state to update.
-                                        :pod/unknown (kill-pod-in-weird-state compute-cluster pod-name
-                                                                              nil k8s-actual-state-dict)
-                                        ; This can occur in testing when you're e.g., blowing away the database.
-                                        ; It will go through :missing,:missing and then be deleted from the map.
-                                        ; TODO: May be evidence of a bug where we process pod changes when we're starting up.
-                                        ; Currently occurs because kill's can race ahead of launches, we kill something that has
-                                        ; been added to datomic, but hasn't been submitted to k8s yet.
-                                        :pod/waiting (kill-pod api-client cook-expected-state-dict pod)))]
-      (when-not (cook-expected-state-equivalent? cook-expected-state-dict new-cook-expected-state-dict)
+                                          ; This can occur in testing when you're e.g., blowing away the database.
+                                          ; It will go through :missing,:missing and then be deleted from the map.
+                                          ; TODO: May be evidence of a bug where we process pod changes when we're starting up.
+                                          ; Currently occurs because kill's can race ahead of launches, we kill something that has
+                                          ; been added to datomic, but hasn't been submitted to k8s yet.
+                                          :pod/waiting (kill-pod api-client name cook-expected-state-dict pod)))]
+        ; We do not want to gate whether we update on cook-expected-state-equivalent?.
+        ; cook-expected-state-equivalent? is intended to identify when the states are different in a way that
+        ; may need reprocessing in the state machine.
+        ; However, the state may have changed (e.g., metric changes) and we want to
+        ; capture that change.
         (update-or-delete! cook-expected-state-map pod-name new-cook-expected-state-dict)
-        (log/info "In compute cluster" name ", processing pod" pod-name "after cook-expected-state-change")
-        (recur new-cook-expected-state-dict k8s-actual-state-dict)))))
+        (when-not (cook-expected-state-equivalent? cook-expected-state-dict new-cook-expected-state-dict)
+          (log/info "In compute cluster" name ", processing pod" pod-name "after cook-expected-state-change")
+          (recur new-cook-expected-state-dict k8s-actual-state-dict))))))
 
 (defn pod-update
   "Update the k8s actual state for a pod. Include some business logic to e.g., not change a state to the same value more than once.
   Invoked by callbacks from kubernetes."
   [{:keys [k8s-actual-state-map name] :as compute-cluster} ^V1Pod new-pod]
   (let [pod-name (api/V1Pod->name new-pod)]
-    (locking (calculate-lock pod-name)
-      (let [new-state {:pod new-pod
-                       :synthesized-state (api/pod->synthesized-pod-state new-pod)
-                       :sandbox-file-server-container-state (api/pod->sandbox-file-server-container-state new-pod)}
-            old-state (get @k8s-actual-state-map pod-name)]
-        ; We always store the updated state, but only reprocess it if it is genuinely different.
-        (swap! k8s-actual-state-map assoc pod-name new-state)
-        (let [new-file-server-state (:sandbox-file-server-container-state new-state)
-              old-file-server-state (:sandbox-file-server-container-state old-state)]
-          (when (and (= new-file-server-state :running) (not= old-file-server-state :running))
+    (timers/time! (metrics/timer "pod-update" name)
+      (timers/time! (metrics/timer "process-lock" name)
+        (locking (calculate-lock pod-name)
+          (let [new-state {:pod new-pod
+                           :synthesized-state (api/pod->synthesized-pod-state new-pod)
+                           :sandbox-file-server-container-state (api/pod->sandbox-file-server-container-state new-pod)}
+                old-state (get @k8s-actual-state-map pod-name)]
+            ; We always store the updated state, but only reprocess it if it is genuinely different.
+            (swap! k8s-actual-state-map assoc pod-name new-state)
+            (let [new-file-server-state (:sandbox-file-server-container-state new-state)
+                  old-file-server-state (:sandbox-file-server-container-state old-state)]
+              (when (and (= new-file-server-state :running) (not= old-file-server-state :running))
             (record-sandbox-url pod-name new-state)))
-        (when-not (k8s-actual-state-equivalent? old-state new-state)
-          (try
-            (process compute-cluster pod-name)
-            (catch Exception e
-              (log/error e (str "In compute-cluster " name ", error while processing pod-update for " pod-name)))))))))
+            (when-not (k8s-actual-state-equivalent? old-state new-state)
+              (try
+                (process compute-cluster pod-name)
+                (catch Exception e
+                  (log/error e (str "In compute-cluster " name ", error while processing pod-update for " pod-name)))))))))))
 
 (defn pod-deleted
   "Indicate that kubernetes does not have the pod. Invoked by callbacks from kubernetes."
   [{:keys [k8s-actual-state-map name] :as compute-cluster} ^V1Pod pod-deleted]
   (let [pod-name (api/V1Pod->name pod-deleted)]
     (log/info "In compute cluster" name ", detected pod" pod-name "deleted")
-    (locking (calculate-lock pod-name)
-      (swap! k8s-actual-state-map dissoc pod-name)
-      (try
-        (process compute-cluster pod-name)
-        (catch Exception e
-          (log/error e (str "In compute-cluster " name ", error while processing pod-delete for " pod-name)))))))
-
+    (timers/time! (metrics/timer "pod-deleted" name)
+      (timers/time! (metrics/timer "process-lock" name)
+        (locking (calculate-lock pod-name)
+          (swap! k8s-actual-state-map dissoc pod-name)
+          (try
+            (process compute-cluster pod-name)
+            (catch Exception e
+              (log/error e (str "In compute-cluster " name ", error while processing pod-delete for " pod-name)))))))))
 
 (defn update-cook-expected-state
   "Update the cook expected state. Include some business logic to e.g., not change a state to the same value more than once. Marks any state changes Also has a lattice of state. Called externally and from state machine."
-  [{:keys [cook-expected-state-map] :as compute-cluster} pod-name new-cook-expected-state-dict]
-  (locking (calculate-lock [pod-name])
-    (let [old-state (get @cook-expected-state-map pod-name)
-          ; Save the launch pod. We may need it in order to kill it. See note under (:killed, :missing) in process, above.
-          old-pod (:launch-pod old-state)
-          new-expected-state-dict-merged (merge {:launch-pod old-pod} new-cook-expected-state-dict)]
-      (when-not (cook-expected-state-equivalent? new-expected-state-dict-merged old-state)
-        (swap! cook-expected-state-map assoc pod-name new-expected-state-dict-merged)
-        (process compute-cluster pod-name)))))
+  [{:keys [cook-expected-state-map name] :as compute-cluster} pod-name new-cook-expected-state-dict]
+  (timers/time! (metrics/timer "update-cook-expected-state" name)
+    (timers/time! (metrics/timer "process-lock" name)
+      (locking (calculate-lock [pod-name])
+        (let [old-state (get @cook-expected-state-map pod-name)
+              ; Save the launch pod. We may need it in order to kill it. See note under (:killed, :missing) in process, above.
+              old-pod (:launch-pod old-state)
+              new-expected-state-dict-merged (merge {:launch-pod old-pod} new-cook-expected-state-dict)]
+          (when-not (cook-expected-state-equivalent? new-expected-state-dict-merged old-state)
+            (swap! cook-expected-state-map assoc pod-name new-expected-state-dict-merged)
+            (process compute-cluster pod-name)))))))
 
 (defn starting-namespaced-pod-name->pod
   "Returns a map from {:namespace pod-namespace :name pod-name}->pod for all instances that we're attempting to send to
@@ -564,6 +602,8 @@
 
 (defn scan-process
   "Special verison of process run during scanning. It grabs the lock before processing the pod."
-  [{:keys [api-client k8s-actual-state-map cook-expected-state-map] :as compute-cluster} pod-name]
-  (locking (calculate-lock pod-name)
-    (process compute-cluster pod-name)))
+  [{:keys [name] :as compute-cluster} pod-name]
+  (timers/time! (metrics/timer "scan-process" name)
+    (timers/time! (metrics/timer "process-lock" name)
+      (locking (calculate-lock pod-name)
+        (process compute-cluster pod-name)))))

--- a/scheduler/src/cook/kubernetes/metrics.clj
+++ b/scheduler/src/cook/kubernetes/metrics.clj
@@ -1,0 +1,27 @@
+(ns cook.kubernetes.metrics
+  (:require [metrics.counters :as counters]
+            [metrics.meters :as meters]
+            [metrics.timers :as timers]))
+
+(defn calculate-name
+  "Given a metric name and compute cluster name, come up with the metric path to use."
+  [metric-name compute-cluster-name]
+  ["cook"
+   "k8s-compute-cluster"
+   metric-name
+   (str "compute-cluster-" compute-cluster-name)])
+
+(defn counter
+  "Given a metric name and a compute cluster name, returns a counter metric."
+  [metric-name compute-cluster-name]
+  (counters/counter (calculate-name metric-name compute-cluster-name)))
+
+(defn meter
+  "Given a metric name and a compute cluster name, returns a meter metric."
+  [metric-name compute-cluster-name]
+  (meters/meter (calculate-name metric-name compute-cluster-name)))
+
+(defn timer
+  "Given a metric name and a compute cluster name, returns a timer metric."
+  [metric-name compute-cluster-name]
+  (timers/timer (calculate-name metric-name compute-cluster-name)))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -39,7 +39,7 @@
                                               tu/make-task-request
                                               tu/make-task-assignment-result)))
         launched-pod-atom (atom nil)]
-    (with-redefs [api/launch-pod (fn [_ {:keys [launch-pod]} _]
+    (with-redefs [api/launch-pod (fn [_ _ {:keys [launch-pod]} _]
                                    (reset! launched-pod-atom launch-pod))
                   api/make-security-context (constantly (V1PodSecurityContext.))]
       (testing "static namespace"
@@ -148,7 +148,7 @@
                        (make-task-request-fn job-uuid-2)
                        (make-task-request-fn job-uuid-3)]
         launched-pods-atom (atom [])]
-    (with-redefs [api/launch-pod (fn [_ cook-expected-state-dict _]
+    (with-redefs [api/launch-pod (fn [_ _ cook-expected-state-dict _]
                                    (swap! launched-pods-atom conj cook-expected-state-dict))]
       (cc/autoscale! compute-cluster pool-name task-requests))
     (is (= 2 (count @launched-pods-atom)))

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -26,9 +26,9 @@
         do-process (fn [cook-expected-state k8s-actual-state & {:keys [create-namespaced-pod-fn]
                                                                 :or {create-namespaced-pod-fn (constantly true)}}]
                      (reset! reason nil)
-                     (with-redefs [controller/delete-pod (fn [_ cook-expected-state-dict _]
+                     (with-redefs [controller/delete-pod (fn [_ _ cook-expected-state-dict _]
                                                            cook-expected-state-dict)
-                                   controller/kill-pod (fn [_ cook-expected-state-dict _]
+                                   controller/kill-pod (fn [_ _ cook-expected-state-dict _]
                                                          cook-expected-state-dict)
                                    controller/handle-pod-killed (fn [_ _]
                                                                   {:cook-expected-state :cook-expected-state/completed})
@@ -97,7 +97,7 @@
         extract-cook-expected-state (fn []
                                       (:cook-expected-state (get @cook-expected-state-map pod-name {})))
         count-kill-pod (atom 0)]
-    (with-redefs [controller/kill-pod  (fn [_ cook-expected-state-dict _] (swap! count-kill-pod inc) cook-expected-state-dict)
+    (with-redefs [controller/kill-pod  (fn [_ _ cook-expected-state-dict _] (swap! count-kill-pod inc) cook-expected-state-dict)
                   controller/launch-pod (fn [_ cook-expected-state-dict _] cook-expected-state-dict)
                   controller/handle-pod-completed (fn [_ _ _] {:cook-expected-state :cook-expected-state/completed})
                   controller/handle-pod-killed (fn [_ _]
@@ -139,7 +139,7 @@
                          name)
                        (:cook-expected-state (get @cook-expected-state-map name {}))))
         count-delete-pod (atom 0)]
-    (with-redefs [controller/delete-pod  (fn [_ cook-expected-state-dict _] (swap! count-delete-pod inc) cook-expected-state-dict)
+    (with-redefs [controller/delete-pod  (fn [_ _ cook-expected-state-dict _] (swap! count-delete-pod inc) cook-expected-state-dict)
                   controller/handle-pod-completed (fn [_ _ _] {:cook-expected-state :cook-expected-state/completed})
                   controller/write-status-to-datomic (fn [_] :illegal_return_value_should_be_unused)]
 


### PR DESCRIPTION
## Changes proposed in this PR

- Add metrics on time to process actions caused by k8s events including pod-deleted pod-updated.
- Add metrics on the rate of k8s events, including pod-deleted about pod-updated.
- Add metrics on lock contention and delays from locking.
- Add metrics on loading all nodes and all pods from k8s.
- Add metrics on time-to-waiting and time-to-running (to characterize watch delays, k8s delays, and time it takes for a pod to become running)
- Add metrics on rate of generating synthetic pods.
- Add metrics on k8s operations, including creating and deleting a pod.
- Add metrics on error rates when sending pods to k8s, distinguishing between bad pod specifications versus other errors. 
- Add metrics on the workload cook is putting on the kubernetes compute cluster -- specifically creating and killing tasks.
- Add metrics on the rate of scan-induced events processing.

## Why are we making these changes?

To both measure kubernetes behavior, cook behavior as well to characterize the workload cook is putting on kubernetes and the load kubernetes is putting on cook. 