### PR TITLE
Lowers default auth-bypass request rate limit

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -234,7 +234,7 @@
                                      {:json-value "config-impersonation"})))
      :rate-limit (fnk [[:config {rate-limit nil}]]
                    (let [{:keys [auth-bypass-limit-per-m expire-minutes job-launch job-submission user-limit-per-m]
-                          :or {auth-bypass-limit-per-m 400
+                          :or {auth-bypass-limit-per-m 600
                                expire-minutes 120
                                user-limit-per-m 600}} rate-limit]
                      {:expire-minutes expire-minutes

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -234,7 +234,7 @@
                                      {:json-value "config-impersonation"})))
      :rate-limit (fnk [[:config {rate-limit nil}]]
                    (let [{:keys [auth-bypass-limit-per-m expire-minutes job-launch job-submission user-limit-per-m]
-                          :or {auth-bypass-limit-per-m 10000
+                          :or {auth-bypass-limit-per-m 400
                                expire-minutes 120
                                user-limit-per-m 600}} rate-limit]
                      {:expire-minutes expire-minutes


### PR DESCRIPTION
## Changes proposed in this PR

Lowering the default request rate limit for auth-bypass requests to 600 / minute.

## Why are we making these changes?

To have a more conservative default.
