### PR TITLE
Launches k8s tasks in parallel

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -546,7 +546,7 @@
 
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."
-  [namespace compute-cluster-name compute-cluster-node-blocklist-labels
+  [namespace compute-cluster-name
    {:keys [task-id command container task-request hostname pod-labels pod-hostnames-to-avoid
            pod-priority-class pod-supports-cook-init? pod-supports-cook-sidecar?]
     :or {pod-priority-class cook-job-pod-priority-class

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -511,10 +511,16 @@
                     :namespace "cook"}
          node-blocklist-labels (list)
          scan-frequency-seconds 120
-         use-google-service-account? true}}
+         use-google-service-account? true}
+    :as compute-cluster-config}
    {:keys [exit-code-syncer-state
            trigger-chans]}]
   (guard-invalid-synthetic-pods-config compute-cluster-name synthetic-pods)
+  (when (not (< 0 launch-task-num-threads 64))
+    (throw
+      (ex-info
+        "Please configure :launch-task-num-threads to > 0 and < 64 in your config file."
+        compute-cluster-config)))
   (let [conn cook.datomic/conn
         cluster-entity-id (get-or-create-cluster-entity-id conn compute-cluster-name)
         api-client (make-api-client config-file base-path use-google-service-account? bearer-token-refresh-seconds verifying-ssl ca-cert-path)

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -39,11 +39,13 @@
             [ring.middleware.params :refer (wrap-params)]
             [cook.scheduler.scheduler :as sched]
             [cook.mesos.task :as task])
-  (:import (java.util UUID)
-           (org.apache.log4j ConsoleAppender Logger PatternLayout)
+  (:import (com.netflix.fenzo SimpleAssignmentResult)
            (io.kubernetes.client.custom Quantity$Format Quantity)
-           (io.kubernetes.client.models V1Container V1ResourceRequirements V1Pod V1ObjectMeta V1PodSpec V1Node V1NodeStatus V1NodeSpec V1Taint)
-           (com.netflix.fenzo SimpleAssignmentResult)))
+           (io.kubernetes.client.models V1Container V1ResourceRequirements V1Pod V1ObjectMeta V1PodSpec V1Node
+                                        V1NodeStatus V1NodeSpec V1Taint)
+           (java.util UUID)
+           (java.util.concurrent Executors)
+           (org.apache.log4j ConsoleAppender Logger PatternLayout)))
 
 (defn create-dummy-mesos-compute-cluster
   [compute-cluster-name framework-id db-id driver-atom]
@@ -557,4 +559,5 @@
                                     nil ; max-pods-per-node
                                     synthetic-pods-config ; synthetic-pods-config
                                     node-blocklist-labels ; node-blocklist-labels
+                                    (Executors/newSingleThreadExecutor) ; launch-task-executor-service
                                     )))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -74,7 +74,7 @@
                                           :scalar-requests {"mem" 512
                                                             "cpus" 1.0}}
                            :hostname "kubehost"}
-            pod (api/task-metadata->pod "cook" "testing-cluster" [] task-metadata)]
+            pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)]
         (is (= "my-task" (-> pod .getMetadata .getName)))
         (is (= "cook" (-> pod .getMetadata .getNamespace)))
         (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
@@ -138,7 +138,7 @@
                                         :scalar-requests {"mem" 512
                                                           "cpus" 1.0}}
                          :hostname "kubehost"}
-          pod (api/task-metadata->pod "cook" "test-cluster" [] task-metadata)]
+          pod (api/task-metadata->pod "cook" "test-cluster" task-metadata)]
       (is (= 100 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
       (is (= 10 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))))
 
@@ -149,7 +149,7 @@
                          :task-request {:job {:job/pool {:pool/name pool-name}}
                                         :scalar-requests {"mem" 512
                                                           "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod nil nil [] task-metadata)
+          ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
           ^V1PodSpec pod-spec (.getSpec pod)
           node-selector (.getNodeSelector pod-spec)]
       (is (contains? node-selector api/cook-pool-label))
@@ -162,7 +162,7 @@
                          :hostname hostname
                          :task-request {:scalar-requests {"mem" 512
                                                           "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod nil nil [] task-metadata)
+          ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
           ^V1PodSpec pod-spec (.getSpec pod)
           node-selector (.getNodeSelector pod-spec)]
       (is (contains? node-selector api/k8s-hostname-label))
@@ -179,15 +179,15 @@
                                 (-> resources .getLimits (get "cpu"))))]
 
       (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? true})]
-        (let [^V1Pod pod (api/task-metadata->pod nil nil [] task-metadata)]
+        (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
           (is (= 1.0 (-> pod pod->cpu-limit-fn .getNumber .doubleValue)))))
 
       (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? false})]
-        (let [^V1Pod pod (api/task-metadata->pod nil nil [] task-metadata)]
+        (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
           (is (nil? (pod->cpu-limit-fn pod)))))
 
       (with-redefs [config/kubernetes (constantly {})]
-        (let [^V1Pod pod (api/task-metadata->pod nil nil [] task-metadata)]
+        (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
           (is (nil? (pod->cpu-limit-fn pod))))))))
 
 (defn- k8s-volume->clj [^V1Volume volume]

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -4,6 +4,7 @@
             [cook.kubernetes.api :as api]
             [cook.kubernetes.compute-cluster :as kcc]
             [cook.mesos.task :as task]
+            [cook.scheduler.scheduler :as sched]
             [cook.test.testutil :as tu]
             [datomic.api :as d])
   (:import (clojure.lang ExceptionInfo)


### PR DESCRIPTION
## Changes proposed in this PR

- allowing k8s pods to be launched in parallel with a configurable amount of parallelism per compute cluster

## Why are we making these changes?

We want to be able to launch pods at a higher rate.
