### PR TITLE
Sends matches to launch-tasks in bulk

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -42,10 +42,11 @@
 (def kill-lock-object (Object.))
 
 (defprotocol ComputeCluster
-  ; These methods should accept bulk data and process in batches.
-  ;(kill-tasks [this task]
-  (launch-tasks [this offers task-metadata-seq])
-  (compute-cluster-name [this])
+  (launch-tasks [this pool-name matches]
+    "Launches the tasks contained in the given matches collection")
+
+  (compute-cluster-name [this]
+    "Returns the name of this compute cluster")
 
   (db-id [this]
     "Get a database entity-id for this compute cluster (used for putting it into a task structure).")

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -42,7 +42,7 @@
 (def kill-lock-object (Object.))
 
 (defprotocol ComputeCluster
-  (launch-tasks [this pool-name matches]
+  (launch-tasks [this pool-name matches process-task-post-launch-fn]
     "Launches the tasks contained in the given matches collection")
 
   (compute-cluster-name [this]

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -232,14 +232,15 @@
   (compute-cluster-name [this]
     compute-cluster-name)
 
-  (launch-tasks [_ pool-name matches]
+  (launch-tasks [_ pool-name matches process-task-post-launch-fn]
     (doseq [{:keys [leases task-metadata-seq]} matches
             :let [offers (mapv :offer leases)]]
       (log/info "In" pool-name "pool, launching" (count offers)
                 "offers for" compute-cluster-name "compute cluster")
       (mesos/launch-tasks! @driver-atom
                            (mapv :id offers)
-                           (task/compile-mesos-messages framework-id offers task-metadata-seq))))
+                           (task/compile-mesos-messages framework-id offers task-metadata-seq))
+      (run! process-task-post-launch-fn task-metadata-seq)))
 
   (kill-task [this task-id]
     (mesos/kill-task! @driver-atom {:value task-id}))

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -232,10 +232,14 @@
   (compute-cluster-name [this]
     compute-cluster-name)
 
-  (launch-tasks [this offers task-metadata-seq]
-    (mesos/launch-tasks! @driver-atom
-                         (mapv :id offers)
-                         (task/compile-mesos-messages framework-id offers task-metadata-seq)))
+  (launch-tasks [_ pool-name matches]
+    (doseq [{:keys [leases task-metadata-seq]} matches
+            :let [offers (mapv :offer leases)]]
+      (log/info "In" pool-name "pool, launching" (count offers)
+                "offers for" compute-cluster-name "compute cluster")
+      (mesos/launch-tasks! @driver-atom
+                           (mapv :id offers)
+                           (task/compile-mesos-messages framework-id offers task-metadata-seq))))
 
   (kill-task [this task-id]
     (mesos/kill-task! @driver-atom {:value task-id}))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -49,7 +49,7 @@
                                                                       compute-cluster
                                                                       (task-assignment-result-helper "testuser"))]
 
-          (cc/launch-tasks compute-cluster [] [task-metadata])
+          (cc/launch-tasks compute-cluster "test-pool" [{:task-metadata-seq [task-metadata]}])
           (is (= "cook" (-> @launched-pod-atom
                             :pod
                             .getMetadata
@@ -64,7 +64,7 @@
                                                                       nil
                                                                       compute-cluster
                                                                       (task-assignment-result-helper "testuser"))]
-          (cc/launch-tasks compute-cluster [] [task-metadata])
+          (cc/launch-tasks compute-cluster "test-pool" [{:task-metadata-seq [task-metadata]}])
           (is (= "testuser" (-> @launched-pod-atom
                                 :pod
                                 .getMetadata
@@ -89,7 +89,7 @@
           job-ent-2 (d/entity db j2)
           task-1 (tu/make-task-metadata job-ent-1 db compute-cluster)
           task-2 (tu/make-task-metadata job-ent-2 db compute-cluster)
-          _ (cc/launch-tasks compute-cluster nil [task-1 task-2])
+          _ (cc/launch-tasks compute-cluster "no-pool" [{:task-metadata-seq [task-1 task-2]}])
           task-1-id (-> task-1 :task-request :task-id)
           pod-name->pod {{:namespace "cook" :name "podA"} (tu/pod-helper "podA" "nodeA"
                                                                          {:cpus 0.25 :mem 250.0}

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -49,7 +49,7 @@
                                                                       compute-cluster
                                                                       (task-assignment-result-helper "testuser"))]
 
-          (cc/launch-tasks compute-cluster "test-pool" [{:task-metadata-seq [task-metadata]}])
+          (cc/launch-tasks compute-cluster "test-pool" [{:task-metadata-seq [task-metadata]}] (fn [_]))
           (is (= "cook" (-> @launched-pod-atom
                             :pod
                             .getMetadata
@@ -64,7 +64,7 @@
                                                                       nil
                                                                       compute-cluster
                                                                       (task-assignment-result-helper "testuser"))]
-          (cc/launch-tasks compute-cluster "test-pool" [{:task-metadata-seq [task-metadata]}])
+          (cc/launch-tasks compute-cluster "test-pool" [{:task-metadata-seq [task-metadata]}] (fn [_]))
           (is (= "testuser" (-> @launched-pod-atom
                                 :pod
                                 .getMetadata
@@ -89,7 +89,7 @@
           job-ent-2 (d/entity db j2)
           task-1 (tu/make-task-metadata job-ent-1 db compute-cluster)
           task-2 (tu/make-task-metadata job-ent-2 db compute-cluster)
-          _ (cc/launch-tasks compute-cluster "no-pool" [{:task-metadata-seq [task-1 task-2]}])
+          _ (cc/launch-tasks compute-cluster "no-pool" [{:task-metadata-seq [task-1 task-2]}] (fn [_]))
           task-1-id (-> task-1 :task-request :task-id)
           pod-name->pod {{:namespace "cook" :name "podA"} (tu/pod-helper "podA" "nodeA"
                                                                          {:cpus 0.25 :mem 250.0}

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1927,7 +1927,7 @@
     (let [matches [{:leases [{:offer {}}]}]]
       (with-redefs [cc/db-id (constantly -1)
                     cc/compute-cluster-name (constantly "foo")
-                    cc/launch-tasks (fn [_ _ _] (throw (ex-info "Foo" {})))
+                    cc/launch-tasks (fn [_ _ _ _] (throw (ex-info "Foo" {})))
                     datomic/transact (constantly nil)]
         (sched/launch-matched-tasks! matches nil nil nil nil nil)))))
 


### PR DESCRIPTION
This is a follow-up PR to #1529.

## Changes proposed in this PR

Sending all matches for a given compute cluster to `launch-tasks` in a single call instead of making one call per match.

For example, let's say our matches are:

```
[{:task-metadata-seq [t1 t2] ...} ; k8s compute cluster A
 {:task-metadata-seq [t3 t4] ...} ; k8s compute cluster A
 {:task-metadata-seq [t5 t6] ...} ; k8s compute cluster B
 {:task-metadata-seq [t7 t8] ...} ; k8s compute cluster B
 {:task-metadata-seq [t9] ...}]   ; k8s compute cluster B
```

Previously, this would result in 5 calls to `launch-tasks`, one for each match in the above collection.

Now, this will result in 2 calls to `launch-tasks`, one for `A`:

```
[{:task-metadata-seq [t1 t2] ...}  ; k8s compute cluster A
 {:task-metadata-seq [t3 t4] ...}] ; k8s compute cluster A
```

and one for `B`:

```
[{:task-metadata-seq [t5 t6] ...} ; k8s compute cluster B
 {:task-metadata-seq [t7 t8] ...} ; k8s compute cluster B
 {:task-metadata-seq [t9] ...}]   ; k8s compute cluster B
```

## Why are we making these changes?

The `KubernetesComputeCluster`, as of #1529, launches k8s pods in parallel. #1529 parallelized the synthetic pod path, and this PR allows the real-job pod path to benefit fully from the same parallelization. 

Without this change, each match is resulting in a call to `launch-tasks`, which means that we're only able to parallelize the number of pod submissions in the match, instead of all pod submissions corresponding to a compute cluster in each matching iteration.
