### PR TITLE
Refactor to propagate pool-name into quota filters.

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2194,7 +2194,7 @@
                     (pc/for-map [[pool-name queue] pool->queue]
                                 pool-name (->> queue
                                                (util/filter-pending-jobs-for-quota
-                                                 (pool->user->quota pool-name)
+                                                 pool-name (pool->user->quota pool-name)
                                                  (pool->user->usage pool-name)
                                                  (util/global-pool-quota (config/pool-quotas) pool-name))
                                                (take (::limit ctx)))))))))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -709,7 +709,7 @@
             (not (and is-rate-limited? enforcing-job-launch-rate-limit?))))
         considerable-jobs
         (->> pending-jobs
-             (tools/filter-pending-jobs-for-quota user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name))
+             (tools/filter-pending-jobs-for-quota pool-name user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name))
              (filter (fn [job] (tools/job-allowed-to-start? db job)))
              (filter user-within-launch-rate-limit?-fn)
              (filter launch-plugin/filter-job-launches)
@@ -1066,7 +1066,7 @@
                 ;; trigger autoscaling beyond what users have quota to actually run
                 autoscalable-jobs (->> pool-name
                                        (get @pool-name->pending-jobs-atom)
-                                       (tools/filter-pending-jobs-for-quota
+                                       (tools/filter-pending-jobs-for-quota pool-name
                                          user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name)))]
             ;; This call needs to happen *after* launch-matched-tasks!
             ;; in order to avoid autoscaling tasks taking up available

--- a/scheduler/test/cook/test/tools.clj
+++ b/scheduler/test/cook/test/tools.clj
@@ -764,13 +764,13 @@
         queue [(make-job 1 2 2048) (make-job 2 1 1024) (make-job 3 3 4096) (make-job 4 1 1024)]]
     (testing "no jobs included"
       (is (= []
-             (util/filter-based-on-pool-quota {:count 1, :cpus 2, :mem 1024} usage queue))))
+             (util/filter-based-on-pool-quota nil {:count 1, :cpus 2, :mem 1024} usage queue))))
     (testing "all jobs included"
       (is (= [(make-job 1 2 2048) (make-job 2 1 1024) (make-job 3 3 4096) (make-job 4 1 1024)]
-             (util/filter-based-on-pool-quota {:count 10, :cpus 20, :mem 32768} usage queue))))
+             (util/filter-based-on-pool-quota nil {:count 10, :cpus 20, :mem 32768} usage queue))))
     (testing "room for later jobs not included"
       (is (= [(make-job 1 2 2048) (make-job 2 1 1024)]
-             (util/filter-based-on-pool-quota {:count 4, :cpus 20, :mem 6144} usage queue))))))
+             (util/filter-based-on-pool-quota nil {:count 4, :cpus 20, :mem 6144} usage queue))))))
 
 (deftest test-filter-based-on-user-quota
   (let [test-user "john"
@@ -783,13 +783,13 @@
         queue [(make-job 1 2 2048) (make-job 2 1 1024) (make-job 3 3 4096) (make-job 4 1 1024)]]
     (testing "no jobs included"
       (is (= []
-             (util/filter-based-on-user-quota {test-user {:count 1, :cpus 2, :mem 1024}} user->usage queue))))
+             (util/filter-based-on-user-quota nil {test-user {:count 1, :cpus 2, :mem 1024}} user->usage queue))))
     (testing "all jobs included"
       (is (= [(make-job 1 2 2048) (make-job 2 1 1024) (make-job 3 3 4096) (make-job 4 1 1024)]
-             (util/filter-based-on-user-quota {test-user {:count 10, :cpus 20, :mem 32768}} user->usage queue))))
+             (util/filter-based-on-user-quota nil {test-user {:count 10, :cpus 20, :mem 32768}} user->usage queue))))
     (testing "room for later jobs not included"
       (is (= [(make-job 1 2 2048) (make-job 2 1 1024)]
-             (util/filter-based-on-user-quota {test-user {:count 4, :cpus 20, :mem 6144}} user->usage queue))))))
+             (util/filter-based-on-user-quota nil {test-user {:count 4, :cpus 20, :mem 6144}} user->usage queue))))))
 
 (deftest test-filter-pending-jobs-for-quota
   (let [test-user-1 "john"
@@ -807,7 +807,7 @@
     ; queue would be seen by the user quota and we'd only launch job-1.
     (testing "User quota filters first."
       (is (= [job-1 job-4]
-             (util/filter-pending-jobs-for-quota user->quota user->usage pool-quota queue))))))
+             (util/filter-pending-jobs-for-quota nil user->quota user->usage pool-quota queue))))))
 
 (deftest test-pool->user->usage
   (let [uri "datomic:mem://test-pool-user-usage"


### PR DESCRIPTION
## Changes proposed in this PR

- Refactor to propagate pool-name into quota filters.

## Why are we making these changes?

No functionality change except to add an extra field to a debug log line, but this enables future changes where we want the quota filter to be pool specific. 
