### PR TITLE
Do not schedule nodes with unschedulable node-spec

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -25,7 +25,7 @@
              V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1EnvVarSource V1Event V1HostPathVolumeSource
              V1HTTPGetAction V1ObjectFieldSelector V1Node V1NodeAffinity V1NodeSelector V1NodeSelectorRequirement
              V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodCondition V1PodSecurityContext V1PodSpec
-             V1PodStatus V1Probe V1ResourceRequirements V1Toleration V1Volume V1VolumeBuilder V1VolumeMount V1NodeSpec)
+             V1PodStatus V1Probe V1ResourceRequirements V1Toleration V1Volume V1VolumeBuilder V1VolumeMount)
            (io.kubernetes.client.util Watch)
            (java.net SocketTimeoutException)
            (java.util.concurrent Executors ExecutorService)))
@@ -420,7 +420,7 @@
                                   (.getKey %))
                                taints-on-node)
           node-name (some-> node .getMetadata .getName)
-          ^V1NodeSpec node-unschedulable (some-> node .getSpec .getUnschedulable)
+          node-unschedulable (some-> node .getSpec .getUnschedulable)
           num-pods-on-node (-> node-name->pods (get node-name []) count)
           labels-on-node (or (some-> node .getMetadata .getLabels) {})
           matching-node-blocklist-keyvals (select-keys labels-on-node node-blocklist-labels)]

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -25,7 +25,7 @@
              V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1EnvVarSource V1Event V1HostPathVolumeSource
              V1HTTPGetAction V1ObjectFieldSelector V1Node V1NodeAffinity V1NodeSelector V1NodeSelectorRequirement
              V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodCondition V1PodSecurityContext V1PodSpec
-             V1PodStatus V1Probe V1ResourceRequirements V1Toleration V1Volume V1VolumeBuilder V1VolumeMount)
+             V1PodStatus V1Probe V1ResourceRequirements V1Toleration V1Volume V1VolumeBuilder V1VolumeMount V1NodeSpec)
            (io.kubernetes.client.util Watch)
            (java.net SocketTimeoutException)
            (java.util.concurrent Executors ExecutorService)))
@@ -420,20 +420,26 @@
                                   (.getKey %))
                                taints-on-node)
           node-name (some-> node .getMetadata .getName)
+          ^V1NodeSpec node-unschedulable (some-> node .getSpec .getUnschedulable)
           num-pods-on-node (-> node-name->pods (get node-name []) count)
           labels-on-node (or (some-> node .getMetadata .getLabels) {})
           matching-node-blocklist-keyvals (select-keys labels-on-node node-blocklist-labels)]
-      (cond  (seq other-taints) (do
-                                  (log/info "Filtering out" node-name "because it has taints" other-taints)
-                                  false)
-             (>= num-pods-on-node pod-count-capacity) (do
-                                                        (log/info "Filtering out" node-name "because it is at or above its pod count capacity of"
-                                                                  pod-count-capacity "(" num-pods-on-node ")")
-                                                        false)
-             (seq matching-node-blocklist-keyvals) (do
-                                                     (log/info "Filtering out" node-name "because it has node blocklist labels" matching-node-blocklist-keyvals)
-                                                     false)
-             :else true))))
+      (cond
+        ;; Note that node-unschedulable may be nil or false or true.
+        node-unschedulable (do
+                             (log/info "Filtering out" node-name "because it is unschedulable" node-unschedulable)
+                             false)
+        (seq other-taints) (do
+                             (log/info "Filtering out" node-name "because it has taints" other-taints)
+                             false)
+        (>= num-pods-on-node pod-count-capacity) (do
+                                                   (log/info "Filtering out" node-name "because it is at or above its pod count capacity of"
+                                                             pod-count-capacity "(" num-pods-on-node ")")
+                                                   false)
+        (seq matching-node-blocklist-keyvals) (do
+                                                (log/info "Filtering out" node-name "because it has node blocklist labels" matching-node-blocklist-keyvals)
+                                                false)
+        :else true))))
 
 (defn add-gpu-model-to-resource-map
   "Given a map from node-name->resource-type->capacity, perform the following operation:

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -565,17 +565,18 @@
                                                               Quantity$Format/DECIMAL_SI))
       (.putLabelsItem metadata "gpu-type" (or gpu-model "nvidia-tesla-p100")))
 
