### PR TITLE
Fixes test-config-settings

### DIFF
--- a/scheduler/test/cook/test/config.clj
+++ b/scheduler/test/cook/test/config.clj
@@ -96,7 +96,7 @@
       (is (thrown? ExceptionInfo (config-settings bad-config))))
     (let [bad-config (assoc-in (api/minimal-config)
                                [:config :kubernetes :controller-lock-num-shards]
-                               256)]
+                               32778)]
       (is (thrown? ExceptionInfo (config-settings bad-config))))))
 
 (deftest test-valid-gpu-models-config-settings


### PR DESCRIPTION
This is a follow-up PR to #1724.

## Changes proposed in this PR

- fixing the unit test that became broken in PR #1724 

## Why are we making these changes?

To make the unit test agree with the new maximum number of controller lock shards.
