### PR TITLE
Supports running the CLI integration tests against k8s

### DIFF
--- a/integration/tests/cook/cli.py
+++ b/integration/tests/cook/cli.py
@@ -73,6 +73,16 @@ def cli(args, cook_url=None, flags=None, stdin=None, env=None, wait_for_exit=Tru
 
 def submit(command=None, cook_url=None, flags=None, submit_flags=None, stdin=None):
     """Submits one job via the CLI"""
+    default_pool = util.default_submit_pool()
+    if default_pool:
+        message = f'Submitting explicitly to the {default_pool} pool (set as default)'
+        if not submit_flags:
+            submit_flags = f'--pool {default_pool}'
+            logger.info(message)
+        elif '--pool' not in submit_flags:
+            submit_flags += f' --pool {default_pool}'
+            logger.info(message)
+
     args = 'submit %s%s' % (submit_flags + ' ' if submit_flags else '', command if command else '')
     cp = cli(args, cook_url, flags, stdin)
     uuids = [s for s in stdout(cp).split() if len(s) == 36 and util.is_valid_uuid(s)]

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -716,6 +716,7 @@ if __name__ == '__main__':
         finally:
             util.kill_jobs(self.cook_url, job_uuids, assert_response=False)
 
+    @unittest.skipIf(util.using_kubernetes(), 'This test is not yet supported on kubernetes')
     def test_ssh_job_uuid(self):
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -768,6 +769,7 @@ if __name__ == '__main__':
         self.assertEqual(1, cp.returncode, cp.stdout)
         self.assertIn('You provided a job group uuid', cli.decode(cp.stderr))
 
+    @unittest.skipIf(util.using_kubernetes(), 'This test is not yet supported on kubernetes')
     def test_ssh_instance_uuid(self):
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--name {self.current_name()}')
         self.assertEqual(0, cp.returncode, cp.stderr)
@@ -855,6 +857,7 @@ if __name__ == '__main__':
         self.assertEqual(0, cp.returncode, cp.stderr)
         self.assertEqual('helloworld' * pow(2, iterations), cli.decode(cp.stdout))
 
+    @unittest.skipIf(util.using_kubernetes(), 'This test is not yet supported on kubernetes')
     def test_tail_follow(self):
         sleep_seconds_between_lines = 0.5
         cp, uuids = cli.submit(
@@ -1975,7 +1978,7 @@ if __name__ == '__main__':
 
         all_uuids = [uuid_1, uuid_2, uuid_3, uuid_4, uuid_5, uuid_6, uuid_7, uuid_8, uuid_9]
 
-        default_pool = util.default_pool(self.cook_url)
+        default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)
         active_pools, _ = util.active_pools(self.cook_url)
         extra_pool = None
 


### PR DESCRIPTION
## Changes proposed in this PR

- respecting `COOK_TEST_DEFAULT_SUBMIT_POOL` in CLI tests
- marking 3 CLI tests as skip-on-k8s

## Why are we making these changes?

These changes allow us to run the CLI integration tests against k8s by specifically targeting k8s Cook pools (i.e. setting `COOK_TEST_DEFAULT_SUBMIT_POOL` to a k8s Cook pool).
