### PR TITLE
Add disk fields for cs show

### DIFF
--- a/cli/cook/subcommands/show.py
+++ b/cli/cook/subcommands/show.py
@@ -48,10 +48,10 @@ def tabulate_job(cluster_name, job):
         job_definition.append(['Max Runtime', millis_to_timedelta(job['max_runtime'])])
     if 'disk' in job:
         job_definition.append(['Disk Request', job['disk']['request']])
-    if 'limit' in job['disk']:
-        job_definition.append(['Disk Limit', job['disk']['limit']])
-    if 'type' in job['disk']:
-        job_definition.append(['Disk Type', job['disk']['type']])
+        if 'limit' in job['disk']:
+            job_definition.append(['Disk Limit', job['disk']['limit']])
+        if 'type' in job['disk']:
+            job_definition.append(['Disk Type', job['disk']['type']])
     if job['gpus'] > 0:
         job_definition.append(['GPUs', job['gpus']])
     if job['ports'] > 0:

--- a/cli/cook/subcommands/show.py
+++ b/cli/cook/subcommands/show.py
@@ -46,14 +46,14 @@ def tabulate_job(cluster_name, job):
                       ['Priority', job['priority']]]
     if job['max_runtime'] != DEFAULT_MAX_RUNTIME:
         job_definition.append(['Max Runtime', millis_to_timedelta(job['max_runtime'])])
+    if job['gpus'] > 0:
+        job_definition.append(['GPUs', job['gpus']])
     if 'disk' in job:
         job_definition.append(['Disk Request', job['disk']['request']])
         if 'limit' in job['disk']:
             job_definition.append(['Disk Limit', job['disk']['limit']])
         if 'type' in job['disk']:
             job_definition.append(['Disk Type', job['disk']['type']])
-    if job['gpus'] > 0:
-        job_definition.append(['GPUs', job['gpus']])
     if job['ports'] > 0:
         job_definition.append(['Ports Requested', job['ports']])
     if len(job['constraints']) > 0:

--- a/cli/cook/subcommands/show.py
+++ b/cli/cook/subcommands/show.py
@@ -46,6 +46,12 @@ def tabulate_job(cluster_name, job):
                       ['Priority', job['priority']]]
     if job['max_runtime'] != DEFAULT_MAX_RUNTIME:
         job_definition.append(['Max Runtime', millis_to_timedelta(job['max_runtime'])])
+    if 'disk' in job:
+        job_definition.append(['Disk Request', job['disk']['request']])
+    if 'limit' in job['disk']:
+        job_definition.append(['Disk Limit', job['disk']['limit']])
+    if 'type' in job['disk']:
+        job_definition.append(['Disk Type', job['disk']['type']])
     if job['gpus'] > 0:
         job_definition.append(['GPUs', job['gpus']])
     if job['ports'] > 0:

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1294,10 +1294,6 @@ if __name__ == '__main__':
         self.assertIn("Disk Limit", cli.stdout(cp))
         self.assertIn("Disk Type", cli.stdout(cp))
 
-
-
-
-
     def test_submit_with_executor(self):
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--executor cook')
         self.assertEqual(0, cp.returncode, cp.stderr)

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1255,6 +1255,46 @@ if __name__ == '__main__':
             self.assertIn('Command exited with status 0', stdout)
             self.assertIn('Executor completed execution', stdout)
 
+    def test_show_disk(self):
+        # No disk
+        raw_job = {'command': 'ls'}
+        cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp = cli.show(uuids, self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertNotIn("Disk", cli.stdout(cp))
+
+        # Disk with request, limit, and type
+        raw_job = {'command': 'ls', 'disk': {'request': 10.0, 'limit': 20.0, 'type': 'standard'}}
+        cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp = cli.show(uuids, self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertIn("Disk Request", cli.stdout(cp))
+        self.assertIn("Disk Limit", cli.stdout(cp))
+        self.assertIn("Disk Type", cli.stdout(cp))
+
+        # Disk with only request and limit
+        raw_job = {'command': 'ls', 'disk': {'request': 10.0, 'limit': 20.0}}
+        cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')
+        self.assertEqual(0, cp.returncode, cp.stderr)
+
+        cp = cli.show(uuids, self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertIn("Disk Request", cli.stdout(cp))
+        self.assertIn("Disk Limit", cli.stdout(cp))
+        self.assertNotIn("Disk Type", cli.stdout(cp))
+
+        # Disk with only request
+        raw_job = {'command': 'sleep 100', 'disk': {'request': 10.0}}
+        cp, uuids = cli.submit(stdin=cli.encode(json.dumps(raw_job)), cook_url=self.cook_url, submit_flags='--raw')
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        cp = cli.show(uuids, self.cook_url)
+        self.assertEqual(0, cp.returncode, cp.stderr)
+        self.assertIn("Disk Request", cli.stdout(cp))
+        self.assertNotIn("Disk Limit", cli.stdout(cp))
+        self.assertNotIn("Disk Type", cli.stdout(cp))
+
     def test_submit_with_executor(self):
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags='--executor cook')
         self.assertEqual(0, cp.returncode, cp.stderr)

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -121,8 +121,8 @@
                                                      :parameters []}}}]
          :disk
          [{:pool-regex "^k8s-alpha$"
-           :valid-types #{"pd-ssd"}
-           :default-type "pd-ssd"
+           :valid-types #{"standard"}
+           :default-type "standard"
            :max-size 256000.0}]
          :valid-gpu-models
          [{:pool-regex "k8s-alpha"


### PR DESCRIPTION
## Changes proposed in this PR
- Add 'Disk Request', 'Disk Limit', and 'Disk Type' fields to cs show

## Why are we making these changes?
- Allow users to see disk specs on jobs they submitted

