### PR TITLE
Reverse order of quota application

### DIFF
--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -963,8 +963,8 @@
   ; Use the already precomputed user->usage map and just aggregate by users to get pool usage.
   (let [pool-usage (reduce (partial merge-with +) (vals user->usage))]
     (->> queue
-         (filter-based-on-pool-quota pool-quota pool-usage)
-         (filter-based-on-user-quota user->quota user->usage))))
+         (filter-based-on-user-quota user->quota user->usage)
+         (filter-based-on-pool-quota pool-quota pool-usage))))
 
 (defn pool->user->usage
   "Returns a map from pool name to user name to usage for all users in all pools."

--- a/scheduler/test/cook/test/tools.clj
+++ b/scheduler/test/cook/test/tools.clj
@@ -796,11 +796,8 @@
         test-user-2 "bob"
         user->usage {test-user-1 {:count 1, :cpus 1, :mem 1} test-user-2 {:count 1, :cpus 1, :mem 1}}
         pool-quota {:count 4, :cpus 100, :mem 100}
-        job-user (atom 0)
         make-job (fn [user]
-                   (swap! job-user inc)
-                   {:db/id @job-user
-                    :job/user user
+                   {:job/user user
                     :job/resource [{:resource/type :cpus, :resource/amount 1}
                                    {:resource/type :mem, :resource/amount 1}]})
         queue [(make-job test-user-1) (make-job test-user-1) (make-job test-user-1) (make-job test-user-2)]


### PR DESCRIPTION
## Changes proposed in this PR

- Reverse order of quota application

## Why are we making these changes?

Applying quotas in the wrong order can also cause us to not launch
jobs that are within quota. A user who's already at their quota will
appear to falsely use global quota that they can't really use.
