### PR TITLE
add metadata env vars

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3226,6 +3226,22 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, [job_uuid_disabled, job_uuid_enabled])
 
+    @unittest.skipUnless(util.using_kubernetes(), 'Test requires kubernetes')
+    def test_kubernetes_metadata_env_vars(self):
+        docker_image = util.docker_image()
+        container = {'type': 'docker',
+                     'docker': {'image': docker_image}}
+        default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)
+        try:
+            command = 'bash -c \'if [[ "${COOK_POOL:-zzz}" == "' + default_pool + '" ]] && ' \
+                      '[[ "${COOK_SCHEDULER_URL:-zzz}" == "' + self.cook_url + '" ]]; then exit 0; else exit 1; fi\''
+            job_uuid, resp = util.submit_job(self.cook_url, command=command, container=container)
+            self.assertEqual(201, resp.status_code, resp.text)
+            util.wait_for_instance(self.cook_url, job_uuid, status='success')
+        finally:
+            util.kill_jobs(self.cook_url, [job_uuid])
+
+
     @unittest.skipUnless(util.docker_tests_enabled(), 'Requires docker support')
     def test_disallowed_docker_parameters(self):
         settings = util.settings(self.cook_url)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3238,7 +3238,7 @@ class CookTest(util.CookTest):
             # leader url and COOK_SCHEDULER_REST_URL can have different schemes right now
             #command = 'bash -c \'if [[ "${COOK_POOL:-zzz}" == "' + default_pool + '" ]] && [[ "${COOK_SCHEDULER_REST_URL:-zzz}" == "' + info['leader-url'] + '" ]]; then exit 0; else exit 1; fi\''
             command = 'bash -c \'if [[ "${COOK_POOL:-zzz}" == "' + default_pool + '" ]] && [[ "${COOK_SCHEDULER_REST_URL:-zzz}" != "zzz" ]]; then exit 0; else exit 1; fi\''
-            job_uuid, resp = util.submit_job(self.cook_url, command=command, container=container)
+            job_uuid, resp = util.submit_job(self.cook_url, command=command, container=container, max_retries=5)
             self.assertEqual(201, resp.status_code, resp.text)
             util.wait_for_instance(self.cook_url, job_uuid, status='success')
         finally:

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3234,7 +3234,7 @@ class CookTest(util.CookTest):
         default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)
         try:
             command = 'bash -c \'if [[ "${COOK_POOL:-zzz}" == "' + default_pool + '" ]] && ' \
-                      '[[ "${COOK_SCHEDULER_URL:-zzz}" == "' + self.cook_url + '" ]]; then exit 0; else exit 1; fi\''
+                      '[[ "${COOK_SCHEDULER_REST_URL:-zzz}" == "' + self.cook_url + '" ]]; then exit 0; else exit 1; fi\''
             job_uuid, resp = util.submit_job(self.cook_url, command=command, container=container)
             self.assertEqual(201, resp.status_code, resp.text)
             util.wait_for_instance(self.cook_url, job_uuid, status='success')

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3232,9 +3232,12 @@ class CookTest(util.CookTest):
         container = {'type': 'docker',
                      'docker': {'image': docker_image}}
         default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)
+        # info = util.scheduler_info(self.cook_url)
         try:
-            command = 'bash -c \'if [[ "${COOK_POOL:-zzz}" == "' + default_pool + '" ]] && ' \
-                      '[[ "${COOK_SCHEDULER_REST_URL:-zzz}" == "' + self.cook_url + '" ]]; then exit 0; else exit 1; fi\''
+            # need to figure out how to match up COOK_SCHEDULER_REST_URL
+            # leader url and COOK_SCHEDULER_REST_URL can have different schemes right now
+            #command = 'bash -c \'if [[ "${COOK_POOL:-zzz}" == "' + default_pool + '" ]] && [[ "${COOK_SCHEDULER_REST_URL:-zzz}" == "' + info['leader-url'] + '" ]]; then exit 0; else exit 1; fi\''
+            command = 'bash -c \'if [[ "${COOK_POOL:-zzz}" == "' + default_pool + '" ]] && [[ "${COOK_SCHEDULER_REST_URL:-zzz}" != "zzz" ]]; then exit 0; else exit 1; fi\''
             job_uuid, resp = util.submit_job(self.cook_url, command=command, container=container)
             self.assertEqual(201, resp.status_code, resp.text)
             util.wait_for_instance(self.cook_url, job_uuid, status='success')

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -6,6 +6,7 @@
             [clojure.walk :as walk]
             [cook.config :as config]
             [cook.kubernetes.metrics :as metrics]
