### PR TITLE
Refactor to make pool taint / label and context configurable

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -35,8 +35,6 @@
 (def workload-class-label "workload-class")
 (def workload-id-label "workload-id")
 (def resource-owner-label "resource-owner")
-(def cook-pool-label "cook-pool")
-(def cook-pool-taint "cook-pool")
 (def cook-sandbox-volume-name "cook-sandbox-volume")
 (def cook-job-pod-priority-class "cook-workload")
 (def cook-synthetic-pod-priority-class "synthetic-pod")
@@ -242,10 +240,10 @@
 
 (defn get-node-pool
   "Get the pool for a node. In the case of no pool, return 'no-pool"
-  [^V1Node node]
+  [cook-pool-taint-name ^V1Node node]
   ; In the case of nil, we have taints-on-node == [], and we'll map to no-pool.
   (let [taints-on-node (or (some-> node .getSpec .getTaints) [])
-        found-cook-pool-taint (filter #(= cook-pool-taint (.getKey %)) taints-on-node)]
+        found-cook-pool-taint (filter #(= cook-pool-taint-name (.getKey %)) taints-on-node)]
     (if (= 1 (count found-cook-pool-taint))
       (-> found-cook-pool-taint first .getValue)
       "no-pool")))
@@ -253,7 +251,7 @@
 (declare initialize-node-watch)
 (defn initialize-node-watch-helper
   "Help creating node watch. Returns a new watch Callable"
-  [{:keys [^ApiClient api-client current-nodes-atom pool->node-name->node] compute-cluster-name :name :as compute-cluster}]
+  [{:keys [^ApiClient api-client current-nodes-atom pool->node-name->node cook-pool-taint-name] compute-cluster-name :name :as compute-cluster}]
   (let [api (CoreV1Api. api-client)
         current-nodes-raw
         (timers/time! (metrics/timer "get-all-nodes" compute-cluster-name)
@@ -271,7 +269,7 @@
         current-nodes (pc/map-from-vals node->node-name (.getItems current-nodes-raw))
         callbacks
         [(tools/make-atom-updater current-nodes-atom) ; Update the set of all pods.
-         (tools/make-nested-atom-updater pool->node-name->node get-node-pool node->node-name)]
+         (tools/make-nested-atom-updater pool->node-name->node (partial get-node-pool cook-pool-taint-name) node->node-name)]
         old-current-nodes @current-nodes-atom
         new-node-names (set (keys current-nodes))
         old-node-names (set (keys old-current-nodes))]
@@ -412,12 +410,12 @@
   "Can we schedule on a node. For now, yes, unless there are other taints on it or it contains any label in the
   node-blocklist-labels list.
   TODO: Incorporate other node-health measures here."
-  [^V1Node node pod-count-capacity node-name->pods node-blocklist-labels]
+  [{:keys [node-blocklist-labels cook-pool-taint-name]} ^V1Node node pod-count-capacity node-name->pods]
   (if (nil? node)
     false
     (let [taints-on-node (or (some-> node .getSpec .getTaints) [])
           other-taints (remove #(contains?
-                                  #{cook-pool-taint k8s-deletion-candidate-taint gpu-node-taint}
+                                  #{cook-pool-taint-name k8s-deletion-candidate-taint gpu-node-taint}
                                   (.getKey %))
                                taints-on-node)
           node-name (some-> node .getMetadata .getName)
@@ -548,9 +546,9 @@
 
 (defn toleration-for-pool
   "For a given cook pool name, create the right V1Toleration so that Cook will ignore that cook-pool taint."
-  [pool-name]
+  [cook-pool-taint-name pool-name]
   (let [^V1Toleration toleration (V1Toleration.)]
-    (.setKey toleration cook-pool-taint)
+    (.setKey toleration cook-pool-taint-name)
     (.setValue toleration pool-name)
     (.setOperator toleration "Equal")
     (.setEffect toleration "NoSchedule")
@@ -750,7 +748,7 @@
 
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."
-  [namespace compute-cluster-name
+  [namespace {:keys [cook-pool-taint-name cook-pool-label-name] compute-cluster-name :name}
    {:keys [task-id command container task-request hostname pod-annotations pod-constraints pod-hostnames-to-avoid
            pod-labels pod-priority-class pod-supports-cook-init? pod-supports-cook-sidecar?]
     :or {pod-priority-class cook-job-pod-priority-class
@@ -960,12 +958,12 @@
     ; user. For the time being, this isn't a problem only if / when
     ; the default pool is not being fed offers from Kubernetes.
     (when pool-name
-      (.addTolerationsItem pod-spec (toleration-for-pool pool-name))
+      (.addTolerationsItem pod-spec (toleration-for-pool cook-pool-taint-name pool-name))
       ; Add a node selector for nodes labeled with the Cook pool
       ; we're launching in. This is technically only needed for
       ; synthetic pods (which don't specify a node name), but it
       ; doesn't hurt to add it for all pods we submit.
-      (add-node-selector pod-spec cook-pool-label pool-name))
+      (add-node-selector pod-spec cook-pool-label-name pool-name))
 
     (when pod-constraints
       (doseq [{:keys [constraint/attribute

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -539,7 +539,7 @@
     (.setCreationTimestamp pod-metadata creation-timestamp)
     (-> outstanding-synthetic-pod
         .getSpec
-        (.addTolerationsItem (kapi/toleration-for-pool pool-name)))
+        (.addTolerationsItem (kapi/toleration-for-pool "cook-pool-taint-A" pool-name)))
     outstanding-synthetic-pod))
 
 (defn node-helper [node-name cpus mem gpus gpu-model pool]
@@ -567,7 +567,7 @@
 
     (when pool
       (let [^V1Taint taint (V1Taint.)]
-        (.setKey taint kapi/cook-pool-taint)
+        (.setKey taint "foo-taint-probably-broken-TODO")
         (.setValue taint pool)
         (.setEffect taint "NoSchedule")
         (-> spec (.addTaintsItem taint))
@@ -606,4 +606,6 @@
                                     (atom :running) ; state atom
                                     (atom false) ; state-locked? atom
                                     false ; dynamic-cluster-config?
-                                    rate-limit/AllowAllRateLimiter)))
+                                    rate-limit/AllowAllRateLimiter
+                                    "some-random-taint-A"
+                                    "some-random-label-A")))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -70,7 +70,7 @@
                                                               {:kind :static :namespace "cook"} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
                                                               {} (atom :running) (atom false) false
-                                                              cook.rate-limit/AllowAllRateLimiter)
+                                                              cook.rate-limit/AllowAllRateLimiter "t-a" "l-a")
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -88,7 +88,7 @@
                                                               {:kind :per-user} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
                                                               {} (atom :running) (atom false) false
-                                                              cook.rate-limit/AllowAllRateLimiter)
+                                                              cook.rate-limit/AllowAllRateLimiter "t-b" "l-b")
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -108,7 +108,7 @@
                                                           {:kind :static :namespace "cook"} nil 3 nil nil
                                                           (Executors/newSingleThreadExecutor)
                                                           {} (atom :running) (atom false) false
-                                                          cook.rate-limit/AllowAllRateLimiter)
+                                                          cook.rate-limit/AllowAllRateLimiter "t-c" "l-c")
           node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 10 "nvidia-tesla-p100" nil)
                            "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 25 "nvidia-tesla-p100" nil)
                            "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil nil nil)


### PR DESCRIPTION
…ontext configurable

## Changes proposed in this PR

- Add configuration knobs to choose which node selector cook puts on its pods.
- Add configuration knobs to choose which taint cook uses to choose its pool name.
- Add configuration knob to select one context out of a kubeconfig file.

## Why are we making these changes?

Give us  more configurability for how we connect to k8s.
