### PR TITLE
Fix "unable to get node from node name XXXX" errors.

### DIFF
--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -72,7 +72,9 @@
                                 :gpus "1"
                                 :gpu-model "nvidia-tesla-k80"})
                 (tu/pod-helper "podD" "hostC"
-                               {:cpus 1.0})]
+                               {:cpus 1.0})
+                (tu/pod-helper "podD" nil ; nil host should be skipped and not included in output.
+                               {:cpus 12.0})]
           node-name->pods (api/pods->node-name->pods pods)]
       (is (= {"hostA" {:cpus 2.0 :mem 100.0 :gpus {"nvidia-tesla-p100" 3}}
               "hostB" {:cpus 3.0 :mem 130.0 :gpus {"nvidia-tesla-k80" 1}}

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -116,6 +116,8 @@
                                                                 {:cpus 0.25 :mem 250.0 :gpus "1" :gpu-model "nvidia-tesla-p100"})
                 {:namespace "cook" :name "podC"} (tu/pod-helper "podC" "nodeB"
                                                                 {:cpus 1.0 :mem 1100.0 :gpus "10" :gpu-model "nvidia-tesla-p100"})
+                {:namespace "cook" :name "podD"} (tu/pod-helper "podD" "nodeD"
+                                                                {:cpus 1.0 :mem 1100.0 :gpus "10" :gpu-model "nvidia-tesla-p100"})
                 {:namespace "cook" :name task-1-id} (tu/pod-helper task-1-id "my.fake.host"
                                                                    {:cpus 0.1 :mem 10.0})}
           node-name->pods (api/pods->node-name->pods (kcc/add-starting-pods compute-cluster pods))


### PR DESCRIPTION
## Changes proposed in this PR

- Fix bug where we try to calculate consumption for pods that don't have a node.
- Do some more filtering to keep wrong-pool nodes from being injected into consumption processing.

## Why are we making these changes?

Avoid thousands of "unable to get node from node name" ERROR logged.
