### PR TITLE
help-make-cluster script uses now unavailable gke k8s version.

### DIFF
--- a/scheduler/bin/help-make-cluster
+++ b/scheduler/bin/help-make-cluster
@@ -17,7 +17,7 @@ ZONE=$2
 CLUSTERNAME=$3
 COOK_KUBECONFIG=$4
 
-VERSION=1.15.9-gke.22
+VERSION=1.15.9-gke.26
 
 gcloud="gcloud --project $PROJECT"
 


### PR DESCRIPTION
## Changes proposed in this PR

- Change the version number in the script to one that GKE currently supports.

## Why are we making these changes?

Doesn't work without this change.
