### PR TITLE
Adds /shutdown-leader API endpoint

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1744,47 +1744,69 @@
                        (comp first))]
     (base-read-instances-handler conn is-authorized-fn {:handle-ok handle-ok})))
 
+(defn redirect-to-leader
+  "Returns a map of Liberator resource attribute functions to
+   be used when only the Cook leader should handle the request"
+  [leadership-atom leader-selector]
+  {:can-post-to-gone?
+   (constantly true)
+
+   :handle-moved-temporarily
+   (fn redirect-to-leader-handle-moved-temporarily
+     [ctx]
+     {:location (:location ctx)
+      :message "redirecting to master"})
+
+   :handle-service-not-available
+   (fn redirect-to-leader-handle-service-not-available
+     [{:keys [::message]}]
+     {:message message})
+
+   :moved-temporarily?
+   (fn redirect-to-leader-moved-temporarily?
+     [ctx]
+     ;; the client is expected to cache the redirect location
+     (if-let [leader-url (::leader-url ctx)]
+       (let [request-path (get-in ctx [:request :uri])]
+         [true {:location (str leader-url request-path)}])
+       [false {}]))
+
+   :service-available?
+   (fn redirect-to-leader-service-available?
+     [_]
+     (if @leadership-atom
+       [true {}]
+       (try
+         ;; recording target leader-url for redirect
+         [true {::leader-url (leader-selector->leader-url leader-selector)}]
+         ;; handle leader-not-found errors by responding 503
+         (catch IllegalStateException e
+           [false {::message (.getMessage e)}]))))})
+
 (defn update-instance-progress-handler
   [conn is-authorized-fn leadership-atom leader-selector progress-aggregator-chan]
   (base-cook-handler
-    {:allowed-methods [:post]
-     :initialize-context (fn [ctx]
-                           ;; injecting ::instances into ctx for later handlers
-                           {::instances [(get-in ctx [:request :params :uuid])]})
-     :service-available? (fn [ctx]
-                           (if @leadership-atom
-                             [true {}]
-                             (try
-                               ;; recording target leader-url for redirect
-                               [true {::leader-url (leader-selector->leader-url leader-selector)}]
-                               ;; handle leader-not-found errors by responding 503
-                               (catch IllegalStateException e
-                                 [false {::message (.getMessage e)}]))))
-     :handle-service-not-available (fn [ctx] {:message (::message ctx)})
-     :allowed? (partial instance-request-allowed? conn is-authorized-fn)
-     :exists? (constantly false)  ;; triggers path for moved-temporarily?
-     :existed? instance-request-exists?
-     :can-post-to-missing? (constantly false)
-     :moved-temporarily? (fn [ctx]
-                           ;; only the leader handles progress updates
-                           ;; the client is expected to cache the redirect location
-                           (if-let [leader-url (::leader-url ctx)]
-                             (let [request-path (get-in ctx [:request :uri])]
-                               [true {:location (str leader-url request-path)}])
-                             [false {}]))
-     :handle-moved-temporarily (fn [ctx] {:location (:location ctx)
-                                          :message "redirecting to master"})
-     :can-post-to-gone? (constantly true)
-     :post! (fn [ctx]
-              (let [progress-message-map (get-in ctx [:request :body-params])
-                    task-id (-> ctx ::instances first)]
-                (progress/handle-progress-message!
-                  (d/db conn) task-id progress-aggregator-chan progress-message-map)))
-     :post-enacted? (constantly false)  ;; triggers http 202 "accepted" response
-     :handle-accepted (fn [ctx]
-                        (let [instance (-> ctx ::instances first)
-                              job (-> ctx ::jobs first)]
-                          {:instance instance :job job :message "progress update accepted"}))}))
+    (merge
+      ;; only the leader handles progress updates
+      (redirect-to-leader leadership-atom leader-selector)
+      {:allowed-methods [:post]
+       :initialize-context (fn [ctx]
+                             ;; injecting ::instances into ctx for later handlers
+                             {::instances [(get-in ctx [:request :params :uuid])]})
+       :allowed? (partial instance-request-allowed? conn is-authorized-fn)
+       :exists? (constantly false)  ;; triggers path for moved-temporarily?
+       :existed? instance-request-exists?
+       :can-post-to-missing? (constantly false)
+       :post! (fn [ctx]
+                (let [progress-message-map (get-in ctx [:request :body-params])
+                      task-id (-> ctx ::instances first)]
+                  (progress/handle-progress-message!
+                    (d/db conn) task-id progress-aggregator-chan progress-message-map)))
+       :post-enacted? (constantly false)  ;; triggers http 202 "accepted" response
+       :handle-accepted (fn [ctx]
+                          (let [instance (-> ctx ::instances first)
+                                job (-> ctx ::jobs first)]
+                            {:instance instance :job job :message "progress update accepted"}))})))
 
 ;;; On DELETE; use repeated job argument
 (defn destroy-jobs-handler
@@ -2972,6 +2994,48 @@
      :handle-ok (fn [{:keys [costs]}]
                   costs)}))
 
