### PR TITLE
Changes node label from cook_pool to cook-pool

### DIFF
--- a/scheduler/bin/help-make-cluster
+++ b/scheduler/bin/help-make-cluster
@@ -56,7 +56,7 @@ $gcloud container node-pools create cook-pool-k8s-gamma \
        --enable-autoscaling \
        --min-nodes=3 \
        --max-nodes=6 \
-       --node-labels=cook_pool=k8s-gamma
+       --node-labels=cook-pool=k8s-gamma
 $gcloud container node-pools create cook-pool-k8s-alpha \
        --zone "$ZONE" \
        --cluster="$CLUSTERNAME" \
@@ -66,7 +66,7 @@ $gcloud container node-pools create cook-pool-k8s-alpha \
        --enable-autoscaling \
        --min-nodes=2 \
        --max-nodes=4 \
-       --node-labels=cook_pool=k8s-alpha
+       --node-labels=cook-pool=k8s-alpha
 
 echo "---- Setting up cook namespace in kubernetes"
 KUBECONFIG=${COOK_KUBECONFIG} kubectl create -f docs/make-kubernetes-namespace.json

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -28,6 +28,7 @@
 
 (def cook-pod-label "twosigma.com/cook-scheduler-job")
 (def cook-synthetic-pod-job-uuid-label "twosigma.com/cook-scheduler-synthetic-pod-job-uuid")
+(def cook-pool-label "cook-pool")
 (def cook-workdir-volume-name "cook-workdir-volume")
 (def cook-job-pod-priority-class "cook-workload")
 (def cook-synthetic-pod-priority-class "synthetic-pod")
@@ -669,7 +670,7 @@
       ; we're launching in. This is technically only needed for
       ; synthetic pods (which don't specify a node name), but it
       ; doesn't hurt to add it for all pods we submit.
-      (add-node-selector pod-spec "cook_pool" pool-name))
+      (add-node-selector pod-spec cook-pool-label pool-name))
     (.setVolumes pod-spec (filterv some? (conj volumes init-container-workdir-volume sidecar-workdir-volume)))
     (.setSecurityContext pod-spec security-context)
     (.setPriorityClassName pod-spec pod-priority-class)

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -144,8 +144,8 @@
           ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
           ^V1PodSpec pod-spec (.getSpec pod)
           node-selector (.getNodeSelector pod-spec)]
-      (is (contains? node-selector "cook_pool"))
-      (is (= pool-name (get node-selector "cook_pool")))))
+      (is (contains? node-selector api/cook-pool-label))
+      (is (= pool-name (get node-selector api/cook-pool-label)))))
 
   (testing "node selector for hostname"
     (let [hostname "test-host"


### PR DESCRIPTION
## Changes proposed in this PR

- changing the pool label from `cook_pool` to `cook-pool`
- making it a `def`

## Why are we making these changes?

To make the name match the `cook-pool` taint.
