### PR TITLE
Do not use :missing state for preempted pod.

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -922,66 +922,71 @@
           ;   with the name extra-* fails.
           ; * A job may have additional containers with the name aux-*
           job-status (first (filter (fn [c] (= cook-container-name-for-job (.getName c)))
-                                    container-statuses))]
-      (if (some-> pod .getMetadata .getDeletionTimestamp)
-        ; If a pod has been ordered deleted, treat it as if it was gone, It's being async removed.
-        ; Note that we distinguish between this explicit :missing, and not being there at all when processing
-        ; (:cook-expected-state/killed, :missing) in cook.kubernetes.controller/process
-        {:state :missing
-         :reason "Pod was explicitly deleted"
-         :pod-deleted? true}
-        ; If pod isn't being async removed, then look at the containers inside it.
-        (if job-status
-          (let [^V1ContainerState state (.getState job-status)]
-            (cond
-              (.getWaiting state)
-              (if (pod-containers-not-initialized? (V1Pod->name pod) pod-status)
-                ; If the containers are not getting initialized,
-                ; then we should consider the pod failed. This
-                ; state can occur, for example, when volume
-                ; mounts fail.
-                {:state :pod/failed
-                 :reason "ContainersNotInitialized"}
-                {:state :pod/waiting
-                 :reason (-> state .getWaiting .getReason)})
-              (.getRunning state)
-              {:state :pod/running
-               :reason "Running"}
-              (.getTerminated state)
-              (let [exit-code (-> state .getTerminated .getExitCode)]
-                (if (= 0 exit-code)
-                  {:state :pod/succeeded
-                   :exit exit-code
-                   :reason (-> state .getTerminated .getReason)}
-                  {:state :pod/failed
-                   :exit exit-code
-                   :reason (-> state .getTerminated .getReason)}))
-              :default
-              {:state :pod/unknown
-               :reason "Unknown"}))
-          (cond
-            ; https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
-            ; Failed means:
-            ; All Containers in the Pod have terminated, and at least
-            ; one Container has terminated in failure. That is, the
-            ; Container either exited with non-zero status or was
-            ; terminated by the system.
-            (= (.getPhase pod-status) "Failed") {:state :pod/failed
-                                                 :reason (.getReason pod-status)}
+                                    container-statuses))
+          pod-preempted-timestamp (some-> pod .getMetadata .getLabels (get (or (-> (config/kubernetes) :node-preempted-label) "node-preempted")))
+          synthesized-pod-state
+          (if (some-> pod .getMetadata .getDeletionTimestamp)
+            ; If a pod has been ordered deleted, treat it as if it was gone, It's being async removed.
+            ; Note that we distinguish between this explicit :missing, and not being there at all when processing
+            ; (:cook-expected-state/killed, :missing) in cook.kubernetes.controller/process
+            {:state :missing
+             :reason "Pod was explicitly deleted"
+             :pod-deleted? true}
+            ; If pod isn't being async removed, then look at the containers inside it.
+            (if job-status
+              (let [^V1ContainerState state (.getState job-status)]
+                (cond
+                  (.getWaiting state)
+                  (if (pod-containers-not-initialized? (V1Pod->name pod) pod-status)
+                    ; If the containers are not getting initialized,
+                    ; then we should consider the pod failed. This
+                    ; state can occur, for example, when volume
+                    ; mounts fail.
+                    {:state :pod/failed
+                     :reason "ContainersNotInitialized"}
+                    {:state :pod/waiting
+                     :reason (-> state .getWaiting .getReason)})
+                  (.getRunning state)
+                  {:state :pod/running
+                   :reason "Running"}
+                  (.getTerminated state)
+                  (let [exit-code (-> state .getTerminated .getExitCode)]
+                    (if (= 0 exit-code)
+                      {:state :pod/succeeded
+                       :exit exit-code
+                       :reason (-> state .getTerminated .getReason)}
+                      {:state :pod/failed
+                       :exit exit-code
+                       :reason (-> state .getTerminated .getReason)}))
+                  :default
+                  {:state :pod/unknown
+                   :reason "Unknown"}))
+              (cond
+                ; https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+                ; Failed means:
+                ; All Containers in the Pod have terminated, and at least
+                ; one Container has terminated in failure. That is, the
+                ; Container either exited with non-zero status or was
+                ; terminated by the system.
+                (= (.getPhase pod-status) "Failed") {:state :pod/failed
+                                                     :reason (.getReason pod-status)}
 
-            ; If the pod is unschedulable, then we should consider it failed. Note that
-            ; pod-unschedulable? will never return true for synthetic pods, because
-            ; they will be unschedulable by design, in order to trigger the cluster
-            ; autoscaler to scale up. For non-synthetic pods, however, this state
-            ; likely means something changed about the node we matched to. For example,
-            ; if the ToBeDeletedByClusterAutoscaler taint gets added between when we
-            ; saw available capacity on a node and when we submitted the pod to that
-            ; node, then the pod will never get scheduled.
-            (pod-unschedulable? (V1Pod->name pod) pod-status) {:state :pod/failed
-                                                               :reason "Unschedulable"}
+                ; If the pod is unschedulable, then we should consider it failed. Note that
+                ; pod-unschedulable? will never return true for synthetic pods, because
+                ; they will be unschedulable by design, in order to trigger the cluster
+                ; autoscaler to scale up. For non-synthetic pods, however, this state
+                ; likely means something changed about the node we matched to. For example,
+                ; if the ToBeDeletedByClusterAutoscaler taint gets added between when we
+                ; saw available capacity on a node and when we submitted the pod to that
+                ; node, then the pod will never get scheduled.
+                (pod-unschedulable? (V1Pod->name pod) pod-status) {:state :pod/failed
+                                                                   :reason "Unschedulable"}
 
-            :else {:state :pod/waiting
-                   :reason "Pending"}))))))
+                :else {:state :pod/waiting
+                       :reason "Pending"})))]
+      (if pod-preempted-timestamp
+        (assoc synthesized-pod-state :pod-preempted-timestamp pod-preempted-timestamp)
+        synthesized-pod-state))))
 
 (defn pod->sandbox-file-server-container-state
   "From a V1Pod object, determine the state of the sandbox file server container, running, not running, or unknown.

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -485,9 +485,7 @@
                                         :cook-expected-state/running
                                         (case pod-synthesized-state-modified
                                           ; This indicates that something deleted it behind our back
-                                          :missing (if (some-> synthesized-state :pod-preempted?)
-                                                     (handle-pod-preemption compute-cluster pod-name)
-                                                     (handle-pod-externally-deleted compute-cluster pod-name))
+                                          :missing (handle-pod-externally-deleted compute-cluster pod-name)
                                           ; TODO: May need to mark mea culpa retry
                                           :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
                                           :pod/running cook-expected-state-dict

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -485,7 +485,9 @@
                                         :cook-expected-state/running
                                         (case pod-synthesized-state-modified
                                           ; This indicates that something deleted it behind our back
-                                          :missing (handle-pod-externally-deleted compute-cluster pod-name)
+                                          :missing (if (some-> synthesized-state :pod-preempted-timestamp)
+                                                     (handle-pod-preemption compute-cluster pod-name)
+                                                     (handle-pod-externally-deleted compute-cluster pod-name))
                                           ; TODO: May need to mark mea culpa retry
                                           :pod/failed (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)
                                           :pod/running cook-expected-state-dict

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -381,10 +381,8 @@
         (.setStatus pod pod-status)
         (.setMetadata pod pod-metadata)
         (.setLabels pod-metadata {"node-preempted" 1589084484537})
-        (is (= {:state :missing
-                :reason "Node preempted"
-                :pod-deleted? true
-                :pod-preempted? true}
+        (is (= {:reason "Pending"
+                :state :pod/waiting}
                (api/pod->synthesized-pod-state pod)))))
     (testing "node preempted custom label"
       (with-redefs [config/kubernetes (fn [] {:node-preempted-label "custom-node-preempted"})]
@@ -394,10 +392,8 @@
           (.setStatus pod pod-status)
           (.setMetadata pod pod-metadata)
           (.setLabels pod-metadata {"custom-node-preempted" 1589084484537})
-          (is (= {:state :missing
-                  :reason "Node preempted"
-                  :pod-deleted? true
-                  :pod-preempted? true}
+          (is (= {:reason "Pending"
+                  :state :pod/waiting}
                  (api/pod->synthesized-pod-state pod))))))))
 
 (deftest test-node-schedulable

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -382,7 +382,8 @@
         (.setMetadata pod pod-metadata)
         (.setLabels pod-metadata {"node-preempted" 1589084484537})
         (is (= {:reason "Pending"
-                :state :pod/waiting}
+                :state :pod/waiting
+                :pod-preempted-timestamp 1589084484537}
                (api/pod->synthesized-pod-state pod)))))
     (testing "node preempted custom label"
       (with-redefs [config/kubernetes (fn [] {:node-preempted-label "custom-node-preempted"})]
@@ -393,7 +394,8 @@
           (.setMetadata pod pod-metadata)
           (.setLabels pod-metadata {"custom-node-preempted" 1589084484537})
           (is (= {:reason "Pending"
-                  :state :pod/waiting}
+                  :state :pod/waiting
+                  :pod-preempted-timestamp 1589084484537}
                  (api/pod->synthesized-pod-state pod))))))))
 
 (deftest test-node-schedulable

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -80,10 +80,10 @@
     (is (nil? (do-process :cook-expected-state/running :missing)))
     (is (= :reason-killed-externally @reason))
     (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
-                                                                                    :reason "Node preempted"
+                                                                                    :reason "Pod was explicitly deleted"
                                                                                     :pod-deleted? true
-                                                                                    :pod-preempted? true})))
-    (is (= :reason-killed-externally @reason))
+                                                                                    :pod-preempted-timestamp 1589084484537})))
+    (is (= :reason-slave-removed @reason))
     (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
                                                                                     :reason "Pod was explicitly deleted"
                                                                                     :pod-deleted? true}

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -83,7 +83,7 @@
                                                                                     :reason "Node preempted"
                                                                                     :pod-deleted? true
                                                                                     :pod-preempted? true})))
-    (is (= :reason-slave-removed @reason))
+    (is (= :reason-killed-externally @reason))
     (is (nil? (do-process :cook-expected-state/running :missing :custom-test-state {:state :missing
                                                                                     :reason "Pod was explicitly deleted"
                                                                                     :pod-deleted? true}


### PR DESCRIPTION

## Changes proposed in this PR

- preempted pod label will not change pod state

## Why are we making these changes?

Do not use :missing state for preempted pod. Preempted pod is still alive until a new instance is created.
