### PR TITLE
Require dateutil v2.8.1 for CLI tests

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -8,7 +8,7 @@ requirements = [
     'arrow',
     'blessed',
     'humanfriendly',
-    'python-dateutil',
+    'python-dateutil>=2.8.1',
     'pytz',
     'requests',
     'tabulate',

--- a/cli/travis/setup.sh
+++ b/cli/travis/setup.sh
@@ -11,6 +11,6 @@ else
 fi
 
 # Parse dependencies from setup.py
-dependencies="$(sed -nE "s/^\s+'([-_a-z]+)',$/\1/p" < setup.py)"
+dependencies="$(sed -nE "s/^\\s+'([^']+)',\$/\\1/p" < setup.py)"
 
 pip install $pip_flags $dependencies

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -8,7 +8,7 @@ pip==9.0.1; python_version >= '3.6'
 pytest==5.2.0
 pytest-timeout==1.3.3
 pytest-xdist==1.30.0
-python-dateutil==2.6.1
+python-dateutil==2.8.1
 requests==2.20.0
 retrying==1.3.3
 file:../cli#egg=cook_client


### PR DESCRIPTION
## Changes proposed in this PR

- Update our python-dateutil dependency to latest stable (2.8.1).
- Update the pattern for CLI test dependencies to allow versions (not just names).

## Why are we making these changes?

The CLI unit tests rely on an attribute introduced in v2.7.0, but our integration tests were explicitly pulling an old version, and that was causing problems because the Python dependencies are cached across multiple jobs.