### PR TITLE
Logs offer and job percentiles

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -568,9 +568,9 @@
        offers))
 
 (defn jobs->resource-maps
-  [jobs]
   "Given a collection of jobs, returns a collection
    of maps, where each map is resource-type -> amount"
+  [jobs]
   (map (fn job->resource-map
          [job]
          (let [{:strs [gpus] :as resource-map}

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -22,6 +22,7 @@
             [clojure.edn :as edn]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [cook.compute-cluster :as cc]
             [cook.config :as config]
             [cook.datomic :as datomic]
@@ -40,6 +41,7 @@
             [cook.scheduler.fenzo-utils :as fenzo]
             [cook.scheduler.share :as share]
             [cook.task]
+            [cook.task-stats :as task-stats]
             [cook.tools :as tools]
             [cook.util :as util]
             [datomic.api :as d :refer [q]]
@@ -531,66 +533,102 @@
         pool-specific-resources ((adjust-job-resources-for-pool-fn pool-name) job resources)]
     (->TaskRequestAdapter job pool-specific-resources task-id assigned-resources guuid->considerable-cotask-ids constraints-list scalar-requests)))
 
-(defn offers->resource-totals
-  "Given a collection of offers, returns a map from resource type to total amount"
-  [offers]
-  (->> offers
-       (map (fn offer->resource-map
-              [{:keys [resources]}]
-              (reduce
-                (fn [resource-map {:keys [name type scalar text->scalar] :as resource}]
-                  (case type
-                    ; Range types (e.g. port ranges) aren't
-                    ; amenable to summing across offers
-                    :value-ranges
-                    resource-map
-
-                    :value-scalar
-                    (assoc resource-map name scalar)
-
-                    :value-text->scalar
-                    (reduce
-                      (fn [resource-map-inner [text scalar]]
-                        (assoc resource-map-inner
-                          (str name "/" text)
-                          scalar))
-                      resource-map
-                      text->scalar)
-
-                    (do
-                      (log/warn "Encountered unexpected resource type"
-                                {:resource resource :type type})
-                      resource-map)))
-                {}
-                resources)))
-       (reduce (partial merge-with +))))
-
-(defn jobs->resource-totals
-  "Given a collection of jobs, returns a map from resource type to total amount"
-  [jobs]
-  (->> jobs
-       (map (fn job->resource-map
-              [job]
-              (let [{:keys [gpus] :as resource-map}
-                    (-> job tools/job-ent->resources (dissoc :ports))]
-                (if gpus
-                  (let [env (tools/job-ent->env job)
-                        gpu-model (get env "COOK_GPU_MODEL" "unspecified-gpu-model")
-                        gpus-resource-key (keyword "gpus" gpu-model)]
-                    (-> resource-map
-                        (assoc gpus-resource-key gpus)
-                        (dissoc :gpus)))
-                  resource-map))))
-       (reduce (partial merge-with +))))
-
 (defn format-resource-map
-  "Given a map from resource type to amount,
+  "Given a map with resource amount values,
    formats the amount values for logging"
   [resource-map]
   (pc/map-vals #(if (float? %)
                   (format "%.3f" %)
                   (str %))
                resource-map))
+
+(defn resource-maps->stats
+  "Given a collection of maps, where each map is
+  resource-type -> amount, returns a map of
+  statistics with the following shape:
+
+  {:percentiles {cpus {50 ..., 95 ..., 100 ...}
+                 mem {50 ..., 95 ..., 100 ...}}
+   :totals {mem ..., cpus ..., ...}}"
+  [resource-maps]
+  {:percentiles (pc/map-from-keys
+                  (fn percentiles
+                    [resource]
+                    (let [resource-values (->> resource-maps
+                                               (map #(get % resource))
+                                               (remove nil?))]
+                      (-> resource-values
+                          (task-stats/percentiles 50 95 100)
+                          format-resource-map)))
+                  ["cpus" "mem"])
+   :totals (->> resource-maps
+                (reduce (partial merge-with +))
+                format-resource-map)})
+
+(defn offers->resource-maps
+  "Given a collection of offers, returns a collection
+   of maps, where each map is resource-type -> amount"
+  [offers]
+  (map (fn offer->resource-map
+         [{:keys [resources]}]
+         (reduce
+           (fn [resource-map {:keys [name type scalar text->scalar] :as resource}]
+             (case type
+               ; Range types (e.g. port ranges) aren't
+               ; amenable to summing across offers
+               :value-ranges
+               resource-map
+
+               :value-scalar
+               (assoc resource-map name scalar)
+
+               :value-text->scalar
+               (reduce
+                 (fn [resource-map-inner [text scalar]]
+                   (assoc resource-map-inner
+                     (str name "/" text)
+                     scalar))
+                 resource-map
+                 text->scalar)
+
+               (do
+                 (log/warn "Encountered unexpected resource type"
+                           {:resource resource :type type})
+                 resource-map)))
+           {}
+           resources))
+       offers))
+
+(defn offers->stats
+  "Given a collection of offers, returns stats about the offers"
+  [offers]
+  (-> offers offers->resource-maps resource-maps->stats))
+
+(defn jobs->resource-maps
+  [jobs]
+  "Given a collection of jobs, returns a collection
+   of maps, where each map is resource-type -> amount"
+  (map (fn job->resource-map
+         [job]
+         (let [{:strs [gpus] :as resource-map}
+               (-> job
+                   tools/job-ent->resources
+                   (dissoc :ports)
+                   walk/stringify-keys)]
+           (if gpus
+             (let [env (tools/job-ent->env job)
+                   gpu-model (get env "COOK_GPU_MODEL" "unspecified-gpu-model")
+                   gpus-resource-key (str "gpus/" gpu-model)]
+               (-> resource-map
+                   (assoc gpus-resource-key gpus)
+                   (dissoc "gpus")))
+             resource-map)))
+       jobs))
+
+(defn jobs->stats
+  "Given a collection of jobs, returns stats about the jobs"
+  [jobs]
+  (-> jobs jobs->resource-maps resource-maps->stats))
 
 (defn match-offer-to-schedule
   "Given an offer and a schedule, computes all the tasks should be launched as a result.
@@ -989,9 +1027,7 @@
                                          :number-total (count considerable-jobs)
                                          :number-unmatched (- (count considerable-jobs)
                                                               (count matched-job-uuids))
-                                         :resource-type->total (-> considerable-jobs
-                                                                   jobs->resource-totals
-                                                                   format-resource-map)
+                                         :stats (jobs->stats considerable-jobs)
                                          :user->number-matched user->number-matched-considerable-jobs
                                          :user->number-total user->number-total-considerable-jobs
                                          :user->number-unmatched (merge-with
@@ -1001,9 +1037,7 @@
                      :offers {:number-matched (count offers-scheduled)
                               :number-total (count offers)
                               :number-unmatched (- (count offers) (count offers-scheduled))
-                              :resource-type->total (-> offers
-                                                        offers->resource-totals
-                                                        format-resource-map)}})
+                              :stats (offers->stats offers)}})
 
           (fenzo/record-placement-failures! conn failures)
 

