### PR TITLE
Makes vagrant python bootstrapping not run as root

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,9 +11,44 @@ Vagrant.configure("2") do |config|
 
   # This runs as vagrant:
   $script = <<-SCRIPT
+  repo_root=/vagrant
+  bashrc=$HOME/.bashrc
+
   # Cook jobclient setup
-  cd /vagrant/jobclient || exit 1
+  cd $repo_root/jobclient || exit 1
   mvn install -DskipTests
+
+  # Python setup
+  pip3 install --upgrade pip
+  pip3 install --upgrade setuptools
+  pip3 install --upgrade wheel
+  pip3 install --upgrade virtualenv
+  cd $repo_root || exit 1
+  venv=$repo_root/venv
+  rm -rf $venv
+  $HOME/.local/bin/virtualenv venv --python=python3.6
+  source $venv/bin/activate
+  echo "source $venv/bin/activate" | tee -a $bashrc
+  export PATH=$venv/bin:$PATH
+  echo 'export PATH='$venv'/bin:$PATH' | tee -a $bashrc
+
+  # Integration tests setup
+  echo "export COOK_TEST_DOCKER_IMAGE=gcr.io/google-containers/alpine-with-bash:1.0" | tee -a $bashrc
+  echo "export COOK_TEST_DOCKER_WORKING_DIRECTORY=/mnt/sandbox" | tee -a $bashrc
+  echo "export COOK_TEST_DISALLOW_POOLS_REGEX='(?!^k8s-(alpha)$)'" | tee -a $bashrc
+  echo "export COOK_TEST_DEFAULT_SUBMIT_POOL=k8s-alpha" | tee -a $bashrc
+  echo "export COOK_TEST_COMPUTE_CLUSTER_TYPE=kubernetes" | tee -a $bashrc
+  echo "export COOK_TEST_DEFAULT_TIMEOUT_MS=480000" | tee -a $bashrc
+  echo "export COOK_TEST_DEFAULT_WAIT_INTERVAL_MS=8000" | tee -a $bashrc
+  cd $repo_root/integration || exit 1
+  pip3 install -r requirements.txt
+
+  # Cook Scheduler CLI setup
+  cli=$repo_root/cli
+  cd $cli || exit 1
+  pip3 install -e .
+  rm -f $HOME/.cs.json
+  ln -s $cli/.cs.json $HOME/.cs.json
   SCRIPT
   config.vm.provision "shell", inline: $script, privileged: false
 end

--- a/scheduler/bin/bootstrap
+++ b/scheduler/bin/bootstrap
@@ -53,25 +53,3 @@ gcloud components install kubectl
 
 # Start in the scheduler dir
 echo 'cd '"$scheduler" | tee -a $bashrc
-
-# Python setup
-pip3 install --upgrade pip setuptools wheel
-
-# Cook Scheduler CLI setup
-cli=$scheduler/../cli
-cd $cli || exit 1
-pip3 install -e .
-cs --version
-rm -f $home_dir/.cs.json
-ln -s $cli/.cs.json $home_dir/.cs.json
-
-# Integration tests setup
-echo "export COOK_TEST_DOCKER_IMAGE=gcr.io/google-containers/alpine-with-bash:1.0" | tee -a $bashrc
-echo "export COOK_TEST_DOCKER_WORKING_DIRECTORY=/mnt/sandbox" | tee -a $bashrc
-echo "export COOK_TEST_DISALLOW_POOLS_REGEX='(?!^k8s-(alpha)$)'" | tee -a $bashrc
-echo "export COOK_TEST_DEFAULT_SUBMIT_POOL=k8s-alpha" | tee -a $bashrc
-echo "export COOK_TEST_COMPUTE_CLUSTER_TYPE=kubernetes" | tee -a $bashrc
-echo "export COOK_TEST_DEFAULT_TIMEOUT_MS=480000" | tee -a $bashrc
-echo "export COOK_TEST_DEFAULT_WAIT_INTERVAL_MS=8000" | tee -a $bashrc
-integration=$scheduler/../integration
-pip3 install -r $integration/requirements.txt


### PR DESCRIPTION
## Changes proposed in this PR

- moving the python bootstrapping to the non-root section of the vagrant setup

## Why are we making these changes?

When it was running as root, making changes to the python environment (e.g. the python CLI) was not possible as non-root.