### PR TITLE
support cs cli commands on kubernetes

### DIFF
--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -420,3 +420,13 @@ def query_with_stdin_support(clusters, entity_refs, pred_jobs=None, pred_instanc
 
     query_result = query(clusters_of_interest, entity_refs, pred_jobs, pred_instances, pred_groups, timeout, interval)
     return query_result, clusters_of_interest
+
+def get_compute_cluster_config(cluster, compute_cluster_name):
+    """
+    :param cluster: cook scheduler cluster
+    :param compute_cluster_name: compute cluster
+    :return: config of the compute cluster
+    """
+    cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
+    return next(c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
+                c['compute-cluster-name'] == compute_cluster_name)

--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -243,7 +243,7 @@ def __get_latest_instance(job):
     raise CookRetriableException(f'Job {job["uuid"]} currently has no instances.')
 
 
-def query_unique_and_run(clusters, entity_ref, command_fn, wait=False, resolve_sandbox_directory=True):
+def query_unique_and_run(clusters, entity_ref, command_fn, wait=False):
     """Calls query_unique and then calls the given command_fn on the resulting job instance"""
 
     def query_unique_and_run():
@@ -251,14 +251,12 @@ def query_unique_and_run(clusters, entity_ref, command_fn, wait=False, resolve_s
         if query_result['type'] == Types.JOB:
             job = query_result['data']
             instance = __get_latest_instance(job)
-            directory = mesos.retrieve_instance_sandbox_directory(instance, job) if resolve_sandbox_directory \
-                else partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job)
-            command_fn(instance, directory, query_result['cluster'])
+            directory_fn = partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job)
+            command_fn(instance, directory_fn, query_result['cluster'])
         elif query_result['type'] == Types.INSTANCE:
             instance, job = query_result['data']
-            directory = mesos.retrieve_instance_sandbox_directory(instance, job) if resolve_sandbox_directory \
-                else partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job)
-            command_fn(instance, directory, query_result['cluster'])
+            directory_fn = partial(mesos.retrieve_instance_sandbox_directory, instance=instance, job=job)
+            command_fn(instance, directory_fn, query_result['cluster'])
         else:
             # This should not happen, because query_unique should
             # only return a map with type "job" or type "instance"

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -4,9 +4,9 @@ import os
 import sys
 from functools import partial
 
-from cook import http, plugins
+from cook import plugins
 from cook.mesos import download_file
-from cook.querying import parse_entity_refs, query_unique_and_run, parse_entity_ref
+from cook.querying import get_compute_cluster_config, parse_entity_refs, query_unique_and_run, parse_entity_ref
 from cook.util import guard_no_cluster
 
 def cat_using_download_file(instance, sandbox_dir, path):
@@ -37,9 +37,7 @@ def cat_for_instance(instance, sandbox_dir_fn, cluster, path):
     compute_cluster_name = compute_cluster["name"]
     if compute_cluster_type == "kubernetes":
         kubectl_cat_instance_file_fn = plugins.get_fn('kubectl-cat-for-instance', kubectl_cat_instance_file)
-        cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
-        compute_cluster_config = next(c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
-                                      c['compute-cluster-name'] == compute_cluster_name)
+        compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_cat_instance_file_fn(instance["task_id"], compute_cluster_config, path)
     else:
         cat_using_download_file(instance, sandbox_dir_fn(), path)

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -1,16 +1,15 @@
 import argparse
 import logging
+import os
 import sys
 from functools import partial
 
-from cook import plugins
+from cook import http, plugins
 from cook.mesos import download_file
 from cook.querying import parse_entity_refs, query_unique_and_run, parse_entity_ref
 from cook.util import guard_no_cluster
 
-
-def cat_for_instance(instance, sandbox_dir, _, path):
-    """Outputs the contents of the Mesos sandbox path for the given instance."""
+def cat_using_download_file(instance, sandbox_dir, path):
     retrieve_fn = plugins.get_fn('download-job-instance-file', download_file)
     download = retrieve_fn(instance, sandbox_dir, path)
     try:
@@ -20,6 +19,30 @@ def cat_for_instance(instance, sandbox_dir, _, path):
     except BrokenPipeError as bpe:
         sys.stderr.close()
         logging.exception(bpe)
