### PR TITLE
add kill instance test helper method

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -652,6 +652,13 @@ def kill_jobs(cook_url, jobs, assert_response=True, expected_status_code=204, lo
             assert expected_status_code == response.status_code, response.text
     return response
 
+def kill_instance(cook_url, instance, assert_response=True, expected_status_code=204):
+    """Kill an instance"""
+    params = {'instance': [instance]}
+    response = session.delete(f'{cook_url}/rawscheduler', params=params)
+    if assert_response:
+        assert expected_status_code == response.status_code, response.text
+    return response
 
 def kill_groups(cook_url, groups, assert_response=True, expected_status_code=204):
     """Kill one or more groups of jobs"""


### PR DESCRIPTION
## Changes proposed in this PR

- add kill instance method

## Why are we making these changes?

enhance checkpointing testing by adding functionality like kill instance to simulate preemption
