### PR TITLE
Improves test-job->previous-hosts-to-avoid

### DIFF
--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -350,11 +350,12 @@
 
 (deftest test-job->previous-hosts-to-avoid
   (testing "uniqueness"
-    (is (= (set ["host-1" "host-2" "host-3"])
-           (set (constraints/job->previous-hosts-to-avoid
-                  {:job/instance [{:instance/hostname "host-3"}
-                                  {:instance/hostname "host-2"}
-                                  {:instance/hostname "host-1"}
-                                  {:instance/hostname "host-3"}
-                                  {:instance/hostname "host-2"}
-                                  {:instance/hostname "host-1"}]}))))))
+    (let [hostnames (constraints/job->previous-hosts-to-avoid
+                      {:job/instance [{:instance/hostname "host-3"}
+                                      {:instance/hostname "host-2"}
+                                      {:instance/hostname "host-1"}
+                                      {:instance/hostname "host-3"}
+                                      {:instance/hostname "host-2"}
+                                      {:instance/hostname "host-1"}]})]
+      (is (= 3 (count hostnames)))
+      (is (= (set ["host-1" "host-2" "host-3"]) (set hostnames))))))


### PR DESCRIPTION
This is a follow-up to PR #1477.

## Changes proposed in this PR

- asserting on the length of the returned collection

## Why are we making these changes?

To ensure there aren't duplicates.
