### PR TITLE
Gracefully handles missing resource in total-resource

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -43,7 +43,7 @@
   "Given a map from node-name->resource-keyword->amount and a resource-keyword,
   returns the total amount of that resource for all nodes."
   [node-name->resource-map resource-keyword]
-  (->> node-name->resource-map vals (map resource-keyword) (reduce +)))
+  (->> node-name->resource-map vals (map resource-keyword) (filter some?) (reduce +)))
 
 (defn total-gpu-resource
   "Given a map from node-name->resource-keyword->amount,

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -319,3 +319,7 @@
                    (kcc/factory-fn {:launch-task-num-threads 64
                                     :use-google-service-account? false}
                                    nil))))))
+
+(deftest test-total-resource
+  (testing "gracefully handles missing resource"
+    (= 3 (kcc/total-resource {"node-a" {:cpus 1} "node-b" {} "node-c" {:cpus 2}} :cpus))))


### PR DESCRIPTION
## Changes proposed in this PR

- filtering out `nil` values before summing in `total-resource`

## Why are we making these changes?

Otherwise, `total-resource` throws a NPE when, for example, a node has no pods running on it.
