### PR TITLE
Improves per-user launch-rate-limit logging

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -662,7 +662,14 @@
              ; Force this to be taken eagerly so that the log line is accurate.
              (doall))]
     (swap! pool->user->num-rate-limited-jobs update pool-name (constantly @user->rate-limit-count))
-    (log/info "Users whose job launches are rate-limited " @user->rate-limit-count "( enforcing =" enforcing-job-launch-rate-limit? ")")
+    (when (seq @user->rate-limit-count)
+      (log/info "In" pool-name "pool, job launch rate-limiting"
+                {:count-considerable-jobs (count considerable-jobs)
+                 :enforcing-job-launch-rate-limit? enforcing-job-launch-rate-limit?
+                 :num-considerable num-considerable
+                 :total-rate-limit-count (->> @user->rate-limit-count vals (reduce +))
+                 :user->number-jobs @user->number-jobs
+                 :user->rate-limit-count @user->rate-limit-count}))
     considerable-jobs))
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- only logging when the rate-limit count is > 0
- adding more data to the log

Example:

```
2020-08-16 18:19:28,444 INFO  cook.scheduler.scheduler [async-thread-macro-12] - In k8s-alpha pool, job launch rate-limiting {:count-considerable-jobs 1, :enforcing-job-launch-rate-limit? true, :num-considerable 1000, :total-rate-limit-count 15, :user->number-jobs {vagrant 16}, :user->rate-limit-count {vagrant 15}}
```

## Why are we making these changes?

We don't need to spam the log with this line when the count is 0. When we do log it, having more data can be useful for troubleshooting issues.