### PR TITLE
Adds lock-sharding to k8s controller

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -31,6 +31,7 @@
            (com.netflix.fenzo VMTaskFitnessCalculator)
            (java.io File)
            (java.net InetAddress)
+           (java.util.concurrent.locks ReentrantLock)
            (org.apache.curator.test TestingServer)
            (org.apache.log4j DailyRollingFileAppender Logger PatternLayout)))
 
@@ -456,8 +457,9 @@
                          lock-objects
                          (repeatedly
                            controller-lock-num-shards
-                           #(Object.))]
-                     (merge {:controller-lock-objects (with-meta
+                           #(ReentrantLock.))]
+                     (merge {:controller-lock-num-shards controller-lock-num-shards
+                             :controller-lock-objects (with-meta
                                                         lock-objects
                                                         {:json-value (str lock-objects)})
                              :default-workdir "/mnt/sandbox"

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -447,11 +447,16 @@
                    (let [{:keys [controller-lock-num-shards]
                           :or {controller-lock-num-shards 32}}
                          kubernetes
+                         _
+                         (when (not (< 0 controller-lock-num-shards 256))
+                           (throw
+                             (ex-info
+                               "Please configure :controller-lock-num-shards to > 0 and < 256 in your config file."
+                               kubernetes)))
                          lock-objects
                          (repeatedly
                            controller-lock-num-shards
                            #(Object.))]
-                     (log/info "Doing" controller-lock-num-shards "way lock-sharding in k8s")
                      (merge {:controller-lock-objects (with-meta
                                                         lock-objects
                                                         {:json-value (str lock-objects)})

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -444,7 +444,8 @@
                                   :default-pool "no-pool"}
                                  pool-selection)})))
      :kubernetes (fnk [[:config {kubernetes {}}]]
-                   (merge {:default-workdir "/mnt/sandbox"
+                   (merge {:controller-lock-num-shards 32
+                           :default-workdir "/mnt/sandbox"
                            :pod-condition-containers-not-initialized-seconds 120
                            :pod-condition-unschedulable-seconds 60
                            :reconnect-delay-ms 60000

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -26,7 +26,7 @@
            (nth lock-objects#
                 (-> ~pod-name
                     hash
-                    (mod (count lock-objects#))))
+                    (mod (:controller-lock-num-shards (config/kubernetes)))))
            timer-context#
            (timers/start
              (metrics/timer

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -14,18 +14,31 @@
            (io.kubernetes.client.models V1Pod V1ContainerStatus V1PodStatus)
            (java.net URLEncoder)))
 
-(let [{:keys [controller-lock-num-shards]} (config/kubernetes)
-      lock-objects (repeatedly controller-lock-num-shards #(Object.))]
+(let [{:keys [controller-lock-num-shards]} (config/kubernetes)]
 
   (log/info "Doing" controller-lock-num-shards "way lock-sharding in k8s controller")
 
-  (defn calculate-lock
-    "Given a pod-name, return an object suitable for locking for accessing it."
-    [pod-name]
-    (nth lock-objects
-         (-> pod-name
-             hash
-             (mod controller-lock-num-shards)))))
+  (def ^:private lock-objects (repeatedly controller-lock-num-shards #(Object.))))
+
+(defmacro with-process-lock
+  "Evaluates body (which should contain a call to
+  process) after acquiring the pod-name-based lock"
+  [compute-cluster-name pod-name & body]
+  `(timers/time!
+     (metrics/timer "process-lock" ~compute-cluster-name)
+     (let [lock-object#
+           (nth lock-objects
+                (-> ~pod-name
+                    hash
+                    (mod (count lock-objects))))
+           timer-context#
+           (timers/start
+             (metrics/timer
+               "process-lock-acquire"
+               ~compute-cluster-name))]
+       (locking lock-object#
+         (.stop timer-context#)
+         ~@body))))
 
 (defn canonicalize-cook-expected-state
   "Canonicalize the expected states before comparing if they're equivalent"
@@ -570,38 +583,45 @@
   (let [pod-name (api/V1Pod->name new-pod)]
     (timers/time!
       (metrics/timer "pod-update" name)
-      (timers/time!
-        (metrics/timer "process-lock" name)
-        (locking (calculate-lock pod-name)
-          (synthesize-state-and-process-pod-if-changed compute-cluster pod-name new-pod))))))
+      (with-process-lock
+        name
+        pod-name
+        (synthesize-state-and-process-pod-if-changed compute-cluster pod-name new-pod)))))
 
 (defn pod-deleted
   "Indicate that kubernetes does not have the pod. Invoked by callbacks from kubernetes."
   [{:keys [k8s-actual-state-map name] :as compute-cluster} ^V1Pod pod-deleted]
   (let [pod-name (api/V1Pod->name pod-deleted)]
     (log/info "In compute cluster" name ", detected pod" pod-name "deleted")
-    (timers/time! (metrics/timer "pod-deleted" name)
-      (timers/time! (metrics/timer "process-lock" name)
-        (locking (calculate-lock pod-name)
-          (swap! k8s-actual-state-map dissoc pod-name)
-          (try
-            (process compute-cluster pod-name)
-            (catch Exception e
-              (log/error e (str "In compute-cluster " name ", error while processing pod-delete for " pod-name)))))))))
+    (timers/time!
+      (metrics/timer "pod-deleted" name)
+      (with-process-lock
+        name
+        pod-name
+        (swap! k8s-actual-state-map dissoc pod-name)
+        (try
+          (process compute-cluster pod-name)
+          (catch Exception e
+            (log/error e (str "In compute-cluster " name ", error while processing pod-delete for " pod-name))))))))
 
 (defn update-cook-expected-state
-  "Update the cook expected state. Include some business logic to e.g., not change a state to the same value more than once. Marks any state changes Also has a lattice of state. Called externally and from state machine."
+  "Update the cook expected state. Include some business logic to e.g., not
+   change a state to the same value more than once. Marks any state changes.
+   Also has a lattice of state. Called externally and from state machine."
   [{:keys [cook-expected-state-map name] :as compute-cluster} pod-name new-cook-expected-state-dict]
-  (timers/time! (metrics/timer "update-cook-expected-state" name)
-    (timers/time! (metrics/timer "process-lock" name)
-      (locking (calculate-lock pod-name)
-        (let [old-state (get @cook-expected-state-map pod-name)
-              ; Save the launch pod. We may need it in order to kill it. See note under (:killed, :missing) in process, above.
-              old-pod (:launch-pod old-state)
-              new-expected-state-dict-merged (merge {:launch-pod old-pod} new-cook-expected-state-dict)]
-          (when-not (cook-expected-state-equivalent? new-expected-state-dict-merged old-state)
-            (swap! cook-expected-state-map assoc pod-name new-expected-state-dict-merged)
-            (process compute-cluster pod-name)))))))
+  (timers/time!
+    (metrics/timer "update-cook-expected-state" name)
+    (with-process-lock
+      name
+      pod-name
+      (let [old-state (get @cook-expected-state-map pod-name)
+            ; Save the launch pod. We may need it in order to kill it.
+            ; See note under (:killed, :missing) in process, above.
+            old-pod (:launch-pod old-state)
+            new-expected-state-dict-merged (merge {:launch-pod old-pod} new-cook-expected-state-dict)]
+        (when-not (cook-expected-state-equivalent? new-expected-state-dict-merged old-state)
+          (swap! cook-expected-state-map assoc pod-name new-expected-state-dict-merged)
+          (process compute-cluster pod-name))))))
 
 (defn starting-namespaced-pod-name->pod
   "Returns a map from {:namespace pod-namespace :name pod-name}->pod for all instances that we're attempting to send to
@@ -622,8 +642,8 @@
   [{:keys [k8s-actual-state-map name] :as compute-cluster} pod-name]
   (timers/time!
     (metrics/timer "scan-process" name)
-    (timers/time!
-      (metrics/timer "process-lock" name)
-      (locking (calculate-lock pod-name)
-        (let [{:keys [pod]} (get @k8s-actual-state-map pod-name)]
-          (synthesize-state-and-process-pod-if-changed compute-cluster pod-name pod))))))
+    (with-process-lock
+      name
+      pod-name
+      (let [{:keys [pod]} (get @k8s-actual-state-map pod-name)]
+        (synthesize-state-and-process-pod-if-changed compute-cluster pod-name pod)))))

--- a/scheduler/test/cook/test/config.clj
+++ b/scheduler/test/cook/test/config.clj
@@ -15,10 +15,11 @@
 ;;
 (ns cook.test.config
   (:require [clojure.test :refer :all]
-            [cook.config :refer (config default-pool env read-edn-config
+            [cook.config :refer (config config-settings default-pool env read-edn-config
                                  config-string->fitness-calculator)]
             [cook.test.testutil :refer (setup)])
-  (:import com.netflix.fenzo.VMTaskFitnessCalculator))
+  (:import (clojure.lang ExceptionInfo)
+           com.netflix.fenzo.VMTaskFitnessCalculator))
 
 (deftest test-read-edn-config
   (is (= {} (read-edn-config "{}")))
@@ -76,3 +77,22 @@
   (testing "something other than a VMTaskFitnessCalculator"
     (is (thrown? IllegalArgumentException (config-string->fitness-calculator
                                             "System/out")))))
+
+(deftest test-config-settings
+  (testing "k8s controller lock num shards is in a sane range"
+    (let [valid-config (assoc-in (cook.test.rest.api/minimal-config)
+                                 [:config :kubernetes :controller-lock-num-shards]
+                                 1)]
+      (is (config-settings valid-config)))
+    (let [valid-config (assoc-in (cook.test.rest.api/minimal-config)
+                                 [:config :kubernetes :controller-lock-num-shards]
+                                 32)]
+      (is (config-settings valid-config)))
+    (let [bad-config (assoc-in (cook.test.rest.api/minimal-config)
+                               [:config :kubernetes :controller-lock-num-shards]
+                               0)]
+      (is (thrown? ExceptionInfo (config-settings bad-config))))
+    (let [bad-config (assoc-in (cook.test.rest.api/minimal-config)
+                               [:config :kubernetes :controller-lock-num-shards]
+                               256)]
+      (is (thrown? ExceptionInfo (config-settings bad-config))))))

--- a/scheduler/test/cook/test/config.clj
+++ b/scheduler/test/cook/test/config.clj
@@ -17,6 +17,7 @@
   (:require [clojure.test :refer :all]
             [cook.config :refer (config config-settings default-pool env read-edn-config
                                  config-string->fitness-calculator)]
+            [cook.test.rest.api :as api]
             [cook.test.testutil :refer (setup)])
   (:import (clojure.lang ExceptionInfo)
            com.netflix.fenzo.VMTaskFitnessCalculator))
@@ -80,19 +81,19 @@
 
 (deftest test-config-settings
   (testing "k8s controller lock num shards is in a sane range"
-    (let [valid-config (assoc-in (cook.test.rest.api/minimal-config)
+    (let [valid-config (assoc-in (api/minimal-config)
                                  [:config :kubernetes :controller-lock-num-shards]
                                  1)]
       (is (config-settings valid-config)))
-    (let [valid-config (assoc-in (cook.test.rest.api/minimal-config)
+    (let [valid-config (assoc-in (api/minimal-config)
                                  [:config :kubernetes :controller-lock-num-shards]
                                  32)]
       (is (config-settings valid-config)))
-    (let [bad-config (assoc-in (cook.test.rest.api/minimal-config)
+    (let [bad-config (assoc-in (api/minimal-config)
                                [:config :kubernetes :controller-lock-num-shards]
                                0)]
       (is (thrown? ExceptionInfo (config-settings bad-config))))
-    (let [bad-config (assoc-in (cook.test.rest.api/minimal-config)
+    (let [bad-config (assoc-in (api/minimal-config)
                                [:config :kubernetes :controller-lock-num-shards]
                                256)]
       (is (thrown? ExceptionInfo (config-settings bad-config))))))

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1597,7 +1597,7 @@
                            :query-params {:job uuid}})]
         (is (= 403 (:status resp)))))))
 
-(defn- minimal-config
+(defn minimal-config
   "Returns a minimal configuration map"
   []
   {:config {:database {:datomic-uri "datomic:mem://cook-jobs"}


### PR DESCRIPTION
## Changes proposed in this PR

- adding configuration field `:kubernetes :controller-lock-num-shards`
- creating the corresponding number of lock objects
- introducing `with-process-lock`, a macro that captures the timers and locking logic for anything that makes a call to `process`

## Why are we making these changes?

We want to introduce parallelism for pod submission API calls, and this is a prerequisite. Without this, any parallelism will get bottle-necked on the current single lock acquisition.
