### PR TITLE
Change log from ERROR to WARN

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -464,7 +464,7 @@
           (if (:update-succeeded update-result)
             (log/info "Update for cluster" (:cluster-name update) "successful")
             (log/error "Update failed!" update))
-          (log/error "Invalid update!" update)))
+          (log/warn "Invalid update!" update)))
       updates-with-results)))
 
 (defn update-compute-clusters


### PR DESCRIPTION
## Changes proposed in this PR

- For API requests that are wrong should be reported as WARN's, not ERROR's. 

## Why are we making these changes?
Avoid ERROR's during integration test runs.

