### PR TITLE
Remove circular dependency by moving a query out of cook.tools

### DIFF
--- a/scheduler/src/cook/queries.clj
+++ b/scheduler/src/cook/queries.clj
@@ -1,0 +1,30 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.queries
+  (:require [datomic.api :as d :refer [q]]))
+
+;;
+;; This file is intended to break circular dependencies by letting us place datomic queries into a
+;; place that no other cook code depends on. DO NOT REQUITE ANY COOK NAMESPACE.
+
+(defn get-all-resource-types
+  "Return a list of all supported resources types. Example, :cpus :mem :gpus ..."
+  [db]
+  (->> (q '[:find ?ident
+            :where
+            [?e :resource.type/mesos-name ?ident]]
+          db)
+       (map first)))

--- a/scheduler/src/cook/quota.clj
+++ b/scheduler/src/cook/quota.clj
@@ -17,7 +17,7 @@
   (:require [clojure.set :as set]
             [cook.pool :as pool]
             [cook.schema]
-            [cook.tools :as util]
+            [cook.queries :as queries]
             [datomic.api :as d]
             [metatransaction.core :refer [db]]
             [plumbing.core :as pc]))
@@ -69,7 +69,7 @@
    return Double.MAX_VALUE."
   [db user pool-name]
   (let [mesos-resource-quota (pc/map-from-keys (fn [type] (get-quota-by-type-or-default db type user pool-name))
-                                               (util/get-all-resource-types db))
+                                               (queries/get-all-resource-types db))
         ;; As part of the pool migration, there might be a mix of quotas that have the count as an attribute or a resource.
         ;; We prefer to read the resource if available and fall back to the attribute.
         count-quota (or (get-quota-by-type db :resource.type/count user pool-name) ; prefer resource
@@ -200,7 +200,7 @@
   [db pool-name]
   (let [default-type->quota (get-quota db default-user pool-name)
         default-count-quota (get default-type->quota :count)
-        all-resource-types (util/get-all-resource-types db)
+        all-resource-types (queries/get-all-resource-types db)
         type->user->quota (pc/map-from-keys #(retrieve-user->resource-quota-amount db pool-name %) all-resource-types)
         all-quota-users (d/q '[:find [?user ...] :where [?q :quota/user ?user]] db) ;; returns a sequence without duplicates
         user->count-quota (retrieve-user->count-quota db pool-name all-quota-users default-count-quota)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -38,6 +38,7 @@
             [cook.plugins.submission :as submission-plugin]
             [cook.pool :as pool]
             [cook.progress :as progress]
+            [cook.queries :as queries]
             [cook.quota :as quota]
             [cook.rate-limit :as rate-limit]
             [cook.scheduler.constraints :as constraints]
@@ -2588,7 +2589,7 @@
      :handle-created (partial retrieve-user-limit get-limit-fn conn)
      :malformed? (fn [ctx]
                    (let [resource-types
-                         (set (apply conj (util/get-all-resource-types (d/db conn))
+                         (set (apply conj (queries/get-all-resource-types (d/db conn))
                                      extra-resource-types))
                          limits (->> (get-in ctx [:request :body-params limit-type])
                                      keywordize-keys

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -33,6 +33,7 @@
             [cook.plugins.definitions :as plugins]
             [cook.plugins.launch :as launch-plugin]
             [cook.pool :as pool]
+            [cook.queries :as queries]
             [cook.quota :as quota]
             [cook.rate-limit :as ratelimit]
             [cook.scheduler.constraints :as constraints]
@@ -1443,7 +1444,7 @@
      {user (if (seq used-resources)
              used-resources
              ;; Return all 0's for a user who does NOT have any running job.
-             (zipmap (tools/get-all-resource-types db) (repeat 0.0)))})))
+             (zipmap (queries/get-all-resource-types db) (repeat 0.0)))})))
 
 (defn limit-over-quota-jobs
   "Filters task-ents, preserving at most (config/max-over-quota-jobs) that would exceed the user's quota"

--- a/scheduler/src/cook/scheduler/share.clj
+++ b/scheduler/src/cook/scheduler/share.clj
@@ -17,7 +17,7 @@
   (:require [clojure.tools.logging :as log]
             [cook.config :as config]
             [cook.pool :as pool]
-            [cook.tools :as util]
+            [cook.queries :as queries]
             [datomic.api :as d]
             [metatransaction.core :refer [db]]
             [metrics.timers :as timers]
@@ -110,7 +110,7 @@
   ([db user]
    (get-share db user nil))
   ([db user pool]
-   (get-share db user pool (util/get-all-resource-types db)))
+   (get-share db user pool (queries/get-all-resource-types db)))
   ([db user pool resource-types]
    (let [type->default (get-share-by-types db default-user pool resource-types {})]
      (get-share db user pool resource-types type->default)))
@@ -127,7 +127,7 @@
   ([db users]
    (get-shares db users nil))
   ([db users pool-name]
-   (get-shares db users pool-name (util/get-all-resource-types db)))
+   (get-shares db users pool-name (queries/get-all-resource-types db)))
   ([db users pool-name resource-types]
    (timers/time!
      get-shares-duration
@@ -138,7 +138,7 @@
 (defn retract-share!
   [conn user pool reason]
   (let [db (d/db conn)]
-    (->> (util/get-all-resource-types db)
+    (->> (queries/get-all-resource-types db)
          (map (fn [type]
                 [type (retract-share-by-type! conn type user pool)]))
          (into {})))


### PR DESCRIPTION
## Changes proposed in this PR

- Remove circular dependency by moving a first query out of cook.tools.

## Why are we making these changes?

Cook tools depends on a lot of cook code, so that depending on it can accidently introduce circular dependencies. Much of the code there is database queries. If we move this to a new file, then we can break the circular dependencies.

