### PR TITLE
Improve integration test behavior when run single-process

### DIFF
--- a/integration/tests/cook/conftest.py
+++ b/integration/tests/cook/conftest.py
@@ -33,7 +33,7 @@ def _ssh_check(user):
     Check if the current user can ssh as a test user.
     This is necessary to obtain Kerberos auth headers for multi-user tests.
     """
-    hostname = socket.gethostname()
+    hostname = os.getenv('COOK_SWITCH_USER_SSH_HOST', socket.gethostname())
     logging.info(f'Checking ssh as {user} to {hostname}')
     ssh_ok = (0 == subprocess.call(f'ssh {user}@{hostname} echo SSH', shell=True))
     assert ssh_ok, f'Unable to ssh as {user} to {hostname}'

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1210,6 +1210,9 @@ def user_current_usage(cook_url, headers=None, **kwargs):
 
 def query_queue(cook_url, allow_redirects=True, **kwargs):
     """Get current jobs via the queue endpoint (admin-only)"""
+    # We handle redirects manually here because /queue can redirect to a new hostname
+    # (when redirecting to master node), and requests strips and does not re-apply
+    # auth when redirects cross domains.
     response = session.get(f'{cook_url}/queue', allow_redirects=False, **kwargs)
     if allow_redirects and response.is_redirect:
         for _ in range(10):

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1208,9 +1208,17 @@ def user_current_usage(cook_url, headers=None, **kwargs):
     return session.get('%s/usage' % cook_url, params=kwargs, headers=headers)
 
 
-def query_queue(cook_url, **kwargs):
+def query_queue(cook_url, allow_redirects=True, **kwargs):
     """Get current jobs via the queue endpoint (admin-only)"""
-    return session.get(f'{cook_url}/queue', **kwargs)
+    response = session.get(f'{cook_url}/queue', allow_redirects=False, **kwargs)
+    if allow_redirects and response.is_redirect:
+        for _ in range(10):
+            response = session.get(response.headers['Location'], allow_redirects=False, **kwargs)
+            if not response.is_redirect:
+                break
+        else:
+            assert not response.is_redirect, response.headers
+    return response
 
 
 def get_limit(cook_url, limit_type, user, pool=None, headers=None):


### PR DESCRIPTION
## Changes proposed in this PR

- Make `COOK_SWITCH_USER_SSH_HOST` configurable.
- Enable multi-user tests with running with `pytest -n0` by defaulting worker-name value.
- Switch to proper requests library auth object implementation.
- Fetch multi-user credentials based on the target url.

## Why are we making these changes?

I ran into several issues trying to run a single multi-user test with `pytest -n0`. These changes fix those issues. Specifically the switch to a proper auth object eliminates the need for the renewer Timer task, which was causing pytest to hang on "thread join" after all tests completed. This change also makes it safe to nest the KerberosUser context (although I don't know why you'd want to do that), whereas previously the asynchronous refresh made nesting illegal.

Fetching credentials based on the target url also fixes the flaky test test_cannot_impersonate_admin_endpoints, which would flake if the request hit a non-leader and was redirected to the hostname of the current leader.

## Notes

See requests docs for an explanation of custom authentication objects:
https://2.python-requests.org/en/v2.8.1/user/advanced/#custom-authentication
