### PR TITLE
Refactor ratelimit code

### DIFF
--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -33,8 +33,7 @@
         {:keys [rate-limit]} settings
         {:keys [expire-minutes job-submission]} rate-limit]
     (if (seq job-submission)
-      (let [{:keys [bucket-size enforce? tokens-replenished-per-minute]} job-submission]
-        (rtg/make-token-bucket-filter bucket-size tokens-replenished-per-minute expire-minutes enforce?))
+        (rtg/make-token-bucket-filter (assoc job-submission :expire minutes expire minutes))
       AllowAllRateLimiter)))
 
 (mount/defstate job-submission-rate-limiter
@@ -48,8 +47,7 @@
         {:keys [rate-limit]} settings
         {:keys [expire-minutes job-launch]} rate-limit]
     (if (seq job-launch)
-      (let [{:keys [bucket-size enforce? tokens-replenished-per-minute]} job-launch]
-        (rtg/make-token-bucket-filter bucket-size tokens-replenished-per-minute expire-minutes enforce?))
+      (rtg/make-token-bucket-filter (assoc job-launch :expire minutes expire minutes))
       AllowAllRateLimiter)))
 
 (mount/defstate job-launch-rate-limiter
@@ -63,8 +61,7 @@
         {:keys [rate-limit]} settings
         {:keys [expire-minutes global-job-launch]} rate-limit]
     (if (seq global-job-launch)
-      (let [{:keys [bucket-size enforce? tokens-replenished-per-minute]} global-job-launch]
-        (rtg/make-token-bucket-filter bucket-size tokens-replenished-per-minute expire-minutes enforce?))
+      (rtg/make-token-bucket-filter (assoc global-job-launch :expire minutes expire minutes))
       AllowAllRateLimiter)))
 
 (mount/defstate global-job-launch-rate-limiter

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -33,7 +33,7 @@
         {:keys [rate-limit]} settings
         {:keys [expire-minutes job-submission]} rate-limit]
     (if (seq job-submission)
-        (rtg/make-token-bucket-filter (assoc job-submission :expire minutes expire minutes))
+      (rtg/make-token-bucket-filter (assoc job-submission :expire-minutes expire-minutes))
       AllowAllRateLimiter)))
 
 (mount/defstate job-submission-rate-limiter
@@ -47,7 +47,7 @@
         {:keys [rate-limit]} settings
         {:keys [expire-minutes job-launch]} rate-limit]
     (if (seq job-launch)
-      (rtg/make-token-bucket-filter (assoc job-launch :expire minutes expire minutes))
+      (rtg/make-token-bucket-filter (assoc job-launch :expire-minutes expire-minutes))
       AllowAllRateLimiter)))
 
 (mount/defstate job-launch-rate-limiter
@@ -61,7 +61,7 @@
         {:keys [rate-limit]} settings
         {:keys [expire-minutes global-job-launch]} rate-limit]
     (if (seq global-job-launch)
-      (rtg/make-token-bucket-filter (assoc global-job-launch :expire minutes expire minutes))
+      (rtg/make-token-bucket-filter (assoc global-job-launch :expire-minutes expire-minutes))
       AllowAllRateLimiter)))
 
 (mount/defstate global-job-launch-rate-limiter

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -33,7 +33,7 @@
         {:keys [rate-limit]} settings
         {:keys [expire-minutes job-submission]} rate-limit]
     (if (seq job-submission)
-      (rtg/make-token-bucket-filter (assoc job-submission :expire-minutes expire-minutes))
+      (rtg/make-tbf-rate-limiter (assoc job-submission :expire-minutes expire-minutes))
       AllowAllRateLimiter)))
 
 (mount/defstate job-submission-rate-limiter
@@ -47,7 +47,7 @@
         {:keys [rate-limit]} settings
         {:keys [expire-minutes job-launch]} rate-limit]
     (if (seq job-launch)
-      (rtg/make-token-bucket-filter (assoc job-launch :expire-minutes expire-minutes))
+      (rtg/make-tbf-rate-limiter (assoc job-launch :expire-minutes expire-minutes))
       AllowAllRateLimiter)))
 
 (mount/defstate job-launch-rate-limiter
@@ -61,7 +61,7 @@
         {:keys [rate-limit]} settings
         {:keys [expire-minutes global-job-launch]} rate-limit]
     (if (seq global-job-launch)
-      (rtg/make-token-bucket-filter (assoc global-job-launch :expire-minutes expire-minutes))
+      (rtg/make-tbf-rate-limiter (assoc global-job-launch :expire-minutes expire-minutes))
       AllowAllRateLimiter)))
 
 (mount/defstate global-job-launch-rate-limiter

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -42,10 +42,10 @@
 (defn ->tbf
   "Given a tocken bucket parameters and size, create an empty tbf that has the target parameters"
   [tokens-replenished-per-minute bucket-size]
-    (tbf/create-tbf (/ tokens-replenished-per-minute 60000.)
-                    bucket-size
-                    (current-time-in-millis)
-                    bucket-size))
+  (tbf/create-tbf (/ tokens-replenished-per-minute 60000.)
+                  bucket-size
+                  (current-time-in-millis)
+                  bucket-size))
 
 (defn config->tbf
   "Given a configuration dictionary with a token bucket paremters, create an empty tbf that has those parameters."
@@ -72,7 +72,7 @@
   gotten anything from them in a long time. (Assuming the TTL is set at least as high as
   (:bucket-size/:tokens-replenished-per-minute))."
   [{:keys [^LoadingCache cache] :as ratelimiter} key]
-    (.get cache key))
+  (.get cache key))
 
 (defn earn-tokens!
   "Account for any earned tokens for the requested key."

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -40,7 +40,7 @@
   (or key "*NULL_TBF_KEY*"))
 
 (defn ->tbf
-  "Given a tocken bucket parameters and size, create an empty tbf that has the target parameters"
+  "Given a tocken bucket parameters and size, create an empty tbf that has the target parameters."
   [tokens-replenished-per-minute bucket-size]
   (tbf/create-tbf (/ tokens-replenished-per-minute 60000.)
                   bucket-size

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -121,7 +121,7 @@
                                   enforce?))
 
 (defn ^RateLimiter make-token-bucket-filter
-  [^long bucket-size ^double tokens-replenished-per-minute ^long bucket-expire-minutes enforce?]
+  [{:keys [bucket-size tokens-replenished-per-minute bucket-expire-minutes enforce?]}]
   {:pre [(> bucket-size 0)
          (> tokens-replenished-per-minute 0.0)
          (> bucket-expire-minutes 0)

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -39,7 +39,7 @@
   [key]
   (or key "*NULL_TBF_KEY*"))
 
-(defn ->tbf
+(defn make-token-bucket-filter
   "Given a tocken bucket parameters and size, create an empty tbf that has the target parameters."
   [tokens-replenished-per-minute bucket-size]
   (tbf/create-tbf (/ tokens-replenished-per-minute 60000.)
@@ -50,7 +50,7 @@
 (defn config->token-bucket-filter
   "Given a configuration dictionary with a token bucket paremters, create an empty tbf that has those parameters."
   [{:keys [tokens-replenished-per-minute bucket-size]}]
-  (->tbf tokens-replenished-per-minute bucket-size))
+  (make-token-bucket-filter tokens-replenished-per-minute bucket-size))
 
 (defn make-tbf-fn->CacheLoader
   "Given a function from a single argument, make it a CacheLoader"

--- a/scheduler/src/cook/rate_limit/token_bucket_filter.clj
+++ b/scheduler/src/cook/rate_limit/token_bucket_filter.clj
@@ -61,13 +61,13 @@
   [{:keys [last-update token-rate] :as tbf} ^long current-time]
   (let [current-time (max current-time last-update)]
     (cond-> tbf
-            (not (= current-time last-update))
-            (update-tbf
-              (-> current-time
-                  (- last-update)
-                  (* token-rate)
-                  long)
-              current-time))))
+      (not (= current-time last-update))
+      (update-tbf
+        (-> current-time
+            (- last-update)
+            (* token-rate)
+            long)
+        current-time))))
 
 (defn time-until
   "Assumes tokens have been dispensed. Reports how many time units until the balance is positive and a request can be granted."

--- a/scheduler/src/cook/rate_limit/token_bucket_filter.clj
+++ b/scheduler/src/cook/rate_limit/token_bucket_filter.clj
@@ -21,8 +21,8 @@
 
   This token bucket filter is a bit unusual, instead of earning tokens that you can later spend, we allow the current
   tokens to be negative. Thus, you can (in one request) spend an unbounded number of tokens. However, you will be
-  in debt until your token balance is at least 0. This design allows the tokens in a single request to exceed the max-tokens
-  in the tbf. (If we didn't do it this way, max-tokens is an implicit maximum limit on request size.) This way
+  in debt until your token balance is at least 0. This design allows the tokens in a single request to exceed the bucket-size
+  in the tbf. (If we didn't do it this way, bucket-size is an implicit maximum limit on request size.) This way
   we can independently pick the burst size in the tbf and the maximum request size.
 
   This library does not handle blocking or other operations. Typical workflows are to:
@@ -37,23 +37,23 @@
   If you want to delay requests instead of rejecting. Take the tokens the request needs, pause for the returned pause time.
   (E.g., schedule the message to be sent at that particular pause time.
   "
-  ([^double token-rate ^long max-tokens ^long current-time ^long current-tokens]
+  ([^double token-rate ^long bucket-size ^long current-time ^long current-tokens]
    {:pre [(> token-rate 0)
-          (>= max-tokens 0)]}
-   {:token-rate token-rate :max-tokens max-tokens :last-update current-time :current-tokens current-tokens})
-  ([^double token-rate ^long max-tokens ^long current-time]
-   (create-tbf token-rate max-tokens current-time 0)))
+          (>= bucket-size 0)]}
+   {:token-rate token-rate :bucket-size bucket-size :last-update current-time :current-tokens current-tokens})
+  ([^double token-rate ^long bucket-size ^long current-time]
+   (create-tbf token-rate bucket-size current-time 0)))
 
 (defn- update-tbf
   "Add tokens (if there are any). If less than a whole token added, keep the current state. Returns the current state.
-  Enforces max-tokens limit. Allows tokens to be removed or added. If no timestamp supplied, just alters the token count."
-  [{:keys [current-tokens max-tokens] :as tbf} ^long tokens-to-dispense ^long current-time]
+  Enforces bucket-size limit. Allows tokens to be removed or added. If no timestamp supplied, just alters the token count."
+  [{:keys [current-tokens bucket-size] :as tbf} ^long tokens-to-dispense ^long current-time]
   (if (zero? tokens-to-dispense)
     ; Only dispense when we have at least a whole token to add on.
     tbf
     (-> tbf
         (assoc :last-update current-time)
-        (update :current-tokens #(-> % (+ tokens-to-dispense) (min max-tokens))))))
+        (update :current-tokens #(-> % (+ tokens-to-dispense) (min bucket-size))))))
 
 (defn earn-tokens
   "Earn tokens. Helper function, takes the current timestamp and adds in any newly earned tokens. It is numerically

--- a/scheduler/src/cook/unscheduled.clj
+++ b/scheduler/src/cook/unscheduled.clj
@@ -156,7 +156,7 @@
                              (map #(get % user 0))
                              (reduce + 0))
         being-ratelimited? (pos? num-ratelimited)
-        {:keys [tokens-replenished-per-minute]} ratelimit/job-launch-rate-limiter]
+        tokens-replenished-per-minute (get-in ratelimit/job-launch-rate-limiter [:config :tokens-replenished-per-minute])]
     (when (and enforcing-job-launch-rate-limit? being-ratelimited?)
       ["You are currently rate limited on how many jobs you launch per minute."
        {:max-jobs-per-minute tokens-replenished-per-minute}])))

--- a/scheduler/test/cook/test/rate_limit/generic.clj
+++ b/scheduler/test/cook/test/rate_limit/generic.clj
@@ -53,15 +53,15 @@
 
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo1") {:current-tokens 0
                                                             :last-update 1000000
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0}))
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo2") {:current-tokens -10
                                                             :last-update 1000000
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0}))
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo3") {:current-tokens -10000
                                                             :last-update 1000000
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0})))
 
     (with-redefs [rtg/current-time-in-millis (fn [] 1000001)]
@@ -72,15 +72,15 @@
 
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo1") {:current-tokens 1
                                                             :last-update 1000001
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0}))
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo2") {:current-tokens -9
                                                             :last-update 1000001
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0}))
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo3") {:current-tokens -9999
                                                             :last-update 1000001
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0})))
 
     (with-redefs [rtg/current-time-in-millis (fn [] 1000025)]
@@ -95,27 +95,27 @@
 
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo1") {:current-tokens 20
                                                             :last-update 1000025
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0}))
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo2") {:current-tokens 15
                                                             :last-update 1000025
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0}))
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo3") {:current-tokens -9975
                                                             :last-update 1000025
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0}))
 
       ; Make sure Foo4 is stale.
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo4") {:current-tokens 0
                                                             :last-update 1000000
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0}))
       (is (= 0 (rtg/time-until-out-of-debt-millis! ratelimit "Foo4")))
       ; And not stale
       (is (= (.getIfPresent (:cache ratelimit nil) "Foo4") {:current-tokens 20
                                                             :last-update 1000025
-                                                            :max-tokens 20
+                                                            :bucket-size 20
                                                             :token-rate 1.0})))))
 
 (deftest per-key-configs
@@ -136,17 +136,17 @@
 
       (is (= (.getIfPresent (:cache ratelimit nil) "Bar1") {:current-tokens 60
                                                             :last-update 1000000
-                                                            :max-tokens 100
+                                                            :bucket-size 100
                                                             :token-rate 1.0}))
       (is (= (.getIfPresent (:cache ratelimit nil) "Bar2") {:current-tokens 170
                                                             :last-update 1000000
-                                                            :max-tokens 200
+                                                            :bucket-size 200
                                                             :token-rate 1.0}))
       (is (= (.getIfPresent (:cache ratelimit nil) "Bar3") {:current-tokens 280
                                                             :last-update 1000000
-                                                            :max-tokens 300
+                                                            :bucket-size 300
                                                             :token-rate 1.0}))
       (is (= (.getIfPresent (:cache ratelimit nil) "Bar4") {:current-tokens 390
                                                             :last-update 1000000
-                                                            :max-tokens 400
+                                                            :bucket-size 400
                                                             :token-rate 1.0})))))

