### PR TITLE
Adds optional command to cs ssh

### DIFF
--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -29,7 +29,7 @@ def ssh_to_instance(job, instance, sandbox_dir_fn, cluster, command_to_run=None)
     if compute_cluster_type == "kubernetes":
         kubectl_exec_to_instance_fn = plugins.get_fn('kubectl-exec-to-instance', kubectl_exec_to_instance)
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
-        kubectl_exec_to_instance_fn(job["user"], instance["task_id"], compute_cluster_config)
+        kubectl_exec_to_instance_fn(job["user"], instance["task_id"], compute_cluster_config, command_to_run)
     else:
         sandbox_dir = sandbox_dir_fn()
         command = os.environ.get('CS_SSH', 'ssh')

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -25,12 +25,12 @@ def ssh_to_instance(job, instance, sandbox_dir_fn, cluster, command_to_run=None)
     compute_cluster = instance["compute-cluster"]
     compute_cluster_type = compute_cluster["type"]
     compute_cluster_name = compute_cluster["name"]
-    command_to_run = command_to_run or ['exec', '/bin/bash']
     if compute_cluster_type == "kubernetes":
         kubectl_exec_to_instance_fn = plugins.get_fn('kubectl-exec-to-instance', kubectl_exec_to_instance)
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_exec_to_instance_fn(job["user"], instance["task_id"], compute_cluster_config, command_to_run)
     else:
+        command_to_run = command_to_run or ['/bin/bash']
         sandbox_dir = sandbox_dir_fn()
         command = os.environ.get('CS_SSH', 'ssh')
         logging.info(f'using ssh command: {command}')

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -25,7 +25,7 @@ def ssh_to_instance(job, instance, sandbox_dir_fn, cluster, command_to_run=None)
     compute_cluster = instance["compute-cluster"]
     compute_cluster_type = compute_cluster["type"]
     compute_cluster_name = compute_cluster["name"]
-    command_to_run = command_to_run or 'exec /bin/bash'
+    command_to_run = command_to_run or ['exec', '/bin/bash']
     if compute_cluster_type == "kubernetes":
         kubectl_exec_to_instance_fn = plugins.get_fn('kubectl-exec-to-instance', kubectl_exec_to_instance)
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -30,7 +30,7 @@ def ssh_to_instance(job, instance, sandbox_dir_fn, cluster, command_to_run=None)
         compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
         kubectl_exec_to_instance_fn(job["user"], instance["task_id"], compute_cluster_config, command_to_run)
     else:
-        command_to_run = command_to_run or ['/bin/bash']
+        command_to_run = command_to_run or ['bash']
         sandbox_dir = sandbox_dir_fn()
         command = os.environ.get('CS_SSH', 'ssh')
         logging.info(f'using ssh command: {command}')

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.3.0'
+VERSION = '3.4.2'


### PR DESCRIPTION
## Changes proposed in this PR

- adding an optional command argument, e.g. `cs ssh $uuid ls -al`

## Why are we making these changes?

So that users can run an arbitrary command on the remote machine and then return.
