### PR TITLE
Make progress an absolute path in k8s

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -832,7 +832,7 @@
                    ;; Add a default progress file path to the environment when missing,
                    ;; preserving compatibility with Meosos + Cook Executor.
                    (not progress-file-path)
-                   (assoc progress-file-var (str task-id ".progress")))
+                   (assoc progress-file-var (str workdir "/" task-id ".progress")))
         main-env-vars (make-filtered-env-vars main-env)
         computed-mem (if checkpoint-memory-overhead (add-as-decimals mem checkpoint-memory-overhead) mem)]
 


### PR DESCRIPTION
## Changes proposed in this PR

- Make the path be an absolute path relative to the workdir

## Why are we making these changes?

This way the path for coordinating between the job and progress reader works regardless of CWD.
