### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,34 @@
+name: 'Cook Scheduler, CLI, and JobClient unit tests'
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+      - 'build**'
+      - kubernetes_integration
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-14.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+      - name: Setup tests
+        run: |
+          ./cli/travis/setup.sh
+          cd scheduler && ./travis/setup.sh
+      - name: Run unit tests
+        run: |
+          pushd ../jobclient/java && mvn test
+          popd && pushd ../jobclient/python && python -m pytest
+          popd && pushd ../cli && python -m pytest
+          popd && lein with-profile +test test :all-but-benchmark

--- a/scheduler/travis/setup.sh
+++ b/scheduler/travis/setup.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Install the current version of the jobclient
-pushd ${TRAVIS_BUILD_DIR}/jobclient/java
+pushd ${GITHUB_WORKSPACE}/jobclient/java
 mvn install
 popd
 


### PR DESCRIPTION
## Changes proposed in this PR

- Move all CI checks to GitHub actions

## Why are we making these changes?

- Better performance, more workers than current CI runner

