### PR TITLE
Allow explicit `None` in JobClient.submit_all

### DIFF
--- a/integration/tests/cook/test_client.py
+++ b/integration/tests/cook/test_client.py
@@ -199,7 +199,7 @@ class ClientTest(util.CookTest):
             {'command': 'ls'},
             {
                 'command': 'echo "Hello World!"',
-                'mem': 256.0
+                'mem': 256.0,
             }
         ]
         uuids = self.client.submit_all(jobspecs,
@@ -213,5 +213,24 @@ class ClientTest(util.CookTest):
             self.assertEqual(jobs[1].uuid, uuids[1])
             self.assertEqual(jobs[1].command, jobspecs[1]['command'])
             self.assertEqual(jobs[1].mem, jobspecs[1]['mem'])
+        finally:
+            self.client.kill_all(uuids)
+
+    def test_bulk_submit_explicit_none(self):
+        jobspecs = [
+            {
+                'command': 'echo "Hello World!"',
+                'mem': 256.0
+                'container': None,
+            }
+        ]
+        uuids = self.client.submit_all(jobspecs,
+                                       pool=util.default_submit_pool())
+        try:
+            jobs = self.client.query_all(uuids)
+
+            self.assertEqual(jobs[0].uuid, uuids[0])
+            self.assertEqual(jobs[0].command, jobspecs[0]['command'])
+            self.assertIsNone(jobs[0].container)
         finally:
             self.client.kill_all(uuids)

--- a/integration/tests/cook/test_client.py
+++ b/integration/tests/cook/test_client.py
@@ -199,7 +199,7 @@ class ClientTest(util.CookTest):
             {'command': 'ls'},
             {
                 'command': 'echo "Hello World!"',
-                'mem': 256.0,
+                'mem': 256.0
             }
         ]
         uuids = self.client.submit_all(jobspecs,
@@ -220,8 +220,8 @@ class ClientTest(util.CookTest):
         jobspecs = [
             {
                 'command': 'echo "Hello World!"',
-                'mem': 256.0
-                'container': None,
+                'mem': 256.0,
+                'container': None
             }
         ]
         uuids = self.client.submit_all(jobspecs,

--- a/integration/tests/cook/test_client.py
+++ b/integration/tests/cook/test_client.py
@@ -231,6 +231,5 @@ class ClientTest(util.CookTest):
 
             self.assertEqual(jobs[0].uuid, uuids[0])
             self.assertEqual(jobs[0].command, jobspecs[0]['command'])
-            self.assertIsNone(jobs[0].container)
         finally:
             self.client.kill_all(uuids)

--- a/jobclient/python/cookclient/__init__.py
+++ b/jobclient/python/cookclient/__init__.py
@@ -378,7 +378,8 @@ class JobClient:
 
         This function will convert the higher-level Python types used in job
         submissions into their JSON primitive counterparts (e.g., timedelta is
-        converted into the number of milliseconds).
+        converted into the number of milliseconds). Additionally, this function
+        will also remove all keys with a value of ``None``.
 
         The provided jobspec will not be touched and a copy will be returned.
         """
@@ -391,7 +392,7 @@ class JobClient:
             jobspec['application'] = jobspec['application'].to_dict()
         if util.is_field_set(jobspec, 'container'):
             jobspec['container'] = jobspec['container'].to_dict()
-        return jobspec
+        return util.prune_nones(jobspec)
 
     def __enter__(self):
         return self

--- a/jobclient/python/cookclient/__init__.py
+++ b/jobclient/python/cookclient/__init__.py
@@ -356,19 +356,19 @@ class JobClient:
         returned.
         """
         jobspec = copy.deepcopy(jobspec)
-        if jobspec.get('uuid', None) is None:
+        if not util.is_field_set(jobspec, 'uuid'):
             jobspec['uuid'] = str(util.make_temporal_uuid())
-        if jobspec.get('cpus', None) is None:
+        if not util.is_field_set(jobspec, 'cpus'):
             jobspec['cpus'] = 1.0
-        if jobspec.get('mem', None) is None:
+        if not util.is_field_set(jobspec, 'mem'):
             jobspec['mem'] = 128.0
-        if jobspec.get('max-retries', None) is None:
+        if not util.is_field_set(jobspec, 'max-retries'):
             jobspec['max-retries'] = 1
-        if jobspec.get('max-runtime', None) is None:
+        if not util.is_field_set(jobspec, 'max-runtime'):
             jobspec['max-runtime'] = timedelta(days=1)
-        if jobspec.get('name', None) is None:
+        if not util.is_field_set(jobspec, 'name'):
             jobspec['name'] = f'{getpass.getuser()}-job'
-        if jobspec.get('application', None) is None:
+        if not util.is_field_set(jobspec, 'application'):
             jobspec['application'] = _CLIENT_APP
         return jobspec
 
@@ -383,13 +383,13 @@ class JobClient:
         The provided jobspec will not be touched and a copy will be returned.
         """
         jobspec = copy.deepcopy(jobspec)
-        if jobspec.get('max-runtime', None) is not None:
+        if util.is_field_set(jobspec, 'max-runtime'):
             jobspec['max-runtime'] = (
                 jobspec['max-runtime'].total_seconds() * 1000
             )
-        if jobspec.get('application', None) is not None:
+        if util.is_field_set(jobspec, 'application'):
             jobspec['application'] = jobspec['application'].to_dict()
-        if jobspec.get('container', None) is not None:
+        if util.is_field_set(jobspec, 'container'):
             jobspec['container'] = jobspec['container'].to_dict()
         return jobspec
 

--- a/jobclient/python/cookclient/__init__.py
+++ b/jobclient/python/cookclient/__init__.py
@@ -28,7 +28,7 @@ from . import util
 from .containers import AbstractContainer
 from .jobs import Application, Job
 
-CLIENT_VERSION = '0.3.0'
+CLIENT_VERSION = '0.3.1'
 
 _LOG = logging.getLogger(__name__)
 _LOG.addHandler(logging.StreamHandler())

--- a/jobclient/python/cookclient/__init__.py
+++ b/jobclient/python/cookclient/__init__.py
@@ -356,19 +356,19 @@ class JobClient:
         returned.
         """
         jobspec = copy.deepcopy(jobspec)
-        if 'uuid' not in jobspec:
+        if jobspec.get('uuid', None) is None:
             jobspec['uuid'] = str(util.make_temporal_uuid())
-        if 'cpus' not in jobspec:
+        if jobspec.get('cpus', None) is None:
             jobspec['cpus'] = 1.0
-        if 'mem' not in jobspec:
+        if jobspec.get('mem', None) is None:
             jobspec['mem'] = 128.0
-        if 'max-retries' not in jobspec:
+        if jobspec.get('max-retries', None) is None:
             jobspec['max-retries'] = 1
-        if 'max-runtime' not in jobspec:
+        if jobspec.get('max-runtime', None) is None:
             jobspec['max-runtime'] = timedelta(days=1)
-        if 'name' not in jobspec:
+        if jobspec.get('name', None) is None:
             jobspec['name'] = f'{getpass.getuser()}-job'
-        if 'application' not in jobspec:
+        if jobspec.get('application', None) is None:
             jobspec['application'] = _CLIENT_APP
         return jobspec
 
@@ -383,13 +383,13 @@ class JobClient:
         The provided jobspec will not be touched and a copy will be returned.
         """
         jobspec = copy.deepcopy(jobspec)
-        if 'max-runtime' in jobspec:
+        if jobspec.get('max-runtime', None) is not None:
             jobspec['max-runtime'] = (
                 jobspec['max-runtime'].total_seconds() * 1000
             )
-        if 'application' in jobspec:
+        if jobspec.get('application', None) is not None:
             jobspec['application'] = jobspec['application'].to_dict()
-        if 'container' in jobspec:
+        if jobspec.get('container', None) is not None:
             jobspec['container'] = jobspec['container'].to_dict()
         return jobspec
 

--- a/jobclient/python/cookclient/util.py
+++ b/jobclient/python/cookclient/util.py
@@ -73,3 +73,8 @@ def clamped_ms_to_timedelta(ms: int) -> timedelta:
         return timedelta(milliseconds=ms)
     except OverflowError:
         return timedelta.max if ms > 0 else timedelta.min
+
+
+def is_field_set(d: dict, key: str) -> bool:
+    """Check whether d has key set to a non-None value."""
+    return d.get(key, None) is not None

--- a/jobclient/python/cookclient/util.py
+++ b/jobclient/python/cookclient/util.py
@@ -78,3 +78,12 @@ def clamped_ms_to_timedelta(ms: int) -> timedelta:
 def is_field_set(d: dict, key: str) -> bool:
     """Check whether d has key set to a non-None value."""
     return d.get(key, None) is not None
+
+
+def prune_nones(d: dict) -> dict:
+    """Remove all None values in d."""
+    return {
+        key: value
+        for key, value in d.items()
+        if value is not None
+    }


### PR DESCRIPTION
## Changes proposed in this PR

- Fix the Python client so that submitting a job with `None` explicitly set on certain parameters no longer causes a `NoneError`

## Why are we making these changes?

The following code snippet:

```python
client = JobClient(COOK_URL)
client.submit_all([{'command': 'ls', 'container': None}])
```

will incorrectly cause a `NoneError`. This is because since the `container` key is explicitly set in the jobspec, the client erroneously assumes it is not `None` and attempts to call `jobspec['container'].to_dict()`. This patch fixes this issue.

