### PR TITLE
match pools in round-robin order

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -483,7 +483,11 @@
                              :pod-condition-unschedulable-seconds 60
                              :reconnect-delay-ms 60000
                              :set-container-cpu-limit? true}
-                            kubernetes)))}))
+                            kubernetes)))
+     :matching-settings (fnk [[:config {matching-settings {}}]]
+                          (merge {:per-pool-match-interval-millis 3000
+                                  :global-min-match-interval-millis 100}
+                                 matching-settings))}))
 
 (defn read-config
   "Given a config file path, reads the config and returns the map"
@@ -614,3 +618,7 @@
 (defn task-constraints
   []
   (get-in config [:settings :task-constraints]))
+
+(defn matching-settings
+  []
+  (-> config :settings :matching-settings))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -485,8 +485,8 @@
                              :set-container-cpu-limit? true}
                             kubernetes)))
      :offer-matching (fnk [[:config {offer-matching {}}]]
-                          (merge {:per-pool-match-interval-millis 3000
-                                  :global-min-match-interval-millis 100}
+                          (merge {:global-min-match-interval-millis 100
+                                  :target-per-pool-match-interval-millis 3000}
                                  offer-matching))}))
 
 (defn read-config

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -484,10 +484,10 @@
                              :reconnect-delay-ms 60000
                              :set-container-cpu-limit? true}
                             kubernetes)))
-     :matching-settings (fnk [[:config {matching-settings {}}]]
+     :offer-matching (fnk [[:config {offer-matching {}}]]
                           (merge {:per-pool-match-interval-millis 3000
                                   :global-min-match-interval-millis 100}
-                                 matching-settings))}))
+                                 offer-matching))}))
 
 (defn read-config
   "Given a config file path, reads the config and returns the map"
@@ -619,6 +619,6 @@
   []
   (get-in config [:settings :task-constraints]))
 
-(defn matching-settings
+(defn offer-matching
   []
-  (-> config :settings :matching-settings))
+  (-> config :settings :offer-matching))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -255,7 +255,7 @@
        (map #(get @node-name->pod-name->pod % {}))
        (reduce into {})))
 
