### PR TITLE
Add checkpoint field

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3019,7 +3019,7 @@ class CookTest(util.CookTest):
             job_uuid_enabled, resp_enabled = util.submit_job(self.cook_url, command=command_enabled, container=container,
                                                              checkpoint={"mode": "auto",
                                                                          "periodic-options": {"period-sec": 555},
-                                                                         "options": {"preserve-paths": ["p1", "p2"]}})
+                                                                         "options": {"preserve-paths": ["p2", "p1"]}})
             self.assertEqual(201, resp_enabled.status_code)
             util.wait_for_instance(self.cook_url, job_uuid_disabled, status='success')
             util.wait_for_instance(self.cook_url, job_uuid_enabled, status='success')

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3011,12 +3011,13 @@ class CookTest(util.CookTest):
         docker_image = util.docker_image()
         container = {'type': 'docker',
                      'docker': {'image': docker_image}}
-        command_disabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE}" == "true" ]]; then exit 1; else exit 0; fi\''
+        command_disabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE:-zzz}" == "zzz" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC:-zzz}" == "zzz" ]]; then exit 0; else exit 1; fi\''
         job_uuid_disabled, resp_disabled = util.submit_job(self.cook_url, command=command_disabled, container=container)
         self.assertEqual(201, resp_disabled.status_code)
-        command_enabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE}" == "true" ]]; then exit 0; else exit 1; fi\''
+        command_enabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE}" == "true" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC}" == "555" ]]; then exit 0; else exit 1; fi\''
         job_uuid_enabled, resp_enabled = util.submit_job(self.cook_url, command=command_enabled, container=container,
-                                                         checkpoint={"enable": True})
+                                                         checkpoint={"enable": True,
+                                                                     "period-sec": 555})
         self.assertEqual(201, resp_enabled.status_code)
         try:
             util.wait_for_instance(self.cook_url, job_uuid_disabled, status='success')

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3012,13 +3012,14 @@ class CookTest(util.CookTest):
         container = {'type': 'docker',
                      'docker': {'image': docker_image}}
         try:
-            command_disabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE:-false}" == "false" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC:-zzz}" == "zzz" ]]; then exit 0; else exit 1; fi\''
+            command_disabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_MODE:-none}" == "none" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC:-zzz}" == "zzz" ]]; then exit 0; else exit 1; fi\''
             job_uuid_disabled, resp_disabled = util.submit_job(self.cook_url, command=command_disabled, container=container)
             self.assertEqual(201, resp_disabled.status_code)
-            command_enabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE}" == "true" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC}" == "555" ]]; then exit 0; else exit 1; fi\''
+            command_enabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_MODE}" == "auto" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC}" == "555" ]] && [[ "${COOK_CHECKPOINT_PRESERVE_PATH_0}" == "p1" ]] && [[ "${COOK_CHECKPOINT_PRESERVE_PATH_1}" == "p2" ]]; then exit 0; else exit 1; fi\''
             job_uuid_enabled, resp_enabled = util.submit_job(self.cook_url, command=command_enabled, container=container,
-                                                             checkpoint={"enable": True,
-                                                                         "period-sec": 555})
+                                                             checkpoint={"mode": "auto",
+                                                                         "periodic-options": {"period-sec": 555},
+                                                                         "options": {"preserve-paths": ["p1", "p2"]}})
             self.assertEqual(201, resp_enabled.status_code)
             util.wait_for_instance(self.cook_url, job_uuid_disabled, status='success')
             util.wait_for_instance(self.cook_url, job_uuid_enabled, status='success')

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3011,20 +3011,19 @@ class CookTest(util.CookTest):
         docker_image = util.docker_image()
         container = {'type': 'docker',
                      'docker': {'image': docker_image}}
