### PR TITLE
Capture stdout/stderr by default on K8s

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -561,15 +561,6 @@ def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, log_requ
         job_specs = [job_specs] * clones
     caller = get_caller()
 
-    def io_redirect(spec):
-        if using_kubernetes() and using_kubernetes_default_shell():
-            # Capture stdout and stderr as files in the sandbox directory
-            # (i.e., mimick the default mesos behavior on k8s).
-            # Assuming custom shell commands handle this logic internally.
-            spec['command'] = f'( {spec["command"]} ) >stdout 2>stderr'
-            logging.debug(f'Rewrote job {spec["uuid"]} command to capture stdout and stderr.')
-        return spec
-
     def full_spec(spec):
         if 'name' not in spec:
             spec['name'] = DEFAULT_JOB_NAME_PREFIX + caller
@@ -580,7 +571,7 @@ def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, log_requ
                 del spec["name"]
             return dict(**spec)
 
-    jobs = [io_redirect(full_spec(j)) for j in job_specs]
+    jobs = [full_spec(j) for j in job_specs]
     request_body = {'jobs': jobs}
     default_pool = default_submit_pool()
     if pool == POOL_UNSPECIFIED:

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -57,8 +57,7 @@
                         :resource-requirements {:cpu-request 0.1
                                                 :cpu-limit 0.1
                                                 :memory-request 128.0
-                                                :memory-limit 128.0}}
-              :custom-shell ["/bin/sh" "-c"]}
+                                                :memory-limit 128.0}}}
  :log {:file #config/env "COOK_LOG_FILE"
        :levels {"datomic.db" :warn
                 "datomic.kv-cluster" :warn

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -94,7 +94,7 @@
         (let [^V1Container container (-> pod .getSpec .getContainers first)
               container-env (.getEnv container)]
           (is (= "required-cook-job-container" (.getName container)))
-          (is (= ["/bin/sh" "-c" "foo && bar"] (.getCommand container)))
+          (is (= (conj api/default-shell "foo && bar") (.getCommand container)))
           (is (= "alpine:latest" (.getImage container)))
           (is (not (nil? container)))
           (is (= ["COOK_SANDBOX" "EXECUTOR_PROGRESS_OUTPUT_FILE" "FOO" "HOME" "MESOS_SANDBOX" "SIDECAR_WORKDIR"]


### PR DESCRIPTION
## Changes proposed in this PR

Capture stdout and stderr in our default Cook-K8s shell for launching job commands.

## Why are we making these changes?

Fixes test_command_length_limit, which was broken by the io_redirect
wrapper in our integration support code. Since the default shell now
does the capture, we no longer need to augment the job command for
integration tests that depend on the stdout and stderr files.