### PR TITLE
Make separate matching chime per pool

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -899,10 +899,7 @@ class MultiUserCookTest(util.CookTest):
                            "EQUALS",
                            "won't get scheduled"]]
         group = {'uuid': str(util.make_temporal_uuid())}
-        job_spec = {'group': group['uuid'],
-                    'command': 'sleep 30',
-                    'cpus': util.max_cpus()}
-        uuids, resp = util.submit_jobs(self.cook_url, job_spec, clones=1, groups=[group], constraints=bad_constraints)
+        uuid, resp = util.submit_job(self.cook_url, command='sleep 30', group=group['uuid'], constraints=bad_constraints)
         self.assertEqual(201, resp.status_code, resp.content)
         try:
             default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)
@@ -914,10 +911,10 @@ class MultiUserCookTest(util.CookTest):
                     return util.query_queue(self.cook_url)
 
                 def queue_predicate(resp):
-                    return any([job['job/uuid'] in uuids for job in resp.json()[pool]])
+                    return any([job['job/uuid'] == uuid for job in resp.json()[pool]])
 
                 resp = util.wait_until(query_queue, queue_predicate)
-                job = [job for job in resp.json()[pool] if job['job/uuid'] in uuids][0]
+                job = [job for job in resp.json()[pool] if job['job/uuid'] == uuid][0]
                 job_group = job['group/_job'][0]
                 self.assertEqual(200, resp.status_code, resp.content)
                 self.assertTrue('group/_job' in job.keys())
@@ -925,7 +922,7 @@ class MultiUserCookTest(util.CookTest):
                 self.assertTrue('group/host-placement' in job_group.keys())
                 self.assertFalse('group/job' in job_group.keys())
         finally:
-            util.kill_jobs(self.cook_url, uuids)
+            util.kill_jobs(self.cook_url, [uuid])
 
     @unittest.skipUnless(util.pool_mover_plugin_configured(), 'Requires the "pool mover" job adjuster plugin')
     def test_pool_mover_plugin(self):

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -895,11 +895,14 @@ class MultiUserCookTest(util.CookTest):
                         self.assertEqual(resp.status_code, 200, resp.text)
 
     def test_queue_endpoint(self):
+        bad_constraints = [["HOSTNAME",
+                           "EQUALS",
+                           "won't get scheduled"]]
         group = {'uuid': str(util.make_temporal_uuid())}
         job_spec = {'group': group['uuid'],
                     'command': 'sleep 30',
                     'cpus': util.max_cpus()}
-        uuids, resp = util.submit_jobs(self.cook_url, job_spec, clones=100, groups=[group])
+        uuids, resp = util.submit_jobs(self.cook_url, job_spec, clones=1, groups=[group], constraints=bad_constraints)
         self.assertEqual(201, resp.status_code, resp.content)
         try:
             default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -938,6 +938,7 @@
 (counters/defcounter [cook-mesos scheduler offer-chan-depth])
 
 (defn make-offer-handler
+  "Make the core scheduling loop for a pool"
   [conn fenzo pool-name->pending-jobs-atom agent-attributes-cache max-considerable scaleback
    floor-iterations-before-warn floor-iterations-before-reset trigger-chan rebalancer-reservation-atom
    mesos-run-as-user pool-name compute-clusters]
@@ -1554,6 +1555,7 @@
   (persist-mea-culpa-failure-limit! conn mea-culpa-failure-limit)
 
   (let [{:keys [match-trigger-chan rank-trigger-chan]} trigger-chans
+        match-trigger-chan-mult (async/mult match-trigger-chan)
         pools (pool/all-pools (d/db conn))
         pools' (if (-> pools count pos?)
                  pools
@@ -1568,7 +1570,8 @@
                         (make-offer-handler
                           conn fenzo pool-name->pending-jobs-atom agent-attributes-cache fenzo-max-jobs-considered
                           fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset
-                          match-trigger-chan rebalancer-reservation-atom mesos-run-as-user pool-name compute-clusters)]
+                          (async/tap match-trigger-chan-mult (async/chan (async/sliding-buffer 1)))
+                          rebalancer-reservation-atom mesos-run-as-user pool-name compute-clusters)]
                     (-> m
                         (assoc-in [:pool->resources-atom pool-name] resources-atom))))
                 {}


### PR DESCRIPTION
## Changes proposed in this PR

- split signal from match-trigger-chan per pool

## Why are we making these changes?

Every pool will get its own chime to do matching instead of randomly getting to match by winning the race to listen on a single chime