+    (.setUnschedulable spec false)
     (when pool
       (let [^V1Taint taint (V1Taint.)]
         (.setKey taint "foo-taint-probably-broken-TODO")
         (.setValue taint pool)
         (.setEffect taint "NoSchedule")
-        (-> spec (.addTaintsItem taint))
-        (-> node (.setSpec spec))))
+        (-> spec (.addTaintsItem taint))))
     (.setStatus node status)
     (.setName metadata node-name)
     (.setMetadata node metadata)
-  node))
+    (.setSpec node spec)
+    node))
 
 (defn make-kubernetes-compute-cluster
   [namespaced-pod-name->pod pool-names node-blocklist-labels additional-synthetic-pods-config]

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -660,6 +660,7 @@
         (.setName metadata "NodeName")
         (.setNamespace metadata "cook")
         (.setMetadata node metadata)
+        (.setUnschedulable spec false)
         (.setSpec node spec)
         (is (not (api/node-schedulable? {:node-blocklist-labels ["blocklist-1"]} node 30 nil)))
         (is (api/node-schedulable? {:node-blocklist-labels ["blocklist-2"]} node 30 nil))))
@@ -676,6 +677,7 @@
         (.setName metadata "NodeName")
         (.setNamespace metadata "cook")
         (.setMetadata node metadata)
+        (.setUnschedulable spec false)
         (.setSpec node spec)
         (is (api/node-schedulable? {:node-blocklist-labels ["blocklist-1"] :cook-pool-taint-name "the-taint-to-use"} node 30 nil))
         (is (not (api/node-schedulable? {:node-blocklist-labels ["blocklist-1"] :cook-pool-taint-name "a-taint-different-than-node"} node 30 nil)))))
@@ -692,6 +694,7 @@
         (.setName metadata "NodeName")
         (.setNamespace metadata "cook")
         (.setMetadata node metadata)
+        (.setUnschedulable spec false)
         (.setSpec node spec)
         (is (not (api/node-schedulable? {:node-blocklist-labels ["blocklist-1"]} node 30 nil)))))
     (testing "GPU Taint"
@@ -707,8 +710,38 @@
         (.setName metadata "NodeName")
         (.setNamespace metadata "cook")
         (.setMetadata node metadata)
+        (.setUnschedulable spec false)
         (.setSpec node spec)
-        (is (api/node-schedulable? {:node-blocklist-labels ["blocklist-1"]} node 30 nil))))))
+        (is (api/node-schedulable? {:node-blocklist-labels ["blocklist-1"]} node 30 nil))))
+    (testing "Unschedule node spec"
+      (let [^V1Node node (V1Node.)
+            metadata (V1ObjectMeta.)
+            ^V1NodeSpec spec (V1NodeSpec.)]
+        (.setName metadata "NodeName")
+        (.setNamespace metadata "cook")
+        (.setMetadata node metadata)
+        (.setUnschedulable spec true)
+        (.setSpec node spec)
+        (is (not (api/node-schedulable? {:node-blocklist-labels []} node 30 nil))))
+      (let [^V1Node node (V1Node.)
+            metadata (V1ObjectMeta.)
+            ^V1NodeSpec spec (V1NodeSpec.)]
+        (.setName metadata "NodeName")
+        (.setNamespace metadata "cook")
+        (.setMetadata node metadata)
+        (.setUnschedulable spec nil)
+        (.setSpec node spec)
+        ; nil Unschedulable should pass.
+        (is (api/node-schedulable? {:node-blocklist-labels []} node 30 nil)))
+      (let [^V1Node node (V1Node.)
+            metadata (V1ObjectMeta.)
+            ^V1NodeSpec spec (V1NodeSpec.)]
+        (.setName metadata "NodeName")
+        (.setNamespace metadata "cook")
+        (.setMetadata node metadata)
+        (.setUnschedulable spec false)
+        (.setSpec node spec)
+        (is (api/node-schedulable? {:node-blocklist-labels []} node 30 nil))))))
 
 (deftest test-initialize-pod-watch-helper
   (testing "only processes each pod once"


### PR DESCRIPTION
## Changes proposed in this PR

- Do not schedule nodes with unschedulable node-spec

## Why are we making these changes?
This allows node cordoning to work.

