### PR TITLE
Automates GKE dev environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,12 @@ scheduler/log/
 scheduler/resources/public/cook-executor*
 scheduler/src/cfg
 scheduler/trace*.csv
+scheduler/.cook_kubeconfig_*
 src/cfg/current.clj
 target
 test-log
 *.orig
 venv
 dist
+.vagrant/
+

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ scheduler/resources/public/cook-executor*
 scheduler/src/cfg
 scheduler/trace*.csv
 scheduler/.cook_kubeconfig_*
+scheduler/cook.p12
+scheduler/datomic/datomic-free-0.9.5394/
 src/cfg/current.clj
 target
 test-log

--- a/README.md
+++ b/README.md
@@ -39,21 +39,27 @@ The quickest way to get Cook running locally against [GKE](https://cloud.google.
 1. [Install Vagrant](https://www.vagrantup.com/downloads.html)
 1. [Install Virtualbox](https://www.virtualbox.org/wiki/Downloads)
 1. Clone down this repo
-1. Run `vagrant up --provider=virtualbox` to create the dev environment
+1. Run `GCP_PROJECT_NAME=<gcp_project_name> vagrant up --provider=virtualbox` to create the dev environment
 1. Run `vagrant ssh` to ssh into the dev environment
 
-In your Vagrant dev environment:
+#### In your Vagrant dev environment
 
 1. Run `gcloud auth login` to login to Google cloud
-1. Run `bin/make-gke-test-clusters <gcp_project_name>` to create GKE clusters
+1. Run `bin/make-gke-test-clusters` to create GKE clusters
 1. Run `bin/start-datomic.sh` to start Datomic (Cook database)
 1. Run `bin/run-local-kubernetes.sh` to start the Cook scheduler
 1. Cook should now be listening locally on port 12321
 
-To test a simple job submission (still inside your Vagrant dev environment):
+To test a simple job submission:
 
 1. Run `cs submit --pool k8s-alpha --cpu 0.5 --mem 32 --docker-image gcr.io/google-containers/alpine-with-bash:1.0 ls` to submit a simple job
 1. Run `cs show <job_uuid>` to show the status of your job (it should eventually show Success)
+
+To run automated tests:
+
+1. Run `lein test :all-but-benchmark` to run unit tests
+1. Run `cd ../integration && pytest -m 'not cli'` to run integration tests
+1. Run `cd ../integration && pytest -k test_basic_submit -n 0 -s` to run a particular integration test
 
 ### Using Mesos
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ Please visit the `scheduler` subproject first to get started.
 
 ## Quickstart
 
+### Using Google Kubernetes Engine (GKE)
+
+The quickest way to get Cook running locally against [GKE](https://cloud.google.com/kubernetes-engine) is with [Vagrant](https://www.vagrantup.com/).
+
+1. [Install Vagrant](https://www.vagrantup.com/downloads.html)
+1. [Install Virtualbox](https://www.virtualbox.org/wiki/Downloads)
+1. Clone down this repo
+1. Run `vagrant up --provider=virtualbox` to create the dev environment
+1. Run `vagrant ssh` to ssh into the dev environment
+1. Run `gcloud auth login` to login to Google cloud
+1. Run `bin/make-gke-test-clusters <gcp_project_name>` to create GKE clusters
+1. Run `bin/run-local-kubernetes.sh` to start the Cook scheduler
+1. Cook should now be listening locally on port 12321
+
+### Using Mesos
+
 The quickest way to get Mesos and Cook running locally is with [docker](https://www.docker.com/) and [minimesos](https://minimesos.org/). 
 
 1. Install `docker`

--- a/README.md
+++ b/README.md
@@ -41,10 +41,19 @@ The quickest way to get Cook running locally against [GKE](https://cloud.google.
 1. Clone down this repo
 1. Run `vagrant up --provider=virtualbox` to create the dev environment
 1. Run `vagrant ssh` to ssh into the dev environment
+
+In your Vagrant dev environment:
+
 1. Run `gcloud auth login` to login to Google cloud
 1. Run `bin/make-gke-test-clusters <gcp_project_name>` to create GKE clusters
+1. Run `bin/start-datomic.sh` to start Datomic (Cook database)
 1. Run `bin/run-local-kubernetes.sh` to start the Cook scheduler
 1. Cook should now be listening locally on port 12321
+
+To test a simple job submission (still inside your Vagrant dev environment):
+
+1. Run `cs submit --pool k8s-alpha --cpu 0.5 --mem 32 --docker-image gcr.io/google-containers/alpine-with-bash:1.0 ls` to submit a simple job
+1. Run `cs show <job_uuid>` to show the status of your job (it should eventually show Success)
 
 ### Using Mesos
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,19 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "hashicorp/bionic64"
-  config.vm.provision :shell, path: "scheduler/bin/bootstrap", env: {"GKE_CLUSTER_OWNER" => ENV["USER"]}
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 6144
+    v.cpus = 2
+  end
+
+  # This runs as root:
+  config.vm.provision :shell, path: "scheduler/bin/bootstrap", env: {"GKE_CLUSTER_OWNER" => ENV["USER"], "GCP_PROJECT_NAME" => ENV["GCP_PROJECT_NAME"]}
+
+  # This runs as vagrant:
+  $script = <<-SCRIPT
+  # Cook jobclient setup
+  cd /vagrant/jobclient || exit 1
+  mvn install -DskipTests
+  SCRIPT
+  config.vm.provision "shell", inline: $script, privileged: false
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,4 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "hashicorp/bionic64"
+  config.vm.provision :shell, path: "scheduler/bin/bootstrap", env: {"GKE_CLUSTER_OWNER" => ENV["USER"]}
+end

--- a/scheduler/bin/bootstrap
+++ b/scheduler/bin/bootstrap
@@ -6,6 +6,12 @@ then
   exit 1
 fi
 
+if [ -z "$GCP_PROJECT_NAME" ]
+then
+  echo "Please set \$GCP_PROJECT_NAME"
+  exit 1
+fi
+
 scheduler=/vagrant/scheduler
 home_dir=/home/vagrant
 bashrc=$home_dir/.bashrc
@@ -15,12 +21,13 @@ echo 'export PATH='$bin':$PATH' | tee -a $bashrc
 apt-get -y update
 add-apt-repository ppa:openjdk-r/ppa
 apt-get -y update
-apt-get --no-install-recommends -y install jq openjdk-8-jdk python3-pip unzip
+apt-get --no-install-recommends -y install jq maven openjdk-8-jdk python3-pip tree unzip
 apt-get clean
 rm -Rf /var/lib/apt/lists/*
 
 # Java setup
 export JAVA_CMD=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
+echo 'export JAVA_CMD='$JAVA_CMD | tee -a $bashrc
 
 # Lein setup (https://leiningen.org/#install)
 mkdir $bin
@@ -40,6 +47,8 @@ tar zxvf gcloud.tar.gz google-cloud-sdk
 export PATH=$bin/google-cloud-sdk/bin:$PATH
 echo 'export PATH='$bin'/google-cloud-sdk/bin:$PATH' | tee -a $bashrc
 echo 'export GKE_CLUSTER_OWNER='"$GKE_CLUSTER_OWNER" | tee -a $bashrc
+echo 'export GCP_PROJECT_NAME='"$GCP_PROJECT_NAME" | tee -a $bashrc
+echo 'gcloud config set project "$GCP_PROJECT_NAME"' | tee -a $bashrc
 gcloud components install kubectl
 
 # Start in the scheduler dir
@@ -56,11 +65,13 @@ cs --version
 rm -f $home_dir/.cs.json
 ln -s $cli/.cs.json $home_dir/.cs.json
 
-# Provide some pointers
-echo "* To login to your dev environment: vagrant ssh"
-echo "* To login to Google cloud:         gcloud auth login"
-echo "* To create GKE clusters:           bin/make-gke-test-clusters <gcp_project_name>"
-echo "* To start Datomic (Cook database): bin/start-datomic.sh"
-echo "* To start Cook Scheduler:          bin/run-local-kubernetes.sh"
-echo "* To submit a k8s job:              cs submit --pool k8s-alpha --cpu 0.5 --mem 32 --docker-image gcr.io/google-containers/alpine-with-bash:1.0 ls"
-echo "* To show the status of your job:   cs show <job_uuid>"
+# Integration tests setup
+echo "export COOK_TEST_DOCKER_IMAGE=gcr.io/google-containers/alpine-with-bash:1.0" | tee -a $bashrc
+echo "export COOK_TEST_DOCKER_WORKING_DIRECTORY=/mnt/sandbox" | tee -a $bashrc
+echo "export COOK_TEST_DISALLOW_POOLS_REGEX='(?!^k8s-(alpha)$)'" | tee -a $bashrc
+echo "export COOK_TEST_DEFAULT_SUBMIT_POOL=k8s-alpha" | tee -a $bashrc
+echo "export COOK_TEST_COMPUTE_CLUSTER_TYPE=kubernetes" | tee -a $bashrc
+echo "export COOK_TEST_DEFAULT_TIMEOUT_MS=480000" | tee -a $bashrc
+echo "export COOK_TEST_DEFAULT_WAIT_INTERVAL_MS=8000" | tee -a $bashrc
+integration=$scheduler/../integration
+pip3 install -r $integration/requirements.txt

--- a/scheduler/bin/bootstrap
+++ b/scheduler/bin/bootstrap
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+if [ -z "$GKE_CLUSTER_OWNER" ]
+then
+  echo "Please set \$GKE_CLUSTER_OWNER"
+  exit 1
+fi
+
+scheduler=/vagrant/scheduler
+home_dir=/home/vagrant
+bashrc=$home_dir/.bashrc
+bin=$home_dir/bin
+echo 'export PATH='$bin':$PATH' | tee -a $bashrc
+
+apt-get -y update
+add-apt-repository ppa:openjdk-r/ppa
+apt-get -y update
+apt-get --no-install-recommends -y install jq openjdk-8-jdk python3-pip unzip
+apt-get clean
+rm -Rf /var/lib/apt/lists/*
+
+# Java setup
+export JAVA_CMD=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
+
+# Lein setup (https://leiningen.org/#install)
+mkdir $bin
+export PATH="$PATH":$bin
+curl -o $bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+chmod a+x $bin/lein
+lein
+
+# Start Datomic
+cd $scheduler || exit 1
+./bin/start-datomic.sh &
+echo 'export COOK_DATOMIC_URI=datomic:free://127.0.0.1:4334/jobs' | tee -a $bashrc
+
+# gcloud setup (https://cloud.google.com/sdk/docs/quickstart-linux)
+curl -o $bin/gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-292.0.0-linux-x86_64.tar.gz
+cd $bin || exit 1
+tar zxvf gcloud.tar.gz google-cloud-sdk
+./google-cloud-sdk/install.sh
+export PATH=$bin/google-cloud-sdk/bin:$PATH
+echo 'export PATH='$bin'/google-cloud-sdk/bin:$PATH' | tee -a $bashrc
+echo 'export GKE_CLUSTER_OWNER='"$GKE_CLUSTER_OWNER" | tee -a $bashrc
+gcloud components install kubectl
+
+# Start in the scheduler dir
+echo 'cd '"$scheduler" | tee -a $bashrc
+
+# Python setup
+pip3 install --upgrade pip setuptools wheel
+
+# Cook Scheduler CLI setup
+cli=$scheduler/../cli
+cd $cli || exit 1
+pip3 install -e .
+cs --version
+rm -f $home_dir/.cs.json
+ln -s $cli/.cs.json $home_dir/.cs.json
+
+# Provide some pointers
+echo "* To login to your dev environment: vagrant ssh"
+echo "* To login to Google cloud:         gcloud auth login"
+echo "* To create GKE clusters:           bin/make-gke-test-clusters <gcp_project_name>"
+echo "* To start Cook Scheduler:          bin/run-local-kubernetes.sh"
+echo "* To submit a k8s job:              cs submit --pool k8s-alpha --cpu 0.5 --mem 32 --docker-image gcr.io/google-containers/alpine-with-bash:1.0 ls"
+echo "* To show the status of your job:   cs show <job_uuid>"

--- a/scheduler/bin/bootstrap
+++ b/scheduler/bin/bootstrap
@@ -29,9 +29,7 @@ curl -o $bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable
 chmod a+x $bin/lein
 lein
 
-# Start Datomic
-cd $scheduler || exit 1
-./bin/start-datomic.sh &
+# Datomic setup
 echo 'export COOK_DATOMIC_URI=datomic:free://127.0.0.1:4334/jobs' | tee -a $bashrc
 
 # gcloud setup (https://cloud.google.com/sdk/docs/quickstart-linux)
@@ -62,6 +60,7 @@ ln -s $cli/.cs.json $home_dir/.cs.json
 echo "* To login to your dev environment: vagrant ssh"
 echo "* To login to Google cloud:         gcloud auth login"
 echo "* To create GKE clusters:           bin/make-gke-test-clusters <gcp_project_name>"
+echo "* To start Datomic (Cook database): bin/start-datomic.sh"
 echo "* To start Cook Scheduler:          bin/run-local-kubernetes.sh"
 echo "* To submit a k8s job:              cs submit --pool k8s-alpha --cpu 0.5 --mem 32 --docker-image gcr.io/google-containers/alpine-with-bash:1.0 ls"
 echo "* To show the status of your job:   cs show <job_uuid>"

--- a/scheduler/bin/help-delete-temporary-clusters
+++ b/scheduler/bin/help-delete-temporary-clusters
@@ -11,13 +11,15 @@ set -e
 
 PROJECT=$1
 ZONE=$2
+GKE_CLUSTER_OWNER=${GKE_CLUSTER_OWNER:-$USER}
 
 gcloud="gcloud --project $PROJECT"
 
 # Nuke all existing temporary clusters; don't want to keep on making more idle clusters each time you invoke this.
-echo "---- Deleting any existing temporary clusters."
-$gcloud container clusters list --filter 'resourceLabels.longevity=temporary'
-for i in $($gcloud container clusters list --filter 'resourceLabels.longevity=temporary' --format="value(name)")
+echo "---- Deleting any existing temporary clusters with owner $GKE_CLUSTER_OWNER"
+filter="resourceLabels.longevity=temporary AND resourceLabels.owner=$GKE_CLUSTER_OWNER"
+$gcloud container clusters list --filter "$filter"
+for i in $($gcloud container clusters list --filter "$filter" --format="value(name)")
 do
     echo "Deleting $i"
     $gcloud --quiet container clusters delete "$i" --zone "$ZONE" &

--- a/scheduler/bin/help-make-cluster
+++ b/scheduler/bin/help-make-cluster
@@ -16,8 +16,9 @@ PROJECT=$1
 ZONE=$2
 CLUSTERNAME=$3
 COOK_KUBECONFIG=$4
+GKE_CLUSTER_OWNER=${GKE_CLUSTER_OWNER:-$USER}
 
-VERSION=1.15.9-gke.26
+VERSION=1.15.11-gke.12
 
 gcloud="gcloud --project $PROJECT"
 
@@ -27,10 +28,10 @@ echo "---- Building kubernetes cluster for project=$PROJECT zone=$ZONE clusterna
 # Create 7 nodes, with three tainted for k8s-alpha, 3 untainted and 3 tainted with k8s-gamma pool.
 # The untainted ones are for GKE's own uses for its system pods. Also convenient to have around if I'm doing non-pool tests.
 # The second line of flags about upgrades and legacy endpoints is to suppress some warnings.
-echo "---- Creating new cluster (please wait 5 minutes)"
+echo "---- Creating new cluster with owner $GKE_CLUSTER_OWNER (please wait 5 minutes)"
 time $gcloud container clusters create "$CLUSTERNAME" --zone "$ZONE" --disk-size=20gb --machine-type=g1-small --preemptible  \
      --no-enable-autoupgrade --no-enable-basic-auth --no-issue-client-certificate --no-enable-ip-alias --metadata disable-legacy-endpoints=true \
-     --labels longevity=temporary --enable-autoscaling --min-nodes=0 --max-nodes=6
+     --labels longevity=temporary,owner="$GKE_CLUSTER_OWNER" --enable-autoscaling --min-nodes=0 --max-nodes=6
 
 echo "---- Setting up gcloud credentials"
 # Add credentials to the kubeconfig used by cook.

--- a/scheduler/bin/make-gke-test-clusters
+++ b/scheduler/bin/make-gke-test-clusters
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# Usage: ./bin/make-gke-test-clusters <project> [<zone>] [<clustername>]
+# Usage: ./bin/make-gke-test-clusters [<project>] [<zone>] [<clustername>]
 #   Configure two kubernetes clusters for running pool-based integration tests and running pools in general.
 #    NOTE: This script labels any clusters it creates and will DELETE old clusters it created.
-#   <project> is a gcloud project.
+#   <project> is a gcloud project and defaults to $GCP_PROJECT_NAME.
 #   <zone> can be a zone. E.g., us-central1-a
 #   <clustername> is the name of a cluster. E.g., 'test-cluster-1'
 
@@ -14,14 +14,8 @@
 
 set -e
 
-if [ $# -eq 0 ]
-then
-    echo "You must provide the GCP project to use!"
-    exit 1
-fi
-
 GKE_CLUSTER_OWNER=${GKE_CLUSTER_OWNER:-$USER}
-PROJECT=$1
+PROJECT=${1:-$GCP_PROJECT_NAME}
 ZONE=${2:-us-central1-a}
 CLUSTERNAME=${3:-$GKE_CLUSTER_OWNER-test-$(date '+%m%d-%H%M%S')}
 

--- a/scheduler/bin/make-gke-test-clusters
+++ b/scheduler/bin/make-gke-test-clusters
@@ -20,13 +20,16 @@ then
     exit 1
 fi
 
+GKE_CLUSTER_OWNER=${GKE_CLUSTER_OWNER:-$USER}
 PROJECT=$1
 ZONE=${2:-us-central1-a}
-CLUSTERNAME=${3:-$USER-test-$(date '+%m%d-%H%M%S')}
+CLUSTERNAME=${3:-$GKE_CLUSTER_OWNER-test-$(date '+%m%d-%H%M%S')}
 
 gcloud="gcloud --project $PROJECT"
 
 bin/help-delete-temporary-clusters "$PROJECT" "$ZONE"
+rm -f .cook_kubeconfig_1
+rm -f .cook_kubeconfig_2
 
 # Make 2 clusters.
 bin/help-make-cluster "$PROJECT" "$ZONE" "${CLUSTERNAME}"-a .cook_kubeconfig_1 &
@@ -34,4 +37,5 @@ bin/help-make-cluster "$PROJECT" "$ZONE" "${CLUSTERNAME}"-b .cook_kubeconfig_2 &
 wait
 
 echo "---- Showing all of the clusters we generated"
-$gcloud container clusters list
+filter="resourceLabels.longevity=temporary AND resourceLabels.owner=$GKE_CLUSTER_OWNER"
+$gcloud container clusters list --filter "$filter"

--- a/scheduler/bin/run-local-kubernetes.sh
+++ b/scheduler/bin/run-local-kubernetes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Usage: ./bin/run-local.sh
+# Usage: ./bin/run-local-kubernetes.sh
 # Runs the cook scheduler locally.
 
 set -e
@@ -50,4 +50,7 @@ export COOK_SSL_PORT="${COOK_SSL_PORT}"
 export COOK_KEYSTORE_PATH="${COOK_KEYSTORE_PATH}"
 
 echo "Starting cook..."
+rm -f "$COOK_LOG_FILE"
+KUBECONFIG=.cook_kubeconfig_1 kubectl get pods --namespace cook
+KUBECONFIG=.cook_kubeconfig_2 kubectl get pods --namespace cook
 lein run config-k8s.edn

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -108,8 +108,7 @@
               :min-dru-diff 1.0
               :safe-dru-threshold 1.0}
  :sandbox-syncer {:sync-interval-ms 1000}
- :scheduler {:fenzo-fitness-calculator "cook.scheduler.data-locality/make-data-local-fitness-calculator"
-             :offer-incubate-ms 15000
+ :scheduler {:offer-incubate-ms 15000
              :task-constraints {:command-length-limit 5000
                                 :cpus 10
                                 :memory-gb 48


### PR DESCRIPTION
## Changes proposed in this PR

- adding Vagrant support that automates dev environment setup (I've tested this from Ubuntu 18.04 and from Macos)
- adding a new Quickstart section to the README with instructions
- making the GKE creation/deletion scripts support separate "owners" in a single GCP project

## Why are we making these changes?

To make dev environment setup for new devs easier, and to allow multiple devs to share a single GCP project without stepping on each other's toes.
