### PR TITLE
Adds workload fields to job application

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1519,6 +1519,17 @@ class CookTest(util.CookTest):
         _, resp = util.submit_job(self.cook_url, application={'name': 'foo-app'})
         self.assertEqual(resp.status_code, 400)
 
+        # Should allow workload- fields
+        application = {'name': 'foo-app',
+                       'version': '0.1.0',
+                       'workload-class': 'foo',
+                       'workload-id': 'bar',
+                       'workload-details': 'baz'}
+        job_uuid, resp = util.submit_job(self.cook_url, application=application)
+        self.assertEqual(resp.status_code, 201)
+        job = util.load_job(self.cook_url, job_uuid)
+        self.assertEqual(application, job['application'])
+
     def test_error_while_creating_job(self):
         job1 = util.minimal_job()
         job2 = util.minimal_job(uuid=job1['uuid'])

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -73,6 +73,11 @@
 ; and MiB back to bytes when submitting to k8s.
 (def memory-multiplier (* 1024 1024))
 
+(def pod-labels-defaults
+  {"workload-class" "cook-job"
+   "workload-id" "unspecified"
+   "workload-details" "none"})
+
 (defn is-cook-scheduler-pod
   "Is this a cook pod? Uses some-> so is null-safe."
   [^V1Pod pod compute-cluster-name]
@@ -720,7 +725,8 @@
                               :application/workload-id
                               :application/workload-details])
                 walk/stringify-keys)]
-    (merge pod-labels-from-job-labels
+    (merge pod-labels-defaults
+           pod-labels-from-job-labels
            pod-labels-from-job-application)))
 
 (defn ^V1Pod task-metadata->pod

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -3,6 +3,7 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [clojure.walk :as walk]
             [cook.config :as config]
             [cook.kubernetes.metrics :as metrics]
             [cook.scheduler.constraints :as constraints]
@@ -702,14 +703,25 @@
 
 (defn job->pod-labels
   "Returns the dictionary of labels that should be
-  added to the job's pod based on the job's labels."
+  added to the job's pod based on the job's labels
+  and/or the job's application fields."
   [job]
-  (if-let [prefix (:add-job-label-to-pod-prefix (config/kubernetes))]
-    (->> job
-         util/job-ent->label
-         (filter (fn [[k _]] (str/starts-with? k prefix)))
-         (into {}))
-    {}))
+  (let [pod-labels-from-job-labels
+        (if-let [prefix (:add-job-label-to-pod-prefix (config/kubernetes))]
+          (->> job
+               util/job-ent->label
+               (filter (fn [[k _]] (str/starts-with? k prefix)))
+               (into {}))
+          {})
+        pod-labels-from-job-application
+        (some-> job
+                :job/application
+                (select-keys [:application/workload-class
+                              :application/workload-id
+                              :application/workload-details])
+                walk/stringify-keys)]
+    (merge pod-labels-from-job-labels
+           pod-labels-from-job-application)))
 
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -265,7 +265,11 @@
     (catch Exception e false)))
 
 (defn valid-k8s-pod-label-value?
-  "TODO(DPO)"
+  "Returns true if s contains only '.', '_', '-' or any word or
+  number characters, has length at least 2 and at most 63, and
+  begins and ends with a word or number character. This is based
+  on the validation for k8s pod label values:
+  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set"
   [s]
   (re-matches #"[a-zA-Z0-9][\.a-zA-Z0-9_-]{0,61}[a-zA-Z0-9]" s))
 
@@ -273,9 +277,9 @@
   "Schema for the application a job corresponds to"
   {:name (s/constrained s/Str non-empty-max-128-characters-and-alphanum?)
    :version (s/constrained s/Str non-empty-max-128-characters-and-alphanum?)
-   (s/optional-key :workload-class) valid-k8s-pod-label-value?
-   (s/optional-key :workload-id) valid-k8s-pod-label-value?
-   (s/optional-key :workload-details) valid-k8s-pod-label-value?})
+   (s/optional-key :workload-class) (s/constrained s/Str valid-k8s-pod-label-value?)
+   (s/optional-key :workload-id) (s/constrained s/Str valid-k8s-pod-label-value?)
+   (s/optional-key :workload-details) (s/constrained s/Str valid-k8s-pod-label-value?)})
 
 ; Datasets represent the data dependencies of jobs, which can be used by the scheduler to schedule jobs
 ; on hosts to take advantage of data locality.

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -589,6 +589,24 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/doc "TODO(DPO)"
+    :db/ident :application/workload-class
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/doc "TODO(DPO)"
+    :db/ident :application/workload-id
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/doc "TODO(DPO)"
+    :db/ident :application/workload-details
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
    ;; Resource attributes
    {:db/id (d/tempid :db.part/db)
     :db/ident :resource/type

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -590,19 +590,19 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
-    :db/doc "TODO(DPO)"
+    :db/doc "The application's workload class"
     :db/ident :application/workload-class
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
-    :db/doc "TODO(DPO)"
+    :db/doc "The application's workload id"
     :db/ident :application/workload-id
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
    {:db/id (d/tempid :db.part/db)
-    :db/doc "TODO(DPO)"
+    :db/doc "The application's workload details"
     :db/ident :application/workload-details
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one


### PR DESCRIPTION
## Changes proposed in this PR

- adding 3 new (optional) fields to the job spec's `application` field: `workload-class`, `workload-id`, `workload-details`
- when set, these fields become pod labels on the job pod in k8s

## Why are we making these changes?

Similar to #1617, but for job pods instead of synthetic pods. This allows for proper attribution of workloads, e.g. when tracking cost.
