### PR TITLE
Makes test_basic_submit more reliable

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -53,7 +53,7 @@ class CookTest(util.CookTest):
 
     def test_basic_submit(self):
         job_executor_type = util.get_job_executor_type()
-        job_uuid, resp = util.submit_job(self.cook_url, executor=job_executor_type)
+        job_uuid, resp = util.submit_job(self.cook_url, executor=job_executor_type, max_retries=5)
         self.assertEqual(resp.status_code, 201, msg=resp.content)
         self.assertEqual(resp.content, str.encode(f"submitted jobs {job_uuid}"))
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')


### PR DESCRIPTION
## Changes proposed in this PR

- giving the job 5 attempts instead of just 1

## Why are we making these changes?

So that transient instance failures don't cause the test to fail.
