### PR TITLE
Add GPUs support to Python JobClient

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1602,6 +1602,29 @@ def are_pools_enabled():
     return len(active_pools(cook_url)[0]) > 1
 
 
+def are_gpus_enabled():
+    """Returns true if GPU jobs can be submitted to this cluster."""
+    cook_url = retrieve_cook_url()
+    settings_dict = settings(cook_url)
+    return settings_dict['mesos-gpu-enabled']
+
+
+def active_pools_support_gpus():
+    """Returns true if the active pools support GPUs."""
+    cook_url = retrieve_cook_url()
+    settings_dict = settings(cook_url)
+    pools, _ = active_pools(cook_url)
+    if len(pools) == 0:
+        return False
+    for pool in pools:
+        pool_name = pool['name']
+        matching_gpu_models = [ii['valid-models'] for ii in valid_gpu_models_config_map
+                               if re.match(ii['pool-regex'], pool_name)]
+        if len(matching_gpu_models) == 0 or len(matching_gpu_models[0]) == 0:
+            return False
+    return True
+
+
 def mesos_hostnames_to_consider(cook_url, mesos_url):
     """
     Returns the hostnames in the default pool, or all hosts if the cluster is not using pools

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1614,6 +1614,7 @@ def active_pools_support_gpus():
     cook_url = retrieve_cook_url()
     settings_dict = settings(cook_url)
     pools, _ = active_pools(cook_url)
+    valid_gpu_models_config_map = settings_dict.get("pools", {}).get("valid_gpu_models", [])
     if len(pools) == 0:
         return False
     for pool in pools:

--- a/jobclient/python/cookclient/__init__.py
+++ b/jobclient/python/cookclient/__init__.py
@@ -109,6 +109,7 @@ class JobClient:
                priority: Optional[int] = None,
                container: Optional[AbstractContainer] = None,
                application: Application = _CLIENT_APP,
+               gpus: Optional[int] = None,
 
                pool: Optional[str] = None,
 
@@ -155,6 +156,11 @@ class JobClient:
         :param pool: Which pool the job should be submitted to, defaults to
             None.
         :type pool: str, optional
+        :param gpus: Number of GPUs to request from Cook, if any. Defaults to
+            None. If you wish to specify the GPU model, add the
+            ``COOK_GPU_MODEL`` environment variable to the environment variable
+            list.
+        :type gpus: int, optional
         :param kwargs: Request kwargs. If kwargs were specified to the client
             on construction, then these will take precedence over those.
         :return: The UUID of the newly-created job.
@@ -182,6 +188,8 @@ class JobClient:
             payload['application'] = application.to_dict()
         if container is not None:
             payload['container'] = container.to_dict()
+        if gpus is not None:
+            payload['gpus'] = gpus
         payload = {'jobs': [payload]}
 
         # Pool requests are assigned to the group payload instead of each

--- a/jobclient/python/cookclient/__init__.py
+++ b/jobclient/python/cookclient/__init__.py
@@ -27,7 +27,7 @@ from . import util
 from .containers import AbstractContainer
 from .jobs import Application, Job
 
-CLIENT_VERSION = '0.2.1'
+CLIENT_VERSION = '0.3.0'
 
 _LOG = logging.getLogger(__name__)
 _LOG.addHandler(logging.StreamHandler())


### PR DESCRIPTION
## Changes proposed in this PR

- Adds a `gpus` arg to `JobClient.submit`

## Why are we making these changes?

This way we can submit jobs requiring GPUs to Cook using the Python client API