### PR TITLE
Fix compute-cluster API tests when run in docker.

### DIFF
--- a/scheduler/bin/run-docker.sh
+++ b/scheduler/bin/run-docker.sh
@@ -55,7 +55,7 @@ case "$COOK_AUTH" in
 esac
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-NAME=cook-scheduler-${COOK_PORT}
+NAME=cook-scheduler-${COOK_PORT}.localhost
 
 echo "About to: Clean up existing image"
 if [ "$(docker ps -aq -f name=${NAME})" ]; then


### PR DESCRIPTION
## Changes proposed in this PR

- Fixes:
  test_compute_cluster_api_delete_invalid
  test_compute_cluster_api_create_invalid

## Why are we making these changes?

Having our tests pass in open source.