--- a/scheduler/test/cook/test/rate_limit/generic.clj
+++ b/scheduler/test/cook/test/rate_limit/generic.clj
@@ -20,7 +20,7 @@
 (deftest independent-keys-1
   (let [ratelimit (rtg/make-token-bucket-filter {:bucket-size 60000
                                                  :tokens-replenished-per-minute 60
-                                                 :bucket-expire-minutes 10000
+                                                 :expire-minutes 10000
                                                  :enforce? true})]
     (rtg/time-until-out-of-debt-millis! ratelimit "Foo2")
     (rtg/spend! ratelimit "Foo4" 100)
@@ -29,7 +29,7 @@
 (deftest independent-keys-2
   (let [ratelimit (rtg/make-token-bucket-filter {:bucket-size 60000
                                                  :tokens-replenished-per-minute 60
-                                                 :bucket-expire-minutes 10000
+                                                 :expire-minutes 10000
                                                  :enforce? true})]
     (rtg/earn-tokens! ratelimit "Foo4")
     (rtg/earn-tokens! ratelimit "Foo1")
@@ -42,7 +42,7 @@
 (deftest earning-tokens-explicit
   (let [ratelimit (rtg/make-token-bucket-filter {:bucket-size 20
                                                  :tokens-replenished-per-minute 60000
-                                                 :bucket-expire-minutes 10
+                                                 :expire-minutes 10
                                                  :enforce? true})]
     ;; take away the full bucket it starts with... (20 tokens)
     (with-redefs [rtg/current-time-in-millis (fn [] 1000000)]
@@ -128,7 +128,7 @@
                                                             :token-rate 1.0})))))
 
 (deftest per-key-configs
-  (let [config {:bucket-expire-minutes 10 :enforce? true}
+  (let [config {:expire-minutes 10 :enforce? true}
         make-tbf-fn (fn [key]
                       (case key
                         "Bar1" (rtg/->tbf 60000 100)

--- a/scheduler/test/cook/test/rate_limit/generic.clj
+++ b/scheduler/test/cook/test/rate_limit/generic.clj
@@ -131,10 +131,10 @@
   (let [config {:expire-minutes 10 :enforce? true}
         make-tbf-fn (fn [key]
                       (case key
-                        "Bar1" (rtg/->tbf 60000 100)
-                        "Bar2" (rtg/->tbf 60000 200)
-                        "Bar3" (rtg/->tbf 60000 300)
-                        "Bar4" (rtg/->tbf 60000 400)
+                        "Bar1" (rtg/make-token-bucket-filter 60000 100)
+                        "Bar2" (rtg/make-token-bucket-filter 60000 200)
+                        "Bar3" (rtg/make-token-bucket-filter 60000 300)
+                        "Bar4" (rtg/make-token-bucket-filter 60000 400)
                         (print "Mismatch key " key)))
         ratelimit (rtg/make-generic-tbf-rate-limiter config make-tbf-fn)]
     (with-redefs [rtg/current-time-in-millis (fn [] 1000000)]

--- a/scheduler/test/cook/test/rate_limit/generic.clj
+++ b/scheduler/test/cook/test/rate_limit/generic.clj
@@ -18,13 +18,19 @@
             [cook.rate-limit.generic :as rtg]))
 
 (deftest independent-keys-1
-  (let [ratelimit (rtg/make-token-bucket-filter 60000 60 10000 true)]
+  (let [ratelimit (rtg/make-token-bucket-filter {:bucket-size 60000
+                                                 :tokens-replenished-per-minute 60
+                                                 :bucket-expire-minutes 10000
+                                                 :enforce? true})]
     (rtg/time-until-out-of-debt-millis! ratelimit "Foo2")
     (rtg/spend! ratelimit "Foo4" 100)
     (is (= 2 (.size (.asMap (:cache ratelimit)))))))
 
 (deftest independent-keys-2
-  (let [ratelimit (rtg/make-token-bucket-filter 60000 60 10000 true)]
+  (let [ratelimit (rtg/make-token-bucket-filter {:bucket-size 60000
+                                                 :tokens-replenished-per-minute 60
+                                                 :bucket-expire-minutes 10000
+                                                 :enforce? true})]
     (rtg/earn-tokens! ratelimit "Foo4")
     (rtg/earn-tokens! ratelimit "Foo1")
     (rtg/time-until-out-of-debt-millis! ratelimit "Foo1")
@@ -34,7 +40,10 @@
     (is (= 4 (.size (.asMap (:cache ratelimit)))))))
 
 (deftest earning-tokens-explicit
-  (let [ratelimit (rtg/make-token-bucket-filter 20 60000 10 true)]
+  (let [ratelimit (rtg/make-token-bucket-filter {:bucket-size 20
+                                                 :tokens-replenished-per-minute 60000
+                                                 :bucket-expire-minutes 10
+                                                 :enforce? true})]
     ;; take away the full bucket it starts with... (20 tokens)
     (with-redefs [rtg/current-time-in-millis (fn [] 1000000)]
       (rtg/spend! ratelimit "Foo1" 20)

--- a/scheduler/test/cook/test/rate_limit/generic.clj
+++ b/scheduler/test/cook/test/rate_limit/generic.clj
@@ -18,19 +18,19 @@
             [cook.rate-limit.generic :as rtg]))
 
 (deftest independent-keys-1
-  (let [ratelimit (rtg/make-token-bucket-filter {:bucket-size 60000
-                                                 :tokens-replenished-per-minute 60
-                                                 :expire-minutes 10000
-                                                 :enforce? true})]
+  (let [ratelimit (rtg/make-tbf-rate-limiter {:bucket-size 60000
+                                              :tokens-replenished-per-minute 60
+                                              :expire-minutes 10000
+                                              :enforce? true})]
     (rtg/time-until-out-of-debt-millis! ratelimit "Foo2")
     (rtg/spend! ratelimit "Foo4" 100)
     (is (= 2 (.size (.asMap (:cache ratelimit)))))))
 
 (deftest independent-keys-2
-  (let [ratelimit (rtg/make-token-bucket-filter {:bucket-size 60000
-                                                 :tokens-replenished-per-minute 60
-                                                 :expire-minutes 10000
-                                                 :enforce? true})]
+  (let [ratelimit (rtg/make-tbf-rate-limiter {:bucket-size 60000
+                                              :tokens-replenished-per-minute 60
+                                              :expire-minutes 10000
+                                              :enforce? true})]
     (rtg/earn-tokens! ratelimit "Foo4")
     (rtg/earn-tokens! ratelimit "Foo1")
     (rtg/time-until-out-of-debt-millis! ratelimit "Foo1")
@@ -40,10 +40,10 @@
     (is (= 4 (.size (.asMap (:cache ratelimit)))))))
 
 (deftest earning-tokens-explicit
-  (let [ratelimit (rtg/make-token-bucket-filter {:bucket-size 20
-                                                 :tokens-replenished-per-minute 60000
-                                                 :expire-minutes 10
-                                                 :enforce? true})]
+  (let [ratelimit (rtg/make-tbf-rate-limiter {:bucket-size 20
+                                              :tokens-replenished-per-minute 60000
+                                              :expire-minutes 10
+                                              :enforce? true})]
     ;; take away the full bucket it starts with... (20 tokens)
     (with-redefs [rtg/current-time-in-millis (fn [] 1000000)]
       (rtg/spend! ratelimit "Foo1" 20)
@@ -136,7 +136,7 @@
                         "Bar3" (rtg/->tbf 60000 300)
                         "Bar4" (rtg/->tbf 60000 400)
                         (print "Mismatch key " key)))
-        ratelimit (rtg/make-generic-token-bucket-filter config make-tbf-fn)]
+        ratelimit (rtg/make-generic-tbf-rate-limiter config make-tbf-fn)]
     (with-redefs [rtg/current-time-in-millis (fn [] 1000000)]
       (rtg/spend! ratelimit "Bar1" 40)
       (rtg/spend! ratelimit "Bar2" 30)

--- a/scheduler/test/cook/test/unscheduled.clj
+++ b/scheduler/test/cook/test/unscheduled.clj
@@ -148,7 +148,7 @@
                 {:count {:limit 2 :usage 3}}]))
 
         (is (= (nth reasons 2)
-               ["You are currently rate limited on how many jobs you launch per minute." {:max-jobs-per-minute 100.0}]))
+               ["You are currently rate limited on how many jobs you launch per minute." {:max-jobs-per-minute 100}]))
 
         (is (= (nth reasons 3)
                ["You have 2 other jobs ahead in the queue."


### PR DESCRIPTION
## Changes proposed in this PR

- Get rate limit code ready to have per-key configurations.
- Do some refactors to reduce glue code and make the keys easier to manage and move config elsewhere in code. 

## Why are we making these changes?
Get ready to have per compute-cluster rate limits as well as other rate limits throughout cook.

