### PR TITLE
Adds compute-cluster-type and url to test metrics

### DIFF
--- a/integration/tests/conftest.py
+++ b/integration/tests/conftest.py
@@ -79,7 +79,9 @@ if 'TEST_METRICS_URL' in os.environ:
                 'build-id': os.getenv('TEST_METRICS_BUILD_ID', None),
                 'result': result,
                 'runtime-milliseconds': (end - start) * 1000,
-                'expected-to-fail': expected_to_fail
+                'expected-to-fail': expected_to_fail,
+                'compute-cluster-type': os.getenv('TEST_METRICS_COMPUTE_CLUSTER_TYPE', None),
+                'url': os.getenv('COOK_SCHEDULER_URL', None)
             }
             timeout = os.getenv('TEST_METRICS_POST_TIMEOUT_SECONDS', 10)
             logging.info(f'Updating test metrics (timeout = {timeout} seconds): {json.dumps(metrics, indent=2)}')


### PR DESCRIPTION
## Changes proposed in this PR

- adding `compute-cluster-type` and `url` to the test metrics entries

## Why are we making these changes?

It's useful to distinguish Mesos from Kubernetes test runs, and runs against different URLs.
