### PR TITLE
Upgrades k8s client library to 7.0.0

### DIFF
--- a/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
+++ b/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
@@ -1,12 +1,12 @@
 package com.twosigma.cook.kubernetes;
 
 import com.google.common.reflect.TypeToken;
-import io.kubernetes.client.ApiClient;
-import io.kubernetes.client.ApiException;
-import io.kubernetes.client.apis.CoreV1Api;
-import io.kubernetes.client.models.V1Event;
-import io.kubernetes.client.models.V1Node;
-import io.kubernetes.client.models.V1Pod;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Event;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.util.Watch;
 
 public class WatchHelper {
@@ -15,7 +15,7 @@ public class WatchHelper {
         CoreV1Api api = new CoreV1Api(apiClient);
         return Watch.createWatch(apiClient,
                 api.listPodForAllNamespacesCall(null, null, null, null, null, null,
-                        resourceVersion, null, true, null, null),
+                        resourceVersion, null, true, null),
                 new TypeToken<Watch.Response<V1Pod>>() {}.getType());
     }
 
@@ -23,8 +23,7 @@ public class WatchHelper {
         CoreV1Api api = new CoreV1Api(apiClient);
         return Watch.createWatch(apiClient,
                 api.listNodeCall(null, null, null, null, null,
-                        null, resourceVersion, null, true, null,
-                        null),
+                        null, resourceVersion, null, true, null),
                 new TypeToken<Watch.Response<V1Node>>() {}.getType());
     }
 
@@ -32,8 +31,7 @@ public class WatchHelper {
         CoreV1Api api = new CoreV1Api(apiClient);
         return Watch.createWatch(apiClient,
                 api.listEventForAllNamespacesCall(null, null, null, null,
-                        null, null, resourceVersion, null, true, null,
-                        null),
+                        null, null, resourceVersion, null, true, null),
                 new TypeToken<Watch.Response<V1Event>>() {}.getType());
     }
 }

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -114,7 +114,7 @@
                  [mount "0.1.12"]
 
                  ;; Kubernetes
-                 [io.kubernetes/client-java "4.0.0"]
+                 [io.kubernetes/client-java "7.0.0"]
                  [com.google.auth/google-auth-library-oauth2-http "0.16.2"]]
 
   :repositories {"maven2" {:url "https://files.couchbase.com/maven2/"}

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -17,12 +17,13 @@
     (io.kubernetes.client.custom Quantity Quantity$Format IntOrString)
     (io.kubernetes.client.openapi ApiClient ApiException JSON)
     (io.kubernetes.client.openapi.apis CoreV1Api)
-    (io.kubernetes.client.openapi.models V1Affinity V1Container V1ContainerPort V1ContainerState V1DeleteOptions
-                                         V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1Event
-                                         V1HostPathVolumeSource V1HTTPGetAction V1Node V1NodeAffinity V1NodeSelector
-                                         V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta V1ObjectReference
-                                         V1Pod V1PodCondition V1PodSecurityContext V1PodSpec V1PodStatus V1Probe
-                                         V1ResourceRequirements V1Toleration V1VolumeBuilder V1Volume V1VolumeMount)
+    (io.kubernetes.client.openapi.models V1Affinity V1Container V1ContainerPort V1ContainerState V1ContainerStatus
+                                         V1DeleteOptions V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar
+                                         V1Event V1HostPathVolumeSource V1HTTPGetAction V1Node V1NodeAffinity
+                                         V1NodeSelector V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta
+                                         V1ObjectReference V1Pod V1PodCondition V1PodSecurityContext V1PodSpec
+                                         V1PodStatus V1Probe V1ResourceRequirements V1Toleration V1VolumeBuilder
+                                         V1Volume V1VolumeMount)
     (io.kubernetes.client.util Watch)
     (java.net SocketTimeoutException)
     (java.util.concurrent Executors ExecutorService)))
