### PR TITLE
Adds lru_cache to util.settings

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -433,6 +433,7 @@ def init_cook_session(*cook_urls):
         logger.info(f'Session auth set to {session.auth}')
 
 
+@functools.lru_cache()
 def settings(cook_url):
     return session.get(f'{cook_url}/settings').json()
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding `lru_cache` to `util.settings`

## Why are we making these changes?

To avoid making repeated calls to `/settings` for the same Cook Scheduler.
