### PR TITLE
Support config-based global quotas for a pool

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2646,9 +2646,12 @@ class CookTest(util.CookTest):
         job_mem = 16
         job_cpus = .01
 
-        if quota["mem"] < job_mem * (job_count + 3):
+        total_cpus_requested = job_count * job_cpus
+        total_mem_requested = job_count * job_mem
+
+        if quota["mem"] < total_mem_requested:
             self.fail("Quota memory too small for test")
-        if quota["cpus"] < job_cpus * (job_count + 3):
+        if quota["cpus"] < total_cpus_requested:
             self.fail("Quota cpus to small for test")
 
         # Now lookup the user quota and make sure it fits and fail if otherwise.
@@ -2656,11 +2659,11 @@ class CookTest(util.CookTest):
         resp = util.get_limit(self.cook_url, 'quota', user)
         user_quota = resp.json()['pools'][pool_name]
         logging.info(f"User quota {user_quota}")
-        if user_quota["count"] < job_count + 3:
+        if user_quota["count"] < job_count:
             self.fail("User quota count too small for test")
-        if user_quota["mem"] < job_mem * (job_count + 3):
+        if user_quota["mem"] < total_mem_requested:
             self.fail("User quota memory too small for test")
-        if user_quota["cpus"] < job_cpus * (job_count + 3):
+        if user_quota["cpus"] < total_cpus_requested:
             self.fail("User Quota cpus to small for test")
 
         sleep_command = f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2680,7 +2680,7 @@ class CookTest(util.CookTest):
             # Wait until at least 2 are running.
             util.wait_until(query, predicate)
             # Wait an extra 60 seconds to see if anything else starts.
-            time.sleep(60.0)
+            time.sleep(20.0)
             jobs = util.query_jobs(self.cook_url, True, uuid=job_uuids).json()
             running = [job for job in jobs if job['status'] == 'running']
             self.assertEqual(2, len(running), jobs)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1810,6 +1810,8 @@ def has_one_agent():
 def supports_exit_code():
     return using_kubernetes() or is_cook_executor_in_use()
 
+def pool_quota_test_pool():
+    return os.getenv("COOK_TEST_POOL_QUOTA_TEST_POOL", None)
 
 def kill_running_and_waiting_jobs(cook_url, user):
     one_hour_in_millis = 60 * 60 * 1000

--- a/scheduler/bin/help-make-cluster
+++ b/scheduler/bin/help-make-cluster
@@ -18,7 +18,7 @@ CLUSTERNAME=$3
 COOK_KUBECONFIG=$4
 GKE_CLUSTER_OWNER=${GKE_CLUSTER_OWNER:-$USER}
 
-VERSION=1.15.11-gke.12
+VERSION=1.15.11-gke.17
 
 gcloud="gcloud --project $PROJECT"
 
@@ -68,6 +68,17 @@ $gcloud container node-pools create cook-pool-k8s-alpha \
        --min-nodes=0 \
        --max-nodes=6 \
        --node-labels=cook-pool=k8s-alpha,test-label=true
+$gcloud container node-pools create cook-pool-k8s-quota \
+       --zone "$ZONE" \
+       --cluster="$CLUSTERNAME" \
+       --disk-size=20gb \
+       --machine-type=g1-small \
+       --node-taints=cook-pool=k8s-quota:NoSchedule \
+       --enable-autoscaling \
+       --min-nodes=0 \
+       --max-nodes=6 \
+       --node-labels=cook-pool=k8s-quota,test-label=true
+
 
 echo "---- Setting up cook namespace in kubernetes"
 KUBECONFIG=${COOK_KUBECONFIG} kubectl create -f docs/make-kubernetes-namespace.json

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -87,11 +87,11 @@
          :job-resource-adjustment {:adjust-job-resources-fn cook.kubernetes.api/adjust-job-resources
                                    :pool-regex "^k8s-.+"}
          :default-containers
