### PR TITLE
Adds agent_id as preferred alternative to slave_id

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -60,6 +60,11 @@ class CookTest(util.CookTest):
         self.assertIn('success', [i['status'] for i in job['instances']], json.dumps(job, indent=2))
         self.assertEqual(False, job['disable_mea_culpa_retries'])
         instance = job['instances'][0]
+
+        # agent_id is a preferred alternative to slave_id with the same value
+        self.assertIn('agent_id', instance)
+        self.assertEqual(instance['slave_id'], instance['agent_id'])
+
         if instance['executor'] == 'cook':
             instance = util.wait_for_exit_code(self.cook_url, job_uuid)
             message = json.dumps(instance, sort_keys=True)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -213,6 +213,7 @@
   {:status s/Str
    :task_id s/Uuid
    :executor_id s/Uuid
+   :agent_id s/Str
    :slave_id s/Str
    :hostname s/Str
    :preempted s/Bool
@@ -1105,6 +1106,7 @@
                :hostname hostname
                :ports (vec (sort (:instance/ports instance)))
                :preempted (:instance/preempted? instance false)
+               :agent_id (:instance/slave-id instance)
                :slave_id (:instance/slave-id instance)
                :status (name (:instance/status instance))
                :task_id task-id}

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1737,10 +1737,11 @@
         compute-cluster (testutil/setup-fake-test-compute-cluster conn)
         job-entity-id (create-dummy-job conn :user "test-user" :job-state :job.state/completed)
         basic-instance-properties {:executor-id (str job-entity-id "-executor-1")
-                                   :slave-id "slave-1"
+                                   :slave-id "agent-1"
                                    :task-id (str job-entity-id "-executor-1")}
         basic-instance-map {:executor_id (str job-entity-id "-executor-1")
-                            :slave_id "slave-1"
+                            :agent_id "agent-1"
+                            :slave_id "agent-1"
                             :task_id (str job-entity-id "-executor-1")
                             :compute-cluster
                             {:name "unittest-default-compute-cluster-name"


### PR DESCRIPTION
## Changes proposed in this PR

- adding `agent_id` on job instances as a preferred alternative to `slave_id`, with the same value

## Why are we making these changes?

As a first step to avoiding language that is exclusive, offensive, or carries negative historical connotations.