+
+def kubectl_cat_instance_file(instance_uuid, _, path):
+    os.execlp('kubectl', 'kubectl',
+              'exec',
+              '-c', os.getenv('COOK_CONTAINER_NAME_FOR_JOB', 'required-cook-job-container'),
+              '-it', instance_uuid,
+              '--', 'cat', path)
+
+def cat_for_instance(instance, sandbox_dir_fn, cluster, path):
+    """
+    Outputs the contents of the Mesos sandbox path for the given instance.
+    When using Kubernetes, calls the exec command of the kubectl cli.
+    """
+    compute_cluster = instance["compute-cluster"]
+    compute_cluster_type = compute_cluster["type"]
+    compute_cluster_name = compute_cluster["name"]
+    if compute_cluster_type == "kubernetes":
+        kubectl_cat_instance_file_fn = plugins.get_fn('kubectl-cat-for-instance', kubectl_cat_instance_file)
+        cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
+        compute_cluster_config = next(c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
+                                      c['compute-cluster-name'] == compute_cluster_name)
+        kubectl_cat_instance_file_fn(instance["task_id"], compute_cluster_config, path)
+    else:
+        cat_using_download_file(instance, sandbox_dir_fn(), path)
 
 
 def cat(clusters, args, _):

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -162,7 +162,7 @@ def ls_for_instance(instance, sandbox_dir_fn, cluster, path, long_format, as_jso
                                       c['compute-cluster-name'] == compute_cluster_name)
         kubectl_ls_for_instance_fn(instance["task_id"], compute_cluster_config, path, long_format, as_json)
     else:
-        ls_for_instance_from_mesos(instance, sandbox_dir_fn(), cluster, path, long_format, as_json)
+        ls_for_instance_from_mesos(instance, sandbox_dir_fn(), path, long_format, as_json)
 
 
 def ls(clusters, args, _):

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import re
+import subprocess
 from datetime import datetime
 from functools import partial
 
@@ -88,9 +90,7 @@ def retrieve_entries_from_mesos(instance, sandbox_dir, path):
 
     return entries
 
-
-def ls_for_instance(instance, sandbox_dir, _, path, long_format, as_json):
-    """Lists contents of the Mesos sandbox path for the given instance"""
+def ls_for_instance_from_mesos(instance, sandbox_dir, path, long_format, as_json):
     retrieve_fn = plugins.get_fn('retrieve-job-instance-files', retrieve_entries_from_mesos)
     entries = retrieve_fn(instance, sandbox_dir, path)
     if as_json:
@@ -105,6 +105,64 @@ def ls_for_instance(instance, sandbox_dir, _, path, long_format, as_json):
                 print('\n'.join(terminal.wrap('  '.join([format_path(e) for e in entries]))))
         else:
             logging.info('the directory is empty')
+
+def kubectl_ls_for_instance(instance_uuid, _, path, long_format, as_json):
+    if as_json:
+        working_dir = subprocess.run(['kubectl',
+                                      'exec',
+                                      '-c', os.getenv('COOK_CONTAINER_NAME_FOR_JOB', 'required-cook-job-container'),
+                                      '-it', instance_uuid,
+                                      '--', 'pwd'],
+                                     stdout=subprocess.PIPE).stdout.decode('utf-8').rstrip()
+        args = ['kubectl',
+                'exec',
+                '-c', os.getenv('COOK_CONTAINER_NAME_FOR_JOB', 'required-cook-job-container'),
+                '-it', instance_uuid,
+                '--', 'ls', '-l', '--time-style=+%s']
+        if path:
+            args.append(path)
+        listing_lines = subprocess.run(args, stdout=subprocess.PIPE).stdout.decode('utf-8').splitlines()
+        entries = [{"mode": mode,
+                    "nlink": int(nlink),
+                    "uid": uid,
+                    "gid": gid,
+                    "size": int(size),
+                    "mtime": int(mtime),
+                    "path": f'{working_dir}/{path}'}
+                   for mode, nlink, uid, gid, size, mtime, path
+                   in [re.split('\ +', line, 6) for line
+                       in listing_lines if not line.startswith("ls: cannot access") and not line.startswith("total")]]
+        if len(entries) == 0 and len([line for line in listing_lines if line.endswith("No such file or directory")]) == 1:
+            raise Exception(f"Cannot access '{path}' (no such file or directory).")
+        print(json.dumps(entries))
+    else:
+        args = ['kubectl', 'kubectl',
+                'exec',
+                '-c', os.getenv('COOK_CONTAINER_NAME_FOR_JOB', 'required-cook-job-container'),
+                '-it', instance_uuid,
+                '--', 'ls']
+        if long_format:
+            args.append("-l")
+        if path:
+            args.append(path)
+        os.execlp(*args)
+
+def ls_for_instance(instance, sandbox_dir_fn, cluster, path, long_format, as_json):
+    """
+    Lists contents of the Mesos sandbox path for the given instance.
+    When using Kubernetes, calls the exec command of the kubectl cli.
+    """
+    compute_cluster = instance["compute-cluster"]
+    compute_cluster_type = compute_cluster["type"]
+    compute_cluster_name = compute_cluster["name"]
+    if compute_cluster_type == "kubernetes":
+        kubectl_ls_for_instance_fn = plugins.get_fn('kubectl-ls-for-instance', kubectl_ls_for_instance)
+        cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
+        compute_cluster_config = next(c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
+                                      c['compute-cluster-name'] == compute_cluster_name)
+        kubectl_ls_for_instance_fn(instance["task_id"], compute_cluster_config, path, long_format, as_json)
+    else:
+        ls_for_instance_from_mesos(instance, sandbox_dir_fn(), cluster, path, long_format, as_json)
 
 
 def ls(clusters, args, _):

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -9,7 +9,7 @@ from functools import partial
 from tabulate import tabulate
 
 from cook import http, mesos, terminal, plugins
