### PR TITLE
Autoscales based on pending jobs instead of match failures

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -70,8 +70,8 @@
   (autoscaling? [this pool-name]
     "Returns true if this compute cluster should autoscale the provided pool to satisfy pending jobs")
 
-  (autoscale! [this pool-name task-requests]
-    "Autoscales the provided pool to satisfy the provided pending task requests")
+  (autoscale! [this pool-name jobs]
+    "Autoscales the provided pool to satisfy the provided pending jobs")
 
   (use-cook-executor? [this]
     "Returns true if this compute cluster makes use of the Cook executor for running tasks")

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -309,14 +309,14 @@
           (log/info "In" name "compute cluster, cannot launch more synthetic pods")
           (let [using-pools? (config/default-pool)
                 synthetic-task-pool-name (when using-pools? pool-name)
-                new-task-requests (remove (fn [{{:keys [job/uuid]} :job}]
+                new-task-requests (remove (fn [{:keys [job/uuid]}]
                                             (some #(= (str uuid) (synthetic-pod->job-uuid %))
                                                   outstanding-synthetic-pods))
                                           task-requests)
                 sidecar-resource-requirements (-> (config/kubernetes) :sidecar :resource-requirements)
                 task-metadata-seq
                 (->> new-task-requests
-                     (map (fn [{{:keys [job/uuid] :as job} :job}]
+                     (map (fn [{:keys [job/uuid] :as job}]
                             {:task-id (str api/cook-synthetic-pod-name-prefix "-" pool-name "-" uuid)
                              :command {:user user :value command}
                              :container {:docker {:image image}}

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -346,15 +346,14 @@
                              :pod-supports-cook-sidecar? false}))
                      (take (- max-pods-outstanding num-synthetic-pods)))]
             (meters/mark! (metrics/meter "synthetic-pod-submit-rate" name) (count task-metadata-seq))
-            (log/info "In" name "compute cluster, launching" (count task-metadata-seq) "synthetic pod(s) for"
-                      (count new-jobs) "new pending job(s) in" synthetic-task-pool-name "pool"
-                      "(there were" (count jobs) "total pending job(s), new and old)")
+            (log/info "In" name "compute cluster, launching" (count task-metadata-seq)
+                      "synthetic pod(s) in" synthetic-task-pool-name "pool")
             (cc/launch-tasks this
                              nil ; offers (not used by KubernetesComputeCluster)
                              task-metadata-seq))))
       (catch Throwable e
-        (log/error e "In" name "compute cluster, encountered error launching synthetic pod(s) for"
-                   (count jobs) "pending job(s) in" pool-name "pool"))))
+        (log/error e "In" name "compute cluster, encountered error launching synthetic pod(s) in"
+                   pool-name "pool"))))
 
   (use-cook-executor? [_] false)
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -783,7 +783,7 @@
   compute-cluster->task-request map. That is the API any future
   improvements need to stick to."
   [task-requests compute-clusters]
