### PR TITLE
Shortens the 'updating dynamic clusters' log

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1944,7 +1944,7 @@ if __name__ == '__main__':
                 self.assertEqual('Hello world!', cli.decode(cp.stdout))
 
     def test_usage(self):
-        command = 'sleep 300'
+        command = f'sleep {util.DEFAULT_TEST_TIMEOUT_SECS}'
 
         # Submit un-grouped jobs
         cp, uuids = cli.submit(command, self.cook_url, submit_flags='--cpus 0.1 --mem 16')

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -451,9 +451,15 @@
 (defn update-compute-clusters-helper
   "Helper function for update-compute-cluster and update-compute-clusters. See those functions for full description."
   [conn db current-configs new-configs force?]
-  (let [updates (compute-config-updates db current-configs new-configs force?)]
+  (let [updates (compute-config-updates db current-configs new-configs force?)
+        dissoc-ca-cert
+        (fn [configs]
+          (map-vals #(dissoc % :ca-cert) configs))]
     (log/info "Updating dynamic clusters."
-              {:current-configs current-configs :new-configs new-configs :force? force? :updates updates})
+              {:current-configs (dissoc-ca-cert current-configs)
+               :force? force?
+               :new-configs (dissoc-ca-cert new-configs)
+               :updates updates})
     (let [updates-with-results (map
                                  #(assoc % :update-result
                                            (when (:valid? %) (execute-update! conn %)))

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -453,13 +453,16 @@
   [conn db current-configs new-configs force?]
   (let [updates (compute-config-updates db current-configs new-configs force?)
         dissoc-ca-cert
+        (fn [config]
+          (dissoc config :ca-cert))
+        dissoc-ca-cert-vals
         (fn [configs]
-          (map-vals #(dissoc % :ca-cert) configs))]
+          (map-vals dissoc-ca-cert configs))]
     (log/info "Updating dynamic clusters."
-              {:current-configs (dissoc-ca-cert current-configs)
+              {:current-configs (dissoc-ca-cert-vals current-configs)
                :force? force?
-               :new-configs (dissoc-ca-cert new-configs)
-               :updates updates})
+               :new-configs (dissoc-ca-cert-vals new-configs)
+               :updates (map #(update % :goal-config dissoc-ca-cert) updates)})
     (let [updates-with-results (map
                                  #(assoc % :update-result
                                            (when (:valid? %) (execute-update! conn %)))


### PR DESCRIPTION
## Changes proposed in this PR

- removing the `:ca-cert` from the cluster configs when logging them

## Why are we making these changes?

The log can get huge (> 80kb), which can cause problems with logstash, and the ca-cert makes the log hard to read.