### PR TITLE
Adds port mappings to k8s pod spec

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -671,7 +671,7 @@
         ;; whereas :scalar-requests always contains the unmodified job resource values.
         {:strs [mem cpus]} scalar-requests
         {:keys [docker volumes]} container
-        {:keys [image parameters]} docker
+        {:keys [image parameters port-mapping]} docker
         {:keys [environment]} command
         pod (V1Pod.)
         pod-spec (V1PodSpec.)
@@ -737,6 +737,15 @@
                        (:value command)))
     (.setEnv container main-env-vars)
     (.setImage container image)
+    (doseq [{:keys [container-port host-port protocol]} port-mapping]
+      (when container-port
+        (let [port (V1ContainerPort.)]
+          (.containerPort port (int container-port))
+          (when host-port
+            (.hostPort port (int host-port)))
+          (when protocol
+            (.protocol port protocol))
+          (.addPortsItem container port))))
 
     ; allocate a TTY to support tools that need to read from stdin
     (.setTty container true)


### PR DESCRIPTION
## Changes proposed in this PR

- adds ports from `port-mapping` to the k8s pod spec

## Why are we making these changes?

To allow k8s-bound jobs to specify ports to open.
