### PR TITLE
Adds different rate limit for auth-bypass requests

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -133,7 +133,8 @@
        :keystore-path #config/env "COOK_KEYSTORE_PATH"
        :keystore-type "pkcs12"
        :keystore-pass "cookstore"}
- :rate-limit {:expire-minutes 1200 ; Expire unused rate limit entries after 20 hours.
+ :rate-limit {:auth-bypass-limit-per-m 10000
+              :expire-minutes 1200 ; Expire unused rate limit entries after 20 hours.
               ; Keep these job-launch and job-submission values as they are for integration tests. Making them smaller can cause
               ; spurious failures, and making them larger will cause test_rate_limit_launching_jobs to skip itself.
               :job-launch {:bucket-size 10000


### PR DESCRIPTION
## Changes proposed in this PR

- introducing `:rate-limit` `:auth-bypass-limit-per-m` (defaults to 10,000)
- using this different limit for requests that bypass authentication

## Why are we making these changes?

We don't want full Kerberos authentication on the progress update requests (`/progress/<uuid>`) to avoid crippling the leader from many progress update requests at the same time. See issue #1367 for the plan to add lightweight authentication.

In the meantime, the issue with bypassing authentication is that all of the progress update requests are being treated as though they were coming from a single user for rate-limiting purposes, which is problematic. This PR allows us to set a different (higher) limit for auth-bypass requests.
