### PR TITLE
Fix config-composite.edn so that we can run tests again.

### DIFF
--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -20,13 +20,25 @@
          ; (like test_default_container_volumes) will fail without this set.
          :run-as-user "root"}
  :compute-clusters [{:factory-fn cook.kubernetes.compute-cluster/factory-fn
-                     :config {:compute-cluster-name "minikube"
+                     :config {:compute-cluster-name "gke-1"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
-                              :config-file "../scheduler/.cook_kubeconfig_1"}}
+                              :config-file "../scheduler/.cook_kubeconfig_1"
+                              :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
+                                               :max-pods-outstanding 128
+                                               :user #config/env "USER"
+                                               :command "exit 0"
+                                               :pools #{"k8s-alpha" "k8s-gamma"}}
+                              :node-blocklist-labels ["blocklist-nodes-with-this-label-key"]}}
                     {:factory-fn cook.kubernetes.compute-cluster/factory-fn
-                     :config {:compute-cluster-name "minikube-2"
+                     :config {:compute-cluster-name "gke-2"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
-                              :config-file "../scheduler/.cook_kubeconfig_2"}}
+                              :config-file "../scheduler/.cook_kubeconfig_2"
+                              :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
+                                               :max-pods-outstanding 128
+                                               :user #config/env "USER"
+                                               :command "exit 0"
+                                               :pools #{"k8s-alpha"}}
+                              :node-blocklist-labels ["blocklist-nodes-with-this-label-key-1" "blocklist-nodes-with-this-label-key-2"]}}
                     {:factory-fn cook.mesos.mesos-compute-cluster/factory-fn
                      :config {:failover-timeout-ms nil ; When we close the instance of Cook, all its tasks are killed by Mesos
                               :master #config/env "MESOS_MASTER"

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -64,7 +64,7 @@
                 "datomic.kv-cluster" :warn
                 "datomic.peer" :warn
                 "cook.scheduler.data-locality" :debug
-                "cook.mesos.fenzo-utils" :debug
+                "cook.scheduler.fenzo-utils" :debug
                 "cook.scheduler.rebalancer" :debug
                 "cook.scheduler.scheduler" :debug
                 "cook.kubernetes.compute-cluster" :debug


### PR DESCRIPTION
## Changes proposed in this PR

- Make composite.edn config work with synthetic pods, now that the help-make-cluster script creates clusters that have to have thta support.
- Refresh it with other updates that were made to config-k8s.edn that weren't copied here.

## Why are we making these changes?
Config doesn't work without these changes.

