### PR TITLE
Fix Python job client docs for readthedocs

### DIFF
--- a/jobclient/python/docs/source/conf.py
+++ b/jobclient/python/docs/source/conf.py
@@ -57,3 +57,7 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# Set the master_doc value, as readthedocs uses an older version of Sphinx
+# which will default to `contents` instead of `index`.
+master_doc = 'index'

--- a/jobclient/python/requirements.txt
+++ b/jobclient/python/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/jobclient/python/requirements.txt
+++ b/jobclient/python/requirements.txt
@@ -1,1 +1,3 @@
 requests
+sphinx ~= 3.0.4
+sphinx-rtd-theme ~= 0.4.3


### PR DESCRIPTION
## Changes proposed in this PR

- Explicitly set `master_doc` in the documentation's `conf.py` file
- Set up a `requirements.txt` file including `requests` as well as the versions of `sphinx` and `sphinx-rtd-theme` the documentation has been tested with.

## Why are we making these changes?

We want to publish the Python job client's documentation to readthedocs.io; however, they appear to be using an older version of Sphinx which expects the documentation's root document to be `contents.rst` instead of `index.rst`.

We explicitly set `master_doc` to `index` in the documentation's `conf.py` file, which Sphinx will then pick up as the master doc. Additionally, we specify the versions of `sphinx` and `sphinx-rtd-theme` we use in `requirements.txt` so as to minimize any future headaches involving these configurations.