-  (group-by (fn [{:keys [job]}]
+  (group-by (fn [job]
               (nth compute-clusters
                    (-> job :job/uuid hash (mod (count compute-clusters)))))
             task-requests))
@@ -794,7 +794,7 @@
   - There is at least one compute cluster configured to do autoscaling"
   [failures pool-name compute-clusters]
   (try
-    (let [task-requests (map #(.. (first %) (getRequest)) failures)
+    (let [task-requests failures
           num-task-requests (count task-requests)
           autoscaling-compute-clusters (filter #(cc/autoscaling? % pool-name) compute-clusters)
           num-autoscaling-compute-clusters (count autoscaling-compute-clusters)]
@@ -879,7 +879,7 @@
             ;; This call needs to happen *after* launch-matched-tasks!
             ;; in order to avoid autoscaling tasks taking up available
             ;; capacity that was already matched for real Cook tasks.
-            (trigger-autoscaling! failures pool-name compute-clusters)
+            (trigger-autoscaling! (get @pool-name->pending-jobs-atom pool-name) pool-name compute-clusters)
             matched-head-or-no-matches?))
         (catch Throwable t
           (meters/mark! handle-resource-offer!-errors)

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -141,9 +141,9 @@
         ^V1Pod outstanding-synthetic-pod-1 (tu/synthetic-pod-helper job-uuid-1 pool-name nil)
         compute-cluster (tu/make-kubernetes-compute-cluster {nil outstanding-synthetic-pod-1} #{pool-name})
         make-task-request-fn (fn [job-uuid]
-                               {:job {:job/resource [{:resource/type :cpus, :resource/amount 0.1}
-                                                     {:resource/type :mem, :resource/amount 32}]
-                                      :job/uuid job-uuid}})
+                               {:job/resource [{:resource/type :cpus, :resource/amount 0.1}
+                                               {:resource/type :mem, :resource/amount 32}]
+                                :job/uuid job-uuid})
         task-requests [(make-task-request-fn job-uuid-1)
                        (make-task-request-fn job-uuid-2)
                        (make-task-request-fn job-uuid-3)]

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1989,16 +1989,16 @@
                                                                 :task-requests task-requests}))
                           (compute-cluster-name [_] "test-compute-cluster"))
         conn (restore-fresh-database! "datomic:mem://test-trigger-autoscaling")
-        make-task-request-fn (fn []
-                               (let [job-id (create-dummy-job conn)
-                                     job (->> job-id (d/entity (d/db conn)) util/job-ent->map)]
-                                 job))
-        task-request-1 (make-task-request-fn)
-        task-request-2 (make-task-request-fn)
-        task-request-3 (make-task-request-fn)
-        failures [task-request-1 task-request-2 task-request-3]]
-    (sched/trigger-autoscaling! failures "test-pool" [compute-cluster])
+        make-job-fn (fn []
+                      (let [job-id (create-dummy-job conn)
+                            job (->> job-id (d/entity (d/db conn)) util/job-ent->map)]
+                        job))
+        job-1 (make-job-fn)
+        job-2 (make-job-fn)
+        job-3 (make-job-fn)
+        jobs [job-1 job-2 job-3]]
+    (sched/trigger-autoscaling! jobs "test-pool" [compute-cluster])
     (is (= 1 (count @autoscale!-invocations)))
     (is (= compute-cluster (-> @autoscale!-invocations first :compute-cluster)))
     (is (= "test-pool" (-> @autoscale!-invocations first :pool-name)))
-    (is (= [task-request-1 task-request-2 task-request-3] (-> @autoscale!-invocations first :task-requests)))))
+    (is (= [job-1 job-2 job-3] (-> @autoscale!-invocations first :task-requests)))))

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1991,19 +1991,12 @@
         conn (restore-fresh-database! "datomic:mem://test-trigger-autoscaling")
         make-task-request-fn (fn []
                                (let [job-id (create-dummy-job conn)
-                                     job (->> job-id (d/entity (d/db conn)) util/job-ent->map)
-                                     task-request (sched/make-task-request (d/db conn) job nil)]
-                                 task-request))
-        make-match-failure-fn (fn [task-request]
-                                (let [failure (fu/assignment-failure :mem)
-                                      assignment-result (SimpleAssignmentResult. [failure] nil task-request)]
-                                  [assignment-result]))
+                                     job (->> job-id (d/entity (d/db conn)) util/job-ent->map)]
+                                 job))
         task-request-1 (make-task-request-fn)
         task-request-2 (make-task-request-fn)
         task-request-3 (make-task-request-fn)
-        failures [(make-match-failure-fn task-request-1)
-                  (make-match-failure-fn task-request-2)
-                  (make-match-failure-fn task-request-3)]]
+        failures [task-request-1 task-request-2 task-request-3]]
     (sched/trigger-autoscaling! failures "test-pool" [compute-cluster])
     (is (= 1 (count @autoscale!-invocations)))
     (is (= compute-cluster (-> @autoscale!-invocations first :compute-cluster)))


### PR DESCRIPTION
## Changes proposed in this PR

- instead of using match failures, using `pending-jobs` post-match to trigger autoscaling

## Why are we making these changes?

Let's say we have 1000 jobs in the queue, we send the top 200 to Fenzo, and 100 of those get matched. Instead of autoscaling for only the remaining 100, we want to autoscale for the 900 still-pending jobs. Of course, the KCC `autoscale!` implementation still has a configurable cap on the number of outstanding synthetic pods per compute cluster.
