### PR TITLE
Fix errors when using dynamic clusters

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -419,7 +419,7 @@
                             {:template template})))
         full-cluster-config (-> (:config cluster-definition-template) (merge config) (assoc :dynamic-cluster-config? true))
         cluster (resolved full-cluster-config {:exit-code-syncer-state @exit-code-syncer-state-atom})]
-    (initialize-cluster cluster {:pool-name->fenzo @pool-name->fenzo-atom})))
+    (initialize-cluster cluster @pool-name->fenzo-atom)))
 
 (defn execute-update!
   "Attempt to execute a valid cluster configuration update.

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -146,7 +146,9 @@
   [compute-cluster-name]
   (let [result (@cluster-name->compute-cluster-atom compute-cluster-name)]
     (when-not result
-      (log/error "Was asked to lookup db-id for" compute-cluster-name "and got nil"))
+      (try (throw (ex-info "Exception to show stack trace" {}))
+           (catch Exception e
+             (log/error e "Was asked to lookup db-id for" compute-cluster-name "and got nil"))))
     result))
 
 (defn get-default-cluster-for-legacy

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -146,9 +146,7 @@
   [compute-cluster-name]
   (let [result (@cluster-name->compute-cluster-atom compute-cluster-name)]
     (when-not result
-      (try (throw (ex-info "Exception to show stack trace" {}))
-           (catch Exception e
-             (log/error e "Was asked to lookup db-id for" compute-cluster-name "and got nil"))))
+      (log/error (ex-info (str "Was asked to lookup db-id for " compute-cluster-name " and got nil") {})))
     result))
 
 (defn get-default-cluster-for-legacy

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1062,7 +1062,7 @@
   [instance-entity]
   (if-let [sandbox-url (:instance/sandbox-url instance-entity)]
     sandbox-url
-    (when-let [compute-cluster (task/task-ent->ComputeCluster instance-entity)]
+    (when-let [compute-cluster (task/get-ComputeCluster-for-task-ent-if-present instance-entity)]
       (cc/retrieve-sandbox-url-path compute-cluster instance-entity))))
 
 (defn compute-cluster-entity->map

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1062,9 +1062,8 @@
   [instance-entity]
   (if-let [sandbox-url (:instance/sandbox-url instance-entity)]
     sandbox-url
-    (if-let [compute-cluster (task/task-ent->ComputeCluster instance-entity)]
-      (cc/retrieve-sandbox-url-path compute-cluster instance-entity)
-      (log/error "Unable to get sandbox URL for" instance-entity "whose compute cluster resolves to nil"))))
+    (when-let [compute-cluster (task/task-ent->ComputeCluster instance-entity)]
+      (cc/retrieve-sandbox-url-path compute-cluster instance-entity))))
 
 (defn compute-cluster-entity->map
   "Attached to the the instance object when we send it in API responses"

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1062,7 +1062,7 @@
   [instance-entity]
   (if-let [sandbox-url (:instance/sandbox-url instance-entity)]
     sandbox-url
-    (when-let [compute-cluster (task/get-ComputeCluster-for-task-ent-if-present instance-entity)]
+    (when-let [compute-cluster (task/get-compute-cluster-for-task-ent-if-present instance-entity)]
       (cc/retrieve-sandbox-url-path compute-cluster instance-entity))))
 
 (defn compute-cluster-entity->map

--- a/scheduler/src/cook/task.clj
+++ b/scheduler/src/cook/task.clj
@@ -52,7 +52,7 @@
   [task-ent]
   (some-> task-ent
     task-entity->compute-cluster-name
-    @cc/cluster-name->compute-cluster-atom))
+    (@cc/cluster-name->compute-cluster-atom)))
 
 (def progress-meta-env-name
   "Meta environment variable name for declaring the environment variable

--- a/scheduler/src/cook/task.clj
+++ b/scheduler/src/cook/task.clj
@@ -47,6 +47,13 @@
           task-entity->compute-cluster-name
           cc/compute-cluster-name->ComputeCluster))
 
