### PR TITLE
Improves k8s autoscaling metrics

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -803,9 +803,7 @@
                                         pending-jobs autoscaling-compute-clusters)]
             (log/info "In" pool-name "pool, starting autoscaling")
             (doseq [[compute-cluster jobs-for-cluster] compute-cluster->jobs]
-              (timers/time!
-                (timers/timer (metric-title "autoscale-duration" pool-name compute-cluster))
-                (cc/autoscale! compute-cluster pool-name jobs-for-cluster)))
+              (cc/autoscale! compute-cluster pool-name jobs-for-cluster))
             (log/info "In" pool-name "pool, done autoscaling"))))
       (catch Throwable e
         (log/error e "In" pool-name "pool, encountered error while triggering autoscaling")))))


### PR DESCRIPTION
## Changes proposed in this PR

- moving the `autoscale!` timer from `scheduler` to the KCC and renaming it
- renaming `synthetic-pod-submit-rate` -> `cc-synthetic-pod-submit-rate`
- adding a timer specifically around the `launch-tasks` call in `autoscale!`

## Why are we making these changes?

To be consistent with the other KCC metrics, and to have better autoscaling metrics.
