### PR TITLE
Runs only one pool in test_list_jobs_by_pool

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1201,8 +1201,8 @@ class CookTest(util.CookTest):
         jobs = []
         name = str(util.make_temporal_uuid())
         pools, _ = util.active_pools(self.cook_url)
-        # Running this for the first two pools only is enough
-        pools = pools[:2]
+        # Running this for the first pool only is enough
+        pools = pools[:1]
         start = util.current_milli_time()
         sleep_command = f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'
         for pool in pools:


### PR DESCRIPTION
## Changes proposed in this PR

- running the test for 1 pool instead of 2

## Why are we making these changes?

This is our 4th longest running non-`xfail` test over the last 30 days, taking an average of ~125 seconds, and there's no reason it should take this long.