### PR TITLE
Fix memory leak in k8s state for deleted pods

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1212,7 +1212,7 @@
           (let [code (.getCode e)
                 already-deleted? (contains? #{404} code)]
             (if already-deleted?
-              (log/info e "In" compute-cluster-name "compute cluster, pod" pod-name "was already deleted")
+              (log/info "In" compute-cluster-name "compute cluster, pod" pod-name "was already deleted")
               (throw e))))))))
 
 (defn create-namespaced-pod

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -600,7 +600,7 @@
      ; we may leak a deleted pod back into this dictionary where it will never be recoverable.
      ;
      ; We only reprocess if something important has actually changed.
-     (when-not (and (nil? pod))
+     (when (some? pod)
        (swap! k8s-actual-state-map assoc pod-name new-state))
      (let [new-file-server-state (:sandbox-file-server-container-state new-state)
            old-file-server-state (:sandbox-file-server-container-state old-state)]

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -254,10 +254,14 @@
 (deftest test-synthesize-state-and-process-pod-if-changed
   (testing "gracefully handles nil pod"
     (let [compute-cluster {:k8s-actual-state-map (atom {})
-                           :cook-expected-state-map (atom {})}
+                           :cook-expected-state-map (atom {})
+                           :cook-starting-pods (atom {})} ; So that we don't get a NPE running the test
           pod-name "test-pod"
           pod nil]
-      (controller/synthesize-state-and-process-pod-if-changed compute-cluster pod-name pod))))
+      (controller/synthesize-state-and-process-pod-if-changed compute-cluster pod-name pod)
+      ; Make sure no memory leak --- we shouldn't create a pod in this circumstance.
+      (is (= {} @(get compute-cluster :k8s-actual-state-map)))
+      (is (= {} @(get compute-cluster :cook-expected-state-map))))))
 
 (deftest test-scan-process
   (testing "gracefully handles nil pod"


### PR DESCRIPTION
## Changes proposed in this PR

- Fix a leak where we we would unconditionally write back to the k8s state when the state scanner visited a pod which had been deleted. This ends up leaking.

## Why are we making these changes?
- Avoids a memory leak.

