### PR TITLE
Uses 1024*1024 as the k8s memory multiplier

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -499,7 +499,8 @@ if __name__ == '__main__':
         waiting_uuid = uuids[0]
 
         # Submit a long-running job
-        cp, uuids = cli.submit('sleep 300', self.cook_url, submit_flags='--name %s' % name)
+        sleep_command = f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'
+        cp, uuids = cli.submit(sleep_command, self.cook_url, submit_flags='--name %s' % name)
         self.assertEqual(0, cp.returncode, cp.stderr)
         running_uuid = uuids[0]
 

--- a/integration/tests/cook/test_client.py
+++ b/integration/tests/cook/test_client.py
@@ -115,6 +115,7 @@ class ClientTest(util.CookTest):
         uuid = self.client.submit(command=f'{hostname_progress_cmd} && nc -l -p {JOB_PORT} $(hostname -I)',
                                   container=container,
                                   env={progress_file_env: 'progress.txt'},
+                                  max_retries=5,
                                   pool=util.default_submit_pool())
 
         addr = None

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -63,9 +63,10 @@
 
 (def ^ExecutorService kubernetes-executor (Executors/newCachedThreadPool))
 
-; Cook, Fenzo, and Mesos use MB for memory. Convert bytes from k8s to MB when passing to fenzo, and MB back to bytes
-; when submitting to k8s.
-(def memory-multiplier (* 1000 1000))
+; Cook, Fenzo, and Mesos use mebibytes (MiB) for memory.
+; Convert bytes from k8s to MiB when passing to Fenzo,
+; and MiB back to bytes when submitting to k8s.
+(def memory-multiplier (* 1024 1024))
 
 (defn is-cook-scheduler-pod
   "Is this a cook pod? Uses some-> so is null-safe."


### PR DESCRIPTION
## Changes proposed in this PR

- using 1024^2 (MiB) as the k8s memory multiplier instead of 1000^2 (MB)

## Why are we making these changes?

Cook, Fenzo, and Mesos use mebibytes (MiB) for memory, so we need to convert bytes from k8s to MiB when passing to Fenzo, and MiB back to bytes when submitting to k8s.