### PR TITLE
Add COOK_SANDBOX, deprecate COOK_WORKDIR for sidecar

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -630,7 +630,10 @@
           (.setPorts container [(.containerPort (V1ContainerPort.) (int port))])
 
           (.setEnv container (conj main-env-vars
+                                   (make-env "COOK_SANDBOX" workdir)
                                    (make-env "COOK_SCHEDULER_REST_URL" (config/scheduler-rest-url))
+                                   ;; DEPRECATED - sidecar should use COOK_SANDBOX instead.
+                                   ;; Will remove this environment variable in a future release.
                                    (make-env "COOK_WORKDIR" workdir)))
 
           (.setPort http-get-action (-> port int IntOrString.))


### PR DESCRIPTION
## Changes proposed in this PR

- Add `COOK_SANDBOX` env var to k8s sidecar container
- Deprecate `COOK_WORKDIR` env var for k8s sidecar container

## Why are we making these changes?

This is the first step for untangling the concepts of the _sandbox_ and the _working directory_ for our Cook K8s jobs. Updating the sidecar logic to use `COOK_SANDBOX`, updating the scheduler to allow different values for the two paths, and finally deleting `COOK_WORKDIR` from the sidecar container will each come as later incremental patches.