### PR TITLE
Don't connect to kubernetes on finished instance

### DIFF
--- a/cli/cook/mesos.py
+++ b/cli/cook/mesos.py
@@ -63,8 +63,9 @@ def retrieve_instance_sandbox_directory(instance, job):
     return directories[0]
 
 
-def read_file(instance, sandbox_dir, path, offset=None, length=None):
+def read_file(instance, sandbox_dir_fn, path, offset=None, length=None):
     """Calls the Mesos agent files/read API for the given path, offset, and length"""
+    sandbox_dir = sandbox_dir_fn()
     logging.info(f'reading file from sandbox {sandbox_dir} with path {path} at offset {offset} and length {length}')
     agent_url = instance_to_agent_url(instance)
     params = {'path': os.path.join(sandbox_dir, path)}
@@ -84,8 +85,9 @@ def read_file(instance, sandbox_dir, path, offset=None, length=None):
     return resp.json()
 
 
-def download_file(instance, sandbox_dir, path):
+def download_file(instance, sandbox_dir_fn, path):
     """Calls the Mesos agent files/download API for the given path"""
+    sandbox_dir = sandbox_dir_fn()
     logging.info(f'downloading file from sandbox {sandbox_dir} with path {path}')
     agent_url = instance_to_agent_url(instance)
     params = {'path': os.path.join(sandbox_dir, path)}

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -35,7 +35,7 @@ def cat_for_instance(instance, sandbox_dir_fn, cluster, path):
     compute_cluster = instance["compute-cluster"]
     compute_cluster_type = compute_cluster["type"]
     compute_cluster_name = compute_cluster["name"]
-    if compute_cluster_type == "kubernetes":
+    if compute_cluster_type == "kubernetes" and ("end_time" not in instance or instance["end_time"] is None):
         kubectl_cat_instance_file_fn = plugins.get_fn('kubectl-cat-for-instance', kubectl_cat_instance_file)
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_cat_instance_file_fn(instance["task_id"], compute_cluster_config, path)

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -9,9 +9,9 @@ from cook.mesos import download_file
 from cook.querying import get_compute_cluster_config, parse_entity_refs, query_unique_and_run, parse_entity_ref
 from cook.util import guard_no_cluster
 
-def cat_using_download_file(instance, sandbox_dir, path):
+def cat_using_download_file(instance, sandbox_dir_fn, path):
     retrieve_fn = plugins.get_fn('download-job-instance-file', download_file)
-    download = retrieve_fn(instance, sandbox_dir, path)
+    download = retrieve_fn(instance, sandbox_dir_fn, path)
     try:
         for data in download(chunk_size=4096):
             if data:
@@ -40,7 +40,7 @@ def cat_for_instance(instance, sandbox_dir_fn, cluster, path):
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_cat_instance_file_fn(instance["task_id"], compute_cluster_config, path)
     else:
-        cat_using_download_file(instance, sandbox_dir_fn(), path)
+        cat_using_download_file(instance, sandbox_dir_fn, path)
 
 
 def cat(clusters, args, _):

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -75,8 +75,9 @@ def browse_files(instance, sandbox_dir, path):
     return resp.json()
 
 
-def retrieve_entries_from_mesos(instance, sandbox_dir, path):
+def retrieve_entries_from_mesos(instance, sandbox_dir_fn, path):
     """Retrieves the contents of the Mesos sandbox path for the given instance"""
+    sandbox_dir = sandbox_dir_fn()
     entries = browse_files(instance, sandbox_dir, path)
     if len(entries) == 0 and path:
         # Mesos will return 200 with an empty list in two cases:
@@ -90,9 +91,9 @@ def retrieve_entries_from_mesos(instance, sandbox_dir, path):
 
     return entries
 
-def ls_for_instance_from_mesos(instance, sandbox_dir, path, long_format, as_json):
+def ls_for_instance_from_mesos(instance, sandbox_dir_fn, path, long_format, as_json):
     retrieve_fn = plugins.get_fn('retrieve-job-instance-files', retrieve_entries_from_mesos)
-    entries = retrieve_fn(instance, sandbox_dir, path)
+    entries = retrieve_fn(instance, sandbox_dir_fn, path)
     if as_json:
         print(json.dumps(entries))
     else:
@@ -160,7 +161,7 @@ def ls_for_instance(instance, sandbox_dir_fn, cluster, path, long_format, as_jso
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_ls_for_instance_fn(instance["task_id"], compute_cluster_config, path, long_format, as_json)
     else:
-        ls_for_instance_from_mesos(instance, sandbox_dir_fn(), path, long_format, as_json)
+        ls_for_instance_from_mesos(instance, sandbox_dir_fn, path, long_format, as_json)
 
 
 def ls(clusters, args, _):

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -155,7 +155,7 @@ def ls_for_instance(instance, sandbox_dir_fn, cluster, path, long_format, as_jso
     compute_cluster = instance["compute-cluster"]
     compute_cluster_type = compute_cluster["type"]
     compute_cluster_name = compute_cluster["name"]
-    if compute_cluster_type == "kubernetes":
+    if compute_cluster_type == "kubernetes" and ("end_time" not in instance or instance["end_time"] is None):
         kubectl_ls_for_instance_fn = plugins.get_fn('kubectl-ls-for-instance', kubectl_ls_for_instance)
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_ls_for_instance_fn(instance["task_id"], compute_cluster_config, path, long_format, as_json)

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -105,9 +105,9 @@ def tail_follow(file_size, read_fn, follow_sleep_seconds):
 
         time.sleep(follow_sleep_seconds)
 
-def tail_using_read_file(instance, sandbox_dir, path, num_lines_to_print, follow, follow_sleep_seconds):
+def tail_using_read_file(instance, sandbox_dir_fn, path, num_lines_to_print, follow, follow_sleep_seconds):
     retrieve_fn = plugins.get_fn('read-job-instance-file', read_file)
-    read = partial(retrieve_fn, instance=instance, sandbox_dir=sandbox_dir, path=path)
+    read = partial(retrieve_fn, instance=instance, sandbox_dir_fn=sandbox_dir_fn, path=path)
     file_size = read()['offset']
     tail_backwards(file_size, read, num_lines_to_print)
     if follow:
@@ -139,7 +139,7 @@ def tail_for_instance(instance, sandbox_dir_fn, cluster, path, num_lines_to_prin
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_tail_instance_file_fn(instance["task_id"], compute_cluster_config, path, num_lines_to_print, follow)
     else:
-        tail_using_read_file(instance, sandbox_dir_fn(), path, num_lines_to_print, follow, follow_sleep_seconds)
+        tail_using_read_file(instance, sandbox_dir_fn, path, num_lines_to_print, follow, follow_sleep_seconds)
 
 
 def tail(clusters, args, _):

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -134,7 +134,7 @@ def tail_for_instance(instance, sandbox_dir_fn, cluster, path, num_lines_to_prin
     compute_cluster = instance["compute-cluster"]
     compute_cluster_type = compute_cluster["type"]
     compute_cluster_name = compute_cluster["name"]
-    if compute_cluster_type == "kubernetes":
+    if compute_cluster_type == "kubernetes" and ("end_time" not in instance or instance["end_time"] is None):
         kubectl_tail_instance_file_fn = plugins.get_fn('kubectl-tail-instance-file', kubectl_tail_instance_file)
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_tail_instance_file_fn(instance["task_id"], compute_cluster_config, path, num_lines_to_print, follow)


### PR DESCRIPTION
## Changes proposed in this PR

- don't connect to kubernetes on finished instance

## Why are we making these changes?

cs file commands like cat shouldn't try to connect to kubernetes when the instance has stopped running

