### PR TITLE
Support for specifying the default container on a per-pool basis

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1870,7 +1870,7 @@ class CookTest(util.CookTest):
         expected_container = matching_containers[0]
         # Make sure we have a different configured docker image and default image, we fail the test to make sure that we
         # don't inadvertently skip it.
-        self.failIfEqual(expected_container["docker"]["image"],util.docker_image())
+        self.failIfEqual(expected_container["docker"]["image"], util.docker_image())
 
         # Special logic in util.submit_jobs.full_spec maps container=None and removes it from the submitted job spec.
         job_uuid, resp = util.submit_job(

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1855,6 +1855,18 @@ class CookTest(util.CookTest):
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
         self.assertIn('success', [i['status'] for i in job['instances']])
 
+    @unittest.skipUnless(util.docker_tests_enabled(), "Requires a test docker image")
+    def test_default_container_for_pool(self):
+        # Special logic in util.submit_jobs.full_spec maps container=None and removes it from the submitted job spec.
+        job_uuid, resp = util.submit_job(
+            self.cook_url,
+            command='cat /.dockerenv',
+            container=None,
+            max_retries=5)
+        self.assertEqual(resp.status_code, 201)
+        job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
+        self.assertIn('success', [i['status'] for i in job['instances']])
+
     @unittest.skipUnless(util.has_docker_service() and not util.using_kubernetes(),
                          "Requires `docker inspect`. On kubernetes, need to add support and write a separate test.")
     def test_docker_port_mapping(self):
@@ -3108,6 +3120,8 @@ class CookTest(util.CookTest):
         self.assertEqual('failed', job['instances'][0]['status'], job)
         self.assertEqual('Invalid task', job['instances'][0]['reason_string'], job)
 
+    @unittest.skipUnless(util.docker_image_for_default_pool() and not util.docker_image(),
+                         'We need a docker image to run this test, but dont have a pool from which to learn it.')
     def test_submit_pool_unspecified(self):
         job_uuid, resp = util.submit_job(self.cook_url, pool=util.POOL_UNSPECIFIED)
         self.assertEqual(resp.status_code, 201, resp.content)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1860,7 +1860,7 @@ class CookTest(util.CookTest):
     def test_default_container_for_pool(self):
         default_pool = util.default_submit_pool()
         settings_dict = util.settings(self.cook_url)
-        list_of_pool_match_rules = settings_dict.get("pools", {}).get("default-container-for-pool", [])
+        list_of_pool_match_rules = settings_dict.get("pools", {}).get("default-containers", [])
         if len(list_of_pool_match_rules) == 0:
             self.skipTest("No pool match rules defined")
         matching_containers = [ii["container"] for ii in list_of_pool_match_rules if

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1868,6 +1868,10 @@ class CookTest(util.CookTest):
         if len(matching_containers) == 0:
             self.skipTest("No rule matches the default submit pool")
         expected_container = matching_containers[0]
+        # Make sure we have a different configured docker image and default image, we fail the test to make sure that we
+        # don't inadvertently skip it.
+        self.failIfEqual(expected_container["docker"]["image"],util.docker_image())
+
         # Special logic in util.submit_jobs.full_spec maps container=None and removes it from the submitted job spec.
         job_uuid, resp = util.submit_job(
             self.cook_url,

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1880,7 +1880,7 @@ class CookTest(util.CookTest):
             max_retries=5)
         self.assertEqual(resp.status_code, 201)
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
-        self.assertEquals(job["container"]["docker"]["image"], expected_container["docker"]["image"])
+        self.assertEqual(job["container"]["docker"]["image"], expected_container["docker"]["image"])
         self.assertIn('success', [i['status'] for i in job['instances']])
 
     @unittest.skipUnless(util.has_docker_service() and not util.using_kubernetes(),

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -603,15 +603,15 @@ def submit_jobs(cook_url, job_specs, clones=1, pool=None, headers=None, log_requ
     caller = get_caller()
 
     def full_spec(spec):
-        if "container" in spec and spec["container"] is None:
-            del spec["container"]
+        if 'container' in spec and spec['container'] is None:
+            del spec['container']
         if 'name' not in spec:
             spec['name'] = DEFAULT_JOB_NAME_PREFIX + caller
         if 'uuid' not in spec:
             return minimal_job(**spec)
         else:
-            if "name" in spec and spec["name"] is None:
-                del spec["name"]
+            if 'name' in spec and spec['name'] is None:
+                del spec['name']
             return dict(**spec)
 
     jobs = [full_spec(j) for j in job_specs]

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -64,19 +64,13 @@
  :pools {:default "mesos-gamma"
          :job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
                                    :pool-regex "^k8s-.+"}
-         :default-container-for-pool
-         [{:pool-regex "k8s-alpha" :container {:type "docker"
-                                               :docker {
-                                                        :image "python:3.6",
-                                                        :network "HOST"
-                                                        :force-pull-image false
-                                                        :parameters []}}}
-          {:pool-regex "k8s-gamma" :container {:type "docker"
-                                               :docker {
-                                                        :image "python:3.6",
-                                                        :network "HOST"
-                                                        :force-pull-image false
-                                                        :parameters []}}}]}
+         :default-containers
+         [{:pool-regex "k8s-.*" :container {:type "docker"
+                                            :docker {
+                                                     :image "python:3.6",
+                                                     :network "HOST"
+                                                     :force-pull-image false
+                                                     :parameters []}}}]}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -61,20 +61,22 @@
            :user-metrics-interval-seconds 60}
  :nrepl {:enabled? true
          :port #config/env-int "COOK_NREPL_PORT"}
- :pools {:default "mesos-gamma"}
- :default-container-for-pool
- {"k8s-alpha" {:type "docker"
-               :docker {
-                        :image "python:3.5.9-stretch",
-                        :network "HOST"
-                        :force-pull-image false
-                        :parameters []}}
-  "k8s-gamma" {:type "docker"
-               :docker {
-                        :image "python:3.5.9-stretch",
-                        :network "HOST"
-                        :force-pull-image false
-                        :parameters []}}}
+ :pools {:default "mesos-gamma"
+         :job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
+                                   :pool-regex "^k8s-.+"}
+         :default-container-for-pool
+         [{:pool-regex "k8s-alpha" :container {:type "docker"
+                                               :docker {
+                                                        :image "python:3.6",
+                                                        :network "HOST"
+                                                        :force-pull-image false
+                                                        :parameters []}}}
+          {:pool-regex "k8s-gamma" :container {:type "docker"
+                                               :docker {
+                                                        :image "python:3.6",
+                                                        :network "HOST"
+                                                        :force-pull-image false
+                                                        :parameters []}}}]}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -66,8 +66,7 @@
                                    :pool-regex "^k8s-.+"}
          :default-containers
          [{:pool-regex "k8s-.*" :container {:type "docker"
-                                            :docker {
-                                                     :image "python:3.6",
+                                            :docker {:image "python:3.6",
                                                      :network "HOST"
                                                      :force-pull-image false
                                                      :parameters []}}}]}

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -62,6 +62,19 @@
  :nrepl {:enabled? true
          :port #config/env-int "COOK_NREPL_PORT"}
  :pools {:default "mesos-gamma"}
+ :default-container-for-pool
+ {"k8s-alpha" {:type "docker"
+               :docker {
+                        :image "python:3.5.9-stretch",
+                        :network "HOST"
+                        :force-pull-image false
+                        :parameters []}}
+  "k8s-gamma" {:type "docker"
+               :docker {
+                        :image "python:3.5.9-stretch",
+                        :network "HOST"
+                        :force-pull-image false
+                        :parameters []}}}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -76,19 +76,13 @@
  :pools {:default "k8s-gamma"
          :job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
                                    :pool-regex "^k8s-.+"}
-         :default-container-for-pool
-         [{:pool-regex "k8s-alpha" :container {:type "docker"
-                                               :docker {
-                                                        :image "python:3.5.9-stretch",
-                                                        :network "HOST"
-                                                        :force-pull-image false
-                                                        :parameters []}}}
-          {:pool-regex "k8s-gamma" :container {:type "docker"
-                                               :docker {
-                                                        :image "python:3.5.9-stretch",
-                                                        :network "HOST"
-                                                        :force-pull-image false
-                                                        :parameters []}}}]}
+         :default-containers
+         [{:pool-regex "k8s-.*" :container {:type "docker"
+                                            :docker {
+                                                     :image "python:3.5.9-stretch",
+                                                     :network "HOST"
+                                                     :force-pull-image false
+                                                     :parameters []}}}]}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -78,7 +78,7 @@
                                    :pool-regex "^k8s-.+"}
          :default-containers
          [{:pool-regex "k8s-.*" :container {:type "docker"
-                                            :docker {:image "python:3.5.9-stretch",
+                                            :docker {:image "python:3.6",
                                                      :network "HOST"
                                                      :force-pull-image false
                                                      :parameters []}}}]}

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -78,8 +78,7 @@
                                    :pool-regex "^k8s-.+"}
          :default-containers
          [{:pool-regex "k8s-.*" :container {:type "docker"
-                                            :docker {
-                                                     :image "python:3.5.9-stretch",
+                                            :docker {:image "python:3.5.9-stretch",
                                                      :network "HOST"
                                                      :force-pull-image false
                                                      :parameters []}}}]}

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -76,6 +76,19 @@
  :pools {:default "k8s-gamma"
          :job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
                                    :pool-regex "^k8s-.+"}}
