### PR TITLE
don't set cpu limit on sidecar if not setting on main container

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -778,7 +778,8 @@
 
           ; resources
           (.putRequestsItem resources "cpu" (double->quantity cpu-request))
-          (.putLimitsItem resources "cpu" (double->quantity cpu-limit))
+          (when set-container-cpu-limit?
+            (.putLimitsItem resources "cpu" (double->quantity cpu-limit)))
           (.putRequestsItem resources "memory" (double->quantity (* memory-multiplier memory-request)))
           (.putLimitsItem resources "memory" (double->quantity (* memory-multiplier memory-limit)))
           (.setResources container resources)


### PR DESCRIPTION
## Changes proposed in this PR

- respect set-container-cpu-limit? in sidecar

## Why are we making these changes?

Sidecar cpu is usually set low, but it also can't burst. We've allowed main container to burst but haven't done so for the sidecar
