### PR TITLE
Avoids synthetic pods in handle-pod-preemption

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -133,12 +133,13 @@
   returns the `completed` cook expected state."
   [{:keys [name] :as compute-cluster} pod-name]
   (log/info "In compute cluster" name ", pod" pod-name "preemption has occurred")
-  (let [instance-id pod-name
-        status {:reason :reason-slave-removed
-                :state :task-failed
-                :task-id {:value instance-id}}]
-    (write-status-to-datomic compute-cluster status)
-    {:cook-expected-state :cook-expected-state/completed}))
+  (when-not (api/synthetic-pod? pod-name)
+    (let [instance-id pod-name
+          status {:reason :reason-slave-removed
+                  :state :task-failed
+                  :task-id {:value instance-id}}]
+      (write-status-to-datomic compute-cluster status)))
+  {:cook-expected-state :cook-expected-state/completed})
 
 (defn launch-pod
   [{:keys [api-client name] :as compute-cluster} cook-expected-state-dict pod-name]

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -226,3 +226,11 @@
                            :cook-expected-state-map (atom {})}
           pod-name "test-pod"]
       (controller/scan-process compute-cluster pod-name))))
+
+(deftest test-handle-pod-preemption
+  (testing "avoids datomic write for synthetic pods"
+    (with-redefs [controller/write-status-to-datomic
+                  (fn [_ _]
+                    (throw (ex-info "BAD" {})))]
+      (is (= {:cook-expected-state :cook-expected-state/completed}
+             (controller/handle-pod-preemption {} (str api/cook-synthetic-pod-name-prefix "-test-pod")))))))


### PR DESCRIPTION
## Changes proposed in this PR

- avoiding call to `write-status-to-datomic` for synthetic pods (just like we already do in `handle-pod-submission-failed`, `handle-pod-completed`, etc.)

## Why are we making these changes?

We don't store synthetic pod info in Datomic. This is causing exceptions to get thrown.
