### PR TITLE
Gracefully handles missing pod in k8s task scanning

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -546,9 +546,8 @@
 (defn synthesize-state-and-process-pod-if-changed
   "Synthesizes the k8s-actual-state for the given
   pod and calls process if the state changed."
-  [{:keys [k8s-actual-state-map name] :as compute-cluster} ^V1Pod pod]
-  (let [pod-name (api/V1Pod->name pod)
-        new-state {:pod pod
+  [{:keys [k8s-actual-state-map name] :as compute-cluster} pod-name ^V1Pod pod]
+  (let [new-state {:pod pod
                    :synthesized-state (api/pod->synthesized-pod-state pod)
                    :sandbox-file-server-container-state (api/pod->sandbox-file-server-container-state pod)}
         old-state (get @k8s-actual-state-map pod-name)]
@@ -573,7 +572,7 @@
       (timers/time!
         (metrics/timer "process-lock" name)
         (locking (calculate-lock pod-name)
-          (synthesize-state-and-process-pod-if-changed compute-cluster new-pod))))))
+          (synthesize-state-and-process-pod-if-changed compute-cluster pod-name new-pod))))))
 
 (defn pod-deleted
   "Indicate that kubernetes does not have the pod. Invoked by callbacks from kubernetes."
@@ -626,4 +625,4 @@
       (metrics/timer "process-lock" name)
       (locking (calculate-lock pod-name)
         (let [{:keys [pod]} (get @k8s-actual-state-map pod-name)]
-          (synthesize-state-and-process-pod-if-changed compute-cluster pod))))))
+          (synthesize-state-and-process-pod-if-changed compute-cluster pod-name pod))))))

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -211,3 +211,18 @@
                     controller/write-status-to-datomic (fn [_ status] (reset! reason (:reason status)))]
         (controller/handle-pod-completed nil "podB" {:pod pod :synthesized-state {:state :pod/failed}})
         (is (= :reason-task-unknown @reason))))))
+
+(deftest test-synthesize-state-and-process-pod-if-changed
+  (testing "gracefully handles nil pod"
+    (let [compute-cluster {:k8s-actual-state-map (atom {})
+                           :cook-expected-state-map (atom {})}
+          pod-name "test-pod"
+          pod nil]
+      (controller/synthesize-state-and-process-pod-if-changed compute-cluster pod-name pod))))
+
+(deftest test-scan-process
+  (testing "gracefully handles nil pod"
+    (let [compute-cluster {:k8s-actual-state-map (atom {})
+                           :cook-expected-state-map (atom {})}
+          pod-name "test-pod"]
+      (controller/scan-process compute-cluster pod-name))))


### PR DESCRIPTION
This is a bug-fix follow-up to PR #1489.

## Changes proposed in this PR

- in `synthesize-state-and-process-pod-if-changed`, allowing the pod to be `nil` (meaning that it doesn't currently exist in k8s) instead of throwing a NPE

## Why are we making these changes?

To avoid this NPE when the pod doesn't exist in k8s during task scanning:

```
java.lang.NullPointerException: null
 at cook.kubernetes.api$V1Pod__GT_name.invokeStatic (api.clj:766)
    cook.kubernetes.api$V1Pod__GT_name.invoke (api.clj:763)
    cook.kubernetes.controller$synthesize_state_and_process_pod_if_changed.invokeStatic (controller.clj:550)
    cook.kubernetes.controller$synthesize_state_and_process_pod_if_changed.invoke (controller.clj:546)
    cook.kubernetes.controller$scan_process$fn__37882$fn__37883.invoke (controller.clj:629)
    cook.kubernetes.controller.proxy$java.lang.Object$Callable$7da976d4.call (:-1)
    com.codahale.metrics.Timer.time (Timer.java:99)
    cook.kubernetes.controller$scan_process$fn__37882.invoke (controller.clj:625)
    cook.kubernetes.controller.proxy$java.lang.Object$Callable$7da976d4.call (:-1)
    com.codahale.metrics.Timer.time (Timer.java:99)
    cook.kubernetes.controller$scan_process.invokeStatic (controller.clj:623)
    cook.kubernetes.controller$scan_process.invoke (controller.clj:619)
    cook.test.kubernetes.controller$fn__38180.invokeStatic (controller.clj:228)
    cook.test.kubernetes.controller/fn (controller.clj:223)
...
```