### PR TITLE
Remove dependency on docker apt to build Cook image

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -1,7 +1,10 @@
 FROM mesosphere/mesos:1.3.0
 
 
-RUN apt-get -y update && apt-get -y install software-properties-common && \ 
+# Removing docker.list because docker APT repo has been deleted:
+# https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/
+RUN rm /etc/apt/sources.list.d/docker.list && \
+    apt-get -y update && apt-get -y install software-properties-common && \
     add-apt-repository ppa:openjdk-r/ppa && apt-get -y update && \
     apt-get --no-install-recommends -y install \
     curl \


### PR DESCRIPTION
## Changes proposed in this PR

Remove dependency on docker apt to build Cook image

## Why are we making these changes?

The Docker APT repo has been deleted. The current version hits the following URL when trying to do an `apt update`, and it returns the following error message.

https://apt.dockerproject.org/repo/dists/ubuntu-trusty/main/binary-amd64/Packages

>**Notice: Shutting down dockerproject.org APT and YUM repos 2020-03-31**
>
>Docker will be shutting down the deprecated APT and YUM repositories hosted at  "dockerproject.org" and "dockerproject.com" on the 31st of March 2020.
>
>We noticed that this project is referencing one of these repositories, and recommend updating to use the "download.docker.com" repository to prevent disruption.
>
>More info: https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/