### PR TITLE
Make our cache sizes configurable from the configuration file.

### DIFF
--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -1,0 +1,31 @@
+(ns cook.caches
+  (:require [chime]
+            [cook.cache :as ccache]
+            [cook.config :as config]
+            [mount.core :as mount])
+  (:import (com.google.common.cache Cache CacheBuilder)
+           (java.util.concurrent TimeUnit)))
+
+(defn new-cache [config]
+  "Build a new cache"
+  (-> (CacheBuilder/newBuilder)
+      (.maximumSize (get-in config [:settings :cache-working-set-size]))
+      ;; if its not been accessed in 2 hours, whatever is going on, its not being visted by the
+      ;; scheduler loop anymore. E.g., its probably failed/done and won't be needed. So,
+      ;; lets kick it out to keep cache small.
+      (.expireAfterAccess 2 TimeUnit/HOURS)
+      (.build)))
+
+
+(defn lookup-cache-datomic-entity!
+  "Specialized function for caching where datomic entities are the key.
+  Extracts :db/id so that we don't keep the entity alive in the cache."
+  [cache miss-fn entity]
+  (ccache/lookup-cache! cache :db/id miss-fn entity))
+
+(mount/defstate ^Cache job-ent->resources-cache :start (new-cache config/config))
+(mount/defstate ^Cache job-ent->pool-cache :start (new-cache config/config))
+(mount/defstate ^Cache task-ent->user-cache :start (new-cache config/config))
+(mount/defstate ^Cache job-ent->user-cache :start (new-cache config/config))
+(mount/defstate ^Cache task->feature-vector-cache :start (new-cache config/config))
+(mount/defstate ^Cache job-uuid->dataset-maps-cache :start (new-cache config/config))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -22,6 +22,8 @@
             [compojure.route :as route]
             [congestion.middleware :refer [ip-rate-limit wrap-rate-limit]]
             [congestion.storage :as storage]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.caches namespace.
+            [cook.caches]
             [cook.compute-cluster :as cc]
             [cook.config :refer [config]]
             [cook.datomic :as datomic]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -434,6 +434,8 @@
                 (assoc :quotas [])))
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
+     :cache-working-set-size (fnk [[:config {cache-working-set-size 1000000}]]
+                               cache-working-set-size)
      :estimated-completion-constraint (fnk [[:config {estimated-completion-constraint nil}]]
                                         (merge {:agent-start-grace-period-mins 10}
                                                estimated-completion-constraint))

--- a/scheduler/src/cook/plugins/launch.clj
+++ b/scheduler/src/cook/plugins/launch.clj
@@ -58,11 +58,11 @@
 
 ; We may see up to the entire scheduler queue, so have a big cache here.
 ; This is called in the scheduler loop. If it hasn't been looked at in more than 2 hours, the job has almost assuredly long since run.
-(def ^Cache job-launch-cache
-  (-> (CacheBuilder/newBuilder)
-      (.maximumSize 100000)
-      (.expireAfterAccess 2 TimeUnit/HOURS)
-      (.build)))
+(mount/defstate job-launch-cache
+  :start (-> (CacheBuilder/newBuilder)
+             (.maximumSize (get-in config/config [:settings :cache-working-set-size]))
+             (.expireAfterAccess 2 TimeUnit/HOURS)
+             (.build)))
 
 
 (defn aged-out?

--- a/scheduler/src/cook/plugins/submission.clj
+++ b/scheduler/src/cook/plugins/submission.clj
@@ -96,11 +96,11 @@
 
 ; We may see up to the entire scheduler queue, so have a big cache here.
 ; This is called in the scheduler loop. If it hasn't been looked at in more than 2 hours, the job has almost assuredly long since run.
-(def ^Cache job-launch-cache
-  (-> (CacheBuilder/newBuilder)
-      (.maximumSize 100000)
-      (.expireAfterAccess 2 TimeUnit/HOURS)
-      (.build)))
+(mount/defstate ^Cache job-launch-cache
+  :start (-> (CacheBuilder/newBuilder)
+             (.maximumSize (get-in config/config [:settings :cache-working-set-size]))
+             (.expireAfterAccess 2 TimeUnit/HOURS)
+             (.build)))
 
 (defn plugin-jobs-submission
   [jobs]

--- a/scheduler/src/cook/scheduler/data_locality.clj
+++ b/scheduler/src/cook/scheduler/data_locality.clj
@@ -7,6 +7,7 @@
             [clojure.set :as set]
             [clojure.tools.logging :as log]
             [cook.cache :as ccache]
+            [cook.caches :as caches]
             [cook.config :as config]
             [cook.tools :as util]
             [datomic.api :as d]
@@ -17,8 +18,6 @@
            (java.util UUID)))
 
 (def partition-date-format (:basic-date tf/formatters))