-from cook.querying import query_unique_and_run, parse_entity_refs
+from cook.querying import get_compute_cluster_config, query_unique_and_run, parse_entity_refs
 from cook.util import guard_no_cluster
 
 
@@ -157,9 +157,7 @@ def ls_for_instance(instance, sandbox_dir_fn, cluster, path, long_format, as_jso
     compute_cluster_name = compute_cluster["name"]
     if compute_cluster_type == "kubernetes":
         kubectl_ls_for_instance_fn = plugins.get_fn('kubectl-ls-for-instance', kubectl_ls_for_instance)
-        cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
-        compute_cluster_config = next(c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
-                                      c['compute-cluster-name'] == compute_cluster_name)
+        compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_ls_for_instance_fn(instance["task_id"], compute_cluster_config, path, long_format, as_json)
     else:
         ls_for_instance_from_mesos(instance, sandbox_dir_fn(), path, long_format, as_json)

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -1,8 +1,8 @@
 import logging
 import os
 
-from cook import http, plugins, terminal
-from cook.querying import query_unique_and_run, parse_entity_refs
+from cook import plugins, terminal
+from cook.querying import get_compute_cluster_config, query_unique_and_run, parse_entity_refs
 from cook.util import print_info, guard_no_cluster
 
 
@@ -25,9 +25,7 @@ def ssh_to_instance(instance, sandbox_dir_fn, cluster):
     compute_cluster_name = compute_cluster["name"]
     if compute_cluster_type == "kubernetes":
         kubectl_exec_to_instance_fn = plugins.get_fn('kubectl-exec-to-instance', kubectl_exec_to_instance)
-        cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
-        compute_cluster_config = next(c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
-                                      c['compute-cluster-name'] == compute_cluster_name)
+        compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_exec_to_instance_fn(instance["task_id"], compute_cluster_config)
     else:
         sandbox_dir = sandbox_dir_fn()

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -15,8 +15,10 @@ def kubectl_exec_to_instance(instance_uuid, _):
 
 
 def ssh_to_instance(instance, sandbox_dir_fn, cluster):
-    """When using Mesos, attempts to ssh (using os.execlp) to the Mesos agent corresponding to the given instance.
-    When using Kubernetes, calls the exec command of the kubectl cli."""
+    """
+    When using Mesos, attempts to ssh (using os.execlp) to the Mesos agent corresponding to the given instance.
+    When using Kubernetes, calls the exec command of the kubectl cli.
+    """
     print_info(f'Attempting ssh for job instance {terminal.bold(instance["task_id"])}...')
     compute_cluster = instance["compute-cluster"]
     compute_cluster_type = compute_cluster["type"]
@@ -44,7 +46,7 @@ def ssh(clusters, args, _):
         # argparse should prevent this, but we'll be defensive anyway
         raise Exception(f'You can only provide a single uuid.')
 
-    query_unique_and_run(clusters_of_interest, entity_refs[0], ssh_to_instance, resolve_sandbox_directory=False)
+    query_unique_and_run(clusters_of_interest, entity_refs[0], ssh_to_instance)
 
 
 def register(add_parser, _):

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -1,7 +1,8 @@
+import os
 import time
 from functools import partial
 
-from cook import plugins
+from cook import http, plugins
 from cook.mesos import read_file
 from cook.querying import query_unique_and_run, parse_entity_refs
 from cook.util import check_positive, guard_no_cluster
@@ -104,18 +105,43 @@ def tail_follow(file_size, read_fn, follow_sleep_seconds):
 
         time.sleep(follow_sleep_seconds)
 
-
-def tail_for_instance(instance, sandbox_dir, _, path, num_lines_to_print, follow, follow_sleep_seconds):
-    """
-    Tails the contents of the Mesos sandbox path for the given instance. If follow is truthy, it will
-    try and read more data from the file until the user terminates. This assumes files will not shrink.
-    """
+def tail_using_read_file(instance, sandbox_dir, path, num_lines_to_print, follow, follow_sleep_seconds):
     retrieve_fn = plugins.get_fn('read-job-instance-file', read_file)
     read = partial(retrieve_fn, instance=instance, sandbox_dir=sandbox_dir, path=path)
     file_size = read()['offset']
     tail_backwards(file_size, read, num_lines_to_print)
     if follow:
         tail_follow(file_size, read, follow_sleep_seconds)
+
+def kubectl_tail_instance_file(instance_uuid, _, path, num_lines_to_print, follow):
+    args = ['kubectl', 'kubectl',
+            'exec',
+            '-c', os.getenv('COOK_CONTAINER_NAME_FOR_JOB', 'required-cook-job-container'),
+            '-it', instance_uuid,
+            '--', 'tail', '-n', str(num_lines_to_print)]
+    if follow:
+        args.append("-f")
+    args.append(path)
+    os.execlp(*args)
+
+
+def tail_for_instance(instance, sandbox_dir_fn, cluster, path, num_lines_to_print, follow, follow_sleep_seconds):
+    """
+    Tails the contents of the Mesos sandbox path for the given instance. If follow is truthy, it will
+    try and read more data from the file until the user terminates. This assumes files will not shrink.
+    When using Kubernetes, calls the exec command of the kubectl cli.
+    """
+    compute_cluster = instance["compute-cluster"]
+    compute_cluster_type = compute_cluster["type"]
+    compute_cluster_name = compute_cluster["name"]
+    if compute_cluster_type == "kubernetes":
+        kubectl_tail_instance_file_fn = plugins.get_fn('kubectl-tail-instance-file', kubectl_tail_instance_file)
+        cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
+        compute_cluster_config = next(c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
+                                      c['compute-cluster-name'] == compute_cluster_name)
+        kubectl_tail_instance_file_fn(instance["task_id"], compute_cluster_config, path, num_lines_to_print, follow)
+    else:
+        tail_using_read_file(instance, sandbox_dir_fn(), path, num_lines_to_print, follow, follow_sleep_seconds)
 
 
 def tail(clusters, args, _):

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -2,9 +2,9 @@ import os
 import time
 from functools import partial
 
-from cook import http, plugins
+from cook import plugins
 from cook.mesos import read_file
-from cook.querying import query_unique_and_run, parse_entity_refs
+from cook.querying import get_compute_cluster_config, query_unique_and_run, parse_entity_refs
 from cook.util import check_positive, guard_no_cluster
 
 CHUNK_SIZE = 4096
@@ -136,9 +136,7 @@ def tail_for_instance(instance, sandbox_dir_fn, cluster, path, num_lines_to_prin
     compute_cluster_name = compute_cluster["name"]
     if compute_cluster_type == "kubernetes":
         kubectl_tail_instance_file_fn = plugins.get_fn('kubectl-tail-instance-file', kubectl_tail_instance_file)
-        cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
-        compute_cluster_config = next(c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
-                                      c['compute-cluster-name'] == compute_cluster_name)
+        compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_tail_instance_file_fn(instance["task_id"], compute_cluster_config, path, num_lines_to_print, follow)
     else:
         tail_using_read_file(instance, sandbox_dir_fn(), path, num_lines_to_print, follow, follow_sleep_seconds)


### PR DESCRIPTION
## Changes proposed in this PR

- change cs cli commands to leverage kubectl

## Why are we making these changes?

the cs cli commands rely on Mesos APIs. kubectl can be used to implement the same functionality on Kubernetes
