### PR TITLE
Allows pods to briefly be Unschedulable without failing

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -445,6 +445,7 @@
                                  pool-selection)})))
      :kubernetes (fnk [[:config {kubernetes {}}]]
                    (merge {:default-workdir "/mnt/sandbox"
+                           :pod-condition-unschedulable-seconds 60
                            :reconnect-delay-ms 60000}
                           kubernetes))}))
 

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -1,5 +1,6 @@
 (ns cook.test.kubernetes.api
-  (:require [clojure.test :refer :all]
+  (:require [clj-time.core :as t]
+            [clojure.test :refer :all]
             [cook.config :as config]
             [cook.kubernetes.api :as api]
             [cook.test.testutil :as tu]
@@ -273,6 +274,7 @@
       (.setType pod-condition "PodScheduled")
       (.setStatus pod-condition "False")
       (.setReason pod-condition "Unschedulable")
+      (.setLastTransitionTime pod-condition (t/epoch))
       (.addConditionsItem pod-status pod-condition)
       (.setStatus pod pod-status)
       (.setName pod-metadata "test-pod")

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -1,5 +1,6 @@
 (ns cook.test.kubernetes.controller
-  (:require [clojure.test :refer :all]
+  (:require [clj-time.core :as t]
+            [clojure.test :refer :all]
             [cook.compute-cluster :as cc]
             [cook.kubernetes.api :as api]
             [cook.kubernetes.controller :as controller]
@@ -81,7 +82,8 @@
                                                       :pod-condition (doto (V1PodCondition.)
                                                                        (.setType "PodScheduled")
                                                                        (.setStatus "False")
-                                                                       (.setReason "Unschedulable")))))
+                                                                       (.setReason "Unschedulable")
+                                                                       (.setLastTransitionTime (t/epoch))))))
     (is (= :reason-scheduling-failed-on-host @reason))
     (is (= :cook-expected-state/running (do-process :cook-expected-state/starting :pod/running)))
     (is (= :reason-running @reason))


### PR DESCRIPTION
This is a follow-up to PR #1466.

## Changes proposed in this PR

- instead of immediately considering unschedulable pods to be failed, require that they've been in that state for `:pod-condition-unschedulable-seconds` seconds (defaults to 60)

## Why are we making these changes?

Kubernetes can be briefly report pods as being unschedulable on their way to getting scheduled. In the wild, we've seen this when a pod (e.g. Cook workload) is preempting another pod (e.g. synthetic pod). Until the preemption is complete, the pod that is doing the preempting is reported as unschedulable.
