### PR TITLE
Shortens the 'launching matched tasks' log

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -899,13 +899,9 @@
               user->num-jobs (->> matches
                                   (mapcat :task-metadata-seq)
                                   (map (comp tools/job-ent->user :job :task-request))
-                                  frequencies)
-              hostnames-matched (->> offers-matched
-                                     (map :hostname)
-                                     distinct)]
+                                  frequencies)]
           (log/info "In" pool-name "pool, launching matched tasks"
-                    {:hostnames-matched hostnames-matched
-                     :number-offers-matched num-offers-matched
+                    {:number-offers-matched num-offers-matched
                      :number-tasks (count task-txns)
                      :user->number-jobs user->num-jobs})
           (meters/mark! scheduler-offer-matched num-offers-matched)


### PR DESCRIPTION
## Changes proposed in this PR

- removing the list of hostnames matched from the log

## Why are we making these changes?

The list of hostnames can get long and is not very useful. This log line can get > 9k, which can cause problems for logstash.
