### PR TITLE
Makes "Container launch failed" mea culpa

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -384,7 +384,6 @@ class CookTest(util.CookTest):
             self.assertIn({'mode': 'RW',
                            'host-path': '/var/lib/mno',
                            'container-path': '/var/lib/pqr'}, volumes)
-            util.wait_for_job(self.cook_url, job_uuid, 'completed')
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -362,7 +362,7 @@
       (dissoc (s/optional-key :group))
       (dissoc (s/optional-key :status))
       (merge {:framework-id (s/maybe s/Str)
-              :retries-remaining NonNegInt
+              :retries-remaining s/Int
               :status s/Str
               :state s/Str
               :submit-time (s/maybe PosInt)

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -1326,7 +1326,10 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :reason/string "Container launch failed"
     :reason/name :mesos-container-launch-failed
     :reason/mea-culpa? true
-    :reason/mesos-reason :reason-container-launch-failed}
+    :reason/mesos-reason :reason-container-launch-failed
+    ;; Unless configured otherwise, start counting more
+    ;; than 10 failures against the job's retry limit
+    :reason/failure-limit 10}
    {:db/id (d/tempid :db.part/user)
     :reason/code 4004
     :reason/string "Container update failed"

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -1325,7 +1325,7 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :reason/code 4003
     :reason/string "Container launch failed"
     :reason/name :mesos-container-launch-failed
-    :reason/mea-culpa? false
+    :reason/mea-culpa? true
     :reason/mesos-reason :reason-container-launch-failed}
    {:db/id (d/tempid :db.part/user)
     :reason/code 4004


### PR DESCRIPTION
## Changes proposed in this PR

- making "Container launch failed" mea culpa

## Why are we making these changes?

In the wild, these errors are almost always caused by platform issues rather than issues with the user's job.