+;;
+;; /shutdown-leader
+;;
+
+(def ShutdownLeaderRequest
+  {:reason s/Str})
+
+(defn check-shutdown-leader-allowed
+  [is-authorized-fn ctx]
+  (let [request-user (get-in ctx [:request :authorization/user])
+        impersonator (get-in ctx [:request :authorization/impersonator])
+        request-method (get-in ctx [:request :request-method])]
+    (if-not (is-authorized-fn request-user
+                              request-method
+                              impersonator
+                              {:owner ::system :item :shutdown-leader})
+      [false {::error
+              (str "You are not authorized to shutdown the leader")}]
+      true)))
+
+(defn shutdown!
+  []
+  (System/exit 0))
+
+(defn post-shutdown-leader!
+  [ctx]
+  (let [reason (-> ctx :request :body-params :reason)]
+    (log/info "Exiting from /shutdown-leader request with reason" reason)
+    (shutdown!)))
+
+(defn post-shutdown-leader-handler
+  [is-authorized-fn leadership-atom leader-selector]
+  (base-cook-handler
+    (merge
+      ;; only the leader handles shutdown-leader requests
+      (redirect-to-leader leadership-atom leader-selector)
+      {:allowed-methods [:post]
+       :allowed? (partial check-shutdown-leader-allowed is-authorized-fn)
+       ;; triggers path for moved-temporarily?
+       :exists? (fn [_] @leadership-atom)
+       :post! post-shutdown-leader!})))
+
 (defn streaming-json-encoder
   "Takes as input the response body which can be converted into JSON,
   and returns a function which takes a ServletResponse and writes the JSON
@@ -3302,6 +3366,20 @@
                               :description "The pools were returned."}}
              :get {:summary "Returns the pools."
                    :handler (pools-handler)}}))
+
+        (c-api/context
+          "/shutdown-leader" []
+          (c-api/resource
+            {:produces ["application/json"]
+
+             :post
+             {:summary "TODO(DPO) POST summary"
+              :parameters {:body-params ShutdownLeaderRequest}
+              :handler (post-shutdown-leader-handler is-authorized-fn
+                                                     leadership-atom
+                                                     leader-selector)
+              :responses {400 {:description "TODO(DPO) POST 400 description"}
+                          403 {:description "TODO(DPO) POST 403 description"}}}}))
 
         (c-api/undocumented
           ;; internal api endpoints (don't include in swagger)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1751,6 +1751,12 @@
   {:can-post-to-gone?
    (constantly true)
 
+   :existed?
+   (constantly true)
+
+   ;; triggers path for moved-temporarily?
+   :exists? (fn [_] @leadership-atom)
+
    :handle-moved-temporarily
    (fn redirect-to-leader-handle-moved-temporarily
      [ctx]
@@ -3032,8 +3038,6 @@
       (redirect-to-leader leadership-atom leader-selector)
       {:allowed-methods [:post]
        :allowed? (partial check-shutdown-leader-allowed is-authorized-fn)
-       ;; triggers path for moved-temporarily?
-       :exists? (fn [_] @leadership-atom)
        :post! post-shutdown-leader!})))
 
 (defn streaming-json-encoder
@@ -3373,13 +3377,13 @@
             {:produces ["application/json"]
 
              :post
-             {:summary "TODO(DPO) POST summary"
+             {:summary "Shutdown the Cook leader"
               :parameters {:body-params ShutdownLeaderRequest}
               :handler (post-shutdown-leader-handler is-authorized-fn
                                                      leadership-atom
                                                      leader-selector)
-              :responses {400 {:description "TODO(DPO) POST 400 description"}
-                          403 {:description "TODO(DPO) POST 403 description"}}}}))
+              :responses {307 {:description "Redirecting request to leader node."}
+                          400 {:description "Invalid request format."}}}}))
 
         (c-api/undocumented
           ;; internal api endpoints (don't include in swagger)

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -693,7 +693,7 @@
               redirect-location (str sample-leader-base-url target-endpoint)]
           (is (= (:status update-resp) 307))
           (is (= (:location update-resp) redirect-location))
-          (is (= (:body update-resp) {:location redirect-location, :message "redirecting to master"})))))
+          (is (= (:body update-resp) {:location redirect-location, :message "redirecting to leader"})))))
 
     (testing "Valid progress update posted to leader results 202 Accepted"
       (with-redefs [api/streaming-json-encoder identity]
@@ -2420,7 +2420,8 @@
       (testing "successful shutdown"
         (let [called-shutdown? (atom false)]
           (with-redefs [api/shutdown! #(reset! called-shutdown? true)]
-            (handler request)
+            (let [{:keys [status]} (handler request)]
+              (is (= 202 status)))
             (is (true? @called-shutdown?)))))
 
       (testing "request from non-admin fails"


### PR DESCRIPTION
## Changes proposed in this PR

- extracting a function for the set of Liberator resource attribute functions needed for redirecting to the leader
- adding the `/shutdown-leader` endpoint, which redirects to the leader and exits on the leader

## Why are we making these changes?

In a multi-node cluster, it's useful to be able to force a leadership election by causing the current leader to relinquish leadership. We don't currently have a clean path for relinquishing leadership other than simply exiting.
