### PR TITLE
Don't checkpoint when max attempts exceeded

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -615,7 +615,7 @@
 (defn calculate-effective-checkpointing-config
   "Given the job's checkpointing config, calculate the effective config. Making any adjustments such as defaults,
   overrides, or other behavior modifications."
-  [{:keys [job/checkpoint job/instance] :as job}]
+  [{:keys [job/checkpoint job/instance] :as job} task-id]
   (when checkpoint
     (let [{:keys [default-checkpoint-config]} (config/kubernetes)
           checkpoint (merge default-checkpoint-config (util/job-ent->checkpoint job))]
@@ -657,7 +657,7 @@
         workdir (get-workdir parameters sandbox-dir)
         {:keys [volumes volume-mounts sandbox-volume-mount-fn]} (make-volumes volumes sandbox-dir)
         {:keys [custom-shell init-container set-container-cpu-limit? sidecar]} (config/kubernetes)
-        checkpoint (calculate-effective-checkpointing-config job)
+        checkpoint (calculate-effective-checkpointing-config job task-id)
         checkpoint-memory-overhead (:memory-overhead checkpoint)
         use-cook-init? (and init-container pod-supports-cook-init?)
         use-cook-sidecar? (and sidecar pod-supports-cook-sidecar?)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -618,9 +618,10 @@
   [{:keys [job/checkpoint job/instance] :as job} task-id]
   (when checkpoint
     (let [{:keys [default-checkpoint-config]} (config/kubernetes)
-          checkpoint (merge default-checkpoint-config (util/job-ent->checkpoint job))]
-      (if-let [max-checkpoint-attempts (:max-checkpoint-attempts checkpoint)]
-        (let [checkpoint-failure-reasons (or (:checkpoint-failure-reasons checkpoint) default-checkpoint-failure-reasons)
+          {:keys [max-checkpoint-attempts checkpoint-failure-reasons] :as checkpoint}
+          (merge default-checkpoint-config (util/job-ent->checkpoint job))]
+      (if max-checkpoint-attempts
+        (let [checkpoint-failure-reasons (or checkpoint-failure-reasons default-checkpoint-failure-reasons)
               checkpoint-failures (filter (fn [{:keys [instance/reason]}]
                                             (contains? checkpoint-failure-reasons (:reason/name reason)))
                                           instance)]

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -624,7 +624,10 @@
               checkpoint-failures (filter (fn [{:keys [instance/reason]}]
                                             (contains? checkpoint-failure-reasons (:reason/name reason)))
                                           instance)]
-          (if (-> checkpoint-failures count (>= max-checkpoint-attempts)) nil checkpoint))
+          (if (-> checkpoint-failures count (>= max-checkpoint-attempts))
+            (log/info "Will not checkpoint task-id" task-id ", there are at least" max-checkpoint-attempts "failed instances"
+                      {:job job})
+            checkpoint))
         checkpoint))))
 
 (defn ^V1Pod task-metadata->pod

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -479,29 +479,29 @@
   (testing "No checkpoint"
     (with-redefs [config/kubernetes (fn [] {})]
       (let [job {}]
-        (is (= nil (api/calculate-effective-checkpointing-config job))))))
+        (is (= nil (api/calculate-effective-checkpointing-config job 1))))))
   (testing "No change"
     (with-redefs [config/kubernetes (fn [] {})]
       (let [checkpoint {:mode "auto"}
             job {:job/checkpoint {:checkpoint/mode "auto"}}]
-        (is (= checkpoint (api/calculate-effective-checkpointing-config job))))))
+        (is (= checkpoint (api/calculate-effective-checkpointing-config job 1))))))
   (testing "Checkpoint and add defaults"
     (with-redefs [config/kubernetes (fn [] {:default-checkpoint-config {:memory-overhead 129}})]
       (let [checkpoint {:mode "auto"
                         :memory-overhead 129}
             job {:job/checkpoint {:checkpoint/mode "auto"}}]
-        (is (= checkpoint (api/calculate-effective-checkpointing-config job))))))
+        (is (= checkpoint (api/calculate-effective-checkpointing-config job 1))))))
   (testing "checkpoint when max attempts not set"
     (with-redefs [config/kubernetes (fn [] {:default-checkpoint-config {}})]
       (let [job {:job/checkpoint {:checkpoint/mode "auto"}
                  :job/instance [{:instance/reason {:reason/name :mesos-unknown}}
                                 {:instance/reason {:reason/name :mesos-unknown}}
                                 {:instance/reason {:reason/name :mesos-unknown}}]}]
-        (is (= {:mode "auto"} (api/calculate-effective-checkpointing-config job))))))
+        (is (= {:mode "auto"} (api/calculate-effective-checkpointing-config job 1))))))
   (testing "Don't checkpoint when max attempts exceeded"
     (with-redefs [config/kubernetes (fn [] {:default-checkpoint-config {:max-checkpoint-attempts 3}})]
       (let [job {:job/checkpoint {:checkpoint/mode "auto"}
                  :job/instance [{:instance/reason {:reason/name :mesos-unknown}}
                                 {:instance/reason {:reason/name :mesos-unknown}}
                                 {:instance/reason {:reason/name :mesos-unknown}}]}]
-        (is (= nil (api/calculate-effective-checkpointing-config job)))))))
+        (is (= nil (api/calculate-effective-checkpointing-config job 1)))))))


### PR DESCRIPTION
## Changes proposed in this PR

- add option to not checkpoint after some number of job attempts have failed

## Why are we making these changes?

Checkpointing itself can cause failure. This will allow a job to complete

