### PR TITLE
Allows prefixed job labels to become k8s pod labels

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -53,7 +53,8 @@
                                :age-out-seen-count 10
                                :factory-fn "cook.plugins.demo-plugin/launch-factory"}}
  :hostname #config/env "COOK_HOSTNAME"
- :kubernetes {:disallowed-container-paths #{"/mnt/bad"}
+ :kubernetes {:add-job-label-to-pod-prefix "platform/"
+              :disallowed-container-paths #{"/mnt/bad"}
               :disallowed-var-names #{"BADVAR"}
               :init-container {:command ["/bin/sh" "-c" "echo sample init container running"]
                                :image "byrnedo/alpine-curl:latest"}

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -963,7 +963,12 @@
                                                  (when cache {:cache? cache})
                                                  (when extract {:extract? extract})))
                                         uris)})
-                 (when labels {:labels (walk/stringify-keys labels)})
+                 ; We need to convert job label keys to strings, but
+                 ; walk/stringify-keys removes the namespace, which would mean
+                 ; that jobs submitted with a label key like "platform/thing"
+                 ; would lose the "platform/" part. Instead we just call str and
+                 ; remove the leading ':'.
+                 (when labels {:labels (pc/map-keys #(-> % str (subs 1)) labels)})
                  ;; Rest framework keywordifies all keys, we want these to be strings!
                  (when constraints {:constraints constraints})
                  (when group-uuid {:group group-uuid})


### PR DESCRIPTION
## Changes proposed in this PR

- adding optional `:add-job-label-to-pod-prefix` configuration option
- when the option is set, adding any job labels with the configured prefix as pod labels

## Why are we making these changes?

To allow upstream platforms to specify job labels that dictate behavior in k8s, e.g. the need to have a particular persistent disk attached.