+ :default-container-for-pool
+ {"k8s-alpha" {:type "docker"
+               :docker {
+                        :image "python:3.5.9-stretch",
+                        :network "HOST"
+                        :force-pull-image false
+                        :parameters []}}
+  "k8s-gamma" {:type "docker"
+               :docker {
+                        :image "python:3.5.9-stretch",
+                        :network "HOST"
+                        :force-pull-image false
+                        :parameters []}}}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -75,20 +75,20 @@
          :port #config/env-int "COOK_NREPL_PORT"}
  :pools {:default "k8s-gamma"
          :job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
-                                   :pool-regex "^k8s-.+"}}
- :default-container-for-pool
- {"k8s-alpha" {:type "docker"
-               :docker {
-                        :image "python:3.5.9-stretch",
-                        :network "HOST"
-                        :force-pull-image false
-                        :parameters []}}
-  "k8s-gamma" {:type "docker"
-               :docker {
-                        :image "python:3.5.9-stretch",
-                        :network "HOST"
-                        :force-pull-image false
-                        :parameters []}}}
+                                   :pool-regex "^k8s-.+"}
+         :default-container-for-pool
+         [{:pool-regex "k8s-alpha" :container {:type "docker"
+                                               :docker {
+                                                        :image "python:3.5.9-stretch",
+                                                        :network "HOST"
+                                                        :force-pull-image false
+                                                        :parameters []}}}
+          {:pool-regex "k8s-gamma" :container {:type "docker"
+                                               :docker {
+                                                        :image "python:3.5.9-stretch",
+                                                        :network "HOST"
+                                                        :force-pull-image false
+                                                        :parameters []}}}]}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -412,6 +412,8 @@
 
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
+     :default-container-for-pool (fnk [[:config {default-container-for-pool {}}]]
+                                   default-container-for-pool)
      :estimated-completion-constraint (fnk [[:config {estimated-completion-constraint nil}]]
                                         (merge {:agent-start-grace-period-mins 10}
                                                estimated-completion-constraint))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -402,18 +402,16 @@
                        (when (zero? port)
                          (throw (ex-info "You enabled nrepl but didn't configure a port. Please configure a port in your config file." {})))
                        ((util/lazy-load-var 'clojure.tools.nrepl.server/start-server) :port port)))
-
      :pools (fnk [[:config {pools nil}]]
               (cond-> pools
                 (:job-resource-adjustment pools)
                 (update :job-resource-adjustment
                         #(-> %
-                           (update :pool-regex re-pattern)))))
-
+                             (update :pool-regex re-pattern)))
+                (not (:default-container-for-pool pools))
+                (assoc :default-container-for-pool [])))
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
-     :default-container-for-pool (fnk [[:config {default-container-for-pool {}}]]
-                                   default-container-for-pool)
      :estimated-completion-constraint (fnk [[:config {estimated-completion-constraint nil}]]
                                         (merge {:agent-start-grace-period-mins 10}
                                                estimated-completion-constraint))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -408,8 +408,8 @@
                 (update :job-resource-adjustment
                         #(-> %
                              (update :pool-regex re-pattern)))
