### PR TITLE
Adds attribution labels to synthetic pods

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -29,6 +29,9 @@
 
 (def cook-pod-label "twosigma.com/cook-scheduler-job")
 (def cook-synthetic-pod-job-uuid-label "twosigma.com/cook-scheduler-synthetic-pod-job-uuid")
+(def workload-class-label "workload-class")
+(def workload-id-label "workload-id")
+(def resource-owner-label "resource-owner")
 (def cook-pool-label "cook-pool")
 (def cook-pool-taint "cook-pool")
 (def cook-sandbox-volume-name "cook-sandbox-volume")

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -428,8 +428,13 @@
                                  :pod-hostnames-to-avoid (constraints/job->previous-hosts-to-avoid job)
                                  ; We need to label the synthetic pods so that we
                                  ; can opt them out of some of the normal plumbing,
-                                 ; like mapping status back to a job instance
-                                 :pod-labels {api/cook-synthetic-pod-job-uuid-label (str uuid)}
+                                 ; like mapping status back to a job instance. We
+                                 ; also want to label the workload as infrastructure
+                                 ; and associate the user as the resource owner.
+                                 :pod-labels {api/cook-synthetic-pod-job-uuid-label (str uuid)
+                                              api/workload-class-label "infrastructure"
+                                              api/workload-id-label "synthetic-pod"
+                                              api/resource-owner-label user}
                                  ; We need to give synthetic pods a lower priority than
                                  ; actual job pods so that the job pods can preempt them
                                  ; (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/);


### PR DESCRIPTION
## Changes proposed in this PR

- adding `workload-class`, `workload-id`, and `resource-owner` labels to synthetic pods

## Why are we making these changes?

So that synthetic pods can be properly attributed.
