### PR TITLE
Fixes whitespace bug in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ matrix:
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh
       script:
-      	- export PYTHONPATH=$PWD/jobclient/python
-      	- ./travis/run_integration.sh --executor=cook --image=python:3.5
+        - export PYTHONPATH=$PWD/jobclient/python
+        - ./travis/run_integration.sh --executor=cook --image=python:3.5
 
     # We want a small rate limit to make the job launch rate limit integration test be stable and not
     # need to launch a lot of jobs. Those low launch rate limit settings would cause other integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       install: sudo ./travis/install_mesos.sh
       before_script: cd integration && ./travis/prepare_integration.sh
       script:
-        - export PYTHONPATH=$PWD/jobclient/python
+        - export PYTHONPATH=$PWD/../jobclient/python
         - ./travis/run_integration.sh --executor=cook --image=python:3.5
 
     # We want a small rate limit to make the job launch rate limit integration test be stable and not

--- a/scheduler/travis/setup.sh
+++ b/scheduler/travis/setup.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Install the current version of the jobclient
-pushd ${TRAVIS_BUILD_DIR}/jobclient
+pushd ${TRAVIS_BUILD_DIR}/jobclient/java
 mvn install
 popd
 


### PR DESCRIPTION
## Changes proposed in this PR

- replacing tab characters with spaces

## Why are we making these changes?

Travis builds are not working because they can't parse the yaml:

![image](https://user-images.githubusercontent.com/444778/85629399-6b6d4080-b637-11ea-987d-80efb6cf311f.png)

(https://travis-ci.org/github/twosigma/Cook/requests)