-         [{:pool-regex "k8s-.*" :container {:type "docker"
-                                            :docker {:image "python:3.6",
-                                                     :network "HOST"
-                                                     :force-pull-image false
-                                                     :parameters []}}}]
+         [{:pool-regex "k8s-(alpha|gamma)" :container {:type "docker"
+                                                      :docker {:image "python:3.6",
+                                                               :network "HOST"
+                                                               :force-pull-image false
+                                                               :parameters []}}}]
          :quotas [{:pool-regex "k8s-quota"
                    :quota {:count 2 :cpus 10000.0 :mem 20000.0}}
                   {:pool-regex "k8s-.*"

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -91,7 +91,11 @@
                                             :docker {:image "python:3.6",
                                                      :network "HOST"
                                                      :force-pull-image false
-                                                     :parameters []}}}]}
+                                                     :parameters []}}}]
+         :quotas [{:pool-regex "k8s-.*"
+                   :quota {:count 10000 :cpus 10000.0 :mem 20000.0}}
+                  {:pool-regex ".*"
+                   :quota {:count 10000 :cpus 10000.0 :mem 20000.0}}]}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -29,7 +29,7 @@
                                                :max-total-nodes 3000
                                                :user #config/env "USER"
                                                :command "exit 0"
-                                               :pools #{"k8s-alpha" "k8s-gamma"}}
+                                               :pools #{"k8s-alpha" "k8s-gamma" "k8s-quota"}}
                               :node-blocklist-labels ["blocklist-nodes-with-this-label-key"]
                               :use-google-service-account? false
                               ;; Used to work around auth problems after upgrading k8s client library to 7.0.0
@@ -92,7 +92,9 @@
                                                      :network "HOST"
                                                      :force-pull-image false
                                                      :parameters []}}}]
-         :quotas [{:pool-regex "k8s-.*"
+         :quotas [{:pool-regex "k8s-quota"
+                   :quota {:count 2 :cpus 10000.0 :mem 20000.0}}
+                  {:pool-regex "k8s-.*"
                    :quota {:count 10000 :cpus 10000.0 :mem 20000.0}}
                   {:pool-regex ".*"
                    :quota {:count 10000 :cpus 10000.0 :mem 20000.0}}]}

--- a/scheduler/datomic/data/seed_k8s_pools.clj
+++ b/scheduler/datomic/data/seed_k8s_pools.clj
@@ -32,6 +32,7 @@
     (create-pool conn "k8s-beta" :pool.state/inactive)
     (create-pool conn "k8s-gamma" :pool.state/active)
     (create-pool conn "k8s-delta" :pool.state/inactive)
+    (create-pool conn "k8s-quota" :pool.state/active)
     (quota/set-quota! conn "default" "k8s-alpha" "For quota-related testing." :cpus 8 :mem 1024)
     (quota/set-quota! conn "default" "k8s-gamma" "For quota-related testing." :cpus 9 :mem 2048)
     (println "Pools & Quotas:")

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -426,7 +426,9 @@
                         #(-> %
                              (update :pool-regex re-pattern)))
                 (not (:default-containers pools))
-                (assoc :default-containers [])))
+                (assoc :default-containers [])
+                (not (:quotas pools))
+                (assoc :quotas [])))
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
      :estimated-completion-constraint (fnk [[:config {estimated-completion-constraint nil}]]
@@ -618,6 +620,10 @@
 (defn task-constraints
   []
   (get-in config [:settings :task-constraints]))
+
+(defn pool-quotas
+  []
+  (get-in config [:settings :pools :quotas]))
 
 (defn offer-matching
   []

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2135,7 +2135,8 @@
                                 pool-name (->> queue
                                                (util/filter-pending-jobs-for-autoscaling
                                                  (pool->user->quota pool-name)
-                                                 (pool->user->usage pool-name))
+                                                 (pool->user->usage pool-name)
+                                                 (util/get-quota-for-pool (config/pool-quotas) pool-name))
                                                (take (::limit ctx)))))))))
 
 ;;

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2133,10 +2133,10 @@
                         pool->user->usage (util/pool->user->usage db)]
                     (pc/for-map [[pool-name queue] pool->queue]
                                 pool-name (->> queue
-                                               (util/filter-pending-jobs-for-autoscaling
+                                               (util/filter-pending-jobs-for-quota
                                                  (pool->user->quota pool-name)
                                                  (pool->user->usage pool-name)
-                                                 (util/get-quota-for-pool (config/pool-quotas) pool-name))
+                                                 (util/global-pool-quota (config/pool-quotas) pool-name))
                                                (take (::limit ctx)))))))))
 
 ;;

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -655,7 +655,7 @@
             (not (and is-rate-limited? enforcing-job-launch-rate-limit?))))
         considerable-jobs
         (->> pending-jobs
-             (tools/filter-pending-jobs-for-autoscaling user->quota user->usage (tools/get-quota-for-pool (config/pool-quotas) pool-name))
+             (tools/filter-pending-jobs-for-quota user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name))
              (filter (fn [job] (tools/job-allowed-to-start? db job)))
              (filter user-within-launch-rate-limit?-fn)
              (filter launch-plugin/filter-job-launches)
