### PR TITLE
Remove sandbox workaround in test_workdir_volume_overlap

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -407,12 +407,7 @@ class CookTest(util.CookTest):
             job = util.load_job(self.cook_url, job_uuid)
             util.wait_for_job(self.cook_url, job_uuid, 'completed')
             settings_dict = util.settings(self.cook_url)
-            # This test provides a non-writeable workdir, so we're adding this temporary change until we separate
-            # the sandbox and workdir.
-            if 'kubernetes' in settings_dict and 'custom-shell' in settings_dict['kubernetes']:
-                util.wait_for_instance(self.cook_url, job_uuid)
-            else:
-                util.wait_for_instance(self.cook_url, job_uuid, status='success')
+            util.wait_for_instance(self.cook_url, job_uuid, status='success')
         finally:
             util.kill_jobs(self.cook_url, [job_uuid], assert_response=False)
 


### PR DESCRIPTION
## Changes proposed in this PR

Remove sandbox workaround in test_workdir_volume_overlap

## Why are we making these changes?

As per the comment in the deleted code:
Now that the sandbox and workdir are separated, this workaround is no longer needed.