### PR TITLE
Fixes Java jobclient path in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,8 @@ Vagrant.configure("2") do |config|
   repo_root=/vagrant
   bashrc=$HOME/.bashrc
 
-  # Cook jobclient setup
-  cd $repo_root/jobclient || exit 1
+  # Cook java jobclient setup
+  cd $repo_root/jobclient/java || exit 1
   mvn install -DskipTests
 
   # Python setup


### PR DESCRIPTION
## Changes proposed in this PR

- `$repo_root/jobclient` -> `$repo_root/jobclient/java`

## Why are we making these changes?

To fix the Vagrantfile with the new location of the Java jobclient.
