### PR TITLE
Adds node anti-affinity for node blocklist labels

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -503,7 +503,7 @@
 
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."
-  [namespace compute-cluster-name
+  [namespace compute-cluster-name compute-cluster-node-blocklist-labels
    {:keys [task-id command container task-request hostname pod-labels pod-hostnames-to-avoid
            pod-priority-class pod-supports-cook-init? pod-supports-cook-sidecar?]
     :or {pod-priority-class cook-job-pod-priority-class
@@ -646,18 +646,32 @@
       (add-node-selector pod-spec k8s-hostname-label hostname)
       (when (seq pod-hostnames-to-avoid)
         ; Use node "anti"-affinity to disallow scheduling
-        ; on hostnames we're being told to avoid
         ; (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity)
         (let [affinity (V1Affinity.)
               node-affinity (V1NodeAffinity.)
               node-selector (V1NodeSelector.)
-              node-selector-term (V1NodeSelectorTerm.)
-              node-selector-requirement (V1NodeSelectorRequirement.)]
-          (.setKey node-selector-requirement k8s-hostname-label)
-          (.setOperator node-selector-requirement "NotIn")
-          (run! #(.addValuesItem node-selector-requirement %) pod-hostnames-to-avoid)
-          (.addMatchExpressionsItem node-selector-term node-selector-requirement)
-          (.addNodeSelectorTermsItem node-selector node-selector-term)
+              node-selector-term-k8s-hostname-label (V1NodeSelectorTerm.)
+              node-selector-requirement-k8s-hostname-label (V1NodeSelectorRequirement.)]
+
+          ; Disallow scheduling on hostnames we're being told to avoid
+          (.setKey node-selector-requirement-k8s-hostname-label k8s-hostname-label)
+          (.setOperator node-selector-requirement-k8s-hostname-label "NotIn")
+          (run! #(.addValuesItem node-selector-requirement-k8s-hostname-label %) pod-hostnames-to-avoid)
+          (.addMatchExpressionsItem node-selector-term-k8s-hostname-label node-selector-requirement-k8s-hostname-label)
+          (.addNodeSelectorTermsItem node-selector node-selector-term-k8s-hostname-label)
+
+          ; Disallow scheduling on nodes with blocklist labels
+          (run!
+            (fn add-node-selector-term-for-blocklist-label
+              [node-blocklist-label]
+              (let [node-selector-term-blocklist-label (V1NodeSelectorTerm.)
+                    node-selector-requirement-blocklist-label (V1NodeSelectorRequirement.)]
+                (.setKey node-selector-requirement-blocklist-label node-blocklist-label)
+                (.setOperator node-selector-requirement-blocklist-label "DoesNotExist")
+                (.addMatchExpressionsItem node-selector-term-blocklist-label node-selector-requirement-blocklist-label)
+                (.addNodeSelectorTermsItem node-selector node-selector-term-blocklist-label)))
+            compute-cluster-node-blocklist-labels)
+
           (.setRequiredDuringSchedulingIgnoredDuringExecution node-affinity node-selector)
           (.setNodeAffinity affinity node-affinity)
           (.setAffinity pod-spec affinity))))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -644,33 +644,36 @@
       ; from happening. We want this pod to preempt lower priority pods
       ; (e.g. synthetic pods).
       (add-node-selector pod-spec k8s-hostname-label hostname)
-      (when (seq pod-hostnames-to-avoid)
-        ; Use node "anti"-affinity to disallow scheduling
+      (when (or (seq pod-hostnames-to-avoid)
+                (seq compute-cluster-node-blocklist-labels))
+        ; Use node "anti"-affinity to disallow scheduling on nodes with particular labels
         ; (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity)
         (let [affinity (V1Affinity.)
               node-affinity (V1NodeAffinity.)
-              node-selector (V1NodeSelector.)
-              node-selector-term-k8s-hostname-label (V1NodeSelectorTerm.)
-              node-selector-requirement-k8s-hostname-label (V1NodeSelectorRequirement.)]
+              node-selector (V1NodeSelector.)]
 
-          ; Disallow scheduling on hostnames we're being told to avoid
-          (.setKey node-selector-requirement-k8s-hostname-label k8s-hostname-label)
-          (.setOperator node-selector-requirement-k8s-hostname-label "NotIn")
-          (run! #(.addValuesItem node-selector-requirement-k8s-hostname-label %) pod-hostnames-to-avoid)
-          (.addMatchExpressionsItem node-selector-term-k8s-hostname-label node-selector-requirement-k8s-hostname-label)
-          (.addNodeSelectorTermsItem node-selector node-selector-term-k8s-hostname-label)
+          ; Disallow scheduling on hostnames we're being told to avoid (if any)
+          (when (seq pod-hostnames-to-avoid)
+            (let [node-selector-term-k8s-hostname-label (V1NodeSelectorTerm.)
+                  node-selector-requirement-k8s-hostname-label (V1NodeSelectorRequirement.)]
+              (.setKey node-selector-requirement-k8s-hostname-label k8s-hostname-label)
+              (.setOperator node-selector-requirement-k8s-hostname-label "NotIn")
+              (run! #(.addValuesItem node-selector-requirement-k8s-hostname-label %) pod-hostnames-to-avoid)
+              (.addMatchExpressionsItem node-selector-term-k8s-hostname-label node-selector-requirement-k8s-hostname-label)
+              (.addNodeSelectorTermsItem node-selector node-selector-term-k8s-hostname-label)))
 
-          ; Disallow scheduling on nodes with blocklist labels
-          (run!
-            (fn add-node-selector-term-for-blocklist-label
-              [node-blocklist-label]
-              (let [node-selector-term-blocklist-label (V1NodeSelectorTerm.)
-                    node-selector-requirement-blocklist-label (V1NodeSelectorRequirement.)]
-                (.setKey node-selector-requirement-blocklist-label node-blocklist-label)
-                (.setOperator node-selector-requirement-blocklist-label "DoesNotExist")
-                (.addMatchExpressionsItem node-selector-term-blocklist-label node-selector-requirement-blocklist-label)
-                (.addNodeSelectorTermsItem node-selector node-selector-term-blocklist-label)))
-            compute-cluster-node-blocklist-labels)
+          ; Disallow scheduling on nodes with blocklist labels (if any)
+          (when (seq compute-cluster-node-blocklist-labels)
+            (run!
+              (fn add-node-selector-term-for-blocklist-label
+                [node-blocklist-label]
+                (let [node-selector-term-blocklist-label (V1NodeSelectorTerm.)
+                      node-selector-requirement-blocklist-label (V1NodeSelectorRequirement.)]
+                  (.setKey node-selector-requirement-blocklist-label node-blocklist-label)
+                  (.setOperator node-selector-requirement-blocklist-label "DoesNotExist")
+                  (.addMatchExpressionsItem node-selector-term-blocklist-label node-selector-requirement-blocklist-label)
+                  (.addNodeSelectorTermsItem node-selector node-selector-term-blocklist-label)))
+              compute-cluster-node-blocklist-labels))
 
           (.setRequiredDuringSchedulingIgnoredDuringExecution node-affinity node-selector)
           (.setNodeAffinity affinity node-affinity)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -223,7 +223,7 @@
       (let [timer-context (timers/start (metrics/timer "cc-launch-tasks" name))
             pod-namespace (get-namespace-from-task-metadata namespace-config task-metadata)
             pod-name (:task-id task-metadata)
-            ^V1Pod pod (api/task-metadata->pod pod-namespace name task-metadata)
+            ^V1Pod pod (api/task-metadata->pod pod-namespace name node-blocklist-labels task-metadata)
             new-cook-expected-state-dict {:cook-expected-state :cook-expected-state/starting
                                           :launch-pod {:pod pod}}]
         (try

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -537,7 +537,7 @@
   node))
 
 (defn make-kubernetes-compute-cluster
-  [namespaced-pod-name->pod pool-names synthetic-pods-user]
+  [namespaced-pod-name->pod pool-names synthetic-pods-user node-blocklist-labels]
   (let [synthetic-pods-config {:image "image"
                                :user synthetic-pods-user
                                :max-pods-outstanding 4
@@ -556,5 +556,5 @@
                                     nil ; scan-frequency-seconds-config
                                     nil ; max-pods-per-node
                                     synthetic-pods-config ; synthetic-pods-config
-                                    nil ; node-blocklist-labels
+                                    node-blocklist-labels ; node-blocklist-labels
                                     )))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -73,7 +73,7 @@
                                           :scalar-requests {"mem" 512
                                                             "cpus" 1.0}}
                            :hostname "kubehost"}
-            pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)]
+            pod (api/task-metadata->pod "cook" "testing-cluster" [] task-metadata)]
         (is (= "my-task" (-> pod .getMetadata .getName)))
         (is (= "cook" (-> pod .getMetadata .getNamespace)))
         (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
@@ -131,7 +131,7 @@
                                         :scalar-requests {"mem" 512
                                                           "cpus" 1.0}}
                          :hostname "kubehost"}
-          pod (api/task-metadata->pod "cook" "test-cluster" task-metadata)]
+          pod (api/task-metadata->pod "cook" "test-cluster" [] task-metadata)]
       (is (= 100 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
       (is (= 10 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))))
 
@@ -142,7 +142,7 @@
                          :task-request {:job {:job/pool {:pool/name pool-name}}
                                         :scalar-requests {"mem" 512
                                                           "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
+          ^V1Pod pod (api/task-metadata->pod nil nil [] task-metadata)
           ^V1PodSpec pod-spec (.getSpec pod)
           node-selector (.getNodeSelector pod-spec)]
       (is (contains? node-selector api/cook-pool-label))
@@ -155,7 +155,7 @@
                          :hostname hostname
                          :task-request {:scalar-requests {"mem" 512
                                                           "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
+          ^V1Pod pod (api/task-metadata->pod nil nil [] task-metadata)
           ^V1PodSpec pod-spec (.getSpec pod)
           node-selector (.getNodeSelector pod-spec)]
       (is (contains? node-selector api/k8s-hostname-label))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -146,7 +146,8 @@
             job-uuid-3 (str (UUID/randomUUID))
             pool-name "test-pool"
             ^V1Pod outstanding-synthetic-pod-1 (tu/synthetic-pod-helper job-uuid-1 pool-name nil)
-            compute-cluster (tu/make-kubernetes-compute-cluster {nil outstanding-synthetic-pod-1} #{pool-name} "user")
+            compute-cluster (tu/make-kubernetes-compute-cluster {nil outstanding-synthetic-pod-1}
+                                                                #{pool-name} "user" nil)
             pending-jobs [(make-job-fn job-uuid-1 nil)
                           (make-job-fn job-uuid-2 nil)
                           (make-job-fn job-uuid-3 nil)]
@@ -162,7 +163,7 @@
       (let [job-uuid-1 (str (UUID/randomUUID))
             job-uuid-2 (str (UUID/randomUUID))
             pool-name "test-pool"
-            compute-cluster (tu/make-kubernetes-compute-cluster {} #{pool-name} nil)
+            compute-cluster (tu/make-kubernetes-compute-cluster {} #{pool-name} nil nil)
             pending-jobs [(make-job-fn job-uuid-1 "user-1")
                           (make-job-fn job-uuid-2 "user-2")]
             launched-pods-atom (atom [])]
@@ -176,7 +177,7 @@
     (testing "synthetic pods avoid job's previous hosts"
       (let [job-uuid-1 (str (UUID/randomUUID))
             pool-name "test-pool"
-            compute-cluster (tu/make-kubernetes-compute-cluster {} #{pool-name} nil)
+            compute-cluster (tu/make-kubernetes-compute-cluster {} #{pool-name} nil nil)
             pending-jobs [(-> (make-job-fn job-uuid-1 "user-1")
                               (assoc :job/instance
                                      [{:instance/hostname "test-host-1"}
@@ -201,4 +202,42 @@
                   first)]
           (is (= api/k8s-hostname-label (.getKey node-selector-requirement)))
           (is (= "NotIn" (.getOperator node-selector-requirement)))
-          (is (= ["test-host-1" "test-host-2"] (.getValues node-selector-requirement))))))))
+          (is (= ["test-host-1" "test-host-2"] (.getValues node-selector-requirement))))))
+
+    (testing "synthetic pods avoid node blocklist labels"
+      (let [job-uuid-1 (str (UUID/randomUUID))
+            pool-name "test-pool"
+            compute-cluster (tu/make-kubernetes-compute-cluster {} #{pool-name} nil ["unhealthy-node" "unready-node"])
+            pending-jobs [(make-job-fn job-uuid-1 "user-1")]
+            launched-pods-atom (atom [])]
+        (with-redefs [api/launch-pod (fn [_ _ cook-expected-state-dict _]
+                                       (swap! launched-pods-atom conj cook-expected-state-dict))]
+          (cc/autoscale! compute-cluster pool-name pending-jobs))
+        (is (= 1 (count @launched-pods-atom)))
+        (let [node-selector-terms
+              (-> @launched-pods-atom
+                  (nth 0)
+                  :launch-pod
+                  :pod
+                  .getSpec
+                  .getAffinity
+                  .getNodeAffinity
+                  .getRequiredDuringSchedulingIgnoredDuringExecution
+                  .getNodeSelectorTerms)]
+          (is (= 2 (count node-selector-terms)))
+          (let [node-selector-requirement
+                (->> node-selector-terms
+                     (filter #(-> % .getMatchExpressions first .getKey (= "unhealthy-node")))
+                     first
+                     .getMatchExpressions
+                     first)]
+            (is (= "unhealthy-node" (.getKey node-selector-requirement)))
+            (is (= "DoesNotExist" (.getOperator node-selector-requirement))))
+          (let [node-selector-requirement
+                (->> node-selector-terms
+                     (filter #(-> % .getMatchExpressions first .getKey (= "unready-node")))
+                     first
+                     .getMatchExpressions
+                     first)]
+            (is (= "unready-node" (.getKey node-selector-requirement)))
+            (is (= "DoesNotExist" (.getOperator node-selector-requirement)))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- adding node anti-affinity for node blocklist labels

## Why are we making these changes?

To prevent synthetic pods from running on nodes with blocklist labels. For example, if there is a node labeled as "unhealthy", we don't want synthetic pods to run there, because the real job pods won't be able to.

