### PR TITLE
Make cli integration adapters module configurable

### DIFF
--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -198,8 +198,9 @@ class temp_config_file:
 
     def __init__(self, config):
         session_module = os.getenv('COOK_SESSION_MODULE')
+        adapters_module = os.getenv('COOK_ADAPTERS_MODULE', session_module)
         if session_module:
-            self.config = {'http': {'modules': {'session-module': session_module, 'adapters-module': session_module}}}
+            self.config = {'http': {'modules': {'session-module': session_module, 'adapters-module': adapters_module}}}
             self.config.update(config)
         else:
             self.config = config


### PR DESCRIPTION
## Changes proposed in this PR

Add environment variable for configuring adapters module for the CLI integration tests.

## Why are we making these changes?

We shouldn't assume that the sessions module and the adapters module are the same.