### PR TITLE
Avoids NPE when pod metadata is nil

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -110,12 +110,12 @@
 
 (defn get-pod-namespaced-key
   [^V1Pod pod]
-  {:namespace (-> pod
-                  .getMetadata
-                  .getNamespace)
-   :name (-> pod
-             .getMetadata
-             .getName)})
+  (if-let [^V1ObjectMeta pod-metadata (some-> pod .getMetadata)]
+    {:namespace (-> pod-metadata .getNamespace)
+     :name (-> pod-metadata .getName)}
+    (throw (ex-info
+             (str "Unable to get namespaced key for pod: " pod)
+             {:pod pod}))))
 
 (defn get-all-pods-in-kubernetes
   "Get all pods in kubernetes."


### PR DESCRIPTION
## Changes proposed in this PR

- avoiding NPE when pod metadata is nil, instead throwing an exception with the string representation of the pod in question

## Why are we making these changes?

We've seen this happen in the wild, and this will help us track down the reason for the pods with no metadata.
