### PR TITLE
Logs pod events

### DIFF
--- a/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
+++ b/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
@@ -4,6 +4,7 @@ import com.google.common.reflect.TypeToken;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.CoreV1Api;
+import io.kubernetes.client.models.V1Event;
 import io.kubernetes.client.models.V1Node;
 import io.kubernetes.client.models.V1Pod;
 import io.kubernetes.client.util.Watch;
@@ -25,5 +26,14 @@ public class WatchHelper {
                         null, resourceVersion, null, true, null,
                         null),
                 new TypeToken<Watch.Response<V1Node>>() {}.getType());
+    }
+
+    public static Watch<V1Event> createEventWatch(ApiClient apiClient, String resourceVersion) throws ApiException {
+        CoreV1Api api = new CoreV1Api(apiClient);
+        return Watch.createWatch(apiClient,
+                api.listEventForAllNamespacesCall(null, null, null, null,
+                        null, null, resourceVersion, null, true, null,
+                        null),
+                new TypeToken<Watch.Response<V1Event>>() {}.getType());
     }
 }

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -289,7 +289,8 @@
                       (when (some-> @all-pods-atom
                                     (get namespaced-pod-name)
                                     (is-cook-scheduler-pod compute-cluster-name))
-                        (log/info "Received pod event"
+                        (log/info "In" compute-cluster-name
+                                  "compute cluster, received pod event"
                                   (.-type watch-response)
                                   (.serialize json event)))))))))
           (catch Exception e

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -291,8 +291,9 @@
                                     (is-cook-scheduler-pod compute-cluster-name))
                         (log/info "In" compute-cluster-name
                                   "compute cluster, received pod event"
-                                  (.-type watch-response)
-                                  (.serialize json event)))))))))
+                                  {:event-reason (.getReason event)
+                                   :event (.serialize json event)
+                                   :watch-response-type (.-type watch-response)}))))))))
           (catch Exception e
             (let [cause (.getCause e)]
               (if (and cause (instance? SocketTimeoutException cause))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -287,6 +287,8 @@
 
         ; Initialize the node watch path.
         (api/initialize-node-watch api-client name current-nodes-atom)
+
+        (api/initialize-event-watch api-client name all-pods-atom)
         (catch Throwable e
           (log/error e "Failed to bring up compute cluster" name)
           (throw e))))

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -348,7 +348,7 @@
   (timers/time! (metrics/timer "controller-process" name)
     (loop [{:keys [cook-expected-state waiting-metric-timer] :as cook-expected-state-dict} (get @cook-expected-state-map pod-name)
            {:keys [synthesized-state pod] :as k8s-actual-state-dict} (get @k8s-actual-state-map pod-name)]
-      (log/info "In compute cluster" name ", processing pod" pod-name ";"
+      (log/info "In" name "compute cluster, processing pod" pod-name ";"
                 "cook-expected:" (prepare-cook-expected-state-dict-for-logging cook-expected-state-dict) ","
                 "k8s-actual:" (prepare-k8s-actual-state-dict-for-logging k8s-actual-state-dict))
       ; We should have the cross product of


### PR DESCRIPTION
## Changes proposed in this PR

- adding an event watch
- logging pod events where the involved object is a Cook Scheduler pod

## Why are we making these changes?

For better troubleshooting. This makes troubleshooting certain types of issues, like "Container initialization timed out" failures, much faster.

## Example

```
$ grep 20050622-2856-4c67-be39-0c5dfb84953b log/cook-12321.log | grep "received pod event"
2020-05-06 22:27:07,750 INFO  cook.kubernetes.api [pool-11-thread-5] - In gke-2 compute cluster, received pod event {:event-reason FailedScheduling, :event {"apiVersion":"v1","count":1,"firstTimestamp":"2020-05-06T22:27:07.000-05:00","involvedObject":{"apiVersion":"v1","kind":"Pod","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b","namespace":"cook","resourceVersion":"15004316","uid":"4fc861eb-09b1-4fc4-b78a-14eaccf5b3e3"},"kind":"Event","lastTimestamp":"2020-05-06T22:27:07.000-05:00","message":"0/2 nodes are available: 1 Insufficient cpu, 2 node(s) didn\u0027t match node selector.","metadata":{"creationTimestamp":"2020-05-06T22:27:07.000-05:00","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca1375cda6c9c","namespace":"cook","resourceVersion":"41921","selfLink":"/api/v1/namespaces/cook/events/synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca1375cda6c9c","uid":"2950a8c6-f08a-4d4a-a0e7-cb395a2b746f"},"reason":"FailedScheduling","reportingComponent":"","reportingInstance":"","source":{"component":"default-scheduler"},"type":"Warning"}, :watch-response-type ADDED}
2020-05-06 22:27:12,361 INFO  cook.kubernetes.api [pool-11-thread-5] - In gke-2 compute cluster, received pod event {:event-reason TriggeredScaleUp, :event {"apiVersion":"v1","count":1,"firstTimestamp":"2020-05-06T22:27:12.000-05:00","involvedObject":{"apiVersion":"v1","kind":"Pod","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b","namespace":"cook","resourceVersion":"15004317","uid":"4fc861eb-09b1-4fc4-b78a-14eaccf5b3e3"},"kind":"Event","lastTimestamp":"2020-05-06T22:27:12.000-05:00","message":"pod triggered scale-up: [{https://content.googleapis.com/compute/v1/projects/ts-cook-gke-dev/zones/us-central1-a/instanceGroups/gke-dpo-test-0327-13-cook-pool-k8s-al-2e2800e0-grp 0-\u003e1 (max: 6)}]","metadata":{"creationTimestamp":"2020-05-06T22:27:12.000-05:00","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca1386dbdbe12","namespace":"cook","resourceVersion":"41923","selfLink":"/api/v1/namespaces/cook/events/synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca1386dbdbe12","uid":"ae9d13ab-fd6d-4a72-951d-e5fc5c24fe78"},"reason":"TriggeredScaleUp","reportingComponent":"","reportingInstance":"","source":{"component":"cluster-autoscaler"},"type":"Normal"}, :watch-response-type ADDED}
2020-05-06 22:28:32,032 INFO  cook.kubernetes.api [pool-11-thread-5] - In gke-2 compute cluster, received pod event {:event-reason FailedScheduling, :event {"apiVersion":"v1","count":2,"firstTimestamp":"2020-05-06T22:27:07.000-05:00","involvedObject":{"apiVersion":"v1","kind":"Pod","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b","namespace":"cook","resourceVersion":"15004316","uid":"4fc861eb-09b1-4fc4-b78a-14eaccf5b3e3"},"kind":"Event","lastTimestamp":"2020-05-06T22:28:31.000-05:00","message":"0/2 nodes are available: 1 Insufficient cpu, 2 node(s) didn\u0027t match node selector.","metadata":{"creationTimestamp":"2020-05-06T22:27:07.000-05:00","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca1375cda6c9c","namespace":"cook","resourceVersion":"41925","selfLink":"/api/v1/namespaces/cook/events/synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca1375cda6c9c","uid":"2950a8c6-f08a-4d4a-a0e7-cb395a2b746f"},"reason":"FailedScheduling","reportingComponent":"","reportingInstance":"","source":{"component":"default-scheduler"},"type":"Warning"}, :watch-response-type MODIFIED}
2020-05-06 22:28:36,128 INFO  cook.kubernetes.api [pool-11-thread-5] - In gke-2 compute cluster, received pod event {:event-reason Scheduled, :event {"apiVersion":"v1","count":1,"firstTimestamp":"2020-05-06T22:28:36.000-05:00","involvedObject":{"apiVersion":"v1","kind":"Pod","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b","namespace":"cook","resourceVersion":"15004317","uid":"4fc861eb-09b1-4fc4-b78a-14eaccf5b3e3"},"kind":"Event","lastTimestamp":"2020-05-06T22:28:36.000-05:00","message":"Successfully assigned cook/synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b to gke-dpo-test-0327-13-cook-pool-k8s-al-2e2800e0-cz3k","metadata":{"creationTimestamp":"2020-05-06T22:28:36.000-05:00","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca14bed5d85fa","namespace":"cook","resourceVersion":"41929","selfLink":"/api/v1/namespaces/cook/events/synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca14bed5d85fa","uid":"67b00f84-3a24-48c2-bc24-e94c0d7843cc"},"reason":"Scheduled","reportingComponent":"","reportingInstance":"","source":{"component":"default-scheduler"},"type":"Normal"}, :watch-response-type ADDED}
2020-05-06 22:28:36,313 INFO  cook.kubernetes.api [pool-11-thread-5] - In gke-2 compute cluster, received pod event {:event-reason NetworkNotReady, :event {"apiVersion":"v1","count":1,"firstTimestamp":"2020-05-06T22:28:36.000-05:00","involvedObject":{"apiVersion":"v1","kind":"Pod","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b","namespace":"cook","resourceVersion":"15004737","uid":"4fc861eb-09b1-4fc4-b78a-14eaccf5b3e3"},"kind":"Event","lastTimestamp":"2020-05-06T22:28:36.000-05:00","message":"network is not ready: runtime network not ready: NetworkReady\u003dfalse reason:NetworkPluginNotReady message:docker: network plugin is not ready: Kubenet does not have netConfig. This is most likely due to lack of PodCIDR","metadata":{"creationTimestamp":"2020-05-06T22:28:36.000-05:00","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca14beff92621","namespace":"cook","resourceVersion":"41940","selfLink":"/api/v1/namespaces/cook/events/synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca14beff92621","uid":"b6452bf8-6790-47d2-9d4f-8d10b9b8a7d0"},"reason":"NetworkNotReady","reportingComponent":"","reportingInstance":"","source":{"component":"kubelet","host":"gke-dpo-test-0327-13-cook-pool-k8s-al-2e2800e0-cz3k"},"type":"Warning"}, :watch-response-type ADDED}
2020-05-06 22:28:39,607 INFO  cook.kubernetes.api [pool-11-thread-5] - In gke-2 compute cluster, received pod event {:event-reason Pulling, :event {"apiVersion":"v1","count":1,"firstTimestamp":"2020-05-06T22:28:39.000-05:00","involvedObject":{"apiVersion":"v1","fieldPath":"spec.containers{required-cook-job-container}","kind":"Pod","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b","namespace":"cook","resourceVersion":"15004737","uid":"4fc861eb-09b1-4fc4-b78a-14eaccf5b3e3"},"kind":"Event","lastTimestamp":"2020-05-06T22:28:39.000-05:00","message":"Pulling image \"gcr.io/google-containers/alpine-with-bash:1.0\"","metadata":{"creationTimestamp":"2020-05-06T22:28:39.000-05:00","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca14cba2438a7","namespace":"cook","resourceVersion":"41949","selfLink":"/api/v1/namespaces/cook/events/synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca14cba2438a7","uid":"7ceeca20-c682-495e-a3cb-63fbc5f9ffbb"},"reason":"Pulling","reportingComponent":"","reportingInstance":"","source":{"component":"kubelet","host":"gke-dpo-test-0327-13-cook-pool-k8s-al-2e2800e0-cz3k"},"type":"Normal"}, :watch-response-type ADDED}
2020-05-06 22:28:47,656 INFO  cook.kubernetes.api [pool-11-thread-5] - In gke-2 compute cluster, received pod event {:event-reason Preempted, :event {"apiVersion":"v1","count":1,"firstTimestamp":"2020-05-06T22:28:47.000-05:00","involvedObject":{"apiVersion":"v1","kind":"Pod","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b","namespace":"cook","resourceVersion":"15004746","uid":"4fc861eb-09b1-4fc4-b78a-14eaccf5b3e3"},"kind":"Event","lastTimestamp":"2020-05-06T22:28:47.000-05:00","message":"by cook/5eb3806f-8502-4067-80ab-eb0f56dc1aa5 on node gke-dpo-test-0327-13-cook-pool-k8s-al-2e2800e0-cz3k","metadata":{"creationTimestamp":"2020-05-06T22:28:47.000-05:00","name":"synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca14e9f8f6410","namespace":"cook","resourceVersion":"41952","selfLink":"/api/v1/namespaces/cook/events/synthetic-k8s-alpha-20050622-2856-4c67-be39-0c5dfb84953b.160ca14e9f8f6410","uid":"d5e1ba56-819d-47f3-b3ef-9f2565f1c483"},"reason":"Preempted","reportingComponent":"","reportingInstance":"","source":{"component":"default-scheduler"},"type":"Normal"}, :watch-response-type ADDED}
```