### PR TITLE
Make config changes more lightweight and not need lein uberjar

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -38,13 +38,13 @@ RUN unzip -uo /opt/cook/datomic/datomic-free-0.9.5394.zip
 
 # Copy the whole scheduler into the container
 COPY docker /opt/cook/docker
-COPY config* /opt/cook/
 COPY resources /opt/cook/resources
 COPY java /opt/cook/java
 COPY src /opt/cook/src
 
 RUN lein uberjar
 RUN cp "target/cook-$(lein print :version | tr -d '"').jar" datomic-free-0.9.5394/lib/cook-$(lein print :version | tr -d '"').jar
+COPY config* /opt/cook/
 
 # Run cook
 EXPOSE \


### PR DESCRIPTION
## Changes proposed in this PR

- Copy the config files into docker after we do lein build

## Why are we making these changes?
- Faster docker file generations. Changing the config no longer requires lein uberjar.