-
-(defonce job-uuid->dataset-maps-cache (util/new-cache))
 
 (defn- make-partition-map
   [partition-type partition]
@@ -47,10 +46,10 @@
 (defn get-dataset-maps
   "Returns the (possibly cached) datasets for the given job"
   [job]
-  (ccache/lookup-cache! job-uuid->dataset-maps-cache
-                      :job/uuid
-                      make-dataset-maps
-                      job))
+  (ccache/lookup-cache! caches/job-uuid->dataset-maps-cache
+                        :job/uuid
+                        make-dataset-maps
+                        job))
 
 (histograms/defhistogram [cook-mesos data-locality cost-update-staleness])
 (histograms/defhistogram [cook-mesos data-locality cost-match-staleness])

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -22,6 +22,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
+            [cook.caches :as caches]
             [cook.compute-cluster :as cc]
             [cook.kubernetes.api :as kapi]
             [cook.kubernetes.compute-cluster :as kcc]
@@ -39,10 +40,11 @@
             [plumbing.core :refer [mapply]]
             [qbits.jet.server :refer [run-jetty]]
             [ring.middleware.params :refer [wrap-params]])
-  (:import (com.netflix.fenzo SimpleAssignmentResult)
+  (:import (com.google.common.cache CacheBuilder)
+           (com.netflix.fenzo SimpleAssignmentResult)
            (io.kubernetes.client.custom Quantity Quantity$Format)
            (io.kubernetes.client.openapi.models V1Container V1Node V1NodeSpec V1NodeStatus V1ObjectMeta V1Pod V1PodSpec V1ResourceRequirements V1Taint)
-           (java.util.concurrent Executors)
+           (java.util.concurrent Executors TimeUnit)
            (java.util UUID)
            (org.apache.log4j ConsoleAppender Logger PatternLayout)))
 
