### PR TITLE
Disables test_output_url for k8s runs

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -97,8 +97,7 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 
     @pytest.mark.travis_skip
-    @unittest.skipIf(util.using_kubernetes() and 'sidecar' not in util.kubernetes_settings(),
-                     'This test requires the sidecar fileserver to be configured when running in Kubernetes')
+    @unittest.skipIf(util.using_kubernetes(), 'We do not currently support output_url in k8s')
     def test_output_url(self):
         job_executor_type = util.get_job_executor_type()
         job_uuid, resp = util.submit_job(self.cook_url,

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -579,7 +579,7 @@ class MultiUserCookTest(util.CookTest):
         job_uuids = []
         try:
             for _ in range(num_jobs):
-                job_uuid, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=2)
+                job_uuid, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=5)
                 self.assertEqual(resp.status_code, 201, msg=resp.content)
                 job_uuids.append(job_uuid)
 

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -738,11 +738,11 @@ class MultiUserCookTest(util.CookTest):
     def test_instance_stats_supports_epoch_time_params(self):
         name = str(util.make_temporal_uuid())
         sleep_command = f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'
-        job_uuid_1, resp = util.submit_job(self.cook_url, command=sleep_command, name=name, max_retries=2)
+        job_uuid_1, resp = util.submit_job(self.cook_url, command=sleep_command, name=name, max_retries=5)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_2, resp = util.submit_job(self.cook_url, command=sleep_command, name=name, max_retries=2)
+        job_uuid_2, resp = util.submit_job(self.cook_url, command=sleep_command, name=name, max_retries=5)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
-        job_uuid_3, resp = util.submit_job(self.cook_url, command=sleep_command, name=name, max_retries=2)
+        job_uuid_3, resp = util.submit_job(self.cook_url, command=sleep_command, name=name, max_retries=5)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         job_uuids = [job_uuid_1, job_uuid_2, job_uuid_3]
         try:


### PR DESCRIPTION
## Changes proposed in this PR

- skipping `test_output_url` for k8s runs
- adding retries to some test jobs

## Why are we making these changes?

We don't yet support `output_url` on k8s.

The retries are to make those tests more resilient to transient instance failures.