### PR TITLE
Adds support for EQUALS constraints in k8s

### DIFF
--- a/scheduler/bin/help-make-cluster
+++ b/scheduler/bin/help-make-cluster
@@ -18,9 +18,25 @@ CLUSTERNAME=$3
 COOK_KUBECONFIG=$4
 GKE_CLUSTER_OWNER=${GKE_CLUSTER_OWNER:-$USER}
 
-VERSION=1.15.11-gke.12
+VERSION=1.15.11-gke.15
 
 gcloud="gcloud --project $PROJECT"
+
+function create_node_pool {
+  local cook_pool=$1
+  local machine_type=$2
+  echo "---- Creating $machine_type node pool for Cook pool $cook_pool"
+  $gcloud container node-pools create "cook-pool-$cook_pool-$machine_type" \
+         --zone "$ZONE" \
+         --cluster="$CLUSTERNAME" \
+         --disk-size=20gb \
+         --machine-type="$machine_type" \
+         --node-taints="cook-pool=$cook_pool:NoSchedule" \
+         --enable-autoscaling \
+         --min-nodes=0 \
+         --max-nodes=6 \
+         --node-labels="cook-pool=$cook_pool,test-label=true,node-type=$machine_type"
+}
 
 echo "---- Building kubernetes cluster for project=$PROJECT zone=$ZONE clustername=$CLUSTERNAME kubeconfig=$COOK_KUBECONFIG"
 
@@ -48,26 +64,10 @@ KUBECONFIG=${COOK_KUBECONFIG} kubectl create -f "${DIR}/priority-class-synthetic
 
 # Make some node-pools --- this takes a while, but it helps guarantee that we have nodes with the appropriate cook-pool taints.
 echo "---- Making extra k8s-alpha and k8s-gamma nodepools for cook pools (please wait 5-10 minutes)"
-$gcloud container node-pools create cook-pool-k8s-gamma \
-       --zone "$ZONE" \
-       --cluster="$CLUSTERNAME" \
-       --disk-size=20gb \
-       --machine-type=g1-small \
-       --node-taints=cook-pool=k8s-gamma:NoSchedule \
-       --enable-autoscaling \
-       --min-nodes=0 \
-       --max-nodes=6 \
-       --node-labels=cook-pool=k8s-gamma,test-label=true
-$gcloud container node-pools create cook-pool-k8s-alpha \
-       --zone "$ZONE" \
-       --cluster="$CLUSTERNAME" \
-       --disk-size=20gb \
-       --machine-type=g1-small \
-       --node-taints=cook-pool=k8s-alpha:NoSchedule \
-       --enable-autoscaling \
-       --min-nodes=0 \
-       --max-nodes=6 \
-       --node-labels=cook-pool=k8s-alpha,test-label=true
+create_node_pool k8s-alpha g1-small
+create_node_pool k8s-gamma g1-small
+create_node_pool k8s-alpha e2-small
+create_node_pool k8s-gamma e2-small
 
 echo "---- Setting up cook namespace in kubernetes"
 KUBECONFIG=${COOK_KUBECONFIG} kubectl create -f docs/make-kubernetes-namespace.json

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -90,8 +90,15 @@
                                                      :network "HOST"
                                                      :force-pull-image false
                                                      :parameters []}}}]
-        :valid-gpu-models
-        [{:pool-regex "k8s-alpha" :valid-models #{"nvidia-tesla-k80" "nvidia-tesla-p100"} :default-model "nvidia-tesla-p100"}]}
+         :valid-gpu-models
+         [{:pool-regex "k8s-alpha"
+           :valid-models #{"nvidia-tesla-k80" "nvidia-tesla-p100"}
+           :default-model "nvidia-tesla-p100"}]
+         :default-job-constraints
+         [{:pool-regex "k8s-.*"
+           :default-constraints [{:constraint/attribute "node-type"
+                                  :constraint/operator :constraint.operator/equals
+                                  :constraint/pattern "g1-small"}]}]}
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -551,6 +551,18 @@
   []
   (-> config :settings :pools :job-resource-adjustment))
 