-        command_disabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE:-zzz}" == "zzz" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC:-zzz}" == "zzz" ]]; then exit 0; else exit 1; fi\''
-        job_uuid_disabled, resp_disabled = util.submit_job(self.cook_url, command=command_disabled, container=container)
-        self.assertEqual(201, resp_disabled.status_code)
-        command_enabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE}" == "true" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC}" == "555" ]]; then exit 0; else exit 1; fi\''
-        job_uuid_enabled, resp_enabled = util.submit_job(self.cook_url, command=command_enabled, container=container,
-                                                         checkpoint={"enable": True,
-                                                                     "period-sec": 555})
-        self.assertEqual(201, resp_enabled.status_code)
         try:
+            command_disabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE:-false}" == "false" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC:-zzz}" == "zzz" ]]; then exit 0; else exit 1; fi\''
+            job_uuid_disabled, resp_disabled = util.submit_job(self.cook_url, command=command_disabled, container=container)
+            self.assertEqual(201, resp_disabled.status_code)
+            command_enabled = 'bash -c \'if [[ "${COOK_CHECKPOINT_ENABLE}" == "true" ]] && [[ "${COOK_CHECKPOINT_PERIOD_SEC}" == "555" ]]; then exit 0; else exit 1; fi\''
+            job_uuid_enabled, resp_enabled = util.submit_job(self.cook_url, command=command_enabled, container=container,
+                                                             checkpoint={"enable": True,
+                                                                         "period-sec": 555})
+            self.assertEqual(201, resp_enabled.status_code)
             util.wait_for_instance(self.cook_url, job_uuid_disabled, status='success')
             util.wait_for_instance(self.cook_url, job_uuid_enabled, status='success')
         finally:
-            util.kill_jobs(self.cook_url, [job_uuid_disabled])
-            util.kill_jobs(self.cook_url, [job_uuid_enabled])
+            util.kill_jobs(self.cook_url, [job_uuid_disabled, job_uuid_enabled])
 
     @unittest.skipUnless(util.docker_tests_enabled(), 'Requires docker support')
     def test_disallowed_docker_parameters(self):

--- a/scheduler/docs/scheduler-rest-api.adoc
+++ b/scheduler/docs/scheduler-rest-api.adoc
@@ -83,6 +83,7 @@ The request body is list of job maps with each entry containing a map of the fol
 |`env` | JSON map | A map of environment variables to be provided to the job.
 |`constraints` | list | list of constraints in form [attribute, operator, pattern]
 |`disable_mea_culpa_retries` | boolean | Flag to disable mea culpa retries. If true, mea culpa retries will count against the job's retry count.
+|`checkpoint` | JSON map | optional configuration to enable checkpointing.
 |====
 
 .URI JSON Schema (see http://mesos.apache.org/documentation/latest/fetcher/[the Mesos docs] for details)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -515,8 +515,9 @@
 
 (defn- checkpoint->volume-mounts
   "Get custom volume mounts needed for checkpointing"
-  [{:keys [volume-mounts]} shared-volume]
-  (map (fn [{:keys [path sub-path]}] (make-volume-mount shared-volume path sub-path true)) volume-mounts))
+  [{:keys [enable volume-mounts]} shared-volume]
+  (when enable
+    (map (fn [{:keys [path sub-path]}] (make-volume-mount shared-volume path sub-path true)) volume-mounts)))
 
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -515,8 +515,8 @@
 
 (defn- checkpoint->volume-mounts
   "Get custom volume mounts needed for checkpointing"
-  [{:keys [volume-mounts]}]
-  (map (fn [{:keys []}] (make-volume-mount xxx))))
+  [{:keys [volume-mounts]} shared-volume]
+  (map (fn [{:keys [path sub-path]}] (make-volume-mount shared-volume path sub-path true)) volume-mounts))
 
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."
@@ -561,7 +561,7 @@
         scratch-space "/mnt/scratch-space"
         scratch-space-volume (make-empty-volume "cook-scratch-space-volume")
         scratch-space-volume-mount-fn (partial make-volume-mount scratch-space-volume scratch-space)
