### PR TITLE
CLI: fix broken unit tests and warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,13 @@ matrix:
   fast_finish: true
 
   include:
-    - name: 'Cook Scheduler and JobClient unit tests'
-      before_script: cd scheduler && ./travis/setup.sh
+    - name: 'Cook Scheduler, CLI, and JobClient unit tests'
+      before_script:
+        - ./cli/travis/setup.sh
+        - cd scheduler && ./travis/setup.sh
       script:
         - pushd ../jobclient && mvn test
+        - popd && pushd ../cli && python -m pytest
         - popd && lein with-profile +test test :all-but-benchmark
 
     - name: 'Cook Scheduler integration tests with Cook Executor and Docker'

--- a/cli/cook/dateparser.py
+++ b/cli/cook/dateparser.py
@@ -2,11 +2,11 @@ import datetime
 import logging
 
 PATTERN_TO_TIMEDELTA_FN = (
-    ('^(\d+) sec(?:ond)?s? ago$', lambda x: datetime.timedelta(seconds=x)),
-    ('^(\d+) min(?:ute)?s? ago$', lambda x: datetime.timedelta(minutes=x)),
-    ('^(\d+) hours? ago$', lambda x: datetime.timedelta(hours=x)),
-    ('^(\d+) days? ago$', lambda x: datetime.timedelta(days=x)),
-    ('^(\d+) weeks? ago$', lambda x: datetime.timedelta(weeks=x))
+    (r'^(\d+) sec(?:ond)?s? ago$', lambda x: datetime.timedelta(seconds=x)),
+    (r'^(\d+) min(?:ute)?s? ago$', lambda x: datetime.timedelta(minutes=x)),
+    (r'^(\d+) hours? ago$', lambda x: datetime.timedelta(hours=x)),
+    (r'^(\d+) days? ago$', lambda x: datetime.timedelta(days=x)),
+    (r'^(\d+) weeks? ago$', lambda x: datetime.timedelta(weeks=x))
 )
 
 

--- a/cli/cook/http.py
+++ b/cli/cook/http.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 import requests
 
-import cook
+import cook.version
 from cook.util import print_error
 
 session = None

--- a/cli/pytest.ini
+++ b/cli/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    cli: Cook CLI tests

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -18,7 +18,7 @@ requirements = [
 
 test_requirements = [
     'freezegun',
-    'nose',
+    'pytest',
     'requests-mock'
 ]
 

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -19,7 +19,7 @@ requirements = [
 test_requirements = [
     'freezegun',
     'pytest',
-    'requests-mock'
+    'requests-mock',
 ]
 
 setup(

--- a/cli/tests/subcommands/test_dateparser.py
+++ b/cli/tests/subcommands/test_dateparser.py
@@ -2,15 +2,15 @@ import datetime
 import logging
 import unittest
 
+import pytest
 import pytz
 from dateutil.tz import tzlocal, tz
 from freezegun import freeze_time
-from nose.plugins.attrib import attr
 
 from cook import dateparser
 
 
-@attr(cli=True)
+@pytest.mark.cli
 class CookCliTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 

--- a/cli/tests/subcommands/test_querying.py
+++ b/cli/tests/subcommands/test_querying.py
@@ -2,14 +2,14 @@ import logging
 import unittest
 import uuid
 
+import pytest
 import requests_mock
 from cook import http
-from nose.plugins.attrib import attr
 
-from cook.subcommands.show import query_cluster, make_job_request
+from cook.querying import query_cluster, make_job_request
 
 
-@attr(cli=True)
+@pytest.mark.cli
 class CookCliTest(unittest.TestCase):
     _multiprocess_can_split_ = True
 

--- a/cli/travis/setup.sh
+++ b/cli/travis/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cli_dir="$(dirname "$( dirname "${BASH_SOURCE[0]}" )" )"
+cd "$cli_dir"
+
+# Don't use --user in virtualenv
+if [[ "$(pip -V)" != *${HOME}* ]]; then
+    pip_flags=--user
+else
+    pip_flags=
+fi
+
+# Parse dependencies from setup.py
+dependencies="$(sed -nE "s/^\s+'([-_a-z]+)',$/\1/p" < setup.py)"
+
+pip install $pip_flags $dependencies


### PR DESCRIPTION
## Changes proposed in this PR

- Switched to pytest to get rid of warnings from nose
- Changed strings to raw strings in dateparser module to fix warnings about `\d` escape sequence
- Moved "show" tests to "querying" since the command it was checking lives in that module now
- Include CLI tests in the Travis unit tests job

## Why are we making these changes?

We want to run our `dateparser` unit tests to work without errors or warnings.