@@ -996,11 +997,15 @@
   (when pod
     (let [^V1PodStatus pod-status (.getStatus pod)
           container-statuses (.getContainerStatuses pod-status)
-          file-server-status (first (filter (fn [c] (= cook-container-name-for-file-server (.getName c)))
-                                            container-statuses))]
+          ^V1ContainerStatus file-server-status
+          (first
+            (filter
+              (fn [c]
+                (= cook-container-name-for-file-server (.getName c)))
+              container-statuses))]
       (cond
         (nil? file-server-status) :unknown
-        (.isReady file-server-status) :running
+        (.getReady file-server-status) :running
         :else :not-running))))
 
 (defn delete-pod
@@ -1018,12 +1023,12 @@
           api
           pod-name
           pod-namespace
+          nil ; pretty
+          nil ; dryRun
+          nil ; gracePeriodSeconds
+          nil ; oprphanDependents
+          nil ; propagationPolicy
           deleteOptions
-          nil                                               ; pretty
-          nil                                               ; dryRun
-          nil                                               ; gracePeriodSeconds
-          nil                                               ; oprphanDependents
-          nil                                               ; propagationPolicy
           )
         (catch JsonSyntaxException e
           ; Silently gobble this exception.

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -14,15 +14,15 @@
   (:import
     (com.google.gson JsonSyntaxException)
     (com.twosigma.cook.kubernetes WatchHelper)
-    (io.kubernetes.client ApiClient ApiException JSON)
-    (io.kubernetes.client.apis CoreV1Api)
     (io.kubernetes.client.custom Quantity Quantity$Format IntOrString)
-    (io.kubernetes.client.models V1Affinity V1Container V1ContainerPort V1ContainerState V1DeleteOptions
-                                 V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1Event
-                                 V1HostPathVolumeSource V1HTTPGetAction V1Node V1NodeAffinity V1NodeSelector
-                                 V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod
-                                 V1PodCondition V1PodSecurityContext V1PodSpec V1PodStatus V1Probe
-                                 V1ResourceRequirements V1Toleration V1VolumeBuilder V1Volume V1VolumeMount)
+    (io.kubernetes.client.openapi ApiClient ApiException JSON)
+    (io.kubernetes.client.openapi.apis CoreV1Api)
+    (io.kubernetes.client.openapi.models V1Affinity V1Container V1ContainerPort V1ContainerState V1DeleteOptions
+                                         V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1Event
+                                         V1HostPathVolumeSource V1HTTPGetAction V1Node V1NodeAffinity V1NodeSelector
+                                         V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta V1ObjectReference
+                                         V1Pod V1PodCondition V1PodSecurityContext V1PodSpec V1PodStatus V1Probe
+                                         V1ResourceRequirements V1Toleration V1VolumeBuilder V1Volume V1VolumeMount)
     (io.kubernetes.client.util Watch)
     (java.net SocketTimeoutException)
     (java.util.concurrent Executors ExecutorService)))

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -11,7 +11,7 @@
             [clojure.tools.logging :as log]
             [metrics.timers :as timers])
   (:import (clojure.lang IAtom)
-           (io.kubernetes.client.models V1Pod V1ContainerStatus V1PodStatus)
+           (io.kubernetes.client.openapi.models V1Pod V1ContainerStatus V1PodStatus)
            (java.net URLEncoder)
            (java.util.concurrent.locks Lock)))
 

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -41,8 +41,8 @@
             [cook.mesos.task :as task])
   (:import (com.netflix.fenzo SimpleAssignmentResult)
            (io.kubernetes.client.custom Quantity$Format Quantity)
-           (io.kubernetes.client.models V1Container V1ResourceRequirements V1Pod V1ObjectMeta V1PodSpec V1Node
-                                        V1NodeStatus V1NodeSpec V1Taint)
+           (io.kubernetes.client.openapi.models V1Container V1ResourceRequirements V1Pod V1ObjectMeta V1PodSpec V1Node
+                                                V1NodeStatus V1NodeSpec V1Taint)
            (java.util UUID)
            (java.util.concurrent Executors)
            (org.apache.log4j ConsoleAppender Logger PatternLayout)))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -531,3 +531,13 @@
                                 {:instance/reason {:reason/name :mesos-unknown}}
                                 {:instance/reason {:reason/name :mesos-unknown}}]}]
         (is (= nil (api/calculate-effective-checkpointing-config job 1)))))))
