### PR TITLE
Removes group name validation from Java client

### DIFF
--- a/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Group.java
+++ b/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Group.java
@@ -16,7 +16,6 @@
 
 package com.twosigma.cook.jobclient;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -26,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 /**
  * An immutable group implementation.
@@ -69,7 +67,6 @@ final public class Group {
         private HostPlacement _hostPlacement;
         private StragglerHandling _stragglerHandling;
         private List<UUID> _jobs = new ArrayList<>();
-        private boolean _shouldValidate = true;
 
         /**
          * If the group UUID is not provided, the group will be assigned a random UUID, the name cookgroup and a
@@ -94,17 +91,6 @@ final public class Group {
                 _stragglerHandling = new StragglerHandling.Builder().build();
             }
             return new Group(_uuid, _status, _name, _hostPlacement, _stragglerHandling, _jobs);
-        }
-
-        /**
-         * Sets whether or not the Builder should validate arguments
-         *
-         * @param shouldValidate {@link Boolean} true if the Builder should validate.
-         * @return this builder.
-         */
-        public Builder setShouldValidate(Boolean shouldValidate) {
-            _shouldValidate = shouldValidate;
-            return this;
         }
 
         /**
@@ -138,12 +124,6 @@ final public class Group {
          * @return this builder.
          */
         public Builder setName(String name) {
-            if (_shouldValidate) {
-                final Pattern pattern = Pattern.compile("[\\.a-zA-Z0-9_-]{0,128}");
-                Preconditions.checkArgument
-                        (pattern.matcher(name).matches(),
-                                "Name can only contain '.', '_', '-', or any word characters, and must have length at most 128");
-            }
             _name = name;
             return this;
         }
@@ -360,7 +340,7 @@ final public class Group {
         for (int i = 0; i < jsonArray.length(); ++i) {
             JSONObject json = jsonArray.getJSONObject(i);
             JSONArray jobsJson = json.getJSONArray("jobs");
-            Builder groupBuilder = new Builder().setShouldValidate(false);
+            Builder groupBuilder = new Builder();
             groupBuilder.setUUID(UUID.fromString(json.getString("uuid")));
             if (json.has("name")) {
                 groupBuilder.setName(json.getString("name"));

--- a/jobclient/java/src/test/java/com/twosigma/cook/jobclient/GroupTest.java
+++ b/jobclient/java/src/test/java/com/twosigma/cook/jobclient/GroupTest.java
@@ -62,25 +62,15 @@ public class GroupTest {
     }
 
     @Test
-    public void testParseFromJSONAllowsReadingInvalidNames() throws JSONException {
-        final String invalidName = "~~~ invalid group name !!!";
-
-        // Check that we are in fact using an invalid name
-        try {
-            new Group.Builder().setName(invalidName);
-            Assert.fail();
-        } catch (IllegalArgumentException iae) {
-            Assert.assertTrue(iae.getMessage().contains("Name can only contain"));
-        }
-
-        // Check that reading the invalid name from JSON is permitted
+    public void testParseFromJSONAllowsReadingNamesWithOddCharacters() throws JSONException {
+        final String nameWithOddCharacters = "~~~ odd group name !!!";
         final JSONObject json = Group.jsonizeGroup(_initializedGroup);
         json.put("jobs", new JSONArray().put(UUID.randomUUID().toString()));
-        json.put("name", invalidName);
+        json.put("name", nameWithOddCharacters);
         final String jsonString = new JSONArray().put(json).toString();
         final List<Group> groups = Group.parseFromJSON(jsonString);
         Assert.assertEquals(groups.size(), 1);
-        Assert.assertEquals(groups.get(0).getName(), invalidName);
+        Assert.assertEquals(groups.get(0).getName(), nameWithOddCharacters);
     }
 }
 

--- a/jobclient/java/src/test/java/com/twosigma/cook/jobclient/GroupTest.java
+++ b/jobclient/java/src/test/java/com/twosigma/cook/jobclient/GroupTest.java
@@ -60,5 +60,27 @@ public class GroupTest {
         Assert.assertEquals(groups.size(), 1);
         Assert.assertEquals(groups.get(0), _initializedGroup);
     }
+
+    @Test
+    public void testParseFromJSONAllowsReadingInvalidNames() throws JSONException {
+        final String invalidName = "~~~ invalid group name !!!";
+
+        // Check that we are in fact using an invalid name
+        try {
+            new Group.Builder().setName(invalidName);
+            Assert.fail();
+        } catch (IllegalArgumentException iae) {
+            Assert.assertTrue(iae.getMessage().contains("Name can only contain"));
+        }
+
+        // Check that reading the invalid name from JSON is permitted
+        final JSONObject json = Group.jsonizeGroup(_initializedGroup);
+        json.put("jobs", new JSONArray().put(UUID.randomUUID().toString()));
+        json.put("name", invalidName);
+        final String jsonString = new JSONArray().put(json).toString();
+        final List<Group> groups = Group.parseFromJSON(jsonString);
+        Assert.assertEquals(groups.size(), 1);
+        Assert.assertEquals(groups.get(0).getName(), invalidName);
+    }
 }
 


### PR DESCRIPTION
## Changes proposed in this PR

- removing job group name validation from the Java client library

## Why are we making these changes?

The client is validating group names, but these are not currently enforced at the Cook Scheduler level, which is inconsistent and can cause problems when reading job groups created by other clients.
