### PR TITLE
Remove metatransaction.core import that causes problem with mount.

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -341,7 +341,7 @@
     ;
     ; If you get an error about "Can't embed object in code, maybe print-dup not defined: clojure.lang.Delay"
     ; The issue is that at least metatransaction.core seems to be incompatible with mount. It cannot be in the
-    ; dependency tree of anything using mount.
+    ; dependency tree of anything using mount. See also issue #1370
     (mount/start-with-args (cook.config/read-config config-file-path))
     (pool/guard-invalid-default-pool (d/db datomic/conn))
     (metrics-jvm/instrument-jvm)

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -340,7 +340,8 @@
     ; you need to require S's namespace with ns :require. 'ns :require' is how mount finds defstates to initialize.
     ;
     ; If you get an error about "Can't embed object in code, maybe print-dup not defined: clojure.lang.Delay"
-    ; The issue is about metatransaction.core seems to be incompatible with mount. It cannot be in the dependency tree.
+    ; The issue is that at least metatransaction.core seems to be incompatible with mount. It cannot be in the
+    ; dependency tree of anything using mount.
     (mount/start-with-args (cook.config/read-config config-file-path))
     (pool/guard-invalid-default-pool (d/db datomic/conn))
     (metrics-jvm/instrument-jvm)

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -338,6 +338,9 @@
   (try
     ; Note: If the mount/start-with-args fails to initialize a defstate S, and/or you get weird errors on startup,
     ; you need to require S's namespace with ns :require. 'ns :require' is how mount finds defstates to initialize.
+    ;
+    ; If you get an error about "Can't embed object in code, maybe print-dup not defined: clojure.lang.Delay"
+    ; The issue is about metatransaction.core seems to be incompatible with mount. It cannot be in the dependency tree.
     (mount/start-with-args (cook.config/read-config config-file-path))
     (pool/guard-invalid-default-pool (d/db datomic/conn))
     (metrics-jvm/instrument-jvm)

--- a/scheduler/src/cook/quota.clj
+++ b/scheduler/src/cook/quota.clj
@@ -19,7 +19,6 @@
             [cook.schema]
             [cook.tools :as util]
             [datomic.api :as d]
-            [metatransaction.core :refer [db]]
             [plumbing.core :as pc]))
 ;; This namespace is dangerously similar to cook.share (it was copied..)
 ;; it isn't obvious what the abstraction is, but there must be one.


### PR DESCRIPTION
## Changes proposed in this PR

- Remove metatransaction.core import that causes problem with mount.

## Why are we making these changes?

Avoids an incomprehensible error with mount. Diagnoses #1370 with a workaround.
