### PR TITLE
Un-lazy list of hosts a job has run on as a perf optimization

### DIFF
--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -81,7 +81,8 @@
   (->> (:job/instance job)
        (remove #(true? (:instance/preempted? %)))
        (mapv :instance/hostname)
-       distinct))
+       distinct
+       doall))
 
 (defn build-novel-host-constraint
   "Constructs a novel-host-constraint.


### PR DESCRIPTION
## Changes proposed in this PR

- Un-lazy the lost of hosts a job has already run on as a perf optimization.

## Why are we making these changes?

When diagnosing a production problem, I noticed a lot of of threads blocked on unlazy'ing this list.
