### PR TITLE
Make test_instance_stats_running more reliable

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -579,7 +579,7 @@ class MultiUserCookTest(util.CookTest):
         job_uuids = []
         try:
             for _ in range(num_jobs):
-                job_uuid, resp = util.submit_job(self.cook_url, command='sleep 300', name=name, max_retries=5)
+                job_uuid, resp = util.submit_job(self.cook_url, command='sleep 300; exit 1', name=name, max_retries=5)
                 self.assertEqual(resp.status_code, 201, msg=resp.content)
                 job_uuids.append(job_uuid)
 


### PR DESCRIPTION
## Changes proposed in this PR

Force the job to retry until we see a running instance (max 5 tries).

## Why are we making these changes?

We've observed this test fail even though it's sleeping for 5 minutes. The job instance transitioned directly from "unknown" to "success" (missed framework message?).
