### PR TITLE
WIP shell completion support

### DIFF
--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -46,6 +46,7 @@ actions = {
     'wait': wait.register(subparsers.add_parser, configuration.add_defaults)
 }
 
+
 def run(args, plugins):
     """
     Main entrypoint to the cook scheduler CLI. Loads configuration files, 

--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -10,7 +10,7 @@ import cook.plugins
 def ClusterCompleter(parsed_args, **kwargs):
     """
     Autocompletes the cluster name.
-    Uses the  configuration file passed on the command lineif provided.
+    Uses the configuration file passed on the command lineif provided.
     Otherwise it uses the default configuration file.
     """
     args_vars = vars(parsed_args)
@@ -71,7 +71,6 @@ def run(args, plugins):
     config_path = args.pop('config')
     cluster = args.pop('cluster')
     url = args.pop('url')
-
 
     if action is None:
         parser.print_help()

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup
 from cook import version
 
 requirements = [
+    'argcomplete',
     'arrow',
     'blessed',
     'humanfriendly',


### PR DESCRIPTION
## Changes proposed in this PR

Add initial shell completion support

```
$ eval "$(register-python-argcomplete cs)"
$ cs <TAB>
--cluster  --silent   --version  -h         -v         jobs       show       tail
--config   --url      -C         -s         cat        kill       ssh        usage
--help     --verbose  -c         -u         config     ls         submit     wait
$ cs -c <TAB>dev<TAB><TAB>
dev0  dev1
```

## Why are we making these changes?

Autocomplete CLI options to improve user experience use the `cs` CLI