-(defrecord KubernetesComputeCluster [^ApiClient api-client name entity-id match-trigger-chan exit-code-syncer-state
+(defrecord KubernetesComputeCluster [^ApiClient api-client name entity-id exit-code-syncer-state
                                      all-pods-atom current-nodes-atom pool->node-name->node
                                      node-name->pod-name->pod cook-expected-state-map cook-starting-pods k8s-actual-state-map
                                      pool->fenzo-atom namespace-config scan-frequency-seconds-config max-pods-per-node
@@ -565,8 +565,7 @@
          scan-frequency-seconds 120
          use-google-service-account? true}
     :as compute-cluster-config}
-   {:keys [exit-code-syncer-state
-           trigger-chans]}]
+   {:keys [exit-code-syncer-state]}]
   (guard-invalid-synthetic-pods-config compute-cluster-name synthetic-pods)
   (when (not (< 0 launch-task-num-threads 64))
     (throw
@@ -580,7 +579,6 @@
         compute-cluster (->KubernetesComputeCluster api-client 
                                                     compute-cluster-name
                                                     cluster-entity-id
-                                                    (:match-trigger-chan trigger-chans)
                                                     exit-code-syncer-state
                                                     (atom {})
                                                     (atom {})

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -99,7 +99,7 @@
     (cond->
         {:cancelled-task-trigger-chan (prepare-trigger-chan (time/seconds 3))
          :lingering-task-trigger-chan (prepare-trigger-chan (time/minutes timeout-interval-minutes))
-         :match-trigger-chan (prepare-trigger-chan (time/seconds 1))
+         :match-trigger-chan (async/chan (async/sliding-buffer 1))
          :optimizer-trigger-chan (prepare-trigger-chan (time/seconds (:optimizer-interval-seconds optimizer-config 10)))
          :progress-updater-trigger-chan (prepare-trigger-chan (time/millis (:publish-interval-ms progress-config)))
          :rank-trigger-chan (prepare-trigger-chan (time/seconds 5))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1568,6 +1568,10 @@
                                   (/ (count pools)) 
                                   int 
                                   (max global-min-match-interval-millis))]
+    (when (= match-interval-millis global-min-match-interval-millis)
+      (log/warn "match-trigger-chan is set to the global minimum interval of " global-min-match-interval-millis " ms. "
+                "This is a sign that we have more pools, " (count pools) " than we expect to have and we will "
+                "schedule each pool less often than the desired setting of every " per-pool-match-interval-millis " ms."))
     (async/pipe (chime-ch (tools/time-seq (time/now) (time/millis match-interval-millis))) match-trigger-chan)))
 
 (defn create-datomic-scheduler

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1604,8 +1604,8 @@
     (async/go-loop []
       (when-let [x (async/<! match-trigger-chan)]
         (try
-          (let [pool-name (.removeFirst pool-names-linked-list)
-                _ (.addLast pool-names-linked-list pool-name)]
+          (let [pool-name (.removeFirst pool-names-linked-list)]
+            (.addLast pool-names-linked-list pool-name)
             (async/offer! (get pool->match-trigger-chan pool-name) x))
           (catch Exception e
             (log/error e "Exception in match-trigger-chan chime handler ")

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1563,15 +1563,15 @@
 (defn prepare-match-trigger-chan
   "Calculate the required interval for match-trigger-chan and start the chimes"
   [match-trigger-chan pools]
-  (let [{:keys [per-pool-match-interval-millis global-min-match-interval-millis]} (config/offer-matching)
-        match-interval-millis (-> per-pool-match-interval-millis 
+  (let [{:keys [global-min-match-interval-millis target-per-pool-match-interval-millis]} (config/offer-matching)
+        match-interval-millis (-> target-per-pool-match-interval-millis
                                   (/ (count pools)) 
                                   int 
                                   (max global-min-match-interval-millis))]
     (when (= match-interval-millis global-min-match-interval-millis)
       (log/warn "match-trigger-chan is set to the global minimum interval of " global-min-match-interval-millis " ms. "
                 "This is a sign that we have more pools, " (count pools) " than we expect to have and we will "
-                "schedule each pool less often than the desired setting of every " per-pool-match-interval-millis " ms."))
+                "schedule each pool less often than the desired setting of every " target-per-pool-match-interval-millis " ms."))
     (async/pipe (chime-ch (tools/time-seq (time/now) (time/millis match-interval-millis))) match-trigger-chan)))
 
 (defn create-datomic-scheduler

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -392,7 +392,8 @@
      (loop []
        (when-not (pred)
          (if (< (.getTime (java.util.Date.)) (+ start-ms max-wait-ms))
-           (recur)
+           (do (java.lang.Thread/sleep interval-ms)
+               (recur))
            (throw (ex-info (str "pred not true : " (on-exceed-str-fn))
                            {:interval-ms interval-ms
                             :max-wait-ms max-wait-ms}))))))))

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -566,7 +566,6 @@
     (kcc/->KubernetesComputeCluster nil ; api-client
                                     "kubecompute" ; name
                                     nil ; entity-id
-                                    nil ; match-trigger-chan
                                     nil ; exit-code-syncer-state
                                     (atom namespaced-pod-name->pod) ; all-pods-atom
                                     (atom {}) ; current-nodes-atom

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -58,7 +58,7 @@
                                    (reset! launched-pod-atom launch-pod))
                   api/make-security-context (constantly (V1PodSecurityContext.))]
       (testing "static namespace"
-        (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
+        (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                               {:kind :static :namespace "cook"} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor))
@@ -74,7 +74,7 @@
                             .getNamespace)))))
 
       (testing "per-user namespace"
-        (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
+        (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                               {:kind :per-user} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor))
@@ -92,7 +92,7 @@
   (tu/setup)
   (with-redefs [api/launch-pod (constantly true)]
     (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")
-          compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil nil
+          compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil
                                                           (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                           {:kind :static :namespace "cook"} nil 3 nil nil
                                                           (Executors/newSingleThreadExecutor))

--- a/scheduler/test/cook/test/mesos/mesos_mock.clj
+++ b/scheduler/test/cook/test/mesos/mesos_mock.clj
@@ -675,7 +675,7 @@
           make-mesos-driver-fn (fn [config scheduler framework-id] ;; _ is framework-id
                                  (mm/mesos-mock hosts offer-trigger-chan scheduler))]
       (with-cook-scheduler
-        mesos-datomic-conn make-mesos-driver-fn {}
+        mesos-datomic-conn make-mesos-driver-fn {} true
         (share/set-share! mesos-datomic-conn "default" nil "new cluster settings"
                           :mem mem :cpus cpus :gpus 1.0)
         ;; Note these two vars are lazy, need to realize to put them in db.

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2204,12 +2204,12 @@
 
 (deftest test-prepare-match-trigger-chan
   (testing "Match period is a function of # of pools"
-    (test-prepare-match-trigger-chan-helper {:per-pool-match-interval-millis 3000
-                                             :global-min-match-interval-millis 100}
+    (test-prepare-match-trigger-chan-helper {:global-min-match-interval-millis 100
+                                             :target-per-pool-match-interval-millis 3000}
                                             [1 2 3]
                                             1000))
   (testing "Match period does not go below global min"
-    (test-prepare-match-trigger-chan-helper {:per-pool-match-interval-millis 3000
-                                             :global-min-match-interval-millis 100}
+    (test-prepare-match-trigger-chan-helper {:global-min-match-interval-millis 100
+                                             :target-per-pool-match-interval-millis 3000}
                                             (repeat 40 "x")
                                             100)))

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2199,7 +2199,7 @@
                 async/pipe (fn [_ _])
                 chime/chime-ch (fn [times]
                                  (is (= (- (.getMillis (first (next times))) (.getMillis (first times))) expected-period)))
-                config/matching-settings (constantly settings)]
+                config/offer-matching (constantly settings)]
     (sched/prepare-match-trigger-chan (async/chan 99) pools)))
 
 (deftest test-prepare-match-trigger-chan

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -88,7 +88,7 @@
                                :retry-limit 5})
 
 (defmacro with-cook-scheduler
-  [conn make-mesos-driver-fn scheduler-config trigger-matching & body]
+  [conn make-mesos-driver-fn scheduler-config trigger-matching? & body]
   `(let [conn# ~conn
          [zookeeper-server# curator-framework#] (setup-test-curator-framework)
          mesos-mult# (or (:mesos-datomic-mult ~scheduler-config)
@@ -159,7 +159,7 @@
                      datomic/conn conn#
                      sched/prepare-match-trigger-chan (fn [match-trigger-chan# pools#]
                                                         (when
-                                                          ~trigger-matching
+                                                          ~trigger-matching?
                                                           (prepare-match-trigger-chan-orig# match-trigger-chan# pools#)))]
          (testutil/fake-test-compute-cluster-with-driver conn#
                                                          testutil/fake-test-compute-cluster-name

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -25,6 +25,7 @@
             [cook.mesos.mesos-mock :as mm]
             [cook.plugins.completion :as completion]
             [cook.progress :as progress]
+            [cook.scheduler.scheduler :as sched]
             [cook.scheduler.share :as share]
             [cook.test.testutil :as testutil :refer [poll-until restore-fresh-database!]]
             [cook.tools :as util]
@@ -154,7 +155,8 @@
                      ; registration responses matches the configured cook scheduler passes simulator
                      ; and mesos-mock unit tests. (cook.scheduler, lines 1428 create-mesos-scheduler)
                      mcc/make-mesos-driver ~make-mesos-driver-fn
-                     datomic/conn conn#]
+                     datomic/conn conn#
+                     sched/prepare-match-trigger-chan ~(fn [_ _])]
          (testutil/fake-test-compute-cluster-with-driver conn#
                                                          testutil/fake-test-compute-cluster-name
                                                          nil ; no dummy driver - simulator is going to call initialize


### PR DESCRIPTION
## Changes proposed in this PR

- match pools in round-robin order
- add configurable match interval

## Why are we making these changes?

right now pools match all at the same time on every matching tick. this causes a thundering herd problem

