### PR TITLE
Makes test_user_total_usage more reliable

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -497,7 +497,8 @@ class MultiUserCookTest(util.CookTest):
     def test_user_total_usage(self):
         user = self.user_factory.new_user()
         with user:
-            job_spec = {'cpus': 0.11, 'mem': 123, 'command': 'sleep 600'}
+            sleep_command = f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'
+            job_spec = {'cpus': 0.11, 'mem': 123, 'command': sleep_command}
             pools, _ = util.active_pools(self.cook_url)
             job_uuids = []
             try:


### PR DESCRIPTION
## Changes proposed in this PR

- making the jobs sleep for the duration of the test instead of 10 minutes

## Why are we making these changes?

If the test runs for longer than 10 minutes, we don't want the jobs to complete since we're testing the usage (running jobs) of the user.
