### PR TITLE
Check for preemption using preemption pod label

### DIFF
--- a/scheduler/docs/reason-code
+++ b/scheduler/docs/reason-code
@@ -7,6 +7,7 @@
 01005: Running
 01006: Scheduling failed on host
 01007: Container initialization timed out
+01008: Killed externally
 
 02xxx: Job Misconfiguration
 02000: REASON_CONTAINER_LIMITATION

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -923,69 +923,69 @@
           job-status (first (filter (fn [c] (= cook-container-name-for-job (.getName c)))
                                     container-statuses))]
       (if (some-> pod .getMetadata .getDeletionTimestamp)
+        ; If a pod has been ordered deleted, treat it as if it was gone, It's being async removed.
+        ; Note that we distinguish between this explicit :missing, and not being there at all when processing
+        ; (:cook-expected-state/killed, :missing) in cook.kubernetes.controller/process
+        {:state :missing
+         :reason "Pod was explicitly deleted"
+         :pod-deleted? true}
         (if (some-> pod .getMetadata .getLabels (get "node-preempted"))
           {:state :missing
            :reason "Node preempted"
            :pod-deleted? true
            :pod-preempted? true}
-          ; If a pod has been ordered deleted, treat it as if it was gone, It's being async removed.
-          ; Note that we distinguish between this explicit :missing, and not being there at all when processing
-          ; (:cook-expected-state/killed, :missing) in cook.kubernetes.controller/process
-          {:state :missing
-           :reason "Pod was explicitly deleted"
-           :pod-deleted? true})
-        ; If pod isn't being async removed, then look at the containers inside it.
-        (if job-status
-          (let [^V1ContainerState state (.getState job-status)]
-            (cond
-              (.getWaiting state)
-              (if (pod-containers-not-initialized? (V1Pod->name pod) pod-status)
-                ; If the containers are not getting initialized,
-                ; then we should consider the pod failed. This
-                ; state can occur, for example, when volume
-                ; mounts fail.
-                {:state :pod/failed
-                 :reason "ContainersNotInitialized"}
-                {:state :pod/waiting
-                 :reason (-> state .getWaiting .getReason)})
-              (.getRunning state)
-              {:state :pod/running
-               :reason "Running"}
-              (.getTerminated state)
-              (let [exit-code (-> state .getTerminated .getExitCode)]
-                (if (= 0 exit-code)
-                  {:state :pod/succeeded
-                   :exit exit-code
-                   :reason (-> state .getTerminated .getReason)}
+          ; If pod isn't being async removed, then look at the containers inside it.
+          (if job-status
+            (let [^V1ContainerState state (.getState job-status)]
+              (cond
+                (.getWaiting state)
+                (if (pod-containers-not-initialized? (V1Pod->name pod) pod-status)
+                  ; If the containers are not getting initialized,
+                  ; then we should consider the pod failed. This
+                  ; state can occur, for example, when volume
+                  ; mounts fail.
                   {:state :pod/failed
-                   :exit exit-code
-                   :reason (-> state .getTerminated .getReason)}))
-              :default
-              {:state :pod/unknown
-               :reason "Unknown"}))
-          (cond
-            ; https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
-            ; Failed means:
-            ; All Containers in the Pod have terminated, and at least
-            ; one Container has terminated in failure. That is, the
-            ; Container either exited with non-zero status or was
-            ; terminated by the system.
-            (= (.getPhase pod-status) "Failed") {:state :pod/failed
-                                                 :reason (.getReason pod-status)}
+                   :reason "ContainersNotInitialized"}
+                  {:state :pod/waiting
+                   :reason (-> state .getWaiting .getReason)})
+                (.getRunning state)
+                {:state :pod/running
+                 :reason "Running"}
+                (.getTerminated state)
+                (let [exit-code (-> state .getTerminated .getExitCode)]
+                  (if (= 0 exit-code)
+                    {:state :pod/succeeded
+                     :exit exit-code
+                     :reason (-> state .getTerminated .getReason)}
+                    {:state :pod/failed
+                     :exit exit-code
+                     :reason (-> state .getTerminated .getReason)}))
+                :default
+                {:state :pod/unknown
+                 :reason "Unknown"}))
+            (cond
+              ; https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+              ; Failed means:
+              ; All Containers in the Pod have terminated, and at least
+              ; one Container has terminated in failure. That is, the
+              ; Container either exited with non-zero status or was
+              ; terminated by the system.
+              (= (.getPhase pod-status) "Failed") {:state :pod/failed
+                                                   :reason (.getReason pod-status)}
 
-            ; If the pod is unschedulable, then we should consider it failed. Note that
-            ; pod-unschedulable? will never return true for synthetic pods, because
-            ; they will be unschedulable by design, in order to trigger the cluster
-            ; autoscaler to scale up. For non-synthetic pods, however, this state
-            ; likely means something changed about the node we matched to. For example,
-            ; if the ToBeDeletedByClusterAutoscaler taint gets added between when we
-            ; saw available capacity on a node and when we submitted the pod to that
-            ; node, then the pod will never get scheduled.
-            (pod-unschedulable? (V1Pod->name pod) pod-status) {:state :pod/failed
-                                                               :reason "Unschedulable"}
+              ; If the pod is unschedulable, then we should consider it failed. Note that
+              ; pod-unschedulable? will never return true for synthetic pods, because
+              ; they will be unschedulable by design, in order to trigger the cluster
+              ; autoscaler to scale up. For non-synthetic pods, however, this state
+              ; likely means something changed about the node we matched to. For example,
+              ; if the ToBeDeletedByClusterAutoscaler taint gets added between when we
+              ; saw available capacity on a node and when we submitted the pod to that
+              ; node, then the pod will never get scheduled.
+              (pod-unschedulable? (V1Pod->name pod) pod-status) {:state :pod/failed
+                                                                 :reason "Unschedulable"}
 
-            :else {:state :pod/waiting
-                   :reason "Pending"}))))))
+              :else {:state :pod/waiting
+                     :reason "Pending"})))))))
 
 (defn pod->sandbox-file-server-container-state
   "From a V1Pod object, determine the state of the sandbox file server container, running, not running, or unknown.

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -929,7 +929,7 @@
         {:state :missing
          :reason "Pod was explicitly deleted"
          :pod-deleted? true}
-        (if (some-> pod .getMetadata .getLabels (get "node-preempted"))
+        (if (some-> pod .getMetadata .getLabels (get (or (-> (config/kubernetes) :node-preempted-label) "node-preempted")))
           {:state :missing
            :reason "Node preempted"
            :pod-deleted? true

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -476,11 +476,7 @@
                                                      (do
                                                        (log/info "In compute cluster" name ", something deleted"
                                                                  pod-name "behind our back")
-                                                       (if (= api/pod-explicitly-deleted-state-reason (:reason synthesized-state))
-                                                         (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
-                                                         ; A :cook-expected-state/running job suddenly disappearing in k8s is
-                                                         ; a sign of a preemption, so treat this case as a missed preemption.
-                                                         (handle-pod-preemption compute-cluster pod-name))))
+                                                       (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)))
                                           ; TODO: May need to mark mea culpa retry
                                           :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
                                           :pod/running cook-expected-state-dict

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -162,7 +162,7 @@
   (log/info "In compute cluster" name ", pod" pod-name "was externally deleted")
   (when-not (api/synthetic-pod? pod-name)
     (let [instance-id pod-name
-          status {:reason :reason-executor-terminated
+          status {:reason :reason-killed-externally
                   :state :task-failed
                   :task-id {:value instance-id}}]
       (write-status-to-datomic compute-cluster status)))

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -486,10 +486,7 @@
                                           ; This indicates that something deleted it behind our back
                                           :missing (if (some-> synthesized-state :pod-preempted?)
                                                      (handle-pod-preemption compute-cluster pod-name)
-                                                     (do
-                                                       (log/info "In compute cluster" name ", something deleted"
-                                                                 pod-name "behind our back")
-                                                       (handle-pod-externally-deleted compute-cluster pod-name)))
+                                                     (handle-pod-externally-deleted compute-cluster pod-name))
                                           ; TODO: May need to mark mea culpa retry
                                           :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
                                           :pod/running cook-expected-state-dict

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -1282,6 +1282,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :reason/name :container-initialization-timed-out
     :reason/mea-culpa? false
     :reason/mesos-reason :reason-container-initialization-timed-out}
+   {:db/id (d/tempid :db.part/user)
+    :reason/code 1008
+    :reason/string "Killed externally"
+    :reason/name :killed-externally
+    :reason/mea-culpa? true
+    :reason/mesos-reason :reason-killed-externally}
 
    {:db/id (d/tempid :db.part/user)
     :reason/code 2000

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -372,6 +372,32 @@
                       (constantly {:pod-condition-containers-not-initialized-seconds 60})]
           (is (= {:state :pod/failed
                   :reason "ContainersNotInitialized"}
+                 (api/pod->synthesized-pod-state pod))))))
+
+    (testing "node preempted default label"
+      (let [pod (V1Pod.)
+            pod-metadata (V1ObjectMeta.)
+            pod-status (V1PodStatus.)]
+        (.setStatus pod pod-status)
+        (.setMetadata pod pod-metadata)
+        (.setLabels pod-metadata {"node-preempted" 1589084484537})
+        (is (= {:state :missing
+                :reason "Node preempted"
+                :pod-deleted? true
+                :pod-preempted? true}
+               (api/pod->synthesized-pod-state pod)))))
+    (testing "node preempted custom label"
+      (with-redefs [config/kubernetes (fn [] {:node-preempted-label "custom-node-preempted"})]
+        (let [pod (V1Pod.)
+              pod-metadata (V1ObjectMeta.)
+              pod-status (V1PodStatus.)]
+          (.setStatus pod pod-status)
+          (.setMetadata pod pod-metadata)
+          (.setLabels pod-metadata {"custom-node-preempted" 1589084484537})
+          (is (= {:state :missing
+                  :reason "Node preempted"
+                  :pod-deleted? true
+                  :pod-preempted? true}
                  (api/pod->synthesized-pod-state pod))))))))
 
 (deftest test-node-schedulable

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -78,7 +78,7 @@
     (is (= :cook-expected-state/killed (do-process :cook-expected-state/killed :pod/waiting)))
 
     (is (nil? (do-process :cook-expected-state/running :missing)))
-    (is (= :reason-executor-terminated @reason))
+    (is (= :reason-killed-externally @reason))
     (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
                                                                                     :reason "Node preempted"
                                                                                     :pod-deleted? true
@@ -88,11 +88,11 @@
                                                                                     :reason "Pod was explicitly deleted"
                                                                                     :pod-deleted? true}
                           :force-nil-pod? true)))
