### PR TITLE
Increases default and max :controller-lock-num-shards

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -469,13 +469,13 @@
                                  pool-selection)})))
      :kubernetes (fnk [[:config {kubernetes {}}]]
                    (let [{:keys [controller-lock-num-shards]
-                          :or {controller-lock-num-shards 32}}
+                          :or {controller-lock-num-shards 4095}}
                          kubernetes
                          _
-                         (when (not (< 0 controller-lock-num-shards 256))
+                         (when (not (< 0 controller-lock-num-shards 32778))
                            (throw
                              (ex-info
-                               "Please configure :controller-lock-num-shards to > 0 and < 256 in your config file."
+                               "Please configure :controller-lock-num-shards to > 0 and < 32778 in your config file."
                                kubernetes)))
                          lock-objects
                          (repeatedly


### PR DESCRIPTION
## Changes proposed in this PR

- increasing default from 32 to 4095
- increasing max from 255 to 32777

## Why are we making these changes?

To better support environments with high job volume.
