### PR TITLE
Gracefully handles unknown job resource type

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -582,12 +582,22 @@
 (defn offers->stats
   "Given a collection of offers, returns stats about the offers"
   [offers]
-  (-> offers tools/offers->resource-maps resource-maps->stats))
+  (try
+    (-> offers tools/offers->resource-maps resource-maps->stats)
+    (catch Exception e
+      (let [message "Error collecting offer stats"]
+        (log/error e message)
+        message))))
 
 (defn jobs->stats
   "Given a collection of jobs, returns stats about the jobs"
   [jobs]
-  (-> jobs jobs->resource-maps resource-maps->stats))
+  (try
+    (-> jobs jobs->resource-maps resource-maps->stats)
+    (catch Exception e
+      (let [message "Error collecting job stats"]
+        (log/error e message)
+        message))))
 
 (defn match-offer-to-schedule
   "Given an offer and a schedule, computes all the tasks should be launched as a result.

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -264,7 +264,7 @@
   "Take a job entity and return a resource map. NOTE: the keys must be same as mesos resource keys"
   [job]
   (let [job-ent->resources-miss
-        (fn [job-ent]
+        (fn [{:keys [job/uuid] :as job-ent}]
           (reduce (fn [m r]
                     (let [resource (keyword (name (:resource/type r)))]
                       (condp contains? resource
@@ -273,7 +273,12 @@
                                            {:cache (:resource.uri/cache? r false)
                                             :executable (:resource.uri/executable? r false)
                                             :value (:resource.uri/value r)
-                                            :extract (:resource.uri/extract? r false)}))))
+                                            :extract (:resource.uri/extract? r false)})
+                        (do
+                          (log/info "Encountered unknown job resource type"
+                                    {:job-uuid uuid
+                                     :resource resource})
+                          m))))
                   {:ports (:job/ports job-ent 0)}
                   (:job/resource job-ent)))]
     (caches/lookup-cache-datomic-entity! caches/job-ent->resources-cache job-ent->resources-miss job)))

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -275,7 +275,7 @@
                                             :value (:resource.uri/value r)
                                             :extract (:resource.uri/extract? r false)})
                         (do
-                          (log/info "Encountered unknown job resource type"
+                          (log/warn "Encountered unknown job resource type"
                                     {:job-uuid uuid
                                      :resource resource})
                           m))))


### PR DESCRIPTION
## Changes proposed in this PR

- adding `try` / `catch` to `offers->stats` and `jobs->stats`
- ignoring unknown resource types in `job-ent->resources`

## Why are we making these changes?

If a new resource type is added to jobs in the database, as with `disk` in PR #1709, we need old code (that is unaware of the new resource type) to not fail when encountering those jobs.

- If we can't collect stats, the whole matching cycle should not error out.
- If there is an unknown resource type, `job-ent->resources` shouldn't throw.
