### PR TITLE
Use set instead of distinct

### DIFF
--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -80,9 +80,8 @@
   [job]
   (->> (:job/instance job)
        (remove #(true? (:instance/preempted? %)))
-       (mapv :instance/hostname)
-       distinct
-       doall))
+       (map :instance/hostname)
+       set))
 
 (defn build-novel-host-constraint
   "Constructs a novel-host-constraint.

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -252,7 +252,7 @@
                   first)]
           (is (= api/k8s-hostname-label (.getKey node-selector-requirement)))
           (is (= "NotIn" (.getOperator node-selector-requirement)))
-          (is (= ["test-host-1" "test-host-2"] (.getValues node-selector-requirement))))))
+          (is (= #{"test-host-1" "test-host-2"} (set (.getValues node-selector-requirement)))))))
 
     (testing "synthetic pods have safe-to-evict annotation"
       (let [job-uuid-1 (str (UUID/randomUUID))


### PR DESCRIPTION
## Changes proposed in this PR

Use `set` instead of `mapv`->`distinct`

## Why are we making these changes?

After discussion, using a `set` will reduce lock contention when reading already realized `lazy-seq`

