### PR TITLE
Add rate limits per compute cluster.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,15 +48,6 @@ matrix:
         - export PYTHONPATH=$PWD/../jobclient/python
         - ./travis/run_integration.sh --executor=cook --image=python:3.5
 
-    # We want a small rate limit to make the job launch rate limit integration test be stable and not
-    # need to launch a lot of jobs. Those low launch rate limit settings would cause other integration
-    # tests to break, so we run this test separately.
-    - name: 'Cook Scheduler integration tests with job launch rate limit'
-      services: docker
-      install: sudo ./travis/install_mesos.sh
-      before_script: cd integration && ./travis/prepare_integration.sh
-      script: ./travis/run_integration_ratelimit.sh
-
     - name: 'Cook Scheduler Simulator tests'
       services: docker
       install: sudo ./travis/install_mesos.sh

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -338,62 +338,6 @@ class MultiUserCookTest(util.CookTest):
             finally:
                 util.kill_jobs(self.cook_url, job_uuids)
 
-    # Note that subsequent runs of this test under the same user can fail if sufficient time has not
-    # passed; the subsequent run will have used up the rate limit quota and it will need time to recharge.
-    def test_global_rate_limit_launching_jobs(self):
-        settings = util.settings(self.cook_url)
-        if settings['rate-limit']['global-job-launch'] is None:
-            pytest.skip("Can't test job launch rate limit without launch rate limit set.")
-
-        # Allow an environmental variable override.
-        name = os.getenv('COOK_LAUNCH_RATE_LIMIT_USER_NAME')
-        if name is not None:
-            user = self.user_factory.user_class(name)
-        else:
-            user = self.user_factory.new_user()
-
-        if not settings['rate-limit']['global-job-launch']['enforce?']:
-            pytest.skip("Enforcing must be on for test to run")
-        bucket_size = settings['rate-limit']['global-job-launch']['bucket-size']
-        token_rate = settings['rate-limit']['global-job-launch']['tokens-replenished-per-minute']
-        # In some environments, e.g., minimesos, we can only launch so many concurrent jobs.
-        if token_rate < 5 or token_rate > 20:
-            pytest.skip(
-                "Global job launch rate limit test is only validated to reliably work correctly with certain token rates.")
-        if bucket_size < 10 or bucket_size > 20:
-            pytest.skip(
-                "Global job launch rate limit test is only validated to reliably work correctly with certain token bucket sizes.")
-        with user:
-            job_uuids = []
-            try:
-                jobspec = {"command": "sleep 240", 'cpus': 0.03, 'mem': 32}
-
-                self.logger.info(f'Submitting initial batch of {bucket_size - 1} jobs')
-                initial_uuids, initial_response = util.submit_jobs(self.cook_url, jobspec, bucket_size - 1)
-                job_uuids.extend(initial_uuids)
-                self.assertEqual(201, initial_response.status_code, msg=initial_response.content)
-
-                def submit_jobs():
-                    self.logger.info(f'Submitting subsequent batch of {bucket_size - 1} jobs')
-                    subsequent_uuids, subsequent_response = util.submit_jobs(self.cook_url, jobspec, bucket_size - 1)
-                    job_uuids.extend(subsequent_uuids)
-                    self.assertEqual(201, subsequent_response.status_code, msg=subsequent_response.content)
-
-                def is_rate_limit_triggered(_):
-                    jobs1 = util.query_jobs(self.cook_url, True, uuid=job_uuids).json()
-                    running_jobs = [j for j in jobs1 if j['status'] == 'running']
-                    waiting_jobs = [j for j in jobs1 if j['status'] == 'waiting']
-                    self.logger.debug(f'There are {len(waiting_jobs)} waiting jobs')
-                    return len(waiting_jobs) > 0 and len(running_jobs) >= bucket_size
-
-                util.wait_until(submit_jobs, is_rate_limit_triggered, 120000, 5000)
-                jobs2 = util.query_jobs(self.cook_url, True, uuid=job_uuids).json()
-                running_jobs = [j for j in jobs2 if j['status'] == 'running']
-                self.assertGreaterEqual(len(running_jobs), bucket_size)
-                self.assertLessEqual(len(running_jobs), bucket_size + 4)
-            finally:
-                util.kill_jobs(self.cook_url, job_uuids)
-
     def trigger_preemption(self, pool):
         """
         Triggers preemption on the provided pool (which can be None) by doing the following:

--- a/integration/travis/run_integration_ratelimit.sh
+++ b/integration/travis/run_integration_ratelimit.sh
@@ -48,17 +48,9 @@ export COOK_EXECUTOR_COMMAND=""
 ## on travis, ports on 172.17.0.1 are bindable from the host OS, and are also
 ## available for processes inside minimesos containers to connect to
 # Start one cook listening on port 12321, this will be the master of the "cook-framework-1" framework
-export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
-export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
 export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
 export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
 LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=12321 COOK_SSL_PORT=12322 COOK_COOKEEPER_LOCAL=true COOK_COOKEEPER_LOCAL_PORT=5291 COOK_FRAMEWORK_ID=cook-framework-1 COOK_LOGFILE="log/cook-12321.log" COOK_DEFAULT_POOL=${DEFAULT_POOL} lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
-# Start a second cook listening on port 22321, this will be the master of the "cook-framework-2" framework
-export JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10000
-export JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=10000
-export GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE=10
-export GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE=5
-LIBPROCESS_IP=172.17.0.1 COOK_DATOMIC="${COOK_DATOMIC_URI_1}" COOK_PORT=22321 COOK_SSL_PORT=22322 COOK_ZOOKEEPER_LOCAL=true COOK_ZOOKEEPER_LOCAL_PORT=4291 COOK_FRAMEWORK_ID=cook-framework-2 COOK_LOGFILE="log/cook-22321.log" lein run ${PROJECT_DIR}/travis/${CONFIG_FILE} &
 
 # Wait for the cooks to be listening
 timeout 180s bash -c "wait_for_cook 12321" || curl_error=true
@@ -85,10 +77,6 @@ export COOK_MESOS_LEADER_URL=${MINIMESOS_MASTER}
   echo "Using Mesos leader URL: ${COOK_MESOS_LEADER_URL}"
   export COOK_SCHEDULER_URL=http://localhost:12321
   pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_rate_limit_launching_jobs || test_failures=true
-
-
-  export COOK_SCHEDULER_URL=http://localhost:22321
-  pytest -n0 -v --color=no --timeout-method=thread --boxed -m multi_user tests/cook/test_multi_user.py -k test_global_rate_limit_launching_jobs || test_failures=true
  } &> >(tee ./log/pytest.log)
  
 

--- a/integration/travis/scheduler_travis_config.edn
+++ b/integration/travis/scheduler_travis_config.edn
@@ -44,9 +44,6 @@
  :rate-limit {:expire-minutes 120 ; Expire unused rate limit entries after 2 hours.
               ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
               ; spurious failures, and making them larger will cause the rate-limit integration test to skip itself.
-              :global-job-launch {:bucket-size #config/env-int-default ["GLOBAL_JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE" 10000]
-                                  :enforce? true
-                                  :tokens-replenished-per-minute #config/env-int-default ["GLOBAL_JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE" 10000]}
               :job-launch {:bucket-size #config/env-int-default ["JOB_LAUNCH_RATE_LIMIT_BUCKET_SIZE" 10000]
                            :enforce? true
                            :tokens-replenished-per-minute #config/env-int-default ["JOB_LAUNCH_RATE_LIMIT_REPLENISHED_PER_MINUTE" 10000]}

--- a/scheduler/bin/help-make-cluster
+++ b/scheduler/bin/help-make-cluster
@@ -18,8 +18,6 @@ CLUSTERNAME=$3
 COOK_KUBECONFIG=$4
 GKE_CLUSTER_OWNER=${GKE_CLUSTER_OWNER:-$USER}
 
-VERSION=1.15.11-gke.17
-
 gcloud="gcloud --project $PROJECT"
 
 function create_node_pool {
@@ -55,8 +53,6 @@ KUBECONFIG=${COOK_KUBECONFIG} $gcloud container clusters get-credentials "$CLUST
 # Add credentials to default kubeconfig for convenience purposes.
 $gcloud container clusters get-credentials "$CLUSTERNAME" --zone "$ZONE"
 
-echo "---- Upgrading the cluster master version to $VERSION"
-$gcloud container clusters upgrade "$CLUSTERNAME" --cluster-version $VERSION --zone "$ZONE" --quiet --master
 
 echo "---- Setting up cook priority classes in kubernetes"
 KUBECONFIG=${COOK_KUBECONFIG} kubectl create -f "${DIR}/priority-class-cook-workload.yaml"

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -23,10 +23,10 @@
                      :config {:name "gke-1"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_1"
-                              :launch-rate-limit-config {:expire-minutes 1200
-                                                         :enforce? true
-                                                         :bucket-size 10000
-                                                         :tokens-replenished-per-minute 5000}
+                              :compute-cluster-launch-rate-limits {:expire-minutes 1200
+                                                                   :enforce? true
+                                                                   :bucket-size 10000
+                                                                   :tokens-replenished-per-minute 5000}
                               :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                                                :max-pods-outstanding 128
                                                :max-total-pods 30000
@@ -42,10 +42,10 @@
                      :config {:name "gke-2"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_2"
-                              :launch-rate-limit-config {:expire-minutes 1200
-                                                         :enforce? true
-                                                         :bucket-size 10000
-                                                         :tokens-replenished-per-minute 5000}
+                              :compute-cluster-launch-rate-limits {:expire-minutes 1200
+                                                                   :enforce? true
+                                                                   :bucket-size 10000
+                                                                   :tokens-replenished-per-minute 5000}
                               :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                                                :max-pods-outstanding 128
                                                :max-total-pods 20000
@@ -62,10 +62,10 @@
                               :master #config/env "MESOS_MASTER"
                               :framework-id #config/env "COOK_FRAMEWORK_ID"
                               :compute-cluster-name "local-mesos"
-                              :launch-rate-limit-config {:expire-minutes 1200
-                                                         :enforce? true
-                                                         :bucket-size 10000
-                                                         :tokens-replenished-per-minute 5000}}}]
+                              :compute-cluster-launch-rate-limits {:expire-minutes 1200
+                                                                   :enforce? true
+                                                                   :bucket-size 10000
+                                                                   :tokens-replenished-per-minute 5000}}}]
  :cors-origins ["https?://cors.example.com"]
  :data-local {:fitness-calculator {:cache-ttl-ms 60000
                                    :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -23,6 +23,10 @@
                      :config {:name "gke-1"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_1"
+                              :launch-rate-limit-config {:expire-minutes 1200
+                                                         :enforce? true
+                                                         :bucket-size 10000
+                                                         :tokens-replenished-per-minute 5000}
                               :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                                                :max-pods-outstanding 128
                                                :max-total-pods 30000
@@ -38,6 +42,10 @@
                      :config {:name "gke-2"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_2"
+                              :launch-rate-limit-config {:expire-minutes 1200
+                                                         :enforce? true
+                                                         :bucket-size 10000
+                                                         :tokens-replenished-per-minute 5000}
                               :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                                                :max-pods-outstanding 128
                                                :max-total-pods 20000
@@ -53,7 +61,11 @@
                      :config {:failover-timeout-ms nil ; When we close the instance of Cook, all its tasks are killed by Mesos
                               :master #config/env "MESOS_MASTER"
                               :framework-id #config/env "COOK_FRAMEWORK_ID"
-                              :compute-cluster-name "local-mesos"}}]
+                              :compute-cluster-name "local-mesos"
+                              :launch-rate-limit-config {:expire-minutes 1200
+                                                         :enforce? true
+                                                         :bucket-size 10000
+                                                         :tokens-replenished-per-minute 5000}}}]
  :cors-origins ["https?://cors.example.com"]
  :data-local {:fitness-calculator {:cache-ttl-ms 60000
                                    :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"

--- a/scheduler/config-composite.edn
+++ b/scheduler/config-composite.edn
@@ -106,9 +106,6 @@
  :rate-limit {:expire-minutes 1200 ; Expire unused rate limit entries after 20 hours.
               ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
               ; spurious failures, and making them larger will cause test_rate_limit_launching_jobs to skip itself.
-              :global-job-launch {:bucket-size 10000
-                                  :enforce? true
-                                  :tokens-replenished-per-minute 5000}
               :job-launch {:bucket-size 10000
                            :enforce? true
                            :tokens-replenished-per-minute 5000}

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -108,9 +108,6 @@
  :rate-limit {:expire-minutes 1200 ; Expire unused rate limit entries after 20 hours.
               ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
               ; spurious failures, and making them larger will cause test_rate_limit_launching_jobs to skip itself.
-              :global-job-launch {:bucket-size 10000
-                                  :enforce? true
-                                  :tokens-replenished-per-minute 5000}
               :job-launch {:bucket-size 10000
                            :enforce? true
                            :tokens-replenished-per-minute 5000}

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -22,6 +22,10 @@
                      :config {:name "gke-1"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_1"
+                              :launch-rate-limit-config {:expire-minutes 1200
+                                                         :enforce? true
+                                                         :bucket-size 10000
+                                                         :tokens-replenished-per-minute 5000}
                               :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                                                :max-pods-outstanding 128
                                                :user #config/env "USER"
@@ -35,6 +39,10 @@
                      :config {:name "gke-2"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_2"
+                              :launch-rate-limit-config {:expire-minutes 1200
+                                                         :enforce? true
+                                                         :bucket-size 10000
+                                                         :tokens-replenished-per-minute 5000}
                               :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                                                :max-pods-outstanding 128
                                                :user #config/env "USER"
@@ -115,23 +123,6 @@
                                :enforce? true
                                :tokens-replenished-per-minute 600}
               :user-limit-per-m 1000000}
- :compute-cluster-launch-rate-limit {:expire-minutes 1200
-                                     :enforce? true
-                                     :matches
-                                     [{:compute-cluster-regex "^gke-1$"
-                                       :tbf-config {
-                                                    :bucket-size 1000
-                                                    :tokens-replenished-per-minute 2
-                                                    }}
-                                      {:compute-cluster-regex "^gke-2$"
-                                       :tbf-config {
-                                                    :bucket-size 1000
-                                                    :tokens-replenished-per-minute 4
-                                                    }}
-                                      {:compute-cluster-regex "^.*$"
-                                       :tbf-config {
-                                                    :bucket-size 1000
-                                                    :tokens-replenished-per-minute .0001}}]}
  :rebalancer {:dru-scale 1
               :interval-seconds 30
               :max-preemption 500.0

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -22,7 +22,7 @@
                      :config {:name "gke-1"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_1"
-                              :launch-rate-limit-config {:expire-minutes 1200
+                              :compute-cluster-launch-rate-limits {:expire-minutes 1200
                                                          :enforce? true
                                                          :bucket-size 10000
                                                          :tokens-replenished-per-minute 5000}
@@ -39,10 +39,10 @@
                      :config {:name "gke-2"
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_2"
-                              :launch-rate-limit-config {:expire-minutes 1200
-                                                         :enforce? true
-                                                         :bucket-size 10000
-                                                         :tokens-replenished-per-minute 5000}
+                              :compute-cluster-launch-rate-limits {:expire-minutes 1200
+                                                                   :enforce? true
+                                                                   :bucket-size 10000
+                                                                   :tokens-replenished-per-minute 5000}
                               :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                                                :max-pods-outstanding 128
                                                :user #config/env "USER"

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -118,6 +118,23 @@
                                :enforce? true
                                :tokens-replenished-per-minute 600}
               :user-limit-per-m 1000000}
+ :compute-cluster-launch-rate-limit {:expire-minutes 1200
+                                     :enforce? true
+                                     :matches
+                                     [{:compute-cluster-regex "^gke-1$"
+                                       :tbf-config {
+                                                    :bucket-size 1000
+                                                    :tokens-replenished-per-minute 2
+                                                    }}
+                                      {:compute-cluster-regex "^gke-2$"
+                                       :tbf-config {
+                                                    :bucket-size 1000
+                                                    :tokens-replenished-per-minute 4
+                                                    }}
+                                      {:compute-cluster-regex "^.*$"
+                                       :tbf-config {
+                                                    :bucket-size 1000
+                                                    :tokens-replenished-per-minute .0001}}]}
  :rebalancer {:dru-scale 1
               :interval-seconds 30
               :max-preemption 500.0

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -23,9 +23,9 @@
                               ;; Location of the kubernetes config file. Hardcoded to the location specified by bin/make-gke-test-cluster
                               :config-file "../scheduler/.cook_kubeconfig_1"
                               :compute-cluster-launch-rate-limits {:expire-minutes 1200
-                                                         :enforce? true
-                                                         :bucket-size 10000
-                                                         :tokens-replenished-per-minute 5000}
+                                                                   :enforce? true
+                                                                   :bucket-size 10000
+                                                                   :tokens-replenished-per-minute 5000}
                               :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                                                :max-pods-outstanding 128
                                                :user #config/env "USER"

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -73,6 +73,23 @@
                                :enforce? true
                                :tokens-replenished-per-minute 600}
               :user-limit-per-m 1000000}
+ :compute-cluster-launch-rate-limit {:expire-minutes 1200
+                                     :enforce true
+                                     :matches
+                                     [{:compute-cluster-regex "^k8s-.*$"
+                                       :tbf-config {
+                                                    :bucket-size 10000
+                                                    :tokens-replenished-per-minute 5000
+                                                    }}
+                                      {:compute-cluster-regex "^secure-.*$"
+                                       :tbf-config {
+                                                    :bucket-size 10000
+                                                    :tokens-replenished-per-minute 5000
+                                                    }}
+                                      {:compute-cluster-regex "^secure-.*$"
+                                       :tbf-config {
+                                                    :bucket-size 10000
+                                                    :tokens-replenished-per-minute 5000}}]}
  :rebalancer {:dru-scale 1
               :interval-seconds 30
               :max-preemption 500.0

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -21,10 +21,10 @@
                               :container-defaults {:volumes [{:host-path "/tmp/cook-integration-mount"
                                                               :container-path "/mnt/cook-integration"
                                                               :mode "RW"}]}
-                              :launch-rate-limit-config {:expire-minutes 1200
-                                                         :enforce? true
-                                                         :bucket-size 10000
-                                                         :tokens-replenished-per-minute 5000}}}]
+                              :compute-cluster-launch-rate-limits {:expire-minutes 1200
+                                                                   :enforce? true
+                                                                   :bucket-size 10000
+                                                                   :tokens-replenished-per-minute 5000}}}]
  :cors-origins ["https?://cors.example.com"]
  :data-local {:fitness-calculator {:cache-ttl-ms 60000
                                    :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -74,19 +74,19 @@
                                :tokens-replenished-per-minute 600}
               :user-limit-per-m 1000000}
  :compute-cluster-launch-rate-limit {:expire-minutes 1200
-                                     :enforce true
+                                     :enforce? true
                                      :matches
                                      [{:compute-cluster-regex "^k8s-.*$"
                                        :tbf-config {
                                                     :bucket-size 10000
                                                     :tokens-replenished-per-minute 5000
                                                     }}
-                                      {:compute-cluster-regex "^secure-.*$"
+                                      {:compute-cluster-regex "^mesos.*$"
                                        :tbf-config {
                                                     :bucket-size 10000
                                                     :tokens-replenished-per-minute 5000
                                                     }}
-                                      {:compute-cluster-regex "^secure-.*$"
+                                      {:compute-cluster-regex "^.*$"
                                        :tbf-config {
                                                     :bucket-size 10000
                                                     :tokens-replenished-per-minute 5000}}]}

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -63,9 +63,6 @@
  :rate-limit {:expire-minutes 1200 ; Expire unused rate limit entries after 20 hours.
               ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
               ; spurious failures, and making them larger will cause test_rate_limit_launching_jobs to skip itself.
-              :global-job-launch {:bucket-size 10000
-                                  :enforce? true
-                                  :tokens-replenished-per-minute 5000}
               :job-launch {:bucket-size 10000
                            :enforce? true
                            :tokens-replenished-per-minute 5000}

--- a/scheduler/config.edn
+++ b/scheduler/config.edn
@@ -20,7 +20,11 @@
                               :compute-cluster-name "local-mesos"
                               :container-defaults {:volumes [{:host-path "/tmp/cook-integration-mount"
                                                               :container-path "/mnt/cook-integration"
-                                                              :mode "RW"}]}}}]
+                                                              :mode "RW"}]}
+                              :launch-rate-limit-config {:expire-minutes 1200
+                                                         :enforce? true
+                                                         :bucket-size 10000
+                                                         :tokens-replenished-per-minute 5000}}}]
  :cors-origins ["https?://cors.example.com"]
  :data-local {:fitness-calculator {:cache-ttl-ms 60000
                                    :cost-endpoint #config/env "DATA_LOCAL_ENDPOINT"
@@ -70,23 +74,6 @@
                                :enforce? true
                                :tokens-replenished-per-minute 600}
               :user-limit-per-m 1000000}
- :compute-cluster-launch-rate-limit {:expire-minutes 1200
-                                     :enforce? true
-                                     :matches
-                                     [{:compute-cluster-regex "^k8s-.*$"
-                                       :tbf-config {
-                                                    :bucket-size 10000
-                                                    :tokens-replenished-per-minute 5000
-                                                    }}
-                                      {:compute-cluster-regex "^mesos.*$"
-                                       :tbf-config {
-                                                    :bucket-size 10000
-                                                    :tokens-replenished-per-minute 5000
-                                                    }}
-                                      {:compute-cluster-regex "^.*$"
-                                       :tbf-config {
-                                                    :bucket-size 10000
-                                                    :tokens-replenished-per-minute 5000}}]}
  :rebalancer {:dru-scale 1
               :interval-seconds 30
               :max-preemption 500.0

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -95,7 +95,7 @@
      Users will need to add the file path & offset to their query.
      Refer to the 'Using the output_url' section in docs/scheduler-rest-api.adoc for further details.")
 
-  (get-compute-cluster-launch-rate-limiter [this]
+  (launch-rate-limiter [this]
     "Return the RateLimiter that should be used to limit launches to this compute cluster"))
 
 (defn safe-kill-task

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -95,7 +95,7 @@
      Users will need to add the file path & offset to their query.
      Refer to the 'Using the output_url' section in docs/scheduler-rest-api.adoc for further details.")
 
-  (get-launch-rate-limiter [this]
+  (get-compute-cluster-launch-rate-limiter [this]
     "Return the RateLimiter that should be used to limit launches to this compute cluster"))
 
 (defn safe-kill-task

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -93,7 +93,10 @@
   (retrieve-sandbox-url-path [this instance-entity]
     "Constructs a URL to query the sandbox directory of the task.
      Users will need to add the file path & offset to their query.
-     Refer to the 'Using the output_url' section in docs/scheduler-rest-api.adoc for further details."))
+     Refer to the 'Using the output_url' section in docs/scheduler-rest-api.adoc for further details.")
+
+  (get-launch-rate-limiter [this]
+    "Return the RateLimiter that should be used to limit launches to this compute cluster"))
 
 (defn safe-kill-task
   "A safe version of kill task that never throws. This reduces the risk that errors in one compute cluster propagate and cause problems in another compute cluster."

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -236,6 +236,8 @@
                       :job-submission job-submission
                       :job-launch job-launch
                       :user-limit (->UserRateLimit :user-limit user-limit-per-m (t/minutes 1))}))
+     :compute-cluster-launch-rate-limit (fnk [[:config {compute-cluster-launch-rate-limit nil}]]
+                                         compute-cluster-launch-rate-limit)
      :sim-agent-path (fnk [] "/usr/bin/sim-agent")
      :executor (fnk [[:config {executor {}}]]
                  (if (str/blank? (:command executor))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -235,8 +235,6 @@
                       :job-submission job-submission
                       :job-launch job-launch
                       :user-limit (->UserRateLimit :user-limit user-limit-per-m (t/minutes 1))}))
-     :compute-cluster-launch-rate-limit (fnk [[:config {compute-cluster-launch-rate-limit nil}]]
-                                         compute-cluster-launch-rate-limit)
      :sim-agent-path (fnk [] "/usr/bin/sim-agent")
      :executor (fnk [[:config {executor {}}]]
                  (if (str/blank? (:command executor))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -228,11 +228,10 @@
                                      ((util/lazy-load-var 'cook.rest.impersonation/create-impersonation-middleware) impersonators)
                                      {:json-value "config-impersonation"})))
      :rate-limit (fnk [[:config {rate-limit nil}]]
-                   (let [{:keys [expire-minutes user-limit-per-m global-job-launch job-submission job-launch]
+                   (let [{:keys [expire-minutes user-limit-per-m job-submission job-launch]
                           :or {expire-minutes 120
                                user-limit-per-m 600}} rate-limit]
                      {:expire-minutes expire-minutes
-                      :global-job-launch global-job-launch
                       :job-submission job-submission
                       :job-launch job-launch
                       :user-limit (->UserRateLimit :user-limit user-limit-per-m (t/minutes 1))}))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -549,6 +549,7 @@
     ;; Refer to the 'Using the output_url' section in docs/scheduler-rest-api.adoc for further details.
     [_ {:keys [instance/sandbox-url]}]
     sandbox-url)
+
   (get-launch-rate-limiter
     [_] launch-rate-limit))
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -550,7 +550,7 @@
     [_ {:keys [instance/sandbox-url]}]
     sandbox-url)
 
-  (get-compute-cluster-launch-rate-limiter
+  (launch-rate-limiter
     [_] compute-cluster-launch-rate-limiter))
 
 (defn get-or-create-cluster-entity-id

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -304,7 +304,7 @@
                                      synthetic-pods-config node-blocklist-labels
                                      ^ExecutorService launch-task-executor-service
                                      cluster-definition state-atom state-locked?-atom dynamic-cluster-config?
-                                     launch-rate-limit]
+                                     compute-cluster-launch-rate-limiter]
   cc/ComputeCluster
   (launch-tasks [this pool-name matches process-task-post-launch-fn]
     (let [task-metadata-seq (mapcat :task-metadata-seq matches)]
@@ -550,8 +550,8 @@
     [_ {:keys [instance/sandbox-url]}]
     sandbox-url)
 
-  (get-launch-rate-limiter
-    [_] launch-rate-limit))
+  (get-compute-cluster-launch-rate-limiter
+    [_] compute-cluster-launch-rate-limiter))
 
 (defn get-or-create-cluster-entity-id
   [conn compute-cluster-name]
@@ -660,7 +660,7 @@
            ca-cert-path
            ^String config-file
            dynamic-cluster-config?
-           launch-rate-limit-config
+           compute-cluster-launch-rate-limits
            launch-task-num-threads
            max-pods-per-node
            name
@@ -695,7 +695,7 @@
         cluster-entity-id (get-or-create-cluster-entity-id conn name)
         api-client (make-api-client config-file base-path use-google-service-account? bearer-token-refresh-seconds verifying-ssl ca-cert ca-cert-path)
         launch-task-executor-service (Executors/newFixedThreadPool launch-task-num-threads)
-        launch-rate-limit (cook.rate-limit/create-compute-cluster-launch-rate-limiter name launch-rate-limit-config)
+        compute-cluster-launch-rate-limiter (cook.rate-limit/create-compute-cluster-launch-rate-limiter name compute-cluster-launch-rate-limits)
         compute-cluster (->KubernetesComputeCluster api-client 
                                                     name
                                                     cluster-entity-id
@@ -719,6 +719,6 @@
                                                     (atom state)
                                                     (atom state-locked?)
                                                     dynamic-cluster-config?
-                                                    launch-rate-limit)]
+                                                    compute-cluster-launch-rate-limiter)]
     (cc/register-compute-cluster! compute-cluster)
     compute-cluster))

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -333,7 +333,7 @@
         (log/debug e "Unable to retrieve directory path for" task-id "on agent" hostname)
         nil)))
 
-  (get-compute-cluster-launch-rate-limiter [_] compute-cluster-launch-rate-limiter))
+  (launch-rate-limiter [_] compute-cluster-launch-rate-limiter))
 
 ; Internal method
 (defn mesos-cluster->compute-cluster-map-for-datomic

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -332,6 +332,7 @@
       (catch Exception e
         (log/debug e "Unable to retrieve directory path for" task-id "on agent" hostname)
         nil)))
+
   (get-launch-rate-limiter [_] launch-rate-limit))
 
 ; Internal method

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -415,7 +415,7 @@
                                                (async/chan offer-chan-size))
                                              (map :pool/name synthesized-pools))
           compute-cluster-launch-rate-limiter (cook.rate-limit/create-compute-cluster-launch-rate-limiter
-                              compute-cluster-name compute-cluster-launch-rate-limits)
+                                                compute-cluster-name compute-cluster-launch-rate-limits)
           mesos-compute-cluster (->MesosComputeCluster compute-cluster-name
                                                        framework-id
                                                        cluster-entity-id

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -16,8 +16,8 @@
 (ns cook.rate-limit
   (:require [clojure.tools.logging :as log]
             [cook.config :refer [config]]
-            [cook.rate-limit.generic :as rtg]
             [cook.compute-cluster :as cc]
+            [cook.rate-limit.generic :as rtg]
             [cook.regexp-tools :as regexp-tools]
             [mount.core :as mount]))
 
@@ -29,7 +29,7 @@
 (def AllowAllRateLimiter rtg/AllowAllRateLimiter)
 
 (defn initialize-rate-limit-based-on-key
-  "Method to help tocken-bucket-filter pick a default rate limit based a regexp match through a series of patterns.
+  "Method to help token-bucket-filter pick a default rate limit based a regexp match through a series of patterns.
 
   Given a match-list of [{:<field> <regexp> :tbf-config {:tokens-replenished-per-minute ...}}] and a key, return a
   token bucket filter"

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -59,13 +59,13 @@
 (defn create-compute-cluster-launch-rate-limiter
   "From the configuration map, extract the keys that setup the job-launch rate limiter and return
   the constructed object. If the configuration map is not found, the AllowAllRateLimiter is returned."
-  [compute-cluster-name ratelimit-config]
-    (if (seq ratelimit-config)
+  [compute-cluster-name compute-cluster-launch-rate-limits]
+    (if (seq compute-cluster-launch-rate-limits)
       (do
-        (log/info "For compute cluster" compute-cluster-name "configuring global rate limit config" ratelimit-config)
-        (rtg/make-tbf-rate-limiter ratelimit-config))
+        (log/info "For compute cluster" compute-cluster-name "configuring global rate limit config" compute-cluster-launch-rate-limits)
+        (rtg/make-tbf-rate-limiter compute-cluster-launch-rate-limits))
       (do
         (log/info "For compute cluster" compute-cluster-name "not configuring global rate limit because no configuration set")
         AllowAllRateLimiter)))
 
-(def global-job-launch-rate-limiter-key "*DEF*")
+(def compute-cluster-launch-rate-limiter-key "*DEF*")

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -28,17 +28,6 @@
 (def enforce? rtg/enforce?)
 (def AllowAllRateLimiter rtg/AllowAllRateLimiter)
 
-(defn initialize-rate-limit-based-on-key
-  "Method to help token-bucket-filter pick a default rate limit based a regexp match through a series of patterns.
-
-  Given a match-list of [{:<field> <regexp> :tbf-config {:tokens-replenished-per-minute ...}}] and a key, return a
-  token bucket filter"
-  [regexp-name {match-list :matches}]
-  (fn [key]
-    (if-let [tbf-config-dict (regexp-tools/match-based-on-regexp regexp-name :tbf-config match-list key)]
-      (rtg/config->token-bucket-filter tbf-config-dict)
-      (throw (ex-info "Unable to match in matchlist." {:key key :match-list match-list})))))
-
 (defn create-job-submission-rate-limiter
   "From the configuration map, extract the keys that setup the job-submission rate limiter and return
   the constructed object. If the configuration map is not found, the AllowAllRateLimiter is returned."

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -67,20 +67,16 @@
 (mount/defstate job-launch-rate-limiter
   :start (create-job-launch-rate-limiter config))
 
-(defn create-global-job-launch-rate-limiter
+(defn create-compute-cluster-launch-rate-limiter
   "From the configuration map, extract the keys that setup the job-launch rate limiter and return
   the constructed object. If the configuration map is not found, the AllowAllRateLimiter is returned."
-  [config]
-  (let [ratelimit-config (some-> config :settings :compute-cluster-launch-rate-limit)]
+  [compute-cluster-name ratelimit-config]
     (if (seq ratelimit-config)
       (do
-        (log/info "Making global rate limit config with" ratelimit-config)
-        (rtg/make-generic-tbf-rate-limiter
-          ratelimit-config
-          (initialize-rate-limit-based-on-key :compute-cluster-regex ratelimit-config)))
+        (log/info "For compute cluster" compute-cluster-name "configuring global rate limit config" ratelimit-config)
+        (rtg/make-tbf-rate-limiter ratelimit-config))
       (do
-        (log/info "Not configuring global rate limit because no configuration set")
-        AllowAllRateLimiter))))
+        (log/info "For compute cluster" compute-cluster-name "not configuring global rate limit because no configuration set")
+        AllowAllRateLimiter)))
 
-(mount/defstate global-job-launch-rate-limiter
-  :start (create-global-job-launch-rate-limiter config))
+(def global-job-launch-rate-limiter-key "*DEF*")

--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -16,7 +16,6 @@
 (ns cook.rate-limit
   (:require [clojure.tools.logging :as log]
             [cook.config :refer [config]]
-            [cook.compute-cluster :as cc]
             [cook.rate-limit.generic :as rtg]
             [cook.regexp-tools :as regexp-tools]
             [mount.core :as mount]))

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -40,7 +40,7 @@
   (or key "*NULL_TBF_KEY*"))
 
 (defn make-token-bucket-filter
-  "Given a tocken bucket parameters and size, create an empty tbf that has the target parameters."
+  "Given a token bucket parameters and size, create an empty tbf that has the target parameters."
   [tokens-replenished-per-minute bucket-size]
   {:pre [(> bucket-size 0)
          (> tokens-replenished-per-minute 0.0)]}

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -42,6 +42,8 @@
 (defn make-token-bucket-filter
   "Given a tocken bucket parameters and size, create an empty tbf that has the target parameters."
   [tokens-replenished-per-minute bucket-size]
+  {:pre [(> bucket-size 0)
+         (> tokens-replenished-per-minute 0.0)]}
   (tbf/create-tbf (/ tokens-replenished-per-minute 60000.)
                   bucket-size
                   (current-time-in-millis)
@@ -66,6 +68,8 @@
   gotten anything from them in a long time. (Assuming the TTL is set at least as high as
   (:bucket-size/:tokens-replenished-per-minute))."
   [{:keys [^LoadingCache cache] :as ratelimiter} key]
+  {:pre [(not (nil? key))
+         (not (nil? cache))]}
   (.get cache key))
 
 (defn earn-tokens!

--- a/scheduler/src/cook/regexp_tools.clj
+++ b/scheduler/src/cook/regexp_tools.clj
@@ -1,0 +1,32 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.regexp-tools
+  (:require [clojure.tools.logging :as log]))
+
+(defn match-based-on-regexp
+  "Given a list of dictionaries [{:<regexp-name> <regexp> :<field-name> <field>} {:<regexp-name> <regexp> :<field-name> <field>} ...], match-list,
+   a key <field-name> and <regexp-name> name, return the first matching <field> where the <regexp> matches the key."
+  [regexp-name field-name match-list key]
+  (try
+    (-> match-list
+        (->> (filter (fn [map]
+                       (let [regexp (get map regexp-name)
+                             pattern (re-pattern regexp)]
+                         (re-find pattern key)))))
+        first
+        (get field-name))
+    (catch Exception e
+      (throw (ex-info "Failed matching key" {:regexp-name regexp-name :field-name field-name :match-list match-list :key key} e)))))

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -357,11 +357,11 @@
 (defn make-fenzo-job-constraints
   "Returns a sequence of all the constraints for 'job', in Fenzo-compatible format."
   [job]
-  (-> (->> job-constraint-constructors
-           (map (fn [constructor] (constructor job)))
-           (remove nil?)
-           (map fenzoize-job-constraint))
-      (conj (build-max-tasks-per-host-constraint))))
+  (conj (->> job-constraint-constructors
+             (map (fn [constructor] (constructor job)))
+             (remove nil?)
+             (map fenzoize-job-constraint))
+        (build-max-tasks-per-host-constraint)))
 
 (defn build-rebalancer-reservation-constraint
   "Constructs a rebalancer-reservation-constraint"

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -306,21 +306,6 @@
         (when (< 0 max-expected-runtime)
           (->estimated-completion-constraint expected-end-time host-lifetime-mins))))))
 
-(defn build-launch-max-tasks-constraint
-  "This returns a Fenzo hard constraint that ensures that we don't match more than a given number of tasks per cycle. Returns nil
-  if the constraint is disabled."
-  []
-  (let [enforcing? (ratelimit/enforce? ratelimit/global-job-launch-rate-limiter)
-        max-tasks (ratelimit/get-token-count! ratelimit/global-job-launch-rate-limiter ratelimit/global-job-launch-rate-limiter-key)]
-    (when enforcing?
-      (reify ConstraintEvaluator
-        (getName [_] "launch_max_tasks")
-        (evaluate [_ _ _ task-tracker-state]
-          (let [num-assigned (-> task-tracker-state .getAllCurrentlyAssignedTasks .size)]
-            (ConstraintEvaluator$Result.
-              (< num-assigned max-tasks)
-              (str "Hit the global rate limit"))))))))
-
 (defn build-max-tasks-per-host-constraint
   "Returns a Fenzo constraint that ensures that we don't
   match more tasks per host than is allowed (configured)"
@@ -372,13 +357,11 @@
 (defn make-fenzo-job-constraints
   "Returns a sequence of all the constraints for 'job', in Fenzo-compatible format."
   [job]
-  (let [launch-max-tasks-constraint (build-launch-max-tasks-constraint)]
-    (cond-> (->> job-constraint-constructors
-                 (map (fn [constructor] (constructor job)))
-                 (remove nil?)
-                 (map fenzoize-job-constraint))
-            launch-max-tasks-constraint (conj (build-launch-max-tasks-constraint))
-            true (conj (build-max-tasks-per-host-constraint)))))
+  (-> (->> job-constraint-constructors
+           (map (fn [constructor] (constructor job)))
+           (remove nil?)
+           (map fenzoize-job-constraint))
+      (conj (build-max-tasks-per-host-constraint))))
 
 (defn build-rebalancer-reservation-constraint
   "Constructs a rebalancer-reservation-constraint"

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -840,8 +840,12 @@
                                    (let [compute-cluster-name (cc/compute-cluster-name compute-cluster)
                                          launch-rate-limit (cc/get-launch-rate-limiter compute-cluster)
                                          enforce? (ratelimit/enforce? launch-rate-limit)
-                                         token-count (ratelimit/get-token-count! launch-rate-limit ratelimit/global-job-launch-rate-limiter-key)
-                                         resume-millis (ratelimit/time-until-out-of-debt-millis! launch-rate-limit ratelimit/global-job-launch-rate-limiter-key)
+                                         token-count (ratelimit/get-token-count!
+                                                       launch-rate-limit
+                                                       ratelimit/global-job-launch-rate-limiter-key)
+                                         resume-millis (ratelimit/time-until-out-of-debt-millis!
+                                                         launch-rate-limit
+                                                         ratelimit/global-job-launch-rate-limiter-key)
                                          skipping-cycle? (and enforce? (neg? token-count))]
                                      (if skipping-cycle?
                                        {:skip-rate-limit true
@@ -921,7 +925,7 @@
                (map
                  (fn [[compute-cluster matches-in-compute-cluster]]
                    (let [compute-cluster-name (cc/compute-cluster-name compute-cluster)
-                         _ (log/info "In" pool-name "pool, launching matched tasks for" compute-cluster-name "compute cluster.")
+                         _ (log/info "In" pool-name "pool, launching matched tasks for" compute-cluster-name "compute cluster")
                          launch-matches-in-compute-cluster!
                          #(launch-matches! compute-cluster pool-name
                                            matches-in-compute-cluster fenzo)]

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -819,7 +819,7 @@
       (fn process-task-post-launch!
         [{:keys [hostname task-request]}]
         (let [user (get-in task-request [:job :job/user])
-              compute-cluster-launch-rate-limiter (cc/get-compute-cluster-launch-rate-limiter compute-cluster)]
+              compute-cluster-launch-rate-limiter (cc/launch-rate-limiter compute-cluster)]
           (ratelimit/spend! ratelimit/job-launch-rate-limiter user 1)
           (ratelimit/spend! compute-cluster-launch-rate-limiter ratelimit/compute-cluster-launch-rate-limiter-key 1))
         (locking fenzo
@@ -838,7 +838,7 @@
                                (map
                                  (fn [[compute-cluster matches-in-compute-cluster]]
                                    (let [compute-cluster-name (cc/compute-cluster-name compute-cluster)
-                                         compute-cluster-launch-rate-limiter (cc/get-compute-cluster-launch-rate-limiter compute-cluster)
+                                         compute-cluster-launch-rate-limiter (cc/launch-rate-limiter compute-cluster)
                                          enforce? (ratelimit/enforce? compute-cluster-launch-rate-limiter)
                                          token-count (ratelimit/get-token-count!
                                                        compute-cluster-launch-rate-limiter

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -819,9 +819,9 @@
       (fn process-task-post-launch!
         [{:keys [hostname task-request]}]
         (let [user (get-in task-request [:job :job/user])
-              launch-rate-limit (cc/get-launch-rate-limiter compute-cluster)]
+              compute-cluster-launch-rate-limiter (cc/get-compute-cluster-launch-rate-limiter compute-cluster)]
           (ratelimit/spend! ratelimit/job-launch-rate-limiter user 1)
-          (ratelimit/spend! launch-rate-limit ratelimit/global-job-launch-rate-limiter-key 1))
+          (ratelimit/spend! compute-cluster-launch-rate-limiter ratelimit/compute-cluster-launch-rate-limiter-key 1))
         (locking fenzo
           (.. fenzo
               (getTaskAssigner)
@@ -838,14 +838,14 @@
                                (map
                                  (fn [[compute-cluster matches-in-compute-cluster]]
                                    (let [compute-cluster-name (cc/compute-cluster-name compute-cluster)
-                                         launch-rate-limit (cc/get-launch-rate-limiter compute-cluster)
-                                         enforce? (ratelimit/enforce? launch-rate-limit)
+                                         compute-cluster-launch-rate-limiter (cc/get-compute-cluster-launch-rate-limiter compute-cluster)
+                                         enforce? (ratelimit/enforce? compute-cluster-launch-rate-limiter)
                                          token-count (ratelimit/get-token-count!
-                                                       launch-rate-limit
-                                                       ratelimit/global-job-launch-rate-limiter-key)
+                                                       compute-cluster-launch-rate-limiter
+                                                       ratelimit/compute-cluster-launch-rate-limiter-key)
                                          resume-millis (ratelimit/time-until-out-of-debt-millis!
-                                                         launch-rate-limit
-                                                         ratelimit/global-job-launch-rate-limiter-key)
+                                                         compute-cluster-launch-rate-limiter
+                                                         ratelimit/compute-cluster-launch-rate-limiter-key)
                                          skipping-cycle? (and enforce? (neg? token-count))]
                                      (if skipping-cycle?
                                        {:skip-rate-limit true

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -837,8 +837,7 @@
                                (group-by match->compute-cluster)
                                (map
                                  (fn [[compute-cluster matches-in-compute-cluster]]
-                                   (let [compute-cluster (or compute-cluster )
-                                         compute-cluster-name (if compute-cluster
+                                   (let [compute-cluster-name (if compute-cluster
                                                                 (cc/compute-cluster-name compute-cluster)
                                                                 ; In unit tests we may not have a compute cluster.
                                                                 ; If so, swap this compute cluster in.

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -998,7 +998,7 @@
                                            (match-offer-to-schedule db fenzo considerable-jobs offers
                                                                     rebalancer-reservation-atom pool-name))
               matches (filter-matches-for-ratelimit matches)
-              _ (log/debug "In" pool-name "pool, got matches:" matches)
+              _ (log/debug "In" pool-name "pool, got matches after rate limit:" matches)
               offers-scheduled (for [{:keys [leases]} matches
                                      lease leases]
                                  (:offer lease))

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -64,7 +64,8 @@
                                trigger-chans
                                {}
                                {"no-pool" (async/chan 100)}
-                               {})))
+                               {}
+                               rate-limit/AllowAllRateLimiter)))
 
 (defn fake-test-compute-cluster-with-driver
   "Create a test compute cluster with associated driver attached to it. Returns the compute cluster."
@@ -116,7 +117,6 @@
     (mount/start-with-args (merge minimal-config config)
                            #'cook.config/config
                            #'cook.rate-limit/job-launch-rate-limiter
-                           #'cook.rate-limit/global-job-launch-rate-limiter
                            #'cook.plugins.adjustment/plugin
                            #'cook.plugins.file/plugin
                            #'cook.plugins.launch/plugin-object
@@ -586,4 +586,4 @@
                                     (atom :running) ; state atom
                                     (atom false) ; state-locked? atom
                                     false ; dynamic-cluster-config?
-                                    )))
+                                    rate-limit/AllowAllRateLimiter)))

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -27,6 +27,7 @@
             [cook.cache :as ccache]
             [cook.config :as config]
             [cook.pool :as pool]
+            [cook.regexp-tools :as regexp-tools]
             [cook.schema :as schema]
             [datomic.api :as d :refer [q]]
             [metatransaction.core :refer [db]]
@@ -907,32 +908,17 @@
     (cond-> {:count 1 :cpus cpus :mem mem}
       gpus (assoc :gpus gpus))))
 
-(defn match-based-on-regexp
-  "Given a list of dictionaries [{:<regexp-name> <regexp> :<field-name> <field>} {:<regexp-name> <regexp> :<field-name> <field>} ...], match-list,
-   a key <field-name> and <regexp-name> name, return the first matching <field> where the <regexp> matches the key."
-  [regexp-name field-name match-list key]
-  (try
-  (-> match-list
-      (->> (filter (fn [map]
-                     (let [regexp (get map regexp-name)
-                           pattern (re-pattern regexp)]
-                       (re-find pattern key)))))
-      first
-      (get field-name)))
-    (catch Exception e
-      (throw (ex-info "Failed matching key" {:regexp-name regexp-name :field-name field-name :match-list match-list :key key} e)))))
-
 (defn match-based-on-pool-name
   "Given a list of dictionaries [{:pool-regexp .. :field ...} {:pool-regexp .. :field ...}
    a pool name and a <field> name, return the first matching <field> where the regexp matches the pool name."
   [match-list effective-pool-name field]
-  (match-based-on-regexp :pool-regex field match-list effective-pool-name))
+  (regexp-tools/match-based-on-regexp :pool-regex field match-list effective-pool-name))
 
 (defn match-based-on-cc-name
   "Given a list of dictionaries [{:compute-cluster-regex .. :field ...} {:pool-regexp .. :field ...}
    a cluster name and a <field> name, return the first matching <field> where the regexp matches the pool name."
   [match-list effective-pool-name field]
-  (match-based-on-regexp :compute-cluster-regex field match-list effective-pool-name))
+  (regexp-tools/match-based-on-regexp :compute-cluster-regex field match-list effective-pool-name))
 
 (defn global-pool-quota
   "Given a pool name, determine the quota for that pool."

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -914,12 +914,6 @@
   [match-list effective-pool-name field]
   (regexp-tools/match-based-on-regexp :pool-regex field match-list effective-pool-name))
 
-(defn match-based-on-cc-name
-  "Given a list of dictionaries [{:compute-cluster-regex .. :field ...} {:pool-regexp .. :field ...}
-   a cluster name and a <field> name, return the first matching <field> where the regexp matches the pool name."
-  [match-list effective-pool-name field]
-  (regexp-tools/match-based-on-regexp :compute-cluster-regex field match-list effective-pool-name))
-
 (defn global-pool-quota
   "Given a pool name, determine the quota for that pool."
   [quotas effective-pool-name]

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -911,6 +911,7 @@
   "Given a list of dictionaries [{:<regexp-name> <regexp> :<field-name> <field>} {:<regexp-name> <regexp> :<field-name> <field>} ...], match-list,
    a key <field-name> and <regexp-name> name, return the first matching <field> where the <regexp> matches the key."
   [regexp-name field-name match-list key]
+  (try
   (-> match-list
       (->> (filter (fn [map]
                      (let [regexp (get map regexp-name)
@@ -918,12 +919,20 @@
                        (re-find pattern key)))))
       first
       (get field-name)))
+    (catch Exception e
+      (throw (ex-info "Failed matching key" {:regexp-name regexp-name :field-name field-name :match-list match-list :key key} e)))))
 
 (defn match-based-on-pool-name
   "Given a list of dictionaries [{:pool-regexp .. :field ...} {:pool-regexp .. :field ...}
    a pool name and a <field> name, return the first matching <field> where the regexp matches the pool name."
   [match-list effective-pool-name field]
   (match-based-on-regexp :pool-regex field match-list effective-pool-name))
+
+(defn match-based-on-cc-name
+  "Given a list of dictionaries [{:compute-cluster-regex .. :field ...} {:pool-regexp .. :field ...}
+   a cluster name and a <field> name, return the first matching <field> where the regexp matches the pool name."
+  [match-list effective-pool-name field]
+  (match-based-on-regexp :compute-cluster-regex field match-list effective-pool-name))
 
 (defn global-pool-quota
   "Given a pool name, determine the quota for that pool."

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -69,7 +69,8 @@
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                               {:kind :static :namespace "cook"} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
-                                                              {} (atom :running) (atom false) false)
+                                                              {} (atom :running) (atom false) false
+                                                              cook.rate-limit/AllowAllRateLimiter)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -86,7 +87,8 @@
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                               {:kind :per-user} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
-                                                              {} (atom :running) (atom false) false)
+                                                              {} (atom :running) (atom false) false
+                                                              cook.rate-limit/AllowAllRateLimiter)
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -105,7 +107,8 @@
                                                           (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
                                                           {:kind :static :namespace "cook"} nil 3 nil nil
                                                           (Executors/newSingleThreadExecutor)
-                                                          {} (atom :running) (atom false) false)
+                                                          {} (atom :running) (atom false) false
+                                                          cook.rate-limit/AllowAllRateLimiter)
           node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 10 "nvidia-tesla-p100" nil)
                            "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 25 "nvidia-tesla-p100" nil)
                            "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil nil nil)

--- a/scheduler/test/cook/test/regexp_tools.clj
+++ b/scheduler/test/cook/test/regexp_tools.clj
@@ -1,0 +1,26 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.test.regexp_tools
+  (:require [clojure.test :refer :all]
+            [cook.regexp-tools :as regexp-tools]))
+
+(deftest test-match-based-on-regexp
+  (let [key "kubernetes"
+        regexp-name :compute-cluster-regex
+        match-list [{:compute-cluster-regex "^.*$", :tbf-config {:bucket-size 1}}]]
+    (is (= {:bucket-size 1}
+           (regexp-tools/match-based-on-regexp regexp-name :tbf-config match-list key)))))
+

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1604,7 +1604,7 @@
                                           task-metadata-seq))
                               (doseq [task-metadata task-metadata-seq]
                                 (process-task-post-launch-fn task-metadata)))))
-                        (get-compute-cluster-launch-rate-limiter [this] rate-limit/AllowAllRateLimiter))
+                        (launch-rate-limiter [this] rate-limit/AllowAllRateLimiter))
       test-user (System/getProperty "user.name")
       executor {:command "cook-executor"
                 :default-progress-regex-string "regex-string"
@@ -1747,7 +1747,7 @@
             (is (= #{"job-1"} (set @launched-job-names-atom))))))
 
       (with-redefs [rate-limit/job-launch-rate-limiter rate-limit/AllowAllRateLimiter
-                    cc/get-compute-cluster-launch-rate-limiter
+                    cc/launch-rate-limiter
                     (constantly (rate-limit/create-compute-cluster-launch-rate-limiter "fake-name-a" compute-cluster-launch-rate-limits-for-testing))
                     rate-limit/get-token-count! (fn [rate-limiter key]
                                                   (cond
@@ -1764,7 +1764,7 @@
             (is (= #{"job-1" "job-2" "job-3" "job-4"} (set @launched-job-names-atom))))))
 
       (with-redefs [rate-limit/job-launch-rate-limiter rate-limit/AllowAllRateLimiter
-                    cc/get-compute-cluster-launch-rate-limiter
+                    cc/launch-rate-limiter
                     (constantly (rate-limit/create-compute-cluster-launch-rate-limiter "fake-name-b" compute-cluster-launch-rate-limits-for-testing))
                     rate-limit/enforce? (constantly true)
                     rate-limit/get-token-count! (fn [rate-limiter key]

--- a/scheduler/test/cook/test/tools.clj
+++ b/scheduler/test/cook/test/tools.clj
@@ -871,14 +871,6 @@
     (is (= (util/match-based-on-pool-name matchlist "baz" :field) {:bar 2})))
   (is (= (util/match-based-on-pool-name [] "foo" :field) nil)))
 
-(deftest test-match-generic
-  (let [key "kubernetes"
-        regexp-name :compute-cluster-regex
-        match-list [{:compute-cluster-regex "^.*$", :tbf-config {:bucket-size 1}}]]
-    (is (= {:bucket-size 1}
-           (util/match-based-on-regexp regexp-name :tbf-config match-list key)))))
-
-
 (deftest test-atom-updater
   (let [map-atom (atom {})
         testfn (util/make-atom-updater map-atom)]

--- a/scheduler/test/cook/test/tools.clj
+++ b/scheduler/test/cook/test/tools.clj
@@ -870,7 +870,15 @@
     (is (= (util/match-based-on-pool-name matchlist "bar" :field) {:bar 2}))
     (is (= (util/match-based-on-pool-name matchlist "baz" :field) {:bar 2})))
   (is (= (util/match-based-on-pool-name [] "foo" :field) nil)))
-  
+
+(deftest test-match-generic
+  (let [key "kubernetes"
+        regexp-name :compute-cluster-regex
+        match-list [{:compute-cluster-regex "^.*$", :tbf-config {:bucket-size 1}}]]
+    (is (= {:bucket-size 1}
+           (util/match-based-on-regexp regexp-name :tbf-config match-list key)))))
+
+
 (deftest test-atom-updater
   (let [map-atom (atom {})
         testfn (util/make-atom-updater map-atom)]

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -147,7 +147,8 @@
                                                               trigger-chans#
                                                               {}
                                                               {"no-pool" (async/chan 100)}
-                                                              {}))
+                                                              {}
+                                                              cook.rate-limit/AllowAllRateLimiter))
          prepare-match-trigger-chan-orig# ~sched/prepare-match-trigger-chan]
      (try
        (with-redefs [executor-config (constantly executor-config#)


### PR DESCRIPTION
## Changes proposed in this PR

- Remove the old global (across all compute clusters) rate limit.
- Repurpose it as a per-compute-cluster rate limit, using regexp's to look for compute clusters matching a pattern.

## Why are we making these changes?
The global rate limit is to protect the backend. Now that we have separate backends, especially hybrid ones, we don't want them to share the same global rate limit, so now split into separate rate limits. 
