### PR TITLE
Add the ability to flush a rate-limit from the cache

### DIFF
--- a/scheduler/src/cook/rate_limit.clj
+++ b/scheduler/src/cook/rate_limit.clj
@@ -25,6 +25,7 @@
 (def time-until-out-of-debt-millis! rtg/time-until-out-of-debt-millis!)
 (def get-token-count! rtg/get-token-count!)
 (def enforce? rtg/enforce?)
+(def flush! rtg/flush!)
 (def AllowAllRateLimiter rtg/AllowAllRateLimiter)
 
 (defn create-job-submission-rate-limiter

--- a/scheduler/test/cook/test/rate_limit/generic.clj
+++ b/scheduler/test/cook/test/rate_limit/generic.clj
@@ -158,4 +158,19 @@
       (is (= (.getIfPresent (:cache ratelimit nil) "Bar4") {:current-tokens 390
                                                             :last-update 1000000
                                                             :bucket-size 400
-                                                            :token-rate 1.0})))))
+                                                            :token-rate 1.0}))
+      (is (= (rtg/get-token-count! ratelimit "Bar1") 60))
+      (is (= (rtg/get-token-count! ratelimit "Bar2") 170))
+      (is (= (rtg/get-token-count! ratelimit "Bar3") 280))
+      (testing "Flush one and make sure only that one resets"
+        (rtg/flush! ratelimit "Bar1")
+        (is (= (rtg/get-token-count! ratelimit "Bar1") 100))
+        (is (= (rtg/get-token-count! ratelimit "Bar2") 170)))
+      ; Flush all.
+      (testing "Flush all and make sure only the others reset"
+        (rtg/flush! ratelimit nil)
+        (is (= (rtg/get-token-count! ratelimit "Bar2") 200))
+        (is (= (rtg/get-token-count! ratelimit "Bar3") 300))))))
+
+
+


### PR DESCRIPTION
## Changes proposed in this PR

- Add the ability to flush a ratelimit from the cache so it gets reloaded.

## Why are we making these changes?

We want to be able to update ratelimits dynamically.
