### PR TITLE
Add support for ignoring a taint prefix.

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -304,7 +304,7 @@
                                      synthetic-pods-config node-blocklist-labels
                                      ^ExecutorService launch-task-executor-service
                                      cluster-definition state-atom state-locked?-atom dynamic-cluster-config?
-                                     compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-label-name]
+                                     compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name]
   cc/ComputeCluster
   (launch-tasks [this pool-name matches process-task-post-launch-fn]
     (let [task-metadata-seq (mapcat :task-metadata-seq matches)]
@@ -662,6 +662,7 @@
            ca-cert
            ca-cert-path
            cook-pool-taint-name
+           cook-pool-taint-prefix
            cook-pool-label-name
            ^String config-file
            dynamic-cluster-config?
@@ -690,6 +691,7 @@
          state-locked? false
          use-google-service-account? true
          cook-pool-taint-name "cook-pool"
+         cook-pool-taint-prefix ""
          cook-pool-label-name "cook-pool"}
     :as compute-cluster-config}
    {:keys [exit-code-syncer-state]}]
@@ -727,6 +729,6 @@
                                                     (atom state)
                                                     (atom state-locked?)
                                                     dynamic-cluster-config?
-                                                    compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-label-name)]
+                                                    compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name)]
     (cc/register-compute-cluster! compute-cluster)
     compute-cluster))

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -539,7 +539,7 @@
     (.setCreationTimestamp pod-metadata creation-timestamp)
     (-> outstanding-synthetic-pod
         .getSpec
-        (.addTolerationsItem (kapi/toleration-for-pool "cook-pool-taint-A" pool-name)))
+        (.addTolerationsItem (kapi/toleration-for-pool "cook-pool-taint-A" "prefix" pool-name)))
     outstanding-synthetic-pod))
 
 (defn node-helper [node-name cpus mem gpus gpu-model pool]
@@ -608,4 +608,5 @@
                                     false ; dynamic-cluster-config?
                                     rate-limit/AllowAllRateLimiter
                                     "some-random-taint-A"
+                                    "taint-prefix-1"
                                     "some-random-label-A")))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -144,7 +144,7 @@
                                                               "cpus" 1.0}
                                             :job {:job/pool {:pool/name "fake-pool-12"}}}
                              :hostname "kubehost"}