+(defn default-job-constraints
+  "Returns the per-pool-regex default job constraints.
+  This function returns a list with the following shape:
+  [{:pool-regex ...
+    :default-constraints [{:constraint/attribute ...
+                           :constraint/operator ...
+                           :constraint/pattern ...}
+                          ...]}
+   ...]"
+  []
+  (-> config :settings :pools :default-job-constraints))
+
 (defn api-only-mode?
   "Returns true if api-only? mode is turned on"
   []

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -681,8 +681,8 @@
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."
   [namespace compute-cluster-name
-   {:keys [task-id command container task-request hostname pod-annotations pod-labels pod-hostnames-to-avoid
-           pod-priority-class pod-supports-cook-init? pod-supports-cook-sidecar?]
+   {:keys [task-id command container task-request hostname pod-annotations pod-constraints pod-hostnames-to-avoid
+           pod-labels pod-priority-class pod-supports-cook-init? pod-supports-cook-sidecar?]
     :or {pod-priority-class cook-job-pod-priority-class
          pod-supports-cook-init? true
          pod-supports-cook-sidecar? true}}]
@@ -886,6 +886,22 @@
       ; synthetic pods (which don't specify a node name), but it
       ; doesn't hurt to add it for all pods we submit.
       (add-node-selector pod-spec cook-pool-label pool-name))
+
+    (when pod-constraints
+      (doseq [{:keys [constraint/attribute
+                      constraint/operator
+                      constraint/pattern]}
+              pod-constraints]
+        (condp = operator
+          :constraint.operator/equals
+          ; Add a node selector for any EQUALS constraints
+          ; either defined by the user on their job spec
+          ; or defaulted on the Cook pool via configuration
+          (add-node-selector pod-spec attribute pattern)
+          :else
+          (log/error "Encountered unknown constraint operator" operator
+                     "while trying to create pod spec for task" task-id))))
+
     (.setVolumes pod-spec (filterv some? (conj volumes
                                                init-container-workdir-volume
                                                scratch-space-volume

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -942,8 +942,9 @@
           ; or defaulted on the Cook pool via configuration
           (add-node-selector pod-spec attribute pattern)
           :else
-          (log/error "Encountered unknown constraint operator" operator
-                     "while trying to create pod spec for task" task-id))))
+          (throw (ex-info "Encountered unexpected constraint operator"
+                          {:operator operator
+                           :task-id task-id})))))
 
     (.setVolumes pod-spec (filterv some? (conj volumes
                                                init-container-workdir-volume

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -942,6 +942,8 @@
           ; or defaulted on the Cook pool via configuration
           (add-node-selector pod-spec attribute pattern)
           :else
+          ; A bad constraint operator should have
+          ; been blocked at job submission time
           (throw (ex-info "Encountered unexpected constraint operator"
                           {:operator operator
                            :task-id task-id})))))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -247,10 +247,15 @@
                     :pod-namespace pod-namespace
                     :task-metadata task-metadata})))))
 
+(defn get-name->node-for-pool
+  "Given a pool->node-name->node and pool, return a node-name->pool, for any pool"
+  [pool->node-name->node pool]
+  (get pool->node-name->node pool {}))
+
 (defn get-pods-in-pool
   "Given a compute cluster and a pool name, extract the pods that are in the current pool only."
   [{:keys [pool->node-name->node node-name->pod-name->pod]} pool]
-  (->> (get @pool->node-name->node pool)
+  (->> (get-name->node-for-pool @pool->node-name->node pool)
        keys
        (map #(get @node-name->pod-name->pod % {}))
        (reduce into {})))
@@ -335,7 +340,7 @@
     (let [timer (timers/start (metrics/timer "cc-pending-offers-compute" name))
           pods (add-starting-pods this @all-pods-atom)
           nodes @current-nodes-atom
-          offers-this-pool (generate-offers this (@pool->node-name->node pool-name)
+          offers-this-pool (generate-offers this (get-name->node-for-pool @pool->node-name->node pool-name)
                                             (->> (get-pods-in-pool this pool-name)
                                                  (add-starting-pods this)
                                                  (api/pods->node-name->pods)))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -91,19 +91,36 @@
     (->> node-name->available
          (filter #(schedulable-node-filter node-name->node node-name->pods compute-cluster %))
          (map (fn [[node-name available]]
-                {:id {:value (str (UUID/randomUUID))}
-                 :framework-id compute-cluster-name
-                 :slave-id {:value node-name}
-                 :hostname node-name
-                 :resources [{:name "mem" :type :value-scalar :scalar (max 0.0 (:mem available))}
-                             {:name "cpus" :type :value-scalar :scalar (max 0.0 (:cpus available))}
-                             {:name "disk" :type :value-scalar :scalar 0.0}
-                             {:name "gpus" :type :value-text->scalar :text->scalar (:gpus available)}]
-                 :attributes [{:name "compute-cluster-type" :type :value-text :text "kubernetes"}]
-                 :executor-ids []
-                 :compute-cluster compute-cluster
-                 :reject-after-match-attempt true
-                 :offer-match-timer (timers/start (ccmetrics/timer "offer-match-timer" compute-cluster-name))})))))
+                (let [node-label-attributes
+                      ; Convert all node labels to offer
+                      ; attributes so that job constraints
+                      ; can use them in the matching process
+                      (or
+                        (some->> node-name
+                                 ^V1Node (get node-name->node)
+                                 .getMetadata
+                                 .getLabels
+                                 (map (fn [[key value]]
+                                        {:name key
+                                         :type :value-text
+                                         :text value})))
+                        [])]
+                  {:id {:value (str (UUID/randomUUID))}
+                   :framework-id compute-cluster-name
+                   :slave-id {:value node-name}
+                   :hostname node-name
+                   :resources [{:name "mem" :type :value-scalar :scalar (max 0.0 (:mem available))}
+                               {:name "cpus" :type :value-scalar :scalar (max 0.0 (:cpus available))}
+                               {:name "disk" :type :value-scalar :scalar 0.0}
+                               {:name "gpus" :type :value-text->scalar :text->scalar (:gpus available)}]
+                   :attributes (conj node-label-attributes
+                                     {:name "compute-cluster-type"
+                                      :type :value-text
+                                      :text "kubernetes"})
+                   :executor-ids []
+                   :compute-cluster compute-cluster
+                   :reject-after-match-attempt true
+                   :offer-match-timer (timers/start (ccmetrics/timer "offer-match-timer" compute-cluster-name))}))))))
 
 (defn taskids-to-scan
   "Determine all task ids to scan by union-ing task id's from cook expected state and existing task id maps. "
@@ -399,6 +416,10 @@
                                  ; We need to *not* prevent the cluster autoscaler from
                                  ; removing a node just because it's running synthetic pods
                                  :pod-annotations {api/k8s-safe-to-evict-annotation "true"}
+                                 ; Job constraints need to be expressed on synthetic
+                                 ; pods so that we trigger the cluster autoscaler to
+                                 ; spin up nodes that will end up satisfying them
+                                 :pod-constraints (constraints/job->constraints job)
                                  ; Cook has a "novel host constraint", which disallows a job from
                                  ; running on the same host twice. So, we need to avoid running a
                                  ; synthetic pod on any of the hosts that the real job won't be able

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -221,7 +221,12 @@
                      user-specified-machine-type-constraint?
                      (some #{attribute}
                            machine-type-constraint-attributes))))))]
