### PR TITLE
Uses add-as-decimals for synthetic pods

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -496,7 +496,7 @@
          (remove disallowed-var?)
          (mapv #(apply make-env %)))))
 
-(defn- add-as-decimals
+(defn add-as-decimals
   "Takes two doubles and adds them as decimals to avoid floating point error. Kubernetes will not be able to launch a
    pod if the required cpu has too much precision. For example, adding 0.1 and 0.02 as doubles results in 0.12000000000000001"
   [a b]

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -361,7 +361,7 @@
                                                      ; We need to account for any sidecar resource requirements that the
                                                      ; job we're launching this synthetic pod for will need to use.
                                                      sidecar-resource-requirements
-                                                     (merge-with +
+                                                     (merge-with api/add-as-decimals
                                                                  {"cpus" (:cpu-request sidecar-resource-requirements)
                                                                   "mem" (:memory-request sidecar-resource-requirements)}))
                                             :job {:job/pool {:pool/name synthetic-task-pool-name}}}}))


### PR DESCRIPTION
## Changes proposed in this PR

- using `add-as-decimals` when calculating resource requirements for synthetic pods

## Why are we making these changes?

To mitigate floating point rounding error introduced when adding in the sidecar resource requirements.