-                (not (:default-container-for-pool pools))
-                (assoc :default-container-for-pool [])))
+                (not (:default-containers pools))
+                (assoc :default-containers [])))
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
      :estimated-completion-constraint (fnk [[:config {estimated-completion-constraint nil}]]

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -679,10 +679,10 @@
        :dataset.partition/end (coerce-date (partition "end"))}
       :default (throw (IllegalArgumentException. (str "Unsupported partition type " partition-type))))))
 
-(defn match-default-container-for-pool
+(defn get-default-container-for-pool
   "Given a pool name, determine a default container that should be run on it."
-  [default-container-for-pool effective-pool-name]
-  (->> default-container-for-pool
+  [default-containers effective-pool-name]
+  (->> default-containers
        (filter (fn [{:keys [pool-regex]}] (re-find (re-pattern pool-regex) effective-pool-name)))
        first
        :container))
@@ -739,11 +739,11 @@
                                   :constraint/pattern pattern}]))
                             constraints)
         pool-name (or (:pool/name pool) (config/default-pool))
-        default-container-for-pool (get-in config/config [:settings :pools :default-container-for-pool])
+        default-containers (get-in config/config [:settings :pools :default-containers])
         container (if (nil? container)
-                    (let [guessed-container (match-default-container-for-pool default-container-for-pool pool-name)]
-                      (if (and pool-name guessed-container)
-                        (build-container user db-id guessed-container)
+                    (let [default-container (get-default-container-for-pool default-containers pool-name)]
+                      (if (and pool-name default-container)
+                        (build-container user db-id default-container)
                         []))
                     (build-container user db-id container))
         executor (str->executor-enum executor)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -687,7 +687,7 @@
        first
        :container))
 