-    (concat user-specified-constraints default-constraints)))
+
+    (-> user-specified-constraints
+        (concat default-constraints)
+        ; De-lazy the output; Fenzo can call from multiple
+        ; threads and we want to avoid contention in LazySeq
+        vec)))
 
 (defrecord user-defined-constraint [job]
   JobConstraint

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -44,6 +44,13 @@
     (is (= {} (kcc/get-pods-in-pool in :pool-e)))
     (is (= {} (kcc/get-pods-in-pool in :pool-f)))))
 
+(deftest test-get-name->node-for-pool
+  (let [in (atom {:pool-a {:node-1 1 :node-2 2}
+                  :pool-b {}})]
+    (is (= {:node-1 1 :node-2 2} (kcc/get-name->node-for-pool @in :pool-a)))
+    (is (= {} (kcc/get-name->node-for-pool @in :pool-b)))
+    (is (= {} (kcc/get-name->node-for-pool @in nil)))))
+
 (deftest test-namespace-config
   (tu/setup)
   (let [conn (tu/restore-fresh-database! "datomic:mem://test-namespace-config")

--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -39,13 +39,15 @@
          (constraints/group-constraint-name (constraints/->attribute-equals-host-placement-group-constraint nil)))))
 
 (deftest test-user-defined-constraint
+  (setup)
   (let [constraints [{:constraint/attribute "is_spot"
                       :constraint/operator :constraint.operator/equals
                       :constraint/pattern "true"}
                      {:constraint/attribute "instance_type"
                       :constraint/operator :constraint.operator/equals
                       :constraint/pattern "mem.large"}]
-        user-defined-constraint (constraints/->user-defined-constraint constraints)]
+        job {:job/constraint constraints}
+        user-defined-constraint (constraints/->user-defined-constraint job)]
     (is (= true (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "true" "instance_type" "mem.large"}))))
     (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "true" "instance_type" "cpu.large"}))))
     (is (= false (first (constraints/job-constraint-evaluate user-defined-constraint nil {"is_spot" "false" "instance_type" "mem.large"}))))


### PR DESCRIPTION
## Changes proposed in this PR

- adding two new node pools (e2-small) in `help-make-cluster`
- adding support for default job constraints by pool (regex)
- translating EQUALS constraints to node selectors
- mapping all k8s node labels to offer attributes so they can be referenced by constraints

## Why are we making these changes?

We want to allow users to experiment with different machine types in k8s, and this change allows users to use the existing job constraint mechanism to specify (for example) the machine type they want to use. Note that there's nothing specific here to machine types -- this allows any k8s node label to be selected.