### PR TITLE
One GPU task per VM

### DIFF
--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -155,7 +155,7 @@
                               (getTasksCurrentlyAssigned [_] [gpu-task-assignment])
                               (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-gpu-offer 0)))
                             nil)))
-          (str "GPU task on GPU host with the correct number of GPUs but already has task assigned should fail"))
+          (str "We only allow one GPU job per VM. This VM already has a GPU job assigned to it, so it should not get any additional GPU tasks."))
       (is (not (.isSuccessful
                  (.evaluate (constraints/fenzoize-job-constraint (constraints/build-gpu-host-constraint non-gpu-job))
                             (sched/make-task-request db non-gpu-job nil)


### PR DESCRIPTION
## Changes proposed in this PR

- Modify GPU host constraint to only allow one GPU task per VM
- Added unit test for this special case

## Why are we making these changes?
- Brian Bao noticed that when he submitted multiple GPU jobs rapidly in succession, they sometimes got matched to the same VM because the GPU constraint was not accounting for tasks that were already assigned to that VM.

