### PR TITLE
Replaces "Slave" with "Agent" in cs show output

### DIFF
--- a/cli/cook/subcommands/show.py
+++ b/cli/cook/subcommands/show.py
@@ -91,7 +91,7 @@ def tabulate_instance(cluster_name, instance_job_pair):
 
     left = [['Cluster', cluster_name],
             ['Host', instance['hostname']],
-            ['Slave', instance['slave_id']],
+            ['Agent', instance['slave_id']],
             ['Job', '%s (%s)' % (job['name'], job['uuid'])]]
     if len(instance['ports']) > 0:
         left.append(['Ports Allocated', format_list(instance['ports'])])


### PR DESCRIPTION
## Changes proposed in this PR

- replacing "Slave" with "Agent" in the `cs show <instance-uuid>` output

## Why are we making these changes?

To avoid language that is exclusive, offensive, or carries negative historical connotations.