-        checkpoint-volume-mounts (checkpoint->volume-mounts checkpoint)
+        checkpoint-volume-mounts (checkpoint->volume-mounts checkpoint scratch-space-volume)
         sandbox-env {"COOK_SANDBOX" sandbox-dir
                      "HOME" sandbox-dir
                      "MESOS_SANDBOX" sandbox-dir

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -515,9 +515,9 @@
 
 (defn- checkpoint->volume-mounts
   "Get custom volume mounts needed for checkpointing"
-  [{:keys [enable volume-mounts]} shared-volume]
+  [{:keys [enable volume-mounts]} checkpointing-tools-volume]
   (when enable
-    (map (fn [{:keys [path sub-path]}] (make-volume-mount shared-volume path sub-path true)) volume-mounts)))
+    (map (fn [{:keys [path sub-path]}] (make-volume-mount checkpointing-tools-volume path sub-path true)) volume-mounts)))
 
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."
@@ -562,7 +562,7 @@
         scratch-space "/mnt/scratch-space"
         scratch-space-volume (make-empty-volume "cook-scratch-space-volume")
         scratch-space-volume-mount-fn (partial make-volume-mount scratch-space-volume scratch-space)
-        checkpoint-volume-mounts (checkpoint->volume-mounts checkpoint scratch-space-volume)
+        checkpoint-volume-mounts (checkpoint->volume-mounts checkpoint init-container-workdir-volume)
         sandbox-env {"COOK_SANDBOX" sandbox-dir
                      "HOME" sandbox-dir
                      "MESOS_SANDBOX" sandbox-dir

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -569,7 +569,8 @@
                      "SIDECAR_WORKDIR" sidecar-workdir}
         params-env (build-params-env parameters)
         progress-env (task/build-executor-environment job)
