### PR TITLE
Avoids autoscaling beyond what users have quota to run

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2137,8 +2137,9 @@
                         pool->user->usage (util/pool->user->usage db)]
                     (pc/for-map [[pool-name queue] pool->queue]
                                 pool-name (->> queue
-                                               (util/filter-based-on-quota (pool->user->quota pool-name)
-                                                                           (pool->user->usage pool-name))
+                                               (util/filter-pending-jobs-for-autoscaling
+                                                 (pool->user->quota pool-name)
+                                                 (pool->user->usage pool-name))
                                                (take (::limit ctx)))))))))
 
 ;;

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -906,7 +906,8 @@
                 ;; trigger autoscaling beyond what users have quota to actually run
                 autoscalable-jobs (->> pool-name
                                        (get @pool-name->pending-jobs-atom)
-                                       (tools/filter-based-on-quota user->quota user->usage))]
+                                       (tools/filter-pending-jobs-for-autoscaling
+                                         user->quota user->usage))]
             ;; This call needs to happen *after* launch-matched-tasks!
             ;; in order to avoid autoscaling tasks taking up available
             ;; capacity that was already matched for real Cook tasks.

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -908,6 +908,13 @@
               [user->usage' (below-quota? (user->quota user) (get user->usage' user))]))]
     (filter-sequential filter-with-quota user->usage queue)))
 
+(defn filter-pending-jobs-for-autoscaling
+  "Lazily filters jobs to those that should be considered
+  for autoscaling purposes. Note that this is used in two
+  places: the /queue endpoint (Mesos only) and as an
+  argument to scheduler/trigger-autoscaling! (k8s only)."
+  [user->quota user->usage queue]
+  (filter-based-on-quota user->quota user->usage queue))
 
 (defn pool->user->usage
   "Returns a map from pool name to user name to usage for all users in all pools."


### PR DESCRIPTION
## Changes proposed in this PR

- filtering pending jobs based on quota before calling `trigger-autoscaling!`

## Why are we making these changes?

So that we don't trigger autoscaling beyond what users have quota to actually run.
