### PR TITLE
add support for modifying pod image when checkpointing

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -728,10 +728,10 @@
 (defn calculate-effective-image
   "Transform the supplied job's image as necessary. e.g. do special transformation if checkpointing is enabled
   and an image transformation function is supplied."
-  [job-submit-time image {:keys [mode calculate-effective-image-fn]} task-id]
+  [{:keys [calculate-effective-image-fn] :as kubernetes-config} job-submit-time image {:keys [mode]} task-id]
   (if (and mode calculate-effective-image-fn)
     (try
-      ((util/lazy-load-var-memo calculate-effective-image-fn) job-submit-time image)
+      ((util/lazy-load-var-memo calculate-effective-image-fn) kubernetes-config job-submit-time image)
       (catch Exception e
         (log/error e "Error calculating effective image for checkpointing"
                    {:calculate-effective-image-fn calculate-effective-image-fn
@@ -797,7 +797,7 @@
         checkpoint (calculate-effective-checkpointing-config job task-id)
         job-submit-time (when (:job/submit-time job) ; due to a bug, submit time may not exist for some jobs
                           (.getTime (:job/submit-time job)))
-        image (calculate-effective-image job-submit-time image checkpoint task-id)
+        image (calculate-effective-image (config/kubernetes) job-submit-time image checkpoint task-id)
         checkpoint-memory-overhead (:memory-overhead checkpoint)
         use-cook-init? (and init-container pod-supports-cook-init?)
         use-cook-sidecar? (and sidecar pod-supports-cook-sidecar?)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -795,8 +795,7 @@
         {:keys [volumes volume-mounts sandbox-volume-mount-fn]} (make-volumes volumes sandbox-dir)
         {:keys [custom-shell init-container set-container-cpu-limit? sidecar]} (config/kubernetes)
         checkpoint (calculate-effective-checkpointing-config job task-id)
-        job-submit-time (when (:job/submit-time job) ; due to a bug, submit time may not exist for some jobs
-                          (.getTime (:job/submit-time job)))
+        job-submit-time (tools/job->submit-time job)
         image (calculate-effective-image (config/kubernetes) job-submit-time image checkpoint task-id)
         checkpoint-memory-overhead (:memory-overhead checkpoint)
         use-cook-init? (and init-container pod-supports-cook-init?)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -733,7 +733,9 @@
     (try
       ((util/lazy-load-var-memo calculate-effective-image-fn) image)
       (catch Exception e
-        (log/error e "Error calculating effective image for checkpointing" {:calculate-effective-image-fn calculate-effective-image-fn})
+        (log/error e "Error calculating effective image for checkpointing"
+                   {:calculate-effective-image-fn calculate-effective-image-fn
+                    :image image})
         image))
     image))
 

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1276,8 +1276,7 @@
                                   (->> [attribute (str/upper-case (name operator)) pattern]
                                        (map str)))))
           instances (map #(fetch-instance-map db %1) (:job/instance job))
-          submit-time (when (:job/submit-time job) ; due to a bug, submit time may not exist for some jobs
-                        (.getTime (:job/submit-time job)))
+          submit-time (util/job->submit-time job)
           datasets (when (seq (:job/datasets job))
                      (dl/get-dataset-maps job))
           attempts-consumed (util/job-ent->attempts-consumed db job)

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -1030,3 +1030,8 @@
                   (format "%.3f" %)
                   (str %))
                resource-map))
+
+(defn job->submit-time
+  "Get submit-time for a job. due to a bug, submit time may not exist for some jobs"
+  [job]
+  (when (:job/submit-time job) (.getTime (:job/submit-time job))))

--- a/scheduler/src/cook/util.clj
+++ b/scheduler/src/cook/util.clj
@@ -161,6 +161,9 @@
         resolved
         (throw (ex-info "Unable to resolve var, is it valid?" {:var-sym var-sym}))))))
 
+(def lazy-load-var-memo
+  (memoize lazy-load-var))
+
 (def ZeroInt
   (s/both s/Int (s/pred zero? 'zero?)))
 


### PR DESCRIPTION
## Changes proposed in this PR

- add support for modifying pod image when checkpointing


## Why are we making these changes?

We want to be able to modify the image spec when checkpointing. We want to be able to translate to a spec that is based on the image ID and is fixed. We need to get the exact same image when restoring even if new builds of the image have been made in the interim.