-              pod (api/task-metadata->pod "cook" {:name "testing-cluster" :cook-pool-taint-name "test-taint"} task-metadata)]
+              pod (api/task-metadata->pod "cook" {:name "testing-cluster" :cook-pool-taint-name "test-taint" :cook-pool-taint-prefix "taint-prefix-"} task-metadata)]
           (is (= "my-task" (-> pod .getMetadata .getName)))
           (is (= "cook" (-> pod .getMetadata .getNamespace)))
           (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
@@ -157,7 +157,7 @@
           (let [tolerations-on-pod (or (some-> pod .getSpec .getTolerations) [])
                 found-cook-pool-toleration (filter #(= "test-taint" (.getKey %)) tolerations-on-pod)]
             (is (= 1 (count found-cook-pool-toleration)))
-            (is (= "fake-pool-12" (-> found-cook-pool-toleration first .getValue))))
+            (is (= "taint-prefix-fake-pool-12" (-> found-cook-pool-toleration first .getValue))))
 
           (let [cook-sandbox-volume (->> pod
                                          .getSpec

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -100,323 +100,323 @@
 
 (deftest test-task-metadata->pod
   (tu/setup)
+  (let [fake-cc-config {:name "test-compute-cluster" :cook-pool-taint-name "test-taint" :cook-pool-taint-prefix ""}]
+    (testing "supplemental group ids"
+      (with-redefs [sh/sh (constantly {:exit 0 :out "12 34 56 78"})]
+        ; Invocation with user alice, successful
+        (let [task-metadata {:command {:user "alice"}
+                             :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                 fake-cc-config
+                                                 task-metadata)]
+          (is (= [12 34 56 78] (-> pod .getSpec .getSecurityContext .getSupplementalGroups)))))
 
-  (testing "supplemental group ids"
-    (with-redefs [sh/sh (constantly {:exit 0 :out "12 34 56 78"})]
-      ; Invocation with user alice, successful
-      (let [task-metadata {:command {:user "alice"}
-                           :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                               {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                               task-metadata)]
-        (is (= [12 34 56 78] (-> pod .getSpec .getSecurityContext .getSupplementalGroups)))))
+      (with-redefs [sh/sh (constantly {:exit 1})]
+        ; Invocation with user alice, cached
+        (let [task-metadata {:command {:user "alice"}
+                             :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                 fake-cc-config
+                                                 task-metadata)]
+          (is (= [12 34 56 78] (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))
 
-    (with-redefs [sh/sh (constantly {:exit 1})]
-      ; Invocation with user alice, cached
-      (let [task-metadata {:command {:user "alice"}
-                           :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                               {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                               task-metadata)]
-        (is (= [12 34 56 78] (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))
+        ; Invocation with user bob, unsucessful
+        (let [task-metadata {:command {:user "bob"}
+                             :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                 fake-cc-config
+                                                 task-metadata)]
+          (is (nil? (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))))
 
-      ; Invocation with user bob, unsucessful
-      (let [task-metadata {:command {:user "bob"}
-                           :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                               {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                               task-metadata)]
-        (is (nil? (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))))
+    (testing "creates pod from metadata"
+      (with-redefs [config/kubernetes (constantly {:default-workdir "/mnt/sandbox"})]
+        (let [task-metadata {:task-id "my-task"
+                             :command {:value "foo && bar"
+                                       :environment {"FOO" "BAR"}
+                                       :user (System/getProperty "user.name")}
+                             :container {:type :docker
+                                         :docker {:image "alpine:latest"}}
+                             ;; assume this task requested {cpu:1.0,mem:512} for the job's container
+                             ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
+                             :task-request {:resources {:mem 576
+                                                        :cpus 1.1}
+                                            :scalar-requests {"mem" 512
+                                                              "cpus" 1.0}
+                                            :job {:job/pool {:pool/name "fake-pool-12"}}}
+                             :hostname "kubehost"}
+              pod (api/task-metadata->pod "cook" {:name "testing-cluster" :cook-pool-taint-name "test-taint"} task-metadata)]
+          (is (= "my-task" (-> pod .getMetadata .getName)))
+          (is (= "cook" (-> pod .getMetadata .getNamespace)))
+          (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
+          (is (= "kubehost" (-> pod .getSpec .getNodeSelector (get api/k8s-hostname-label))))
+          (is (= 1 (count (-> pod .getSpec .getContainers))))
+          (is (= "testing-cluster" (-> pod .getMetadata .getLabels (get api/cook-pod-label))))
+          (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))
+          (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
 
-  (testing "creates pod from metadata"
-    (with-redefs [config/kubernetes (constantly {:default-workdir "/mnt/sandbox"})]
+          (let [tolerations-on-pod (or (some-> pod .getSpec .getTolerations) [])
+                found-cook-pool-toleration (filter #(= "test-taint" (.getKey %)) tolerations-on-pod)]
+            (is (= 1 (count found-cook-pool-toleration)))
+            (is (= "fake-pool-12" (-> found-cook-pool-toleration first .getValue))))
+
+          (let [cook-sandbox-volume (->> pod
+                                         .getSpec
+                                         .getVolumes
+                                         (filter (fn [^V1Volume v] (= "cook-sandbox-volume" (.getName v))))
+                                         first)]
+            (is (not (nil? cook-sandbox-volume)))
+            (is (not (nil? (.getEmptyDir cook-sandbox-volume)))))
+
+          (let [^V1Container container (-> pod .getSpec .getContainers first)
+                container-env (.getEnv container)]
+            (is (= "required-cook-job-container" (.getName container)))
+            (is (= (conj api/default-shell "foo && bar") (.getCommand container)))
+            (is (= "alpine:latest" (.getImage container)))
+            (is (not (nil? container)))
+            (is (= ["COOK_COMPUTE_CLUSTER_NAME"
+                    "COOK_POOL"
+                    "COOK_SANDBOX"
+                    "COOK_SCHEDULER_REST_URL"
+                    "EXECUTOR_PROGRESS_OUTPUT_FILE"
+                    "FOO"
+                    "HOME"
+                    "HOST_IP"
+                    "MESOS_DIRECTORY"
+                    "MESOS_SANDBOX"
+                    "SIDECAR_WORKDIR"]
+                   (->> container-env (map #(.getName %)) sort)))
+            (is (= "/mnt/sandbox" (.getWorkingDir container)))
+            (let [cook-sandbox-mount (->> container
+                                          .getVolumeMounts
+                                          (filter (fn [^V1VolumeMount m] (= "cook-sandbox-volume" (.getName m))))
+                                          first)]
+              (is (= "/mnt/sandbox" (.getMountPath cook-sandbox-mount))))
+
+            (assert-env-var-value container "FOO" "BAR")
+            (assert-env-var-value container "HOME" (.getWorkingDir container))
+            (assert-env-var-value container "MESOS_SANDBOX" (.getWorkingDir container))
+
+            (let [resources (-> container .getResources)]
+              (is (= 1.0 (-> resources .getRequests (get "cpu") .getNumber .doubleValue)))
+              (is (= (* 512.0 api/memory-multiplier) (-> resources .getRequests (get "memory") .getNumber .doubleValue)))
+              (is (= (* 512.0 api/memory-multiplier) (-> resources .getLimits (get "memory") .getNumber .doubleValue))))))))
+
+    (testing "user parameter"
+      (let [task-metadata {:task-id "my-task"
+                           :command {:value "foo && bar"
+                                     :environment {"FOO" "BAR"}
+                                     :user (System/getProperty "user.name")}
+                           :container {:type :docker
+                                       :docker {:image "alpine:latest"
+                                                :parameters [{:key "user"
+                                                              :value "100:10"}]}}
+                           ;; assume this task requested {cpu:1.0,mem:512} for the job's container
+                           ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
+                           :task-request {:resources {:mem 576
+                                                      :cpus 1.1}
+                                          :scalar-requests {"mem" 512
+                                                            "cpus" 1.0}}
+                           :hostname "kubehost"}
+            pod (api/task-metadata->pod "cook" "test-cluster" task-metadata)]
+        (is (= 100 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
+        (is (= 10 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))))
+
+    (testing "node selector for pool"
+      (let [pool-name "test-pool"
+            task-metadata {:command {:user "user"}
+                           :container {:docker {:parameters [{:key "user"
+                                                              :value "100:10"}]}}
+                           :task-request {:job {:job/pool {:pool/name pool-name}}
+                                          :scalar-requests {"mem" 512
+                                                            "cpus" 1.0}}}
+            ^V1Pod pod (api/task-metadata->pod nil {:cook-pool-label-name "pool-label-1"} task-metadata)
+            ^V1PodSpec pod-spec (.getSpec pod)
+            node-selector (.getNodeSelector pod-spec)]
+        (is (contains? node-selector "pool-label-1"))
+        (is (= pool-name (get node-selector "pool-label-1")))))
+
+    (testing "node selector for hostname"
+      (let [hostname "test-host"
+            task-metadata {:command {:user "user"}
+                           :container {:docker {:parameters [{:key "user"
+                                                              :value "100:10"}]}}
+                           :hostname hostname
+                           :task-request {:scalar-requests {"mem" 512
+                                                            "cpus" 1.0}}}
+            ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
+            ^V1PodSpec pod-spec (.getSpec pod)
+            node-selector (.getNodeSelector pod-spec)]
+        (is (contains? node-selector api/k8s-hostname-label))
+        (is (= hostname (get node-selector api/k8s-hostname-label)))))
+
+    (testing "cpu limit configurability"
+      (let [task-metadata {:command {:user "user"}
+                           :container {:docker {:parameters [{:key "user"
+                                                              :value "100:10"}]}}
+                           :task-request {:scalar-requests {"mem" 512
+                                                            "cpus" 1.0}}}
+            pod->cpu-limit-fn (fn [^V1Pod pod]
+                                (let [^V1Container container (-> pod .getSpec .getContainers first)
+                                      ^V1ResourceRequirements resources (-> container .getResources)]
+                                  (-> resources .getLimits (get "cpu"))))]
+
+        (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? true})]
+          (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
+            (is (= 1.0 (-> pod pod->cpu-limit-fn .getNumber .doubleValue)))))
+
+        (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? false})]
+          (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
+            (is (nil? (pod->cpu-limit-fn pod)))))
+
+        (with-redefs [config/kubernetes (constantly {})]
+          (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
+            (is (nil? (pod->cpu-limit-fn pod)))))))
+
+    (testing "checkpointing volumes"
+      (with-redefs [config/kubernetes (constantly {:default-checkpoint-config {:volume-name "cook-checkpointing-tools-volume"
+                                                                               :init-container-volume-mounts [{:path "/abc/xyz"}]
+                                                                               :main-container-volume-mounts [{:path "/abc/xyz"}
+                                                                                                              {:path "/qed/bbq"
+                                                                                                               :sub-path "efg/hij"}]}
+                                                   :init-container {:command ["init container command"]
+                                                                    :image "init container image"}})]
+        (let [task-metadata {:command {:user "user"}
+                             :container {:docker {:parameters [{:key "user"
+                                                                :value "100:10"}]}}
+                             :task-request {:scalar-requests {"mem" 512
+                                                              "cpus" 1.0}
+                                            :job {:job/checkpoint {:checkpoint/mode "auto"}}}}
+              ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
+              ^V1Container init-container (-> pod .getSpec .getInitContainers first)
+              ^V1Container main-container (-> pod .getSpec .getContainers (->> (filter #(= (.getName %) api/cook-container-name-for-job))) first)
+              init-container-paths (into #{} (-> init-container .getVolumeMounts
+                                                 (->> (filter #(= (.getName %) "cook-checkpointing-tools-volume")))
+                                                 (->> (map #(str (.getMountPath %) (.getSubPath %))))))
+              main-container-paths (into #{} (-> main-container .getVolumeMounts
+                                                 (->> (filter #(= (.getName %) "cook-checkpointing-tools-volume")))
+                                                 (->> (map #(str (.getMountPath %) (.getSubPath %))))))]
+          (is (= #{"/abc/xyz"} init-container-paths))
+          (is (= #{"/abc/xyz" "/qed/bbqefg/hij"} main-container-paths)))))
+
+    (testing "gpu task-metadata"
       (let [task-metadata {:task-id "my-task"
                            :command {:value "foo && bar"
                                      :environment {"FOO" "BAR"}
                                      :user (System/getProperty "user.name")}
                            :container {:type :docker
                                        :docker {:image "alpine:latest"}}
-                           ;; assume this task requested {cpu:1.0,mem:512} for the job's container
-                           ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
                            :task-request {:resources {:mem 576
-                                                      :cpus 1.1}
+                                                      :cpus 1.1
+                                                      :gpus 2}
                                           :scalar-requests {"mem" 512
                                                             "cpus" 1.0}
-                                          :job {:job/pool {:pool/name "fake-pool-12"}}}
+                                          :job {:job/environment #{{:environment/name "COOK_GPU_MODEL"
+                                                                    :environment/value "nvidia-tesla-p100"}}}}
                            :hostname "kubehost"}
-            pod (api/task-metadata->pod "cook" {:name "testing-cluster" :cook-pool-taint-name "test-taint"}  task-metadata)]
-        (is (= "my-task" (-> pod .getMetadata .getName)))
-        (is (= "cook" (-> pod .getMetadata .getNamespace)))
-        (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
-        (is (= "kubehost" (-> pod .getSpec .getNodeSelector (get api/k8s-hostname-label))))
-        (is (= 1 (count (-> pod .getSpec .getContainers))))
-        (is (= "testing-cluster" (-> pod .getMetadata .getLabels (get api/cook-pod-label))))
-        (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))
-        (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
+            ^V1Pod pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)
+            ^V1PodSpec pod-spec (.getSpec pod)
+            ^V1Container container (-> pod-spec .getContainers first)]
+        (is (= (-> pod-spec .getNodeSelector (get "cloud.google.com/gke-accelerator")) "nvidia-tesla-p100"))
+        (is (= (-> pod-spec .getNodeSelector (get "gpu-count")) "2"))
+        (is (= 2 (-> container .getResources .getRequests (get "nvidia.com/gpu") api/to-int)))
+        (is (= 2 (-> container .getResources .getLimits (get "nvidia.com/gpu") api/to-int)))))
 
-        (let [tolerations-on-pod (or (some-> pod .getSpec .getTolerations) [])
-              found-cook-pool-toleration (filter #(= "test-taint" (.getKey %)) tolerations-on-pod)]
-          (is (= 1 (count found-cook-pool-toleration)))
-          (is (= "fake-pool-12" (-> found-cook-pool-toleration first .getValue))))
+    (testing "job labels -> pod labels"
+      (let [task-metadata {:command {:user "test-user"}
+                           :task-request {:job {:job/label [{:label/key "not-platform/foo"
+                                                             :label/value "bar"}
+                                                            {:label/key "platform/baz"
+                                                             :label/value "qux"}
+                                                            {:label/key "platform/another"
+                                                             :label/value "included"}]}
+                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}]
 
-        (let [cook-sandbox-volume (->> pod
-                                       .getSpec
-                                       .getVolumes
-                                       (filter (fn [^V1Volume v] (= "cook-sandbox-volume" (.getName v))))
-                                       first)]
-          (is (not (nil? cook-sandbox-volume)))
-          (is (not (nil? (.getEmptyDir cook-sandbox-volume)))))
+        ; With a prefix configured
+        (with-redefs [config/kubernetes
+                      (constantly {:add-job-label-to-pod-prefix "platform/"})]
+          (let [^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                   fake-cc-config
+                                                   task-metadata)
+                pod-labels (-> pod .getMetadata .getLabels)]
+            (is (= "qux" (get pod-labels "platform/baz")))
+            (is (= "included" (get pod-labels "platform/another")))
+            (is (not (contains? pod-labels "not-platform/foo")))))
 
-        (let [^V1Container container (-> pod .getSpec .getContainers first)
-              container-env (.getEnv container)]
-          (is (= "required-cook-job-container" (.getName container)))
-          (is (= (conj api/default-shell "foo && bar") (.getCommand container)))
-          (is (= "alpine:latest" (.getImage container)))
-          (is (not (nil? container)))
-          (is (= ["COOK_COMPUTE_CLUSTER_NAME"
-                  "COOK_POOL"
-                  "COOK_SANDBOX"
-                  "COOK_SCHEDULER_REST_URL"
-                  "EXECUTOR_PROGRESS_OUTPUT_FILE"
-                  "FOO"
-                  "HOME"
-                  "HOST_IP"
-                  "MESOS_DIRECTORY"
-                  "MESOS_SANDBOX"
-                  "SIDECAR_WORKDIR"]
-                 (->> container-env (map #(.getName %)) sort)))
-          (is (= "/mnt/sandbox" (.getWorkingDir container)))
-          (let [cook-sandbox-mount (->> container
-                                        .getVolumeMounts
-                                        (filter (fn [^V1VolumeMount m] (= "cook-sandbox-volume" (.getName m))))
-                                        first)]
-            (is (= "/mnt/sandbox" (.getMountPath cook-sandbox-mount))))
+        ; With no prefix configured
+        (with-redefs [config/kubernetes (constantly {})]
+          (let [^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                   fake-cc-config
+                                                   task-metadata)
+                pod-labels (-> pod .getMetadata .getLabels)]
+            (is (not (contains? pod-labels "platform/baz")))
+            (is (not (contains? pod-labels "platform/another")))
+            (is (not (contains? pod-labels "not-platform/foo")))))))
 
-          (assert-env-var-value container "FOO" "BAR")
-          (assert-env-var-value container "HOME" (.getWorkingDir container))
-          (assert-env-var-value container "MESOS_SANDBOX" (.getWorkingDir container))
+    (testing "job application -> pod labels"
+      ; All workload- fields specified
+      (let [task-metadata {:command {:user "test-user"}
+                           :task-request {:job {:job/application {:application/workload-class "foo"
+                                                                  :application/workload-id "bar"
+                                                                  :application/workload-details "baz"}}
+                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
+            ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                               fake-cc-config
+                                               task-metadata)
+            pod-labels (-> pod .getMetadata .getLabels)]
+        (is (= "foo" (get pod-labels "workload-class")))
+        (is (= "bar" (get pod-labels "workload-id")))
+        (is (= "baz" (get pod-labels "workload-details"))))
 
-          (let [resources (-> container .getResources)]
-            (is (= 1.0 (-> resources .getRequests (get "cpu") .getNumber .doubleValue)))
-            (is (= (* 512.0 api/memory-multiplier) (-> resources .getRequests (get "memory") .getNumber .doubleValue)))
-            (is (= (* 512.0 api/memory-multiplier) (-> resources .getLimits (get "memory") .getNumber .doubleValue))))))))
+      ; No workload-class specified
+      (let [task-metadata {:command {:user "test-user"}
+                           :task-request {:job {:job/application {:application/workload-id "bar"
+                                                                  :application/workload-details "baz"}}
+                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
+            ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                               fake-cc-config
+                                               task-metadata)
+            pod-labels (-> pod .getMetadata .getLabels)]
+        (is (= "cook-job" (get pod-labels "workload-class")))
+        (is (= "bar" (get pod-labels "workload-id")))
+        (is (= "baz" (get pod-labels "workload-details"))))
 
-  (testing "user parameter"
-    (let [task-metadata {:task-id "my-task"
-                         :command {:value "foo && bar"
-                                   :environment {"FOO" "BAR"}
-                                   :user (System/getProperty "user.name")}
-                         :container {:type :docker
-                                     :docker {:image "alpine:latest"
-                                              :parameters [{:key "user"
-                                                            :value "100:10"}]}}
-                         ;; assume this task requested {cpu:1.0,mem:512} for the job's container
-                         ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
-                         :task-request {:resources {:mem 576
-                                                    :cpus 1.1}
-                                        :scalar-requests {"mem" 512
-                                                          "cpus" 1.0}}
-                         :hostname "kubehost"}
-          pod (api/task-metadata->pod "cook" "test-cluster" task-metadata)]
-      (is (= 100 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
-      (is (= 10 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))))
+      ; No workload-id specified
+      (let [task-metadata {:command {:user "test-user"}
+                           :task-request {:job {:job/application {:application/workload-class "foo"
+                                                                  :application/workload-details "baz"}}
+                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
+            ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                               fake-cc-config
+                                               task-metadata)
+            pod-labels (-> pod .getMetadata .getLabels)]
+        (is (= "foo" (get pod-labels "workload-class")))
+        (is (= "unspecified" (get pod-labels "workload-id")))
+        (is (= "baz" (get pod-labels "workload-details"))))
 
-  (testing "node selector for pool"
-    (let [pool-name "test-pool"
-          task-metadata {:command {:user "user"}
-                         :container {:docker {:parameters [{:key "user"
-                                                            :value "100:10"}]}}
-                         :task-request {:job {:job/pool {:pool/name pool-name}}
-                                        :scalar-requests {"mem" 512
-                                                          "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod nil {:cook-pool-label-name "pool-label-1"} task-metadata)
-          ^V1PodSpec pod-spec (.getSpec pod)
-          node-selector (.getNodeSelector pod-spec)]
-      (is (contains? node-selector "pool-label-1"))
-      (is (= pool-name (get node-selector "pool-label-1")))))
+      ; No workload-details specified
+      (let [task-metadata {:command {:user "test-user"}
+                           :task-request {:job {:job/application {:application/workload-class "foo"
+                                                                  :application/workload-id "bar"}}
+                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
+            ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                               fake-cc-config
+                                               task-metadata)
+            pod-labels (-> pod .getMetadata .getLabels)]
+        (is (= "foo" (get pod-labels "workload-class")))
+        (is (= "bar" (get pod-labels "workload-id")))
+        (is (= "none" (get pod-labels "workload-details"))))
 
-  (testing "node selector for hostname"
-    (let [hostname "test-host"
-          task-metadata {:command {:user "user"}
-                         :container {:docker {:parameters [{:key "user"
-                                                            :value "100:10"}]}}
-                         :hostname hostname
-                         :task-request {:scalar-requests {"mem" 512
-                                                          "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
-          ^V1PodSpec pod-spec (.getSpec pod)
-          node-selector (.getNodeSelector pod-spec)]
-      (is (contains? node-selector api/k8s-hostname-label))
-      (is (= hostname (get node-selector api/k8s-hostname-label)))))
-
-  (testing "cpu limit configurability"
-    (let [task-metadata {:command {:user "user"}
-                         :container {:docker {:parameters [{:key "user"
-                                                            :value "100:10"}]}}
-                         :task-request {:scalar-requests {"mem" 512
-                                                          "cpus" 1.0}}}
-          pod->cpu-limit-fn (fn [^V1Pod pod]
-                              (let [^V1Container container (-> pod .getSpec .getContainers first)
-                                    ^V1ResourceRequirements resources (-> container .getResources)]
-                                (-> resources .getLimits (get "cpu"))))]
-
-      (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? true})]
-        (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
-          (is (= 1.0 (-> pod pod->cpu-limit-fn .getNumber .doubleValue)))))
-
-      (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? false})]
-        (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
-          (is (nil? (pod->cpu-limit-fn pod)))))
-
-      (with-redefs [config/kubernetes (constantly {})]
-        (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
-          (is (nil? (pod->cpu-limit-fn pod)))))))
-
-  (testing "checkpointing volumes"
-    (with-redefs [config/kubernetes (constantly {:default-checkpoint-config {:volume-name "cook-checkpointing-tools-volume"
-                                                                             :init-container-volume-mounts [{:path "/abc/xyz"}]
-                                                                             :main-container-volume-mounts [{:path "/abc/xyz"}
-                                                                                                            {:path "/qed/bbq"
-                                                                                                             :sub-path "efg/hij"}]}
-                                                 :init-container {:command ["init container command"]
-                                                                  :image "init container image"}})]
-      (let [task-metadata {:command {:user "user"}
-                           :container {:docker {:parameters [{:key "user"
-                                                              :value "100:10"}]}}
-                           :task-request {:scalar-requests {"mem" 512
-                                                            "cpus" 1.0}
-                                          :job {:job/checkpoint {:checkpoint/mode "auto"}}}}
-            ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
-            ^V1Container init-container (-> pod .getSpec .getInitContainers first)
-            ^V1Container main-container (-> pod .getSpec .getContainers (->> (filter #(= (.getName %) api/cook-container-name-for-job))) first)
-            init-container-paths (into #{} (-> init-container .getVolumeMounts
-                                                              (->> (filter #(= (.getName %) "cook-checkpointing-tools-volume")))
-                                                              (->> (map #(str (.getMountPath %) (.getSubPath %))))))
-            main-container-paths (into #{} (-> main-container .getVolumeMounts
-                                                              (->> (filter #(= (.getName %) "cook-checkpointing-tools-volume")))
-                                                              (->> (map #(str (.getMountPath %) (.getSubPath %))))))]
-        (is (= #{"/abc/xyz"} init-container-paths))
-        (is (= #{"/abc/xyz" "/qed/bbqefg/hij"} main-container-paths)))))
-
-  (testing "gpu task-metadata"
-    (let [task-metadata {:task-id "my-task"
-                         :command {:value "foo && bar"
-                                   :environment {"FOO" "BAR"}
-                                   :user (System/getProperty "user.name")}
-                         :container {:type :docker
-                                     :docker {:image "alpine:latest"}}
-                         :task-request {:resources {:mem 576
-                                                    :cpus 1.1
-                                                    :gpus 2}
-                                        :scalar-requests {"mem" 512
-                                                          "cpus" 1.0}
-                                        :job {:job/environment #{{:environment/name "COOK_GPU_MODEL"
-                                                                  :environment/value "nvidia-tesla-p100"}}}}
-                         :hostname "kubehost"}
-          ^V1Pod pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)
-          ^V1PodSpec pod-spec (.getSpec pod)
-          ^V1Container container (-> pod-spec .getContainers first)]
-      (is (= (-> pod-spec .getNodeSelector (get "cloud.google.com/gke-accelerator")) "nvidia-tesla-p100"))
-      (is (= (-> pod-spec .getNodeSelector (get "gpu-count")) "2"))
-      (is (= 2 (-> container .getResources .getRequests (get "nvidia.com/gpu") api/to-int)))
-      (is (= 2 (-> container .getResources .getLimits (get "nvidia.com/gpu") api/to-int)))))
-
-  (testing "job labels -> pod labels"
-    (let [task-metadata {:command {:user "test-user"}
-                         :task-request {:job {:job/label [{:label/key "not-platform/foo"
-                                                           :label/value "bar"}
-                                                          {:label/key "platform/baz"
-                                                           :label/value "qux"}
-                                                          {:label/key "platform/another"
-                                                           :label/value "included"}]}
-                                        :scalar-requests {"mem" 512 "cpus" 1.0}}}]
-
-      ; With a prefix configured
-      (with-redefs [config/kubernetes
-                    (constantly {:add-job-label-to-pod-prefix "platform/"})]
-        (let [^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                                 {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                                 task-metadata)
-              pod-labels (-> pod .getMetadata .getLabels)]
-          (is (= "qux" (get pod-labels "platform/baz")))
-          (is (= "included" (get pod-labels "platform/another")))
-          (is (not (contains? pod-labels "not-platform/foo")))))
-
-      ; With no prefix configured
-      (with-redefs [config/kubernetes (constantly {})]
-        (let [^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                                 {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                                 task-metadata)
-              pod-labels (-> pod .getMetadata .getLabels)]
-          (is (not (contains? pod-labels "platform/baz")))
-          (is (not (contains? pod-labels "platform/another")))
-          (is (not (contains? pod-labels "not-platform/foo")))))))
-
-  (testing "job application -> pod labels"
-    ; All workload- fields specified
-    (let [task-metadata {:command {:user "test-user"}
-                         :task-request {:job {:job/application {:application/workload-class "foo"
-                                                                :application/workload-id "bar"
-                                                                :application/workload-details "baz"}}
-                                        :scalar-requests {"mem" 512 "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                             {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                             task-metadata)
-          pod-labels (-> pod .getMetadata .getLabels)]
-      (is (= "foo" (get pod-labels "workload-class")))
-      (is (= "bar" (get pod-labels "workload-id")))
-      (is (= "baz" (get pod-labels "workload-details"))))
-
-    ; No workload-class specified
-    (let [task-metadata {:command {:user "test-user"}
-                         :task-request {:job {:job/application {:application/workload-id "bar"
-                                                                :application/workload-details "baz"}}
-                                        :scalar-requests {"mem" 512 "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                             {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                             task-metadata)
-          pod-labels (-> pod .getMetadata .getLabels)]
-      (is (= "cook-job" (get pod-labels "workload-class")))
-      (is (= "bar" (get pod-labels "workload-id")))
-      (is (= "baz" (get pod-labels "workload-details"))))
-
-    ; No workload-id specified
-    (let [task-metadata {:command {:user "test-user"}
-                         :task-request {:job {:job/application {:application/workload-class "foo"
-                                                                :application/workload-details "baz"}}
-                                        :scalar-requests {"mem" 512 "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                             {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                             task-metadata)
-          pod-labels (-> pod .getMetadata .getLabels)]
-      (is (= "foo" (get pod-labels "workload-class")))
-      (is (= "unspecified" (get pod-labels "workload-id")))
-      (is (= "baz" (get pod-labels "workload-details"))))
-
-    ; No workload-details specified
-    (let [task-metadata {:command {:user "test-user"}
-                         :task-request {:job {:job/application {:application/workload-class "foo"
-                                                                :application/workload-id "bar"}}
-                                        :scalar-requests {"mem" 512 "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                             {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                             task-metadata)
-          pod-labels (-> pod .getMetadata .getLabels)]
-      (is (= "foo" (get pod-labels "workload-class")))
-      (is (= "bar" (get pod-labels "workload-id")))
-      (is (= "none" (get pod-labels "workload-details"))))
-
-    ; No workload- fields specified
-    (let [task-metadata {:command {:user "test-user"}
-                         :task-request {:job {:job/application {}}
-                                        :scalar-requests {"mem" 512 "cpus" 1.0}}}
-          ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                             {:name "test-compute-cluster" :cook-pool-taint-name "test-taint"}
-                                             task-metadata)
-          pod-labels (-> pod .getMetadata .getLabels)]
-      (is (= "cook-job" (get pod-labels "workload-class")))
-      (is (= "unspecified" (get pod-labels "workload-id")))
-      (is (= "none" (get pod-labels "workload-details"))))))
+      ; No workload- fields specified
+      (let [task-metadata {:command {:user "test-user"}
+                           :task-request {:job {:job/application {}}
+                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
+            ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                               fake-cc-config
+                                               task-metadata)
+            pod-labels (-> pod .getMetadata .getLabels)]
+        (is (= "cook-job" (get pod-labels "workload-class")))
+        (is (= "unspecified" (get pod-labels "workload-id")))
+        (is (= "none" (get pod-labels "workload-details")))))))
 
 (defn- k8s-volume->clj [^V1Volume volume]
   {:name (.getName volume)

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -70,7 +70,7 @@
                                                               {:kind :static :namespace "cook"} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
                                                               {} (atom :running) (atom false) false
-                                                              cook.rate-limit/AllowAllRateLimiter "t-a" "l-a")
+                                                              cook.rate-limit/AllowAllRateLimiter "t-a" "p-a" "l-a")
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -88,7 +88,7 @@
                                                               {:kind :per-user} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
                                                               {} (atom :running) (atom false) false
-                                                              cook.rate-limit/AllowAllRateLimiter "t-b" "l-b")
+                                                              cook.rate-limit/AllowAllRateLimiter "t-b" "p-b" "l-b")
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -108,7 +108,7 @@
                                                           {:kind :static :namespace "cook"} nil 3 nil nil
                                                           (Executors/newSingleThreadExecutor)
                                                           {} (atom :running) (atom false) false
-                                                          cook.rate-limit/AllowAllRateLimiter "t-c" "l-c")
+                                                          cook.rate-limit/AllowAllRateLimiter "t-c" "p-c" "l-c")
           node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 10 "nvidia-tesla-p100" nil)
                            "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 25 "nvidia-tesla-p100" nil)
                            "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil nil nil)


### PR DESCRIPTION
## Changes proposed in this PR

- Cook uses a k8s taint to determine which nodes are in which pool. When extracting the value of that taint, have cook subtract off a prefix and place the node in the pool with that suffix.

## Why are we making these changes?
- Gives us more flexibility in the taint value we attach to Cook-used nodes.

