### PR TITLE
Adds safe-to-evict annotation to synthetic pods

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -346,6 +346,9 @@
                               {:command {:user (or user-from-synthetic-pods-config user)
                                          :value command}
                                :container {:docker {:image image}}
+                               ; We need to *not* prevent the cluster autoscaler from
+                               ; removing a node just because it's running synthetic pods
+                               :pod-annotations {api/k8s-safe-to-evict-annotation "true"}
                                ; Cook has a "novel host constraint", which disallows a job from
                                ; running on the same host twice. So, we need to avoid running a
                                ; synthetic pod on any of the hosts that the real job won't be able


### PR DESCRIPTION
## Changes proposed in this PR

- adding the `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation to synthetic pods

## Why are we making these changes?

This pod annotation signals to the cluster autoscaler that it's safe to remove the node on which the pod is running:

https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node

Without this, a node that's running only synthetic pods (e.g. for some reason, real jobs pods aren't getting matched to it) won't get removed, which is not what we want.

## Screenshot

![image](https://user-images.githubusercontent.com/444778/81432090-e6ca6f80-9127-11ea-8903-107a914d1aa5.png)
