### PR TITLE
Makes test_group_kill_simple more reliable

### DIFF
--- a/integration/tests/cook/reasons.py
+++ b/integration/tests/cook/reasons.py
@@ -1,5 +1,6 @@
 # Named constants for failure reason codes from cook or mesos.
 # See scheduler/src/cook/mesos/schema.clj for the reason code names.
+REASON_TASK_KILLED_DURING_LAUNCH = 1004
 MAX_RUNTIME_EXCEEDED = 2003
 EXECUTOR_UNREGISTERED = 6002
 UNKNOWN_MESOS_REASON = 99001

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1701,7 +1701,9 @@ class CookTest(util.CookTest):
                 # cook killed the job during setup, so the executor had an error
                 reasons.EXECUTOR_UNREGISTERED,
                 # we've seen this happen in the wild
-                reasons.UNKNOWN_MESOS_REASON
+                reasons.UNKNOWN_MESOS_REASON,
+                # task was killed before delivery to the executor
+                reasons.REASON_TASK_KILLED_DURING_LAUNCH
             ]
             self.assertTrue(any(i['reason_code'] in valid_reasons for i in jobs[1]['instances']), slow_job_details)
         finally:


### PR DESCRIPTION
## Changes proposed in this PR

- adding constant for `REASON_TASK_KILLED_DURING_LAUNCH`
- allowing for this reason to be the failure reason in `test_group_kill_simple`

## Why are we making these changes?

We added support for this reason to Cook in #1437, and this test was not updated to handle this new reason.