### PR TITLE
Change output of errors from cs submit from stdout to stderr

### DIFF
--- a/cli/cook/subcommands/submit.py
+++ b/cli/cook/subcommands/submit.py
@@ -9,7 +9,7 @@ import uuid
 import requests
 
 from cook import terminal, http, metrics, version
-from cook.util import deep_merge, is_valid_uuid, read_lines, print_info, current_user, guard_no_cluster, check_positive
+from cook.util import deep_merge, is_valid_uuid, read_lines, print_info, print_error, current_user, guard_no_cluster, check_positive
 
 
 def make_temporal_uuid():
@@ -84,7 +84,7 @@ def print_submit_result(cluster, response):
                 reason = json.dumps(data)
         except json.decoder.JSONDecodeError:
             reason = '%s\n' % response.text
-        print_info(submit_failed_message(cluster_name, reason))
+        print_error(submit_failed_message(cluster_name, reason))
 
 
 def submit_federated(clusters, jobs, group, pool):
@@ -92,6 +92,7 @@ def submit_federated(clusters, jobs, group, pool):
     Attempts to submit the provided jobs to each cluster in clusters, until a cluster
     returns a "created" status code. If no cluster returns "created" status, throws.
     """
+    messages = ""
     for cluster in clusters:
         cluster_name = cluster['name']
         cluster_url = cluster['url']
@@ -118,7 +119,8 @@ def submit_federated(clusters, jobs, group, pool):
             logging.exception(ioe)
             reason = f'Cannot connect to {cluster_name} ({cluster_url})'
             message = submit_failed_message(cluster_name, reason)
-            print_info(f'{message}\n')
+            messages.append(message)
+    print_error(messages)
     raise Exception(terminal.failed('Job submission failed on all of your configured clusters.'))
 
 

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -31,6 +31,11 @@ def stdout(cp):
     return decode(cp.stdout).strip()
 
 
+def stderr(cp):
+    """Returns the UTF-8 decoded and stripped stdout of the given CompletedProcess"""
+    return decode(cp.stderr).strip()
+
+
 def sh(command, stdin=None, env=None, wait_for_exit=True):
     """Runs command using subprocess.run"""
     logger.info(command + (f' # stdin: {decode(stdin)}' if stdin else ''))

--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -32,7 +32,7 @@ def stdout(cp):
 
 
 def stderr(cp):
-    """Returns the UTF-8 decoded and stripped stdout of the given CompletedProcess"""
+    """Returns the UTF-8 decoded and stripped stderr of the given CompletedProcess"""
     return decode(cp.stderr).strip()
 
 

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -2148,7 +2148,7 @@ if __name__ == '__main__':
             self.assertEqual(0, cp.returncode, cp.stderr)
         else:
             self.assertEqual(1, cp.returncode, cp.stderr)
-            self.assertIn('GPU support is not enabled', cli.stdout(cp))
+            self.assertIn('GPU support is not enabled', cli.stderr(cp))
 
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--gpus 0')
         self.assertEqual(2, cp.returncode, cp.stderr)
@@ -2174,7 +2174,7 @@ if __name__ == '__main__':
         # Try submitting to a pool that doesn't exist
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--pool {util.make_temporal_uuid()}')
         self.assertEqual(1, cp.returncode, cp.stderr)
-        self.assertIn('is not a valid pool name', cli.stdout(cp))
+        self.assertIn('is not a valid pool name', cli.stderr(cp))
 
     def test_show_from_jupyter(self):
         notebook = {

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -2170,7 +2170,7 @@ if __name__ == '__main__':
                 self.assertEqual(pool_name, jobs[0]['pool'])
             else:
                 self.assertEqual(1, cp.returncode, cp.stderr)
-                self.assertIn(f'{pool_name} is not accepting job submissions', cli.stdout(cp))
+                self.assertIn(f'{pool_name} is not accepting job submissions', cli.stderr(cp))
         # Try submitting to a pool that doesn't exist
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--pool {util.make_temporal_uuid()}')
         self.assertEqual(1, cp.returncode, cp.stderr)


### PR DESCRIPTION
## Changes proposed in this PR

- Change output of errors from cs submit from stdout to stderr

## Why are we making these changes?
If we have an error, we want it printed to stderr to maximize the changes it is seen by users instead of gobbled by a stdout redirection.

