### PR TITLE
Correctly parses jobs with no gpus

### DIFF
--- a/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -1143,7 +1143,9 @@ final public class Job {
             jobBuilder.setUUID(UUID.fromString(json.getString("uuid")));
             jobBuilder.setMemory(json.getDouble("mem"));
             jobBuilder.setCpus(json.getDouble("cpus"));
-            jobBuilder.setGpus(json.getInt("gpus"));
+            if (json.has("gpus")) {
+                jobBuilder.setGpus(json.getInt("gpus"));
+            }
             jobBuilder.setCommand(json.getString("command"));
             if (json.has("executor")) {
                 jobBuilder.setExecutor(json.getString("executor"));

--- a/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
+++ b/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
@@ -312,6 +312,8 @@ public class JobTest {
                 "\"max_runtime\": 1, " +
                 "\"instances\": []" +
                 "}]";
-        Job.parseFromJSON(jsonString, null);
+        final List<Job> jobs = Job.parseFromJSON(jsonString, null);
+        final Job actualJob = jobs.get(0);
+        Assert.assertEquals(0, (long) actualJob.getGpus());
     }
 }

--- a/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
+++ b/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
@@ -298,4 +298,20 @@ public class JobTest {
 
         Assert.assertEquals(datasets.toString(), actualJob.getDatasets().toString());
     }
+
+    @Test
+    public void testParseFromJsonNoGpus() {
+        final String jsonString = "[{" +
+                "\"uuid\": \"" + UUID.randomUUID() + "\", " +
+                "\"mem\": 1, " +
+                "\"cpus\": 0.1, " +
+                "\"command\": \"\", " +
+                "\"priority\": 1, " +
+                "\"status\": \"waiting\", " +
+                "\"max_retries\": 1, " +
+                "\"max_runtime\": 1, " +
+                "\"instances\": []" +
+                "}]";
+        Job.parseFromJSON(jsonString, null);
+    }
 }


### PR DESCRIPTION
## Changes proposed in this PR

- checking if the `gpus` field is present instead of assuming it is

## Why are we making these changes?

Not all jobs have the `gpus` field.
