### PR TITLE
Removes blocklisted node anti-affinity

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -662,8 +662,7 @@
       ; from happening. We want this pod to preempt lower priority pods
       ; (e.g. synthetic pods).
       (add-node-selector pod-spec k8s-hostname-label hostname)
-      (when (or (seq pod-hostnames-to-avoid)
-                (seq compute-cluster-node-blocklist-labels))
+      (when (seq pod-hostnames-to-avoid)
         ; Use node "anti"-affinity to disallow scheduling on nodes with particular labels
         ; (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity)
         (let [affinity (V1Affinity.)
@@ -680,15 +679,15 @@
               (.addMatchExpressionsItem node-selector-term node-selector-requirement-k8s-hostname-label)))
 
           ; Disallow scheduling on nodes with blocklist labels (if any)
-          (when (seq compute-cluster-node-blocklist-labels)
-            (run!
-              (fn add-node-selector-term-for-blocklist-label
-                [node-blocklist-label]
-                (let [node-selector-requirement-blocklist-label (V1NodeSelectorRequirement.)]
-                  (.setKey node-selector-requirement-blocklist-label node-blocklist-label)
-                  (.setOperator node-selector-requirement-blocklist-label "DoesNotExist")
-                  (.addMatchExpressionsItem node-selector-term node-selector-requirement-blocklist-label)))
-              compute-cluster-node-blocklist-labels))
+          ;(when (seq compute-cluster-node-blocklist-labels)
+          ;  (run!
+          ;    (fn add-node-selector-term-for-blocklist-label
+          ;      [node-blocklist-label]
+          ;      (let [node-selector-requirement-blocklist-label (V1NodeSelectorRequirement.)]
+          ;        (.setKey node-selector-requirement-blocklist-label node-blocklist-label)
+          ;        (.setOperator node-selector-requirement-blocklist-label "DoesNotExist")
+          ;        (.addMatchExpressionsItem node-selector-term node-selector-requirement-blocklist-label)))
+          ;    compute-cluster-node-blocklist-labels))
 
           (.addNodeSelectorTermsItem node-selector node-selector-term)
           (.setRequiredDuringSchedulingIgnoredDuringExecution node-affinity node-selector)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -671,23 +671,11 @@
               node-selector-term (V1NodeSelectorTerm.)]
 
           ; Disallow scheduling on hostnames we're being told to avoid (if any)
-          (when (seq pod-hostnames-to-avoid)
-            (let [node-selector-requirement-k8s-hostname-label (V1NodeSelectorRequirement.)]
-              (.setKey node-selector-requirement-k8s-hostname-label k8s-hostname-label)
-              (.setOperator node-selector-requirement-k8s-hostname-label "NotIn")
-              (run! #(.addValuesItem node-selector-requirement-k8s-hostname-label %) pod-hostnames-to-avoid)
-              (.addMatchExpressionsItem node-selector-term node-selector-requirement-k8s-hostname-label)))
-
-          ; Disallow scheduling on nodes with blocklist labels (if any)
-          ;(when (seq compute-cluster-node-blocklist-labels)
-          ;  (run!
-          ;    (fn add-node-selector-term-for-blocklist-label
-          ;      [node-blocklist-label]
-          ;      (let [node-selector-requirement-blocklist-label (V1NodeSelectorRequirement.)]
-          ;        (.setKey node-selector-requirement-blocklist-label node-blocklist-label)
-          ;        (.setOperator node-selector-requirement-blocklist-label "DoesNotExist")
-          ;        (.addMatchExpressionsItem node-selector-term node-selector-requirement-blocklist-label)))
-          ;    compute-cluster-node-blocklist-labels))
+          (let [node-selector-requirement-k8s-hostname-label (V1NodeSelectorRequirement.)]
+            (.setKey node-selector-requirement-k8s-hostname-label k8s-hostname-label)
+            (.setOperator node-selector-requirement-k8s-hostname-label "NotIn")
+            (run! #(.addValuesItem node-selector-requirement-k8s-hostname-label %) pod-hostnames-to-avoid)
+            (.addMatchExpressionsItem node-selector-term node-selector-requirement-k8s-hostname-label))
 
           (.addNodeSelectorTermsItem node-selector node-selector-term)
           (.setRequiredDuringSchedulingIgnoredDuringExecution node-affinity node-selector)

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -202,42 +202,4 @@
                   first)]
           (is (= api/k8s-hostname-label (.getKey node-selector-requirement)))
           (is (= "NotIn" (.getOperator node-selector-requirement)))
-          (is (= ["test-host-1" "test-host-2"] (.getValues node-selector-requirement))))))
-
-    (testing "synthetic pods avoid node blocklist labels"
-      (let [job-uuid-1 (str (UUID/randomUUID))
-            pool-name "test-pool"
-            compute-cluster (tu/make-kubernetes-compute-cluster {} #{pool-name} nil ["unhealthy-node" "unready-node"])
-            pending-jobs [(make-job-fn job-uuid-1 "user-1")]
-            launched-pods-atom (atom [])]
-        (with-redefs [api/launch-pod (fn [_ _ cook-expected-state-dict _]
-                                       (swap! launched-pods-atom conj cook-expected-state-dict))]
-          (cc/autoscale! compute-cluster pool-name pending-jobs))
-        (is (= 1 (count @launched-pods-atom)))
-        (let [node-selector-terms
-              (-> @launched-pods-atom
-                  (nth 0)
-                  :launch-pod
-                  :pod
-                  .getSpec
-                  .getAffinity
-                  .getNodeAffinity
-                  .getRequiredDuringSchedulingIgnoredDuringExecution
-                  .getNodeSelectorTerms)]
-          (is (= 1 (count node-selector-terms)))
-          (let [node-selector-requirement
-                (->> node-selector-terms
-                     first
-                     .getMatchExpressions
-                     (filter #(-> % .getKey (= "unhealthy-node")))
-                     first)]
-            (is (= "unhealthy-node" (.getKey node-selector-requirement)))
-            (is (= "DoesNotExist" (.getOperator node-selector-requirement))))
-          (let [node-selector-requirement
-                (->> node-selector-terms
-                     first
-                     .getMatchExpressions
-                     (filter #(-> % .getKey (= "unready-node")))
-                     first)]
-            (is (= "unready-node" (.getKey node-selector-requirement)))
-            (is (= "DoesNotExist" (.getOperator node-selector-requirement)))))))))
+          (is (= ["test-host-1" "test-host-2"] (.getValues node-selector-requirement))))))))


### PR DESCRIPTION
## Changes proposed in this PR

- deleting the code introduced in PRs #1483 and #1493 that adds on synthetic pods node anti-affinity to nodes with blocklist labels 

## Why are we making these changes?

This is not interacting with the Cluster Autoscaler in the way we expected it would.
