### PR TITLE
Fix dynamic cluster integration tests

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -520,8 +520,8 @@ class CookTest(util.CookTest):
             try:
                 in_mem_compute_clusters = util.compute_clusters(self.cook_url)['in-mem-configs']
                 filtered_compute_clusters.extend(
-                    [cc for cc in [m['cluster-definition']['config'] for m in in_mem_compute_clusters]
-                     if cc['name'] == instance_compute_cluster_name])
+                    [cc for cc in [m['cluster-definition'] for m in in_mem_compute_clusters]
+                     if cc['config']['name'] == instance_compute_cluster_name])
             finally:
                 pass
             self.assertEqual(1, len(filtered_compute_clusters), "Unable to find " + instance_compute_cluster_name + " in compute clusters")


### PR DESCRIPTION
## Changes proposed in this PR

- fix missing key error

## Why are we making these changes?

Missing key error when we attempt to read 'factory-fn' from filtered_compute_clusters in the following code
