### PR TITLE
Makes test_show_progress_message_custom_progress_file more reliable

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1188,7 +1188,8 @@ def dummy_ls_entries(_, __, ___):
                                self.cook_url,
                                submit_flags=f'--executor {executor} '
                                             f'--env {progress_file_env}=progress.txt '
-                                            f'--name {self.current_name()}')
+                                            f'--name {self.current_name()} '
+                                            f'--max-retries 5')
         self.assertEqual(0, cp.returncode, cp.stderr)
         util.wait_for_instance(self.cook_url, uuids[0])
         cp, jobs = cli.show_jobs(uuids, self.cook_url)


### PR DESCRIPTION
## Changes proposed in this PR

- adding retries to the job

## Why are we making these changes?

To make the test more resilient to transient instance failures.
