### PR TITLE
Adds seeding Cook pools to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The quickest way to get Cook running locally against [GKE](https://cloud.google.
 1. Run `gcloud auth login` to login to Google cloud
 1. Run `bin/make-gke-test-clusters` to create GKE clusters
 1. Run `bin/start-datomic.sh` to start Datomic (Cook database)
+1. Run `lein exec -p datomic/data/seed_k8s_pools.clj $COOK_DATOMIC_URI` to seed some Cook pools in the database
 1. Run `bin/run-local-kubernetes.sh` to start the Cook scheduler
 1. Cook should now be listening locally on port 12321
 


### PR DESCRIPTION
## Changes proposed in this PR

- adding a step to the Quickstart to seed Cook pools in the database

## Why are we making these changes?

The pools have to be there in the database or Cook won't start up.