### PR TITLE
Skips match when there are no considerable jobs

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -533,6 +533,7 @@
   (log/info "In" pool-name "pool, matching" (count offers) "offers to"
             (count considerable) "considerable jobs with fenzo")
   (if (and (-> considerable count zero?)
+           (-> offers count pos?)
            (every? :reject-after-match-attempt offers))
     ; If there are 0 considerable jobs and all offers are
     ; destined to get rejected after the match attempt, we

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -97,7 +97,12 @@
                       :compute-clusters [{:factory-fn cook.mesos.mesos-compute-cluster/factory-fn
                                           :config {:compute-cluster-name fake-test-compute-cluster-name}}]
                       :database {:datomic-uri ""}
-                      :log {}
+                      :log (cond-> {}
+                             ; Allow tests that go through the real logging
+                             ; initialization code to log to the console when
+                             ; requested via the property
+                             (System/getProperty "cook.test.logging.console")
+                             (assoc :file "/dev/stdout"))
                       :mesos {:leader-path "", :master ""}
                       :metrics {}
                       :nrepl {}


### PR DESCRIPTION
## Changes proposed in this PR

- if there are 0 considerable jobs and all offers are destined to get rejected after the match attempt (i.e. they came from k8s), skipping the matching iteration

## Why are we making these changes?

We've observed the `match-offer-to-schedule` function take several seconds for k8s pools when there are 0 pending jobs. Mesos offers are retained by Fenzo for a certain amount of time, but k8s offers are immediately rejected after the match attempt, since the k8s offer generation generates a complete set of offers for each cycle. That means we can skip matching for k8s when we have no pending jobs to match against.
