### PR TITLE
CLI release 3.0.0

### DIFF
--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.15.1'
+VERSION = '3.0.0'


### PR DESCRIPTION
## Changes proposed in this PR

- CLI release version 3.0.0
- Major version changed because the plugins refactor is not backwards compatible

## Why are we making these changes?

Pushing to pypi