### PR TITLE
Increase limit for launch-task-num-threads

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -694,10 +694,10 @@
     :as compute-cluster-config}
    {:keys [exit-code-syncer-state]}]
   (guard-invalid-synthetic-pods-config name synthetic-pods)
-  (when (not (< 0 launch-task-num-threads 64))
+  (when (not (< 0 launch-task-num-threads 512))
     (throw
       (ex-info
-        "Please configure :launch-task-num-threads to > 0 and < 64 in your config."
+        "Please configure :launch-task-num-threads to > 0 and < 512 in your config."
         compute-cluster-config)))
   (let [conn cook.datomic/conn
         cluster-entity-id (get-or-create-cluster-entity-id conn name)

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -314,7 +314,7 @@
       (is (kcc/factory-fn {:launch-task-num-threads 1
                            :use-google-service-account? false}
                           nil))
-      (is (kcc/factory-fn {:launch-task-num-threads 63
+      (is (kcc/factory-fn {:launch-task-num-threads 511
                            :use-google-service-account? false}
                           nil))
       (is (thrown? ExceptionInfo
@@ -322,7 +322,7 @@
                                     :use-google-service-account? false}
                                    nil)))
       (is (thrown? ExceptionInfo
-                   (kcc/factory-fn {:launch-task-num-threads 64
+                   (kcc/factory-fn {:launch-task-num-threads 512
                                     :use-google-service-account? false}
                                    nil))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Let us set a range up to 511 threads.

## Why are we making these changes?
- Give is more flexibility in tuning how many threads, in particular when we have to handle slow API response times.