-    (is (= :reason-executor-terminated @reason))
+    (is (= :reason-killed-externally @reason))
     (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
                                                                                     :reason "Pod was explicitly deleted"
                                                                                     :pod-deleted? true})))
-    (is (= :reason-executor-terminated @reason))
+    (is (= :reason-killed-externally @reason))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/succeeded)))
     (is (= :reason-normal-exit @reason))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/failed)))

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -78,6 +78,21 @@
     (is (= :cook-expected-state/killed (do-process :cook-expected-state/killed :pod/waiting)))
 
     (is (nil? (do-process :cook-expected-state/running :missing)))
+    (is (= :reason-executor-terminated @reason))
+    (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
+                                                                                    :reason "Node preempted"
+                                                                                    :pod-deleted? true
+                                                                                    :pod-preempted? true})))
+    (is (= :reason-slave-removed @reason))
+    (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
+                                                                                    :reason "Pod was explicitly deleted"
+                                                                                    :pod-deleted? true}
+                          :force-nil-pod? true)))
+    (is (= :reason-executor-terminated @reason))
+    (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
+                                                                                    :reason "Pod was explicitly deleted"
+                                                                                    :pod-deleted? true})))
+    (is (= :reason-executor-terminated @reason))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/succeeded)))
     (is (= :reason-normal-exit @reason))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/failed)))
@@ -108,21 +123,7 @@
     (is (nil? (do-process :missing :pod/failed)))
     (is (= :missing (do-process :missing :pod/running)))
     (is (nil? (do-process :missing :pod/unknown)))
-    (is (= :missing (do-process :missing :pod/waiting)))
-    (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
-                                                                                    :reason "Node preempted"
-                                                                                    :pod-deleted? true
-                                                                                    :pod-preempted? true})))
-    (is (= :reason-slave-removed @reason))
-    (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
-                                                                                    :reason "Pod was explicitly deleted"
-                                                                                    :pod-deleted? true}
-                          :force-nil-pod? true)))
-    (is (= :reason-executor-terminated @reason))
-    (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
-                                                                                    :reason "Pod was explicitly deleted"
-                                                                                    :pod-deleted? true})))
-    (is (= :reason-executor-terminated @reason))))
+    (is (= :missing (do-process :missing :pod/waiting)))))
 
 (deftest test-launch-kill-process
   (let [pod-name "TestPodName-LKP"


### PR DESCRIPTION
## Changes proposed in this PR

- check preemption pod label instead of assuming running to missing transition implies preemption

## Why are we making these changes?

We can tell the difference between a node just disappearing or getting killed vs being preempted, which is expected on preemptable machines