### PR TITLE
Adds synthetic pod anti-affinity to previous hosts

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -655,6 +655,8 @@
           (.setVolumeMounts container [(workdir-volume-mount-fn true) (sidecar-workdir-volume-mount-fn false)])
           (.addContainersItem pod-spec container))))
 
+    ; We're either using the hostname (in the case of users' job pods)
+    ; or pod-hostnames-to-avoid (in the case of synthetic pods), but not both.
     (if hostname
       ; Why not just set the node name?
       ; The reason is that setting the node name prevents pod preemption
@@ -665,6 +667,7 @@
       (when (seq pod-hostnames-to-avoid)
         ; Use node "anti"-affinity to disallow scheduling
         ; on hostnames we're being told to avoid
+        ; (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity)
         (let [affinity (V1Affinity.)
               node-affinity (V1NodeAffinity.)
               node-selector (V1NodeSelector.)

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -95,7 +95,8 @@
   [job]
   (->> (:job/instance job)
        (remove #(true? (:instance/preempted? %)))
-       (mapv :instance/hostname)))
+       (mapv :instance/hostname)
+       distinct))
 
 (defn build-novel-host-constraint
   "Constructs a novel-host-constraint.

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -89,13 +89,19 @@
     [this _ vm-attributes _]
     (job-constraint-evaluate this _ vm-attributes)))
 
+(defn job->previous-hosts-to-avoid
+  "Given a job, returns the set of hostnames the
+  job's instances have run on (except preemptions)."
+  [job]
+  (->> (:job/instance job)
+       (remove #(true? (:instance/preempted? %)))
+       (mapv :instance/hostname)))
+
 (defn build-novel-host-constraint
   "Constructs a novel-host-constraint.
   The constraint prevents the job from running on hosts it has already run on"
   [job]
-  (let [previous-hosts (->> (:job/instance job)
-                            (remove #(true? (:instance/preempted? %)))
-                            (mapv :instance/hostname))]
+  (let [previous-hosts (job->previous-hosts-to-avoid job)]
     (->novel-host-constraint job previous-hosts)))
 
 (defrecord gpu-host-constraint [job needs-gpus?]

--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -347,3 +347,14 @@
           (is (= [true nil] (constraints/job-constraint-evaluate constraint nil {"HOSTNAME" "hostC"})))
           ;; unsuitable
           (is (= [false "Host is not suitable for datasets"] (constraints/job-constraint-evaluate constraint nil {"HOSTNAME" "hostB"}))))))))
+
+(deftest test-job->previous-hosts-to-avoid
+  (testing "uniqueness"
+    (is (= (set ["host-1" "host-2" "host-3"])
+           (set (constraints/job->previous-hosts-to-avoid
+                  {:job/instance [{:instance/hostname "host-3"}
+                                  {:instance/hostname "host-2"}
+                                  {:instance/hostname "host-1"}
+                                  {:instance/hostname "host-3"}
+                                  {:instance/hostname "host-2"}
+                                  {:instance/hostname "host-1"}]}))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adding node "anti"-affinity to synthetic pods, disallowing them from being scheduled on nodes where their corresponding job has already run

## Why are we making these changes?

Cook has a "novel host constraint", which disallows a job from running on the same host twice. So, we need to avoid running a synthetic pod on any of the hosts that the real job won't be able to run on. Otherwise, the synthetic pod won't trigger the cluster autoscaler.
