### PR TITLE
re-enbable test_kubernetes_checkpointing

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3037,7 +3037,6 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, [job_uuid1, job_uuid2])
 
     @unittest.skipUnless(util.using_kubernetes(), 'Test requires kubernetes')
-    @pytest.mark.xfail
     def test_kubernetes_checkpointing(self):
         docker_image = util.docker_image()
         container = {'type': 'docker',


### PR DESCRIPTION
## Changes proposed in this PR

- re-enbable test_kubernetes_checkpointing

## Why are we making these changes?

should work after MR 567
