### PR TITLE
Deletes unschedulable synthetic pods

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -650,8 +650,7 @@ class CookTest(util.CookTest):
         command = f'{line_1} && sleep 2 && {line_2} && sleep 2 && ' \
                   f'{line_3} && sleep 2 && {line_4} && sleep 2 && ' \
                   f'{line_5} && sleep 2 && echo "Done" && exit 0'
-        job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=job_executor_type,
-                                         max_runtime=60000, max_retries=5)
+        job_uuid, resp = util.submit_job(self.cook_url, command=command, executor=job_executor_type, max_retries=5)
         self.assertEqual(201, resp.status_code, msg=resp.content)
         time.sleep(10) # since the job sleeps for 10 seconds, it won't be done for at least 10 seconds
         util.wait_for_job(self.cook_url, job_uuid, 'completed')

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -478,7 +478,8 @@
                              :pod-condition-containers-not-initialized-seconds 120
                              :pod-condition-unschedulable-seconds 60
                              :reconnect-delay-ms 60000
-                             :set-container-cpu-limit? true}
+                             :set-container-cpu-limit? true
+                             :synthetic-pod-condition-unschedulable-seconds 900}
                             kubernetes)))
      :offer-matching (fnk [[:config {offer-matching {}}]]
                        (merge {:global-min-match-interval-millis 100

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -593,7 +593,7 @@
    (synthesize-state-and-process-pod-if-changed compute-cluster pod-name pod false))
   ([{:keys [k8s-actual-state-map name] :as compute-cluster} pod-name ^V1Pod pod force-process?]
    (let [new-state {:pod pod
-                    :synthesized-state (api/pod->synthesized-pod-state pod)
+                    :synthesized-state (api/pod->synthesized-pod-state pod-name pod)
                     :sandbox-file-server-container-state (api/pod->sandbox-file-server-container-state pod)}
          old-state (get @k8s-actual-state-map pod-name)]
      ; We always store the updated state, but only reprocess it if it is genuinely different.


### PR DESCRIPTION
## Changes proposed in this PR

- adding a new configuration field `:kubernetes` `:synthetic-pod-condition-unschedulable-seconds`, which defaults to 900 seconds (15 minutes)
- changing `pod-unschedulable?` to use the same logic for synthetic pods as for non-synthetic pods, just with a different timeout

## Why are we making these changes?

So that unscheduled synthetic pods don't stay around forever.
