### PR TITLE
Allows removing cpu limit in k8s

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -447,7 +447,8 @@
                    (merge {:default-workdir "/mnt/sandbox"
                            :pod-condition-containers-not-initialized-seconds 120
                            :pod-condition-unschedulable-seconds 60
-                           :reconnect-delay-ms 60000}
+                           :reconnect-delay-ms 60000
+                           :set-container-cpu-limit? false}
                           kubernetes))}))
 
 (defn read-config

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -448,7 +448,7 @@
                            :pod-condition-containers-not-initialized-seconds 120
                            :pod-condition-unschedulable-seconds 60
                            :reconnect-delay-ms 60000
-                           :set-container-cpu-limit? false}
+                           :set-container-cpu-limit? true}
                           kubernetes))}))
 
 (defn read-config

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -624,8 +624,11 @@
 
     (.putRequestsItem resources "memory" (double->quantity (* memory-multiplier mem)))
     (.putLimitsItem resources "memory" (double->quantity (* memory-multiplier mem)))
-    ; We only set a request for cpu, and not a limit, in order to make this burstable
     (.putRequestsItem resources "cpu" (double->quantity cpus))
+    (when (:set-container-cpu-limit? (config/kubernetes))
+      ; Some environments may need pods to run in the "Guaranteed"
+      ; QoS, which requires limits for both memory and cpu
+      (.putLimitsItem resources "cpu" (double->quantity cpus)))
     (.setResources container resources)
     (.setVolumeMounts container (filterv some? (conj (concat volume-mounts checkpoint-volume-mounts)
                                                      (init-container-workdir-volume-mount-fn true)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -624,10 +624,8 @@
 
     (.putRequestsItem resources "memory" (double->quantity (* memory-multiplier mem)))
     (.putLimitsItem resources "memory" (double->quantity (* memory-multiplier mem)))
+    ; We only set a request for cpu, and not a limit, in order to make this burstable
     (.putRequestsItem resources "cpu" (double->quantity cpus))
-    ; We would like to make this burstable, but for various reasons currently need pods to run in the
-    ; "Guaranteed" QoS which requires limits for both memory and cpu.
-    (.putLimitsItem resources "cpu" (double->quantity cpus))
     (.setResources container resources)
     (.setVolumeMounts container (filterv some? (conj (concat volume-mounts checkpoint-volume-mounts)
                                                      (init-container-workdir-volume-mount-fn true)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -571,7 +571,8 @@
         sandbox-dir (:default-workdir (config/kubernetes))
         workdir (get-workdir parameters sandbox-dir)
         {:keys [volumes volume-mounts sandbox-volume-mount-fn]} (make-volumes volumes sandbox-dir)
-        {:keys [custom-shell init-container sidecar default-checkpoint-config]} (config/kubernetes)
+        {:keys [custom-shell default-checkpoint-config init-container set-container-cpu-limit? sidecar]}
+        (config/kubernetes)
         checkpoint (when checkpoint (merge default-checkpoint-config (util/job-ent->checkpoint job)))
         use-cook-init? (and init-container pod-supports-cook-init?)
         use-cook-sidecar? (and sidecar pod-supports-cook-sidecar?)
@@ -625,7 +626,7 @@
     (.putRequestsItem resources "memory" (double->quantity (* memory-multiplier mem)))
     (.putLimitsItem resources "memory" (double->quantity (* memory-multiplier mem)))
     (.putRequestsItem resources "cpu" (double->quantity cpus))
-    (when (:set-container-cpu-limit? (config/kubernetes))
+    (when set-container-cpu-limit?
       ; Some environments may need pods to run in the "Guaranteed"
       ; QoS, which requires limits for both memory and cpu
       (.putLimitsItem resources "cpu" (double->quantity cpus)))


### PR DESCRIPTION
## Changes proposed in this PR

- introducing config field `:set-container-cpu-limit?`, which defaults to `true` (for backwards compatibility)
- if set to `false`, we don't set the cpu limit on the job container

## Why are we making these changes?

To allow pods to get the [Burstable QoS](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-burstable).
