### PR TITLE
Change default check time for cs wait to 15 seconds.

### DIFF
--- a/cli/cook/subcommands/wait.py
+++ b/cli/cook/subcommands/wait.py
@@ -48,7 +48,7 @@ def register(add_parser, add_defaults):
     """Adds this sub-command's parser and returns the action function"""
     default_timeout = None
     default_timeout_text = 'wait indefinitely'
-    default_interval = 5
+    default_interval = 15
     wait_parser = add_parser('wait', help='wait for jobs / instances / groups to complete by uuid')
     wait_parser.add_argument('uuid', nargs='*')
     wait_parser.add_argument('--timeout', '-t',


### PR DESCRIPTION
## Changes proposed in this PR

- Change default check time for cs wait to 15 seconds.

## Why are we making these changes?
Real jobs run much longer than 5 seconds. This reduces load on the
server by 3x and makes it less likely users hit API rate limits.
