### PR TITLE
Improves matching log

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -535,10 +535,15 @@
   [offers]
   (->> offers
        (map (fn offer->resource-map
-              [{:keys [resources] :as offer}]
+              [{:keys [resources]}]
               (reduce
                 (fn [resource-map {:keys [name type scalar text->scalar] :as resource}]
                   (case type
+                    ; Range types (e.g. port ranges) aren't
+                    ; amenable to summing across offers
+                    :value-ranges
+                    resource-map
+
                     :value-scalar
                     (assoc resource-map name scalar)
 
@@ -553,9 +558,7 @@
 
                     (do
                       (log/warn "Encountered unexpected resource type"
-                                {:offer offer
-                                 :resource resource
-                                 :type type})
+                                {:resource resource :type type})
                       resource-map)))
                 {}
                 resources)))


### PR DESCRIPTION
## Changes proposed in this PR

Adding the following to the "matching offers to considerable jobs" log:

- total amount offered by resource
- total amount requested by considerable jobs by resource
- total number of considerable jobs per user

Example log:

```
2020-08-17 02:23:26,290 INFO  cook.scheduler.scheduler [async-thread-macro-8] - In k8s-alpha pool, matching offers to considerable jobs {:count-considerable-jobs 7, :count-offers 3, :resource-type->total-considerable {:cpus 3.500, :mem 224.000}, :resource-type->total-offered {mem 2238.203, cpus 0.878, disk 0.000}, :user->number-jobs {vagrant 7}}
```

## Why are we making these changes?

To get a better sense of the data going into each matching round, especially when troubleshooting issues.