+
+(deftest test-pod->sandbox-file-server-container-state
+  (testing "file server not running"
+    (let [pod (V1Pod.)
+          pod-status (V1PodStatus.)
+          container-status (V1ContainerStatus.)]
+      (.setName container-status api/cook-container-name-for-file-server)
+      (.addContainerStatusesItem pod-status container-status)
+      (.setStatus pod pod-status)
+      (= :not-running (api/pod->sandbox-file-server-container-state pod)))))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -5,10 +5,10 @@
             [cook.kubernetes.api :as api]
             [cook.test.testutil :as tu]
             [datomic.api :as d])
-  (:import (io.kubernetes.client.models V1Container V1ContainerState V1ContainerStateWaiting V1ContainerStatus
-                                        V1EnvVar V1ListMeta V1Node V1NodeSpec V1ObjectMeta V1Pod V1PodCondition
-                                        V1PodList V1PodSpec V1PodStatus V1ResourceRequirements V1Taint V1Volume
-                                        V1VolumeMount)))
+  (:import (io.kubernetes.client.openapi.models V1Container V1ContainerState V1ContainerStateWaiting V1ContainerStatus
+                                                V1EnvVar V1ListMeta V1Node V1NodeSpec V1ObjectMeta V1Pod V1PodCondition
+                                                V1PodList V1PodSpec V1PodStatus V1ResourceRequirements V1Taint V1Volume
+                                                V1VolumeMount)))
 
 (deftest test-get-consumption
   (testing "correctly computes consumption for a single pod"
@@ -199,7 +199,7 @@
 (defn- k8s-mount->clj [^V1VolumeMount mount]
   {:name (.getName mount)
    :mount-path (.getMountPath mount)
-   :read-only? (.isReadOnly mount)})
+   :read-only? (.getReadOnly mount)})
 
 (defn- dummy-uuid-generator []
   (let [n (atom 0)]
@@ -263,7 +263,7 @@
       (is (= (.getName volume)
              (.getName volume-mount)))
       (is (= host-path (-> volume .getHostPath .getPath)))
-      (is (not (.isReadOnly volume-mount)))
+      (is (not (.getReadOnly volume-mount)))
       (is (= container-path (.getMountPath volume-mount)))))
 
   (testing "disallows configured volumes"

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -8,7 +8,7 @@
             [cook.test.testutil :as tu]
             [datomic.api :as d])
   (:import (clojure.lang ExceptionInfo)
-           (io.kubernetes.client.models V1NodeSelectorRequirement V1Pod V1PodSecurityContext)
+           (io.kubernetes.client.openapi.models V1NodeSelectorRequirement V1Pod V1PodSecurityContext)
            (java.util UUID)
            (java.util.concurrent Executors)))
 

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -6,8 +6,8 @@
             [cook.kubernetes.api :as api]
             [cook.kubernetes.controller :as controller]
             [cook.test.testutil :as tu])
-  (:import (io.kubernetes.client ApiException)
-           (io.kubernetes.client.models V1PodCondition V1PodStatus)
+  (:import (io.kubernetes.client.openapi ApiException)
+           (io.kubernetes.client.openapi.models V1PodCondition V1PodStatus)
            (java.util.concurrent.locks ReentrantLock)))
 
 (defn make-test-kubernetes-config


### PR DESCRIPTION
## Changes proposed in this PR

- upgrading the k8s java client library from 4.0.0 to 7.0.0
- fixing breaking changes
- adding a unit test which would have caught a breaking change faster

## Why are we making these changes?

We're targeting k8s 1.16, and version 4.0.0 of the client library was meant to match with 1.12.

https://github.com/kubernetes-client/java/#compatibility