### PR TITLE
Make k8s sidecar readiness probe optional

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -52,6 +52,7 @@
               :sidecar {;; Note that Cook automatically appends the :port given below 
                         ;; as the last argument in this :command vector.
                         :command ["cook-sidecar" "--file-server-port"]
+                        :health-check-endpoint "/readiness-probe"
                         :image "twosigma/cook-sidecar:latest"
                         :port 23906
                         :resource-requirements {:cpu-request 0.1

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -284,8 +284,11 @@
           pod-ip (-> pod .getStatus .getPodIP)
           {:keys [default-workdir pod-ip->hostname-fn sidecar]} (config/kubernetes)
           sandbox-fileserver-port (:port sidecar)
+          sandbox-health-check-endpoint (:health-check-endpoint sidecar)
           sandbox-url (try
-                        (when (and sandbox-fileserver-port (not (str/blank? pod-ip)))
+                        (when (and sandbox-fileserver-port
+                                   sandbox-health-check-endpoint
+                                   (not (str/blank? pod-ip)))
                           (str "http://"
                                ((get-pod-ip->hostname-fn pod-ip->hostname-fn) pod-ip)
                                ":" sandbox-fileserver-port


### PR DESCRIPTION
## Changes proposed in this PR

- The readiness probe endpoint is now configurable and optional.
- When the option is omitted, we don't set an explicit readiness probe.

## Why are we making these changes?

If the file-server is disabled, then the http readiness probe breaks, and the sidecar container is never considered ready. This can cause a lot of error-noise when looking at pod statuses across a cook k8s cluster.