### PR TITLE
add mesos sandbox mount

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2866,6 +2866,23 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 
+    @unittest.skipUnless(util.docker_tests_enabled(), 'Requires docker support')
+    def test_docker_workdir_mesos_sandbox(self):
+        image = util.docker_image()
+        container = {'type': 'docker',
+                     'docker': {'image': image,
+                                'network': 'HOST',
+                                'force-pull-image': False,
+                                'parameters': [{'key': 'workdir',
+                                                'value': '/mnt/mesos/sandbox'}]}}
+        command = 'bash -c \'touch zzz; if [[ $(pwd) == "/mnt/mesos/sandbox" ]] && [[ -f zzz ]]; then exit 0; else exit 1; fi\''
+        job_uuid, resp = util.submit_job(self.cook_url, command=command, container=container)
+        self.assertEqual(201, resp.status_code, resp.text)
+        try:
+            util.wait_for_instance(self.cook_url, job_uuid, status='success')
+        finally:
+            util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
+
     @unittest.skipUnless(util.docker_tests_enabled(), "Requires docker support.")
     def test_default_container_volumes(self):
         settings = util.settings(self.cook_url)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -406,10 +406,12 @@
                                (not= "RW" mode))))
         sandbox-volume (make-empty-volume cook-sandbox-volume-name)
         sandbox-volume-mount-fn #(make-volume-mount sandbox-volume sandbox-dir %)
-        sandbox-volume-mount (sandbox-volume-mount-fn false)]
+        sandbox-volume-mount (sandbox-volume-mount-fn false)
+        ; mesos-sandbox-volume-mount added for Mesos backward compatibility
+        mesos-sandbox-volume-mount (make-volume-mount sandbox-volume "/mnt/mesos/sandbox" false)]
     {:sandbox-volume-mount-fn sandbox-volume-mount-fn
      :volumes (conj volumes sandbox-volume)
-     :volume-mounts (conj volume-mounts sandbox-volume-mount)}))
+     :volume-mounts (conj volume-mounts sandbox-volume-mount mesos-sandbox-volume-mount)}))
 
 (defn toleration-for-pool
   "For a given cook pool name, create the right V1Toleration so that Cook will ignore that cook-pool taint."


### PR DESCRIPTION
## Changes proposed in this PR

- add another mount for the sandbox directory using the legacy mesos path

## Why are we making these changes?

provides backward compatibility for a job that assumes running on mesos 