+(defn get-ComputeCluster-for-task-ent-if-present
+  "Like task-ent->ComputeCluster but do not log errors when there is no cluster"
+  [task-ent]
+  (some-> task-ent
+    task-entity->compute-cluster-name
+    @cc/cluster-name->compute-cluster-atom))
+
 (def progress-meta-env-name
   "Meta environment variable name for declaring the environment variable
    that stores the path of the progress output file."

--- a/scheduler/src/cook/task.clj
+++ b/scheduler/src/cook/task.clj
@@ -47,7 +47,7 @@
           task-entity->compute-cluster-name
           cc/compute-cluster-name->ComputeCluster))
 
-(defn get-ComputeCluster-for-task-ent-if-present
+(defn get-compute-cluster-for-task-ent-if-present
   "Like task-ent->ComputeCluster but do not log errors when there is no cluster"
   [task-ent]
   (some-> task-ent

--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -508,6 +508,7 @@
            dynamic-cluster-config?]
     :as compute-cluster-config} _]
   (when (= "fail" (:name compute-cluster-config)) (throw (ex-info "fail" {})))
+  (reset! pool-name->fenzo-atom {:pool-name :fenzo})
   (let [backing-map {:name name
                      :dynamic-cluster-config? dynamic-cluster-config?
                      :state-atom (atom state)
@@ -515,7 +516,8 @@
                      :cluster-definition {:factory-fn 'cook.kubernetes.compute-cluster/factory-fn :config compute-cluster-config}}
         compute-cluster (reify ComputeCluster
                           (compute-cluster-name [cluster] (:name cluster))
-                          (initialize-cluster [cluster _]
+                          (initialize-cluster [cluster pool->fenzo]
+                            (is (= {:pool-name :fenzo} pool->fenzo))
                             (swap! initialize-cluster-fn-invocations-atom conj (:name cluster)))
                           java.util.Map
                           (get [_ val] (backing-map val))

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1671,7 +1671,7 @@
 (deftest test-retrieve-sandbox-url-path
   (let [agent-hostname "www.mesos-agent-com"]
     ; We have a special gate that the compute cluster isn't nil, so have this return something not nil.
-    (with-redefs [task/task-ent->ComputeCluster (constantly "JustHasToBeNonNil-ComputeCluster")
+    (with-redefs [task/get-ComputeCluster-for-task-ent-if-present (constantly "JustHasToBeNonNil-ComputeCluster")
                   cc/retrieve-sandbox-url-path (fn [_ {:keys [instance/hostname instance/sandbox-directory instance/task-id]}]
                                                  (when (and hostname sandbox-directory)
                                                    (str "http://" hostname ":5051" "/" task-id "/files/read.json?path=" sandbox-directory)))]

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1671,7 +1671,7 @@
 (deftest test-retrieve-sandbox-url-path
   (let [agent-hostname "www.mesos-agent-com"]
     ; We have a special gate that the compute cluster isn't nil, so have this return something not nil.
-    (with-redefs [task/get-ComputeCluster-for-task-ent-if-present (constantly "JustHasToBeNonNil-ComputeCluster")
+    (with-redefs [task/get-compute-cluster-for-task-ent-if-present (constantly "JustHasToBeNonNil-ComputeCluster")
                   cc/retrieve-sandbox-url-path (fn [_ {:keys [instance/hostname instance/sandbox-directory instance/task-id]}]
                                                  (when (and hostname sandbox-directory)
                                                    (str "http://" hostname ":5051" "/" task-id "/files/read.json?path=" sandbox-directory)))]


### PR DESCRIPTION
## Changes proposed in this PR

- fix pool-name->fenzo map
- remove sandbox url error for dynamic clusters

## Why are we making these changes?

These errors were being logged but were not affecting jobs and were not noticed initially

A malformed pool-name->fenzo map was being passed in to write-status-to-datomic

We were attempting to get output_url from non-leader cluster which had no references to dynamic clusters. But we don't actually need a reference to a kubernetes cluster for output_url