-        checkpoint-env {"COOK_CHECKPOINT_ENABLE" (if (:enable checkpoint) "true" "false")}
+        checkpoint-env {"COOK_CHECKPOINT_ENABLE" (if (:enable checkpoint) "true" "false")
+                        "COOK_CHECKPOINT_PERIOD_SEC" (or (str (:period-sec checkpoint)) "")}
         main-env-base (merge environment params-env progress-env sandbox-env checkpoint-env)
         progress-file-var (get main-env-base task/progress-meta-env-name task/default-progress-env-name)
         progress-file-path (get main-env-base progress-file-var)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -530,7 +530,8 @@
        (let [{:keys [preserve-paths]} options]
          (cond-> m
            preserve-paths
-           (#(reduce-kv (fn [map index path] (assoc map (str "COOK_CHECKPOINT_PRESERVE_PATH_" index) path)) % preserve-paths))))))
+           (#(reduce-kv (fn [map index path] (assoc map (str "COOK_CHECKPOINT_PRESERVE_PATH_" index) path))
+                        % (vec (sort preserve-paths))))))))
     periodic-options
     ((fn [m]
        (let [{:keys [period-sec]} periodic-options]

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -169,7 +169,8 @@
 
 (def Checkpoint
   "Schema for a configuration to enable checkpointing"
-  {:enable s/Bool})
+  {:enable s/Bool
+   :period-sec s/Int})
 
 (def Uri
   "Schema for a Mesos fetch URI, which has many options"
@@ -624,11 +625,12 @@
 
 (defn- build-checkpoint
   "Helper for submit-jobs, deal with checkpoint config."
-  [db-id {:keys [enable]}]
+  [db-id {:keys [enable period-sec]}]
   (let [checkpoint-id (d/tempid :db.part/user)]
     [[:db/add db-id :job/checkpoint checkpoint-id]
      {:db/id checkpoint-id
-      :checkpoint/enable enable}]))
+      :checkpoint/enable enable
+      :checkpoint/period-sec period-sec}]))
 
 (defn- str->executor-enum
   "Converts an executor string to the corresponding executor option enum.

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -169,8 +169,7 @@
 
 (def Checkpoint
   "Schema for a configuration to enable checkpointing"
-  {:type s/Str
-   :enable s/Bool})
+  {:enable s/Bool})
 
 (def Uri
   "Schema for a Mesos fetch URI, which has many options"

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -625,9 +625,9 @@
 (defn- build-checkpoint
   "Helper for submit-jobs, deal with checkpoint config."
   [db-id {:keys [enable]}]
-  (let [env-var-id (d/tempid :db.part/user)]
-    [[:db/add db-id :job/checkpoint env-var-id]
-     {:db/id env-var-id
+  (let [checkpoint-id (d/tempid :db.part/user)]
+    [[:db/add db-id :job/checkpoint checkpoint-id]
+     {:db/id checkpoint-id
       :checkpoint/enable enable}]))
 
 (defn- str->executor-enum

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -177,7 +177,10 @@
 
 (def Checkpoint
   "Schema for a configuration to enable checkpointing"
-  {:mode (s/enum "auto" "periodic" "preemptible")
+  ; auto - checkpointing code will select the best method
+  ; periodic - periodically create a checkpoint
+  ; preemption - checkpoint is created on preemption before the VM is stopped
+  {:mode (s/enum "auto" "periodic" "preemption")
    (s/optional-key :options) CheckpointOptions
    (s/optional-key :periodic-options) PeriodicCheckpointOptions})
 

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -169,7 +169,7 @@
 
 (def CheckpointOptions
   "Schema for checkpointing options"
-  {:preserve-paths [s/Str]})
+  {:preserve-paths #{s/Str}})
 
 (def PeriodicCheckpointOptions
   "Schema for periodic checkpointing options"
@@ -940,7 +940,9 @@
                  (when progress-regex-string {:progress-regex-string progress-regex-string})
                  (when application {:application application})
                  (when datasets {:datasets (munge-datasets datasets)})
-                 (when checkpoint {:checkpoint checkpoint}))
+                 (when checkpoint {:checkpoint (if (-> checkpoint :options :preserve-paths)
+                                                 (update-in checkpoint [:options :preserve-paths] set)
+                                                 checkpoint)}))
         params (get-in munged [:container :docker :parameters])]
     (s/validate Job munged)
     (when (and (:gpus munged) (not gpu-enabled?))

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -871,7 +871,7 @@
   [db user task-constraints gpu-enabled? new-group-uuids
    {:keys [cpus mem gpus uuid command priority max-retries max-runtime expected-runtime name
            uris ports env labels container group application disable-mea-culpa-retries
-           constraints executor progress-output-file progress-regex-string datasets]
+           constraints executor progress-output-file progress-regex-string datasets checkpoint]
     :or {group nil
          disable-mea-culpa-retries false}
     :as job}
@@ -910,7 +910,8 @@
                  (when progress-output-file {:progress-output-file progress-output-file})
                  (when progress-regex-string {:progress-regex-string progress-regex-string})
                  (when application {:application application})
-                 (when datasets {:datasets (munge-datasets datasets)}))
+                 (when datasets {:datasets (munge-datasets datasets)})
+                 (when checkpoint {:checkpoint checkpoint}))
         params (get-in munged [:container :docker :parameters])]
     (s/validate Job munged)
     (when (and (:gpus munged) (not gpu-enabled?))

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -170,7 +170,7 @@
 (def Checkpoint
   "Schema for a configuration to enable checkpointing"
   {:enable s/Bool
-   :period-sec s/Int})
+   (s/optional-key :period-sec) s/Int})
 
 (def Uri
   "Schema for a Mesos fetch URI, which has many options"
@@ -628,9 +628,10 @@
   [db-id {:keys [enable period-sec]}]
   (let [checkpoint-id (d/tempid :db.part/user)]
     [[:db/add db-id :job/checkpoint checkpoint-id]
-     {:db/id checkpoint-id
-      :checkpoint/enable enable
-      :checkpoint/period-sec period-sec}]))
+     (cond-> {:db/id checkpoint-id
+              :checkpoint/enable enable}
+       period-sec
+       (assoc :checkpoint/period-sec period-sec))]))
 
 (defn- str->executor-enum
   "Converts an executor string to the corresponding executor option enum.

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -496,13 +496,33 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/ident :constraint.operator/equals}
    ;; Checkpoint attributes
    {:db/id (d/tempid :db.part/db)
-    :db/ident :checkpoint/enable
-    :db/valueType :db.type/boolean
+    :db/ident :checkpoint/mode
+    :db/valueType :db.type/string
+    :db/isComponent true
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
-    :db/ident :checkpoint/period-sec
+    :db/ident :checkpoint/options
+    :db/valueType :db.type/ref
+    :db/isComponent true
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :checkpoint/periodic-options
+    :db/valueType :db.type/ref
+    :db/isComponent true
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :checkpoint-options/preserve-paths
+    :db/valueType :db.type/string
+    :db/isComponent true
+    :db/cardinality :db.cardinality/many
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :checkpoint-periodic-options/period-sec
     :db/valueType :db.type/long
+    :db/isComponent true
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    ;; Application attributes

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -82,6 +82,7 @@
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
     :db/ident :job/checkpoint
+    :db/doc "optional configuration to enable checkpointing"
     :db/valueType :db.type/ref
     :db/isComponent true
     :db/cardinality :db.cardinality/one
@@ -497,28 +498,33 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
    ;; Checkpoint attributes
    {:db/id (d/tempid :db.part/db)
     :db/ident :checkpoint/mode
+    :db/doc "Checkpointing mode, e.g. auto, periodic, preemption"
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
     :db/ident :checkpoint/options
+    :db/doc "Checkpointing options not specific to any checkpointing mode"
     :db/valueType :db.type/ref
     :db/isComponent true
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
     :db/ident :checkpoint/periodic-options
+    :db/doc "Checkpointing options specific to the periodic checkpointing mode"
     :db/valueType :db.type/ref
     :db/isComponent true
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
     :db/ident :checkpoint-options/preserve-paths
+    :db/doc "Set of paths to preserve when checkpointing"
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/many
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
     :db/ident :checkpoint-periodic-options/period-sec
+    :db/doc "Time between checkpoints when using the periodic checkpointing mode"
     :db/valueType :db.type/long
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -500,6 +500,11 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/valueType :db.type/boolean
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :checkpoint/period-sec
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
    ;; Application attributes
    {:db/id (d/tempid :db.part/db)
     :db/doc

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -498,7 +498,6 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
    {:db/id (d/tempid :db.part/db)
     :db/ident :checkpoint/mode
     :db/valueType :db.type/string
-    :db/isComponent true
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
@@ -516,13 +515,11 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
    {:db/id (d/tempid :db.part/db)
     :db/ident :checkpoint-options/preserve-paths
     :db/valueType :db.type/string
-    :db/isComponent true
     :db/cardinality :db.cardinality/many
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
     :db/ident :checkpoint-periodic-options/period-sec
     :db/valueType :db.type/long
-    :db/isComponent true
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    ;; Application attributes

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -81,6 +81,12 @@
              a job may be placed on"
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
+    :db/ident :job/checkpoint
+    :db/valueType :db.type/ref
+    :db/isComponent true
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
     :db/ident :job/state
     :db/valueType :db.type/ref
     :db/cardinality :db.cardinality/one
@@ -488,6 +494,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/user)
     :db/ident :constraint.operator/equals}
+   ;; Checkpoint attributes
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :checkpoint/enable
+    :db/valueType :db.type/boolean
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
    ;; Application attributes
    {:db/id (d/tempid :db.part/db)
     :db/doc

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -224,8 +224,9 @@
 (defn job-ent->checkpoint
   "Take a job entity and return the configuration to enable checkpointing"
   [{:keys [job/checkpoint]}]
-  (let [{:keys [checkpoint/enable]} checkpoint]
-    {:enable enable}))
+  (let [{:keys [checkpoint/enable checkpoint/period-sec]} checkpoint]
+    {:enable enable
+     :period-sec period-sec}))
 
 (defn job-ent->label
   "Take a job entity and return the label map"

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -221,6 +221,11 @@
           {}
           (:job/environment job-ent)))
 
+(defn job-ent->checkpoint
+  "Take a job entity and return the configuration to enable checkpointing"
+  [{:keys [checkpoint/enable]}]
+  {:enable enable})
+
 (defn job-ent->label
   "Take a job entity and return the label map"
   [job-ent]

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -223,8 +223,9 @@
 
 (defn job-ent->checkpoint
   "Take a job entity and return the configuration to enable checkpointing"
-  [{:keys [checkpoint/enable]}]
-  {:enable enable})
+  [{:keys [job/checkpoint]}]
+  (let [{:keys [checkpoint/enable]} checkpoint]
+    {:enable enable}))
 
 (defn job-ent->label
   "Take a job entity and return the label map"

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -224,10 +224,16 @@
 (defn job-ent->checkpoint
   "Take a job entity and return the configuration to enable checkpointing"
   [{:keys [job/checkpoint]}]
-  (let [{:keys [checkpoint/enable checkpoint/period-sec]} checkpoint]
-    (cond-> {:enable enable}
-      period-sec
-      (assoc :period-sec period-sec))))
+  (let [{:keys [checkpoint/mode checkpoint/options checkpoint/periodic-options]} checkpoint]
+    (cond-> {:mode mode}
+      options
+      (assoc :options
+             (let [{:keys [checkpoint-options/preserve-paths]} options]
+               {:preserve-paths preserve-paths}))
+      periodic-options
+      (assoc :periodic-options
+             (let [{:keys [checkpoint-periodic-options/period-sec]} periodic-options]
+               {:period-sec period-sec})))))
 
 (defn job-ent->label
   "Take a job entity and return the label map"

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -225,8 +225,9 @@
   "Take a job entity and return the configuration to enable checkpointing"
   [{:keys [job/checkpoint]}]
   (let [{:keys [checkpoint/enable checkpoint/period-sec]} checkpoint]
-    {:enable enable
-     :period-sec period-sec}))
+    (cond-> {:enable enable}
+      period-sec
+      (assoc :period-sec period-sec))))
 
 (defn job-ent->label
   "Take a job entity and return the label map"

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1395,6 +1395,15 @@
 
         (testing "should work when the job specifies checkpointing options"
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
+                checkpoint {:enable true}
+                {:keys [uuid] :as job} (assoc (minimal-job) :checkpoint checkpoint)]
+            (is (= {::api/results (str "submitted jobs " uuid)}
+                   (testutil/create-jobs! conn {::api/jobs [job]})))
+            (is (= (expected-job-map job)
+                   (dissoc (api/fetch-job-map (db conn) uuid) :submit_time)))))
+
+        (testing "should work when the job specifies checkpointing options 2"
+          (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
                 checkpoint {:enable true
                             :period-sec 777}
                 {:keys [uuid] :as job} (assoc (minimal-job) :checkpoint checkpoint)]

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1395,7 +1395,8 @@
 
         (testing "should work when the job specifies checkpointing options"
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
-                checkpoint {:enable true}
+                checkpoint {:enable true
+                            :period-sec 777}
                 {:keys [uuid] :as job} (assoc (minimal-job) :checkpoint checkpoint)]
             (is (= {::api/results (str "submitted jobs " uuid)}
                    (testutil/create-jobs! conn {::api/jobs [job]})))

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1565,7 +1565,7 @@
 
       (testing "should allow an optional checkpoint field"
         (is (s/validate api/Job (assoc min-job :checkpoint {:mode "periodic"
-                                                            :options {:preserve-paths ["p1" "p2"]}})))
+                                                            :options {:preserve-paths #{"p1" "p2"}}})))
         (is (s/validate api/Job (assoc min-job :checkpoint {:mode "auto"
                                                             :periodic-options {:period-sec 777}})))
         (is (thrown? Exception (s/validate api/Job (assoc min-job :checkpoint {:mode "zzz"}))))


### PR DESCRIPTION
## Changes proposed in this PR

- add checkpoint field to job

## Why are we making these changes?

The checkpoint field will contain configuration to facilitate checkpointing in a job running on kubernetes with a custom shell that supports it. Useful when running on preemptable compute

