### PR TITLE
Logs at start and end of job ranking

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1469,8 +1469,10 @@
         offensive-job-filter (partial filter-offensive-jobs task-constraints offensive-jobs-ch)]
     (tools/chime-at-ch trigger-chan
                       (fn rank-jobs-event []
+                        (log/info "Starting pending job ranking")
                         (reset! pool-name->pending-jobs-atom
-                                (rank-jobs (d/db conn) offensive-job-filter))))))
+                                (rank-jobs (d/db conn) offensive-job-filter))
+                        (log/info "Done with pending job ranking")))))
 
 (meters/defmeter [cook-mesos scheduler mesos-error])
 (meters/defmeter [cook-mesos scheduler offer-chan-full-error])


### PR DESCRIPTION
## Changes proposed in this PR

- adding a log at the start and end of pending job ranking

## Why are we making these changes?

To be able to correlate the ranking and matching cycles in the logs.
