### PR TITLE
Makes synthetic pod anti-affinity use AND across requirements

### DIFF
--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -224,7 +224,7 @@
                   .getNodeAffinity
                   .getRequiredDuringSchedulingIgnoredDuringExecution
                   .getNodeSelectorTerms)]
-          (is (= 2 (count node-selector-terms)))
+          (is (= 1 (count node-selector-terms)))
           (let [node-selector-requirement
                 (->> node-selector-terms
                      (filter #(-> % .getMatchExpressions first .getKey (= "unhealthy-node")))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -227,17 +227,17 @@
           (is (= 1 (count node-selector-terms)))
           (let [node-selector-requirement
                 (->> node-selector-terms
-                     (filter #(-> % .getMatchExpressions first .getKey (= "unhealthy-node")))
                      first
                      .getMatchExpressions
+                     (filter #(-> % .getKey (= "unhealthy-node")))
                      first)]
             (is (= "unhealthy-node" (.getKey node-selector-requirement)))
             (is (= "DoesNotExist" (.getOperator node-selector-requirement))))
           (let [node-selector-requirement
                 (->> node-selector-terms
-                     (filter #(-> % .getMatchExpressions first .getKey (= "unready-node")))
                      first
                      .getMatchExpressions
+                     (filter #(-> % .getKey (= "unready-node")))
                      first)]
             (is (= "unready-node" (.getKey node-selector-requirement)))
             (is (= "DoesNotExist" (.getOperator node-selector-requirement)))))))))


### PR DESCRIPTION
This is bug-fix followup from PR #1483.

## Changes proposed in this PR

- instead of defining multiple `NodeSelectorTerm`s (one for reach requirement), put them all into a single `NodeSelectorTerm`

## Why are we making these changes?

https://github.com/kubernetes/kubernetes/pull/70394#issuecomment-434127780

The terms have OR semantics between them. We want AND semantics, so that e.g. all blocklist labels are removed before the synthetic pod will run.
