### PR TITLE
Rename package from cookclient to cook-client-api

### DIFF
--- a/jobclient/python/setup.py
+++ b/jobclient/python/setup.py
@@ -11,7 +11,7 @@ requirements = [
     'requests'
 ]
 
-setup(name='cookclient',
+setup(name='cook-client-api',
       version=CLIENT_VERSION,
       description="Cook Scheduler Client API for Python",
       long_description=readme,


### PR DESCRIPTION
## Changes proposed in this PR

- Rename the Python client API from `cookclient` to `cook-client-api`
- The actual module name is still `cookclient`

## Why are we making these changes?

Match the convention of Cook's existing pip projects