### PR TITLE
Make it so that we can see who is rate limited in our HTTP log.

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -255,9 +255,9 @@
                                   (cond-> {:ring-handler (routes
                                                            (route/resources "/resource")
                                                            (-> view
-                                                               tell-jetty-about-usename
                                                                (wrap-rate-limit {:storage rate-limit-storage
                                                                                  :limit user-limit})
+                                                               tell-jetty-about-usename
                                                                impersonation-middleware
                                                                (conditional-auth-bypass authorization-middleware)
                                                                wrap-exception-logging


### PR DESCRIPTION
## Changes proposed in this PR

- Make it so that we can see who is rate limited in our HTTP log.

## Why are we making these changes?
Because of the order we inform Jetty of the logged in user, our access.log doesn't tell us who was rate limited.