-  (s/defn make-job-txn
+(s/defn make-job-txn
   "Creates the necessary txn data to insert a job into the database"
   [pool commit-latch-id db job :- Job]
   (let [{:keys [uuid command max-retries max-runtime expected-runtime priority cpus mem gpus

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -741,10 +741,11 @@
         pool-name (or (:pool/name pool) (config/default-pool))
         default-containers (get-in config/config [:settings :pools :default-containers])
         container (if (nil? container)
-                    (let [default-container (get-default-container-for-pool default-containers pool-name)]
-                      (if (and pool-name default-container)
+                    (if pool-name
+                      (if-let [default-container (get-default-container-for-pool default-containers pool-name)]
                         (build-container user db-id default-container)
-                        []))
+                        [])
+                      [])
                     (build-container user db-id container))
         executor (str->executor-enum executor)
         ;; These are optionally set datoms w/ default values

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -730,7 +730,13 @@
                                                                 (str/lower-case operator))
                                   :constraint/pattern pattern}]))
                             constraints)
-        container (if (nil? container) [] (build-container user db-id container))
+        guessed-pool (or (:pool/name pool) (config/default-pool))
+        default-container-for-pool (get-in config/config [:settings :default-container-for-pool guessed-pool])
+        container (if (nil? container)
+                    (if (and guessed-pool default-container-for-pool)
+                      (build-container user db-id default-container-for-pool)
+                      [])
+                    (build-container user db-id container))
         executor (str->executor-enum executor)
         ;; These are optionally set datoms w/ default values
         maybe-datoms (reduce into

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2316,12 +2316,12 @@
   (is (not (api/valid-date-str? "2018-01-01")))
   (is (not (api/valid-date-str? "20180132"))))
 
-(deftest test-match-default-container-for-pool
-  (let [default-container-for-pool
+(deftest test-match-default-containers
+  (let [default-containers
         [{:pool-regex "^foo$" :container {:foo 1}}
          {:pool-regex ".*" :container {:bar 2}}
          {:pool-regex "^baz$" :container {:baz 3}}]]
-    (is (api/match-default-container-for-pool default-container-for-pool "foo") {:foo 1})
-    (is (api/match-default-container-for-pool default-container-for-pool "bar") {:bar 2})
-    (is (api/match-default-container-for-pool default-container-for-pool "baz") {:bar 2}))
-  (is (= (api/match-default-container-for-pool [] "foo") nil)))
+    (is (api/get-default-container-for-pool default-containers "foo") {:foo 1})
+    (is (api/get-default-container-for-pool default-containers "bar") {:bar 2})
+    (is (api/get-default-container-for-pool default-containers "baz") {:bar 2}))
+  (is (= (api/get-default-container-for-pool [] "foo") nil)))

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2315,3 +2315,13 @@
   (is (api/valid-date-str? "20180101"))
   (is (not (api/valid-date-str? "2018-01-01")))
   (is (not (api/valid-date-str? "20180132"))))
+
+(deftest test-match-default-container-for-pool
+  (let [default-container-for-pool
+        [{:pool-regex "^foo$" :container {:foo 1}}
+         {:pool-regex ".*" :container {:bar 2}}
+         {:pool-regex "^baz$" :container {:baz 3}}]]
+    (is (api/match-default-container-for-pool default-container-for-pool "foo") {:foo 1})
+    (is (api/match-default-container-for-pool default-container-for-pool "bar") {:bar 2})
+    (is (api/match-default-container-for-pool default-container-for-pool "baz") {:bar 2}))
+  (is (= (api/match-default-container-for-pool [] "foo") nil)))

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2321,7 +2321,7 @@
         [{:pool-regex "^foo$" :container {:foo 1}}
          {:pool-regex ".*" :container {:bar 2}}
          {:pool-regex "^baz$" :container {:baz 3}}]]
-    (is (api/get-default-container-for-pool default-containers "foo") {:foo 1})
-    (is (api/get-default-container-for-pool default-containers "bar") {:bar 2})
-    (is (api/get-default-container-for-pool default-containers "baz") {:bar 2}))
+    (is (= (api/get-default-container-for-pool default-containers "foo") {:foo 1}))
+    (is (= (api/get-default-container-for-pool default-containers "bar") {:bar 2}))
+    (is (= (api/get-default-container-for-pool default-containers "baz") {:bar 2})))
   (is (= (api/get-default-container-for-pool [] "foo") nil)))


### PR DESCRIPTION
## Changes proposed in this PR

- Support for specifying the default container on a per-pool basis.

## Why are we making these changes?

User convenience. We can specify a default docker image that works for the majority of cases.
