### PR TITLE
Shortens the 'Will not checkpoint' log

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -716,7 +716,7 @@
                                               (contains? checkpoint-failure-reasons (:reason/name reason)))
                                             instance)]
             (if (-> checkpoint-failures count (>= max-checkpoint-attempts))
-              (log/info "Will not checkpoint, there are too many checkpoint failures"
+              (log/info "Will not checkpoint, there are at least" max-checkpoint-attempts "checkpoint failures"
                         {:job-uuid uuid
                          :max-checkpoint-attempts max-checkpoint-attempts
                          :number-checkpoint-failures (count checkpoint-failures)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -704,7 +704,7 @@
 (defn calculate-effective-checkpointing-config
   "Given the job's checkpointing config, calculate the effective config. Making any adjustments such as defaults,
   overrides, or other behavior modifications."
-  [{:keys [job/checkpoint job/instance] :as job} task-id]
+  [{:keys [job/checkpoint job/instance job/uuid] :as job} task-id]
   (when checkpoint
     (let [{:keys [default-checkpoint-config]} (config/kubernetes)
           {:keys [max-checkpoint-attempts checkpoint-failure-reasons disable-checkpointing] :as checkpoint}
@@ -716,8 +716,11 @@
                                               (contains? checkpoint-failure-reasons (:reason/name reason)))
                                             instance)]
             (if (-> checkpoint-failures count (>= max-checkpoint-attempts))
-              (log/info "Will not checkpoint task-id" task-id ", there are at least" max-checkpoint-attempts "failed instances"
-                        {:job job})
+              (log/info "Will not checkpoint, there are too many checkpoint failures"
+                        {:job-uuid uuid
+                         :max-checkpoint-attempts max-checkpoint-attempts
+                         :number-checkpoint-failures (count checkpoint-failures)
+                         :task-id task-id})
               checkpoint))
           checkpoint)))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- not logging the entire job

## Why are we making these changes?

Depending on the job, this log can get very long (> 22k), which can cause problems for logstash.
