### PR TITLE
Refactor out common method for matching regexps against a pool name.

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -680,18 +680,12 @@
 (defn get-default-container-for-pool
   "Given a pool name, determine a default container that should be run on it."
   [default-containers effective-pool-name]
-  (->> default-containers
-       (filter (fn [{:keys [pool-regex]}] (re-find (re-pattern pool-regex) effective-pool-name)))
-       first
-       :container))
+  (util/match-based-on-pool-name default-containers effective-pool-name :container))
 
 (defn get-gpu-models-on-pool
    "Given a pool name, determine the supported GPU models on that pool."
    [valid-gpu-models effective-pool-name]
-   (->> valid-gpu-models
-        (filter (fn [{:keys [pool-regex]}] (re-find (re-pattern pool-regex) effective-pool-name)))
-        first
-        :valid-models))
+   (util/match-based-on-pool-name valid-gpu-models effective-pool-name :valid-models))
 
 (s/defn make-job-txn
   "Creates the necessary txn data to insert a job into the database"

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -893,6 +893,15 @@
     (cond-> {:count 1 :cpus cpus :mem mem}
       gpus (assoc :gpus gpus))))
 
+(defn match-based-on-pool-name
+  "Given a list of dictionaries [{:pool-regexp .. :field ...} {:pool-regexp .. :field ...}
+   a pool name and a <field> name, return the first matching <field> where the regexp matches the pool name."
+  [match-list effective-pool-name field]
+  (->> match-list
+       (filter (fn [{:keys [pool-regex]}] (re-find (re-pattern pool-regex) effective-pool-name)))
+       first
+       field))
+
 (defn filter-based-on-quota
   "Lazily filters jobs for which the sum of running jobs and jobs earlier in the queue exceeds one of the constraints,
    max-jobs, max-cpus or max-mem"

--- a/scheduler/test/cook/test/tools.clj
+++ b/scheduler/test/cook/test/tools.clj
@@ -826,6 +826,16 @@
                         :count 1}}}
            (util/pool->user->usage (d/db conn))))))
 
+(deftest test-match-based-on-pool-name
+  (let [matchlist
+        [{:pool-regex "^foo$" :field {:foo 1}}
+         {:pool-regex ".*" :field {:bar 2}}
+         {:pool-regex "^baz$" :field {:baz 3}}]]
+    (is (= (util/match-based-on-pool-name matchlist "foo" :field) {:foo 1}))
+    (is (= (util/match-based-on-pool-name matchlist "bar" :field) {:bar 2}))
+    (is (= (util/match-based-on-pool-name matchlist "baz" :field) {:bar 2})))
+  (is (= (util/match-based-on-pool-name [] "foo" :field) nil)))
+  
 (deftest test-atom-updater
   (let [map-atom (atom {})
         testfn (util/make-atom-updater map-atom)]


### PR DESCRIPTION
## Changes proposed in this PR

- Refactor some redundant code for matching pools against a list of regexps.

## Why are we making these changes?
Remove redundant code that will be used a third time.

