### PR TITLE
Rename metrics to be consistent with prior metric naming

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -219,7 +219,7 @@
       ; causing breakage.
       ; In addition, it captures controller/update-cook-expected-state and prevents with-redefs on
       ; update-cook-expected-state from working correctly in unit tests.
-      (let [timer-context (timers/start (metrics/timer "compute-cluster-launch-tasks" name))
+      (let [timer-context (timers/start (metrics/timer "cc-launch-tasks" name))
             pod-namespace (get-namespace-from-task-metadata namespace-config task-metadata)
             pod-name (:task-id task-metadata)
             ^V1Pod pod (api/task-metadata->pod pod-namespace name task-metadata)
@@ -237,7 +237,7 @@
   (kill-task [this task-id]
     ; Note we can't use timer/time! because it wraps the body in a Callable, which rebinds 'this' to another 'this'
     ; causing breakage.
-    (let [timer-context (timers/start (metrics/timer "compute-cluster-kill-tasks" name))]
+    (let [timer-context (timers/start (metrics/timer "cc-kill-tasks" name))]
       (controller/update-cook-expected-state this task-id {:cook-expected-state :cook-expected-state/killed})
       (.stop timer-context)))
 

--- a/scheduler/src/cook/kubernetes/metrics.clj
+++ b/scheduler/src/cook/kubernetes/metrics.clj
@@ -6,8 +6,7 @@
 (defn calculate-name
   "Given a metric name and compute cluster name, come up with the metric path to use."
   [metric-name compute-cluster-name]
-  ["cook-scheduler"
-   "cook-k8s"
+  ["cook-k8s"
    metric-name
    (str "compute-cluster-" compute-cluster-name)])
 

--- a/scheduler/src/cook/kubernetes/metrics.clj
+++ b/scheduler/src/cook/kubernetes/metrics.clj
@@ -6,8 +6,8 @@
 (defn calculate-name
   "Given a metric name and compute cluster name, come up with the metric path to use."
   [metric-name compute-cluster-name]
-  ["cook"
-   "k8s-compute-cluster"
+  ["cook-scheduler"
+   "cook-k8s"
    metric-name
    (str "compute-cluster-" compute-cluster-name)])
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -804,7 +804,7 @@
             (log/info "In" pool-name "pool, starting autoscaling")
             (doseq [[compute-cluster jobs-for-cluster] compute-cluster->jobs]
               (timers/time!
-                (timers/timer (metric-title "autoscale!-duration" pool-name compute-cluster))
+                (timers/timer (metric-title "autoscale-duration" pool-name compute-cluster))
                 (cc/autoscale! compute-cluster pool-name jobs-for-cluster)))
             (log/info "In" pool-name "pool, done autoscaling"))))
       (catch Throwable e


### PR DESCRIPTION
## Changes proposed in this PR

- Rename metrics
- Avoid using compute-cluster-* in a metric name. 

## Why are we making these changes?
Make our new metrics more consistent, in naming, with existing metrics. Also, avoid using compute-cluster-* in metric names so that we can pattern-match this substring in logstash.