--- a/scheduler/src/cook/task_stats.clj
+++ b/scheduler/src/cook/task_stats.clj
@@ -71,7 +71,7 @@
              (Math/ceil)
              (dec)))))
 
-(defn- percentiles
+(defn percentiles
   "Calculates the p-th percentiles of the values in coll for
   each p in p-list (where 0 < p <= 100), and returns a map of
   p -> value"

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2259,7 +2259,7 @@
                             :type :value-text->scalar
                             :text->scalar {"nvidia-tesla-k80" 4 "nvidia-tesla-p100" 8}}]}])))))
 
-(deftest test-job->resource-totals
+(deftest test-job->resource-maps
   (testing "adds up resources by type"
     (is (= [{"cpus" 1.2
              "mem" 34

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2214,13 +2214,17 @@
                                             (repeat 40 "x")
                                             100)))
 
-(deftest test-offers->resource-totals
+(deftest test-offers->resource-maps
   (testing "adds up resources by type"
-    (is (= {"cpus" 3.5
-            "mem" 79
-            "gpus/nvidia-tesla-k80" 6
-            "gpus/nvidia-tesla-p100" 12}
-           (sched/offers->resource-totals
+    (is (= [{"cpus" 1.2
+             "mem" 34
+             "gpus/nvidia-tesla-k80" 2
+             "gpus/nvidia-tesla-p100" 4}
+            {"cpus" 2.3
+             "mem" 45
+             "gpus/nvidia-tesla-k80" 4
+             "gpus/nvidia-tesla-p100" 8}]
+           (sched/offers->resource-maps
              [{:resources [{:name "cpus" :type :value-scalar :scalar 1.2}
                            {:name "mem" :type :value-scalar :scalar 34}
                            {:name "gpus"
@@ -2233,11 +2237,16 @@
                             :text->scalar {"nvidia-tesla-k80" 4 "nvidia-tesla-p100" 8}}]}]))))
 
   (testing "gracefully handles unexpected resource type"
-    (is (= {"cpus" 3.5
-            "mem" 79
-            "gpus/nvidia-tesla-k80" 6
-            "gpus/nvidia-tesla-p100" 12}
-           (sched/offers->resource-totals
+    (is (= [{"cpus" 1.2
+             "mem" 34
+             "gpus/nvidia-tesla-k80" 2
+             "gpus/nvidia-tesla-p100" 4}
+            {}
+            {"cpus" 2.3
+             "mem" 45
+             "gpus/nvidia-tesla-k80" 4
+             "gpus/nvidia-tesla-p100" 8}]
+           (sched/offers->resource-maps
              [{:resources [{:name "cpus" :type :value-scalar :scalar 1.2}
                            {:name "mem" :type :value-scalar :scalar 34}
                            {:name "gpus"
@@ -2252,11 +2261,13 @@
 
 (deftest test-job->resource-totals
   (testing "adds up resources by type"
-    (is (= {:cpus 3.5
-            :mem 79
-            :gpus/nvidia-tesla-k80 2
-            :gpus/nvidia-tesla-p100 4}
-           (sched/jobs->resource-totals
+    (is (= [{"cpus" 1.2
+             "mem" 34
+             "gpus/nvidia-tesla-k80" 2}
+            {"cpus" 2.3
+             "mem" 45
+             "gpus/nvidia-tesla-p100" 4}]
+           (sched/jobs->resource-maps
              [{:job/environment [{:environment/name "COOK_GPU_MODEL"
                                   :environment/value "nvidia-tesla-k80"}]
                :job/resource [{:resource/type :cpus :resource/amount 1.2}
@@ -2269,10 +2280,13 @@
                               {:resource/type :gpus :resource/amount 4}]}]))))
 
   (testing "gracefully handles unspecified gpu model"
-    (is (= {:cpus 3.5
-            :mem 79
-            :gpus/unspecified-gpu-model 6}
-           (sched/jobs->resource-totals
+    (is (= [{"cpus" 1.2
+             "mem" 34
+             "gpus/unspecified-gpu-model" 2}
+            {"cpus" 2.3
+             "mem" 45
+             "gpus/unspecified-gpu-model" 4}]
+           (sched/jobs->resource-maps
              [{:job/resource [{:resource/type :cpus :resource/amount 1.2}
                               {:resource/type :mem :resource/amount 34}
                               {:resource/type :gpus :resource/amount 2}]}


### PR DESCRIPTION
## Changes proposed in this PR

- logging p50, p95, and p100 offer and job size by CPUs and memory when matching

## Why are we making these changes?

To be able to better troubleshoot matching issues by understanding the "shapes" of jobs and offers from the logs.
