### PR TITLE
set main container envs on init container

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -647,7 +647,7 @@
           (.setImage container image)
           (.setCommand container command)
           (.setWorkingDir container init-container-workdir)
-
+          (.setEnv container main-env-vars)
           (.setVolumeMounts container [(init-container-workdir-volume-mount-fn false)
                                        (scratch-space-volume-mount-fn false)])
           (.addInitContainersItem pod-spec container))))


### PR DESCRIPTION
## Changes proposed in this PR

- set main container envs on init container

## Why are we making these changes?

The init container needs to be able to adjust what it does based on the main container configuration
