### PR TITLE
Adds API for compute clusters

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -3059,6 +3059,7 @@
       ;; only the leader handles compute-cluster requests
       (redirect-to-leader leadership-atom leader-selector)
       {:allowed? (partial check-compute-cluster-allowed is-authorized-fn)
+       ;; TODO(DPO) This should move to redirect-to-leader
        :existed? (constantly true)
        ;; triggers path for moved-temporarily?
        :exists? (fn [_] @leadership-atom)}

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -3061,6 +3061,7 @@
       {:allowed? (partial check-compute-cluster-allowed is-authorized-fn)
        ;; TODO(DPO) This should move to redirect-to-leader
        :existed? (constantly true)
+       ;; TODO(DPO) This should move to redirect-to-leader
        ;; triggers path for moved-temporarily?
        :exists? (fn [_] @leadership-atom)}
       resource-attrs)))

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -3029,12 +3029,15 @@
 
 (defn check-compute-cluster-conflict
   [conn ctx]
-  (let [db (d/db conn)
-        name (-> ctx :request :body-params :name)
-        exists? (compute-cluster-exists? db name)]
-    (if exists?
-      [true {::error (str "Compute cluster with name " name " already exists")}]
-      false)))
+  (try
+    (let [db (d/db conn)
+          name (-> ctx :request :body-params :name)
+          exists? (compute-cluster-exists? db name)]
+      (if exists?
+        [true {::error (str "Compute cluster with name " name " already exists")}]
+        false))
+    (catch Exception e
+      [true {::error (.toString e)}])))
 
 (defn check-compute-cluster-allowed
   [is-authorized-fn ctx]
@@ -3417,6 +3420,32 @@
              :get {:summary "Returns the pools."
                    :handler (pools-handler)}}))
 
+        (c-api/context
+          "/compute-clusters" []
+          (c-api/resource
+            {:produces ["application/json"]
+
+             :post
+             {:summary "TODO(DPO) POST summary"
+              :parameters {:body-params InsertComputeClusterRequest}
+              :handler (post-compute-clusters-handler conn
+                                                      is-authorized-fn
+                                                      leadership-atom
+                                                      leader-selector)
+              :responses {201 {:description "TODO(DPO) POST 201 description"}
+                          400 {:description "TODO(DPO) POST 400 description"}
+                          403 {:description "TODO(DPO) POST 403 description"}
+                          409 {:description "TODO(DPO) POST 409 description"}}}
+
+             :get
+             {:summary "TODO(DPO) GET summary"
+              :handler (get-compute-clusters-handler conn
+                                                     is-authorized-fn
+                                                     leadership-atom
+                                                     leader-selector)
+              :responses {200 {:description "TODO(DPO) GET 201 description"}
+                          403 {:description "TODO(DPO) GET 403 description"}}}}))
+
         (c-api/undocumented
           ;; internal api endpoints (don't include in swagger)
           (c-api/context
@@ -3453,30 +3482,6 @@
            :responses {200 {:schema DataLocalUpdateTimeResponse}}
            :get {:summary "Returns summary information on the current data locality status"
                  :handler (data-local-update-time-handler conn)}}))
-
-      (c-api/context
-        "/compute-clusters" []
-        (c-api/resource
-          {:produces ["application/json"]
-           :post
-           {:summary "TODO(DPO) POST summary"
-            :parameters {:body-params InsertComputeClusterRequest}
-            :handler (post-compute-clusters-handler conn
-                                                    is-authorized-fn
-                                                    leadership-atom
-                                                    leader-selector)
-            :responses {201 {:description "TODO(DPO) POST 201 description"}
-                        403 {:description "TODO(DPO) POST 403 description"}
-                        409 {:description "TODO(DPO) POST 409 description"}}}
-
-           :get
-           {:summary "TODO(DPO) GET summary"
-            :handler (get-compute-clusters-handler conn
-                                                   is-authorized-fn
-                                                   leadership-atom
-                                                   leader-selector)
-            :responses {200 {:description "TODO(DPO) GET 201 description"}
-                        403 {:description "TODO(DPO) GET 403 description"}}}}))
 
       (ANY "/queue" []
         (waiting-jobs conn mesos-pending-jobs-fn is-authorized-fn leadership-atom leader-selector))

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2417,6 +2417,7 @@
                                  "name" name
                                  "state" "running"
                                  "template" "test-template"}
+                   :headers {"Content-Type" "application/json"}
                    :request-method :post
                    :scheme :http
                    :uri endpoint}]
@@ -2450,7 +2451,14 @@
         (with-redefs [api/leader-selector->leader-url (constantly sample-leader-base-url)]
           (let [{:keys [location status]} (handler request :leader? false)]
             (is (= 307 status))
-            (is (= location (str sample-leader-base-url endpoint))))))))
+            (is (= location (str sample-leader-base-url endpoint))))))
+
+      (testing "no cluster name fails"
+        (let [request-with-no-name (assoc request :body-params (-> request :body-params (dissoc "name")))
+              {:keys [status] :as response} (handler request-with-no-name)]
+          (is (= 400 status))
+          (is (= {"name" "missing-required-key"}
+                 (-> response response->body-data (get "errors"))))))))
 
   (deftest test-read-compute-clusters
     (let [conn (restore-fresh-database! "datomic:mem://test-read-compute-clusters")


### PR DESCRIPTION
## Changes proposed in this PR

- adding API endpoint for creating and query compute clusters

## Why are we making these changes?

This is part of a larger effort to support dynamic (k8s) compute clusters in Cook.
