### PR TITLE
Fix an O(n**2) calculation in computing k8s offers.

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -31,9 +31,9 @@
 
 (defn schedulable-node-filter
   "Is a node schedulable?"
-  [node-name->node [node-name _] {:keys [node-blocklist-labels] :as compute-cluster} pods]
+  [node-name->node node-name->pods {:keys [node-blocklist-labels] :as compute-cluster} [node-name _]]
   (if-let [^V1Node node (node-name->node node-name)]
-    (api/node-schedulable? node (cc/max-tasks-per-host compute-cluster) pods node-blocklist-labels)
+    (api/node-schedulable? node (cc/max-tasks-per-host compute-cluster) node-name->pods node-blocklist-labels)
     (do
       (log/error "In" (cc/compute-cluster-name compute-cluster)
                  "compute cluster, unable to get node from node name" node-name)
@@ -47,10 +47,10 @@
 
 (defn generate-offers
   "Given a compute cluster and maps with node capacity and existing pods, return a map from pool to offers."
-  [compute-cluster node-name->node pods]
+  [compute-cluster node-name->node node-name->pods]
   (let [compute-cluster-name (cc/compute-cluster-name compute-cluster)
         node-name->capacity (api/get-capacity node-name->node)
-        node-name->consumed (api/get-consumption pods)
+        node-name->consumed (api/get-consumption node-name->pods)
         node-name->available (pc/map-from-keys (fn [node-name]
                                                  (merge-with -
                                                              (node-name->capacity node-name)
@@ -68,11 +68,11 @@
     (log/info "In" compute-cluster-name "compute cluster, consumption:" node-name->consumed)
     (log/info "In" compute-cluster-name "compute cluster, filtering out"
               (->> node-name->available
-                   (remove #(schedulable-node-filter node-name->node % compute-cluster pods))
+                   (remove #(schedulable-node-filter node-name->node node-name->pods compute-cluster %))
                    count)
               "nodes as not schedulable")
     (->> node-name->available
-         (filter #(schedulable-node-filter node-name->node % compute-cluster pods))
+         (filter #(schedulable-node-filter node-name->node node-name->pods compute-cluster %))
          (map (fn [[node-name available]]
                 {:id {:value (str (UUID/randomUUID))}
                  :framework-id compute-cluster-name
@@ -309,7 +309,8 @@
     (let [timer (timers/start (metrics/timer "cc-pending-offers-compute" name))
           pods (add-starting-pods this @all-pods-atom)
           nodes @current-nodes-atom
-          offers-all-pools (generate-offers this nodes pods)
+          node-name->pods (api/pods->node-name->pods pods)
+          offers-all-pools (generate-offers this nodes node-name->pods)
           ; TODO: We are generating offers for every pool here, and filtering out only offers for this one pool.
           ; TODO: We should be smarter here and generate once, then reuse for each pool, instead of generating for each pool each time and only keeping one
           offers-this-pool (get offers-all-pools pool-name)

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -13,19 +13,21 @@
 
 (deftest test-get-consumption
   (testing "correctly computes consumption for a single pod"
-    (let [pods [(tu/pod-helper "podA" "hostA" {:cpus 1.0 :mem 100.0})]]
+    (let [pods [(tu/pod-helper "podA" "hostA" {:cpus 1.0 :mem 100.0})]
+          node-name->pods (api/pods->node-name->pods pods)]
       (is (= {"hostA" {:cpus 1.0
                        :mem 100.0}}
-             (api/get-consumption pods)))))
+             (api/get-consumption node-name->pods)))))
 
   (testing "correctly computes consumption for a pod with multiple containers"
     (let [pods [(tu/pod-helper "podA" "hostA"
                                {:cpus 1.0 :mem 100.0}
                                {:cpus 1.0 :mem 0.0}
-                               {:mem 100.0})]]
+                               {:mem 100.0})]
+          node-name->pods (api/pods->node-name->pods pods)]
       (is (= {"hostA" {:cpus 2.0
                        :mem 200.0}}
-             (api/get-consumption pods)))))
+             (api/get-consumption node-name->pods)))))
 
   (testing "correctly aggregates pods by node name"
     (let [pods [(tu/pod-helper "podA" "hostA"
@@ -36,11 +38,12 @@
                                {:cpus 1.0}
                                {:mem 100.0})
                 (tu/pod-helper "podD" "hostC"
-                               {:cpus 1.0})]]
+                               {:cpus 1.0})]
+          node-name->pods (api/pods->node-name->pods pods)]
       (is (= {"hostA" {:cpus 2.0 :mem 100.0}
               "hostB" {:cpus 1.0 :mem 100.0}
               "hostC" {:cpus 1.0 :mem 0.0}}
-             (api/get-consumption pods))))))
+             (api/get-consumption node-name->pods))))))
 
 (deftest test-get-capacity
   (let [node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 100.0 nil)

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -91,17 +91,17 @@
           task-2 (tu/make-task-metadata job-ent-2 db compute-cluster)
           _ (cc/launch-tasks compute-cluster "no-pool" [{:task-metadata-seq [task-1 task-2]}] (fn [_]))
           task-1-id (-> task-1 :task-request :task-id)
-          pod-name->pod {{:namespace "cook" :name "podA"} (tu/pod-helper "podA" "nodeA"
-                                                                         {:cpus 0.25 :mem 250.0}
-                                                                         {:cpus 0.1 :mem 100.0})
-                         {:namespace "cook" :name "podB"} (tu/pod-helper "podB" "nodeA"
-                                                                         {:cpus 0.25 :mem 250.0})
-                         {:namespace "cook" :name "podC"} (tu/pod-helper "podC" "nodeB"
-                                                                         {:cpus 1.0 :mem 1100.0})
-                         {:namespace "cook" :name task-1-id} (tu/pod-helper task-1-id "my.fake.host"
-                                                                            {:cpus 0.1 :mem 10.0})}
-          all-offers (kcc/generate-offers compute-cluster node-name->node
-                                          (kcc/add-starting-pods compute-cluster pod-name->pod))
+          pods {{:namespace "cook" :name "podA"} (tu/pod-helper "podA" "nodeA"
+                                                                {:cpus 0.25 :mem 250.0}
+                                                                {:cpus 0.1 :mem 100.0})
+                {:namespace "cook" :name "podB"} (tu/pod-helper "podB" "nodeA"
+                                                                {:cpus 0.25 :mem 250.0})
+                {:namespace "cook" :name "podC"} (tu/pod-helper "podC" "nodeB"
+                                                                {:cpus 1.0 :mem 1100.0})
+                {:namespace "cook" :name task-1-id} (tu/pod-helper task-1-id "my.fake.host"
+                                                                   {:cpus 0.1 :mem 10.0})}
+          node-name->pods (api/pods->node-name->pods (kcc/add-starting-pods compute-cluster pods))
+          all-offers (kcc/generate-offers compute-cluster node-name->node node-name->pods)
           offers (get all-offers "no-pool")]
       (is (= 4 (count offers)))
       (let [offer (first (filter #(= "nodeA" (:hostname %))


### PR DESCRIPTION
## Changes proposed in this PR

-  Remove an expensive O(n**2) in k8s offer calculation.

## Why are we making these changes?

The former node-schedulable? computation was O(#pods) and was invoked
O(#nodes times). Instead we group-by once at the top level and pass that
down so that now O(#pods) is an O(1) calculation.