@@ -94,6 +96,7 @@
     (or compute-cluster (cc/compute-cluster-name->ComputeCluster cluster-name))))
 
 (let [minimal-config {:authorization {:one-user ""}
+                      :cache-working-set-size 1000
                       :compute-clusters [{:factory-fn cook.mesos.mesos-compute-cluster/factory-fn
                                           :config {:compute-cluster-name fake-test-compute-cluster-name}}]
                       :database {:datomic-uri ""}
@@ -118,9 +121,16 @@
                            #'cook.config/config
                            #'cook.plugins.adjustment/plugin
                            #'cook.plugins.file/plugin
+                           #'cook.plugins.launch/job-launch-cache
                            #'cook.plugins.launch/plugin-object
                            #'cook.plugins.pool/plugin
                            #'cook.plugins.submission/plugin-object
+                           #'caches/job-ent->resources-cache
+                           #'caches/job-uuid->dataset-maps-cache
+                           #'caches/job-ent->pool-cache
+                           #'caches/task-ent->user-cache
+                           #'caches/task->feature-vector-cache
+                           #'caches/job-ent->user-cache
                            #'cook.quota/per-user-per-pool-launch-rate-limiter)))
 
 (defn run-test-server-in-thread
@@ -163,14 +173,23 @@
        (finally
          (async/close! exit-chan#)))))
 
+(defn new-cache []
+  "Build a new cache"
+  (-> (CacheBuilder/newBuilder)
+      (.maximumSize 100)
+      (.expireAfterAccess 2 TimeUnit/HOURS)
+      (.build)))
+
 (defn flush-caches!
   "Flush the caches. Needed in unit tests. We centralize initialization by using it to initialize the caches too."
   []
-  (.invalidateAll util/job-ent->resources-cache)
-  (.invalidateAll util/job-ent->pool-cache)
-  (.invalidateAll util/task-ent->user-cache)
-  (.invalidateAll util/task->feature-vector-cache)
-  (.invalidateAll util/job-ent->user-cache))
+  ; If you get a "java.lang.ClassCastException: mount.core.DerefableState cannot be cast to com.google.common.cache.Cache"
+  ; error here, it is because you didn't (setup) something that uses restore-fresh-database!
+  (.invalidateAll caches/job-ent->resources-cache)
+  (.invalidateAll caches/job-ent->pool-cache)
+  (.invalidateAll caches/task-ent->user-cache)
+  (.invalidateAll caches/task->feature-vector-cache)
+  (.invalidateAll caches/job-ent->user-cache))
 
 (defn restore-fresh-database!
   "Completely delete all data, start a fresh database and apply transactions if

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -21,6 +21,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.walk :refer [keywordize-keys]]
+            [cook.caches :as caches]
             [cook.compute-cluster :as cc]
             [cook.config :as config]
             [cook.mesos.reason :as reason]
@@ -1344,7 +1345,7 @@
             executor (assoc :executor executor)
             checkpoint (assoc :checkpoint checkpoint)
             datasets (assoc :datasets datasets)))]
-    (with-redefs [dl/job-uuid->dataset-maps-cache (util/new-cache)
+    (with-redefs [caches/job-uuid->dataset-maps-cache (testutil/new-cache)
                   config/compute-clusters (constantly [{:factory-fn 'cook.mesos.mesos-compute-cluster/factory-fn
                                                         :config {:framework-id "test-framework"}}])]
 
@@ -1837,6 +1838,7 @@
         (is @fetched-default-cluster-atom)))))
 
 (deftest test-file-plugin
+  (setup)
   (with-redefs [file-plugin/plugin (reify FileUrlGenerator
                                      (file-url [this {:keys [instance/task-id]}]
                                        (str "https://cook-files/instance/" task-id "/file")))]
@@ -2467,6 +2469,7 @@
       endpoint "/compute-clusters"]
 
   (deftest test-create-compute-cluster
+    (setup)
     (with-redefs [config/compute-cluster-templates
                   (constantly {"test-template" {:config {:dynamic-cluster-config? true}
                                                 :a :bb
@@ -2518,6 +2521,7 @@
               (is (= location (str sample-leader-base-url endpoint)))))))))
 
   (deftest test-read-compute-clusters
+    (setup)
     (let [conn (restore-fresh-database! "datomic:mem://test-read-compute-clusters")
           handler (basic-handler conn :is-authorized-fn is-authorized-fn)
           request {:authorization/user admin-user

--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -18,12 +18,14 @@
   (:require [clj-time.coerce :as tc]
             [clj-time.core :as t]
             [clojure.test :refer :all]
+            [cook.caches :as caches]
             [cook.config :as config]
             [cook.scheduler.constraints :as constraints]
             [cook.scheduler.data-locality :as dl]
             [cook.scheduler.scheduler :as sched]
-            [cook.test.testutil :refer [create-dummy-group create-dummy-instance create-dummy-job create-dummy-job-with-instances create-pool
-                                        make-task-assignment-result make-task-request restore-fresh-database! setup]]
+            [cook.test.testutil :as testutil
+             :refer [create-dummy-group create-dummy-instance create-dummy-job create-dummy-job-with-instances create-pool
+                     make-task-assignment-result make-task-request restore-fresh-database! setup]]
             [cook.tools :as util]
             [datomic.api :as d :refer [db]])
   (:import (java.util Date UUID)
@@ -359,7 +361,7 @@
 
 
 (deftest test-data-locality-constraint
-  (with-redefs [dl/job-uuid->dataset-maps-cache (util/new-cache)]
+  (with-redefs [caches/job-uuid->dataset-maps-cache (testutil/new-cache)]
     (testing "disabled when not using data local fitness calculator"
       (with-redefs [config/fitness-calculator-config (constantly config/default-fitness-calculator)
                     config/data-local-fitness-config (constantly {:launch-wait-seconds 60})]

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -24,6 +24,7 @@
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
+            [cook.caches :as caches]
             [cook.compute-cluster :as cc]
             [cook.config :as config]
             [cook.datomic :as datomic]
@@ -1587,6 +1588,7 @@
 
 
 (let [uri "datomic:mem://test-handle-resource-offers"
+      _ (setup) ;To create the caches that are flushed by restore-fresh-database!
       conn (restore-fresh-database! uri)
       compute-cluster-name "kubernetes"
       cluster-entity-id (kcc/get-or-create-cluster-entity-id conn compute-cluster-name)
@@ -1976,7 +1978,7 @@
   (setup)
   (with-redefs [config/data-local-fitness-config (constantly {:data-locality-weight 0.95
                                                               :base-calculator BinPackingFitnessCalculators/cpuMemBinPacker})
-                dl/job-uuid->dataset-maps-cache (tools/new-cache)]
+                caches/job-uuid->dataset-maps-cache (testutil/new-cache)]
     (let [uri "datomic:mem://test-handle-resource-offers-with-data-locality"
           conn (restore-fresh-database! uri)
           test-user (System/getProperty "user.name")


### PR DESCRIPTION
## Changes proposed in this PR

- Make our cache sizes configurable from the configuration file, so they can be sized to an expected working set size.

## Why are we making these changes?
- Better handling with longer queues and reduce the risk of hitting a performance cliff.

