### PR TITLE
Enable tracking of how rate limiting is affecting the queue.

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2199,7 +2199,7 @@
                     (pc/for-map [[pool-name queue] pool->queue]
                                 pool-name (->> queue
                                                (util/filter-pending-jobs-for-quota
-                                                 pool-name (atom {}) (pool->user->quota pool-name)
+                                                 pool-name (atom {}) (atom {}) (pool->user->quota pool-name)
                                                  (pool->user->usage pool-name)
                                                  (util/global-pool-quota (config/pool-quotas) pool-name))
                                                (take (::limit ctx)))))))))

--- a/scheduler/test/cook/test/tools.clj
+++ b/scheduler/test/cook/test/tools.clj
@@ -807,7 +807,8 @@
     ; queue would be seen by the user quota and we'd only launch job-1.
     (testing "User quota filters first."
       (is (= [job-1 job-4]
-             (util/filter-pending-jobs-for-quota nil (atom {}) user->quota user->usage pool-quota queue))))))
+             (util/filter-pending-jobs-for-quota nil (atom {}) (atom {})
+                                                 user->quota user->usage pool-quota queue))))))
 
 (deftest test-pool->user->usage
   (let [uri "datomic:mem://test-pool-user-usage"


### PR DESCRIPTION
## Changes proposed in this PR

- Enable tracking of whenever we rate limit.
- Indicate when we are updating the backing data for /unscheduled (and a sense as to what the changes are) 
- 

## Why are we making these changes?
Track down the consequences of the (expected) race where /unscheduled is showing what we expect. That endpoint is inherently racy, but we think the race is behaving worse than we expected.