@@ -916,8 +916,8 @@
                 ;; trigger autoscaling beyond what users have quota to actually run
                 autoscalable-jobs (->> pool-name
                                        (get @pool-name->pending-jobs-atom)
-                                       (tools/filter-pending-jobs-for-autoscaling
-                                         user->quota user->usage (tools/get-quota-for-pool (config/pool-quotas) pool-name)))]
+                                       (tools/filter-pending-jobs-for-quota
+                                         user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name)))]
             ;; This call needs to happen *after* launch-matched-tasks!
             ;; in order to avoid autoscaling tasks taking up available
             ;; capacity that was already matched for real Cook tasks.

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -641,7 +641,6 @@
   (let [enforcing-job-launch-rate-limit? (ratelimit/enforce? ratelimit/job-launch-rate-limiter)
         user->number-jobs (atom {})
         user->rate-limit-count (atom {})
-        ; Use the already precomputed user->usage map and just aggregate by users.
         user-within-launch-rate-limit?-fn
         (fn
           [{:keys [job/user]}]

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -963,6 +963,7 @@
   user->usage is a map from user to a usage dictionary which is {:mem 123 :cpus 456 ...}
   pool-quota is the quota for the current pool, a quota dictionary which is {:mem 123 :cpus 456 ...}"
   [user->quota user->usage pool-quota queue]
+  ; Use the already precomputed user->usage map and just aggregate by users to get pool usage.
   (let [pool-usage (reduce (partial merge-with +) (vals user->usage))]
     (->> queue
          (filter-based-on-pool-quota pool-quota pool-usage)

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -930,8 +930,8 @@
                   job-usage (job->usage job)
                   user->usage' (update-in user->usage [user] #(merge-with + job-usage %))]
               (log/debug "User quota check" {:user user
-                                        :usage (get user->usage' user)
-                                        :quota (user->quota user)})
+                                             :usage (get user->usage' user)
+                                             :quota (user->quota user)})
               [user->usage' (below-quota? (user->quota user) (get user->usage' user))]))]
     (filter-sequential filter-with-quota user->usage queue)))
 
@@ -953,7 +953,7 @@
               (let [job-usage (job->usage job)
                     usage' (merge-with + job-usage usage)]
                 (log/debug "Pool quota check" {:usage usage'
-                                              :quota quota})
+                                               :quota quota})
                 [usage' (below-quota? quota usage')]))]
       (filter-sequential filter-with-quota usage queue))))
 

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -954,10 +954,7 @@
       (filter-sequential filter-with-quota usage queue))))
 
 (defn filter-pending-jobs-for-quota
-  "Lazily filters jobs to those that should be considered
-  for autoscaling purposes. Note that this is used in two
-  places: the /queue endpoint (Mesos only) and as an
-  argument to scheduler/trigger-autoscaling! (k8s only).
+  "Lazily filters jobs to those that that are in quota.
 
   user->quota is a map from user to a quota dictionary which is {:mem 123 :cpus 456 ...}
   user->usage is a map from user to a usage dictionary which is {:mem 123 :cpus 456 ...}


### PR DESCRIPTION
## Changes proposed in this PR

- Support config-based global quotas for a pool

## Why are we making these changes?
With cloud autoscaling, cook has no limits on autoscaling within cook, only in the underlying k8s cluster. To add more refined control, allow Cook to have specific autoscaling limits.