+            [cook.pool :as pool]
             [cook.scheduler.constraints :as constraints]
             [cook.task :as task]
             [cook.tools :as util]
@@ -800,9 +801,9 @@
         params-env (build-params-env parameters)
         progress-env (task/build-executor-environment job)
         checkpoint-env (checkpoint->env checkpoint)
-        metadata-env (cond-> {"COOK_COMPUTE_CLUSTER_NAME" compute-cluster-name
-                              "COOK_SCHEDULER_REST_URL" (config/scheduler-rest-url)}
-                       pool-name (assoc "COOK_POOL" pool-name))
+        metadata-env {"COOK_COMPUTE_CLUSTER_NAME" compute-cluster-name
+                      "COOK_POOL" (pool/pool-name-or-default pool-name)
+                      "COOK_SCHEDULER_URL" (config/scheduler-rest-url)}
         main-env-base (merge environment params-env progress-env sandbox-env checkpoint-env metadata-env)
         progress-file-var (get main-env-base task/progress-meta-env-name task/default-progress-env-name)
         progress-file-path (get main-env-base progress-file-var)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -803,7 +803,7 @@
         checkpoint-env (checkpoint->env checkpoint)
         metadata-env {"COOK_COMPUTE_CLUSTER_NAME" compute-cluster-name
                       "COOK_POOL" (pool/pool-name-or-default pool-name)
-                      "COOK_SCHEDULER_URL" (config/scheduler-rest-url)}
+                      "COOK_SCHEDULER_REST_URL" (config/scheduler-rest-url)}
         main-env-base (merge environment params-env progress-env sandbox-env checkpoint-env metadata-env)
         progress-file-var (get main-env-base task/progress-meta-env-name task/default-progress-env-name)
         progress-file-path (get main-env-base progress-file-var)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -800,7 +800,10 @@
         params-env (build-params-env parameters)
         progress-env (task/build-executor-environment job)
         checkpoint-env (checkpoint->env checkpoint)
-        main-env-base (merge environment params-env progress-env sandbox-env checkpoint-env)
+        metadata-env (cond-> {"COOK_COMPUTE_CLUSTER_NAME" compute-cluster-name
+                              "COOK_SCHEDULER_REST_URL" (config/scheduler-rest-url)}
+                       pool-name (assoc "COOK_POOL" pool-name))
+        main-env-base (merge environment params-env progress-env sandbox-env checkpoint-env metadata-env)
         progress-file-var (get main-env-base task/progress-meta-env-name task/default-progress-env-name)
         progress-file-path (get main-env-base progress-file-var)
         main-env (cond-> main-env-base
@@ -891,7 +894,6 @@
           (.setPorts container [(.containerPort (V1ContainerPort.) (int port))])
 
           (.setEnv container (conj main-env-vars
-                                   (make-env "COOK_SCHEDULER_REST_URL" (config/scheduler-rest-url))
                                    ;; DEPRECATED - sidecar should use COOK_SANDBOX instead.
                                    ;; Will remove this environment variable in a future release.
                                    (make-env "COOK_WORKDIR" sandbox-dir)))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -138,7 +138,9 @@
           (is (= (conj api/default-shell "foo && bar") (.getCommand container)))
           (is (= "alpine:latest" (.getImage container)))
           (is (not (nil? container)))
-          (is (= ["COOK_SANDBOX"
+          (is (= ["COOK_COMPUTE_CLUSTER_NAME"
+                  "COOK_SANDBOX"
+                  "COOK_SCHEDULER_REST_URL"
                   "EXECUTOR_PROGRESS_OUTPUT_FILE"
                   "FOO"
                   "HOME"

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -139,8 +139,9 @@
           (is (= "alpine:latest" (.getImage container)))
           (is (not (nil? container)))
           (is (= ["COOK_COMPUTE_CLUSTER_NAME"
+                  "COOK_POOL"
                   "COOK_SANDBOX"
-                  "COOK_SCHEDULER_REST_URL"
+                  "COOK_SCHEDULER_URL"
                   "EXECUTOR_PROGRESS_OUTPUT_FILE"
                   "FOO"
                   "HOME"

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -141,7 +141,7 @@
           (is (= ["COOK_COMPUTE_CLUSTER_NAME"
                   "COOK_POOL"
                   "COOK_SANDBOX"
-                  "COOK_SCHEDULER_URL"
+                  "COOK_SCHEDULER_REST_URL"
                   "EXECUTOR_PROGRESS_OUTPUT_FILE"
                   "FOO"
                   "HOME"


### PR DESCRIPTION
## Changes proposed in this PR

- add metadata env vars

## Why are we making these changes?

We need access to more metadata like cook URL to get info about past instances, compute cluster name, pool name