### PR TITLE
Sets supplemental groups in the pod security context

### DIFF
--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -29,3 +29,4 @@
 (mount/defstate ^Cache job-ent->user-cache :start (new-cache config/config))
 (mount/defstate ^Cache task->feature-vector-cache :start (new-cache config/config))
 (mount/defstate ^Cache job-uuid->dataset-maps-cache :start (new-cache config/config))
+(mount/defstate ^Cache user->group-ids-cache :start (new-cache config/config))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -583,6 +583,8 @@
         security-context (V1PodSecurityContext.)]
     (.setRunAsUser security-context uid)
     (.setRunAsGroup security-context gid)
+    (when-let [group-ids (util/user->all-group-ids user)]
+      (.setSupplementalGroups security-context group-ids))
     security-context))
 
 (defn get-workdir

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -131,7 +131,8 @@
                            #'caches/task-ent->user-cache
                            #'caches/task->feature-vector-cache
                            #'caches/job-ent->user-cache
-                           #'cook.quota/per-user-per-pool-launch-rate-limiter)))
+                           #'cook.quota/per-user-per-pool-launch-rate-limiter
+                           #'caches/user->group-ids-cache)))
 
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -99,6 +99,7 @@
     (is (= value (.getValue variable)))))
 
 (deftest test-task-metadata->pod
+  (tu/setup)
   (testing "creates pod from metadata"
     (with-redefs [config/kubernetes (constantly {:default-workdir "/mnt/sandbox"})]
       (let [task-metadata {:task-id "my-task"
@@ -185,7 +186,8 @@
 
   (testing "node selector for pool"
     (let [pool-name "test-pool"
-          task-metadata {:container {:docker {:parameters [{:key "user"
+          task-metadata {:command {:user "user"}
+                         :container {:docker {:parameters [{:key "user"
                                                             :value "100:10"}]}}
                          :task-request {:job {:job/pool {:pool/name pool-name}}
                                         :scalar-requests {"mem" 512
@@ -198,7 +200,8 @@
 
   (testing "node selector for hostname"
     (let [hostname "test-host"
-          task-metadata {:container {:docker {:parameters [{:key "user"
+          task-metadata {:command {:user "user"}
+                         :container {:docker {:parameters [{:key "user"
                                                             :value "100:10"}]}}
                          :hostname hostname
                          :task-request {:scalar-requests {"mem" 512
@@ -210,7 +213,8 @@
       (is (= hostname (get node-selector api/k8s-hostname-label)))))
 
   (testing "cpu limit configurability"
-    (let [task-metadata {:container {:docker {:parameters [{:key "user"
+    (let [task-metadata {:command {:user "user"}
+                         :container {:docker {:parameters [{:key "user"
                                                             :value "100:10"}]}}
                          :task-request {:scalar-requests {"mem" 512
                                                           "cpus" 1.0}}}
@@ -239,7 +243,8 @@
                                                                                                              :sub-path "efg/hij"}]}
                                                  :init-container {:command ["init container command"]
                                                                   :image "init container image"}})]
-      (let [task-metadata {:container {:docker {:parameters [{:key "user"
+      (let [task-metadata {:command {:user "user"}
+                           :container {:docker {:parameters [{:key "user"
                                                               :value "100:10"}]}}
                            :task-request {:scalar-requests {"mem" 512
                                                             "cpus" 1.0}


### PR DESCRIPTION
## Changes proposed in this PR

- adding a cache from user -> group ids
- populating the cache when needed with `id -G`
- setting the supplemental groups in the pod security context

## Why are we making these changes?

So that the pod runs with the proper group membership for the user.
