### PR TITLE
Add ability to parse single Job, update Job -> Builder

### DIFF
--- a/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
+++ b/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
@@ -382,4 +382,24 @@ public class JobTest {
         Assert.assertEquals(diskEntry.getLimit(), actualJob2.getDisk().getLimit(), EPSILON);
         Assert.assertEquals(diskEntry.getType(), actualJob2.getDisk().getType());
     }
+
+    @Test
+    public void testParseFromJsonToBuilder() {
+        final Job.Builder jobBuilder1 = new Job.Builder();
+        populateBuilder(jobBuilder1);
+        jobBuilder1.setDiskRequest(10.0);
+        jobBuilder1.setDiskType("pd-ssd");
+
+        final JSONObject json = convertJobToJsonObject(jobBuilder1.build());
+        final Job job1 = Job.parseFromJSON(json);
+
+        final Job.Builder jobBuilder2 = new Job.Builder().of(job1);
+        final Job job2 = jobBuilder2.build();
+
+        Assert.assertEquals(job1.getCommand(), job2.getCommand());
+        Assert.assertEquals(job1.getEnv(), job2.getEnv());
+        Assert.assertEquals(job1.getDisk().getRequest(), job2.getDisk().getRequest(), EPSILON);
+        Assert.assertEquals(job1.getDisk().getType(), job2.getDisk().getType());
+        Assert.assertEquals(job1.getConstraints().size(), job2.getConstraints().size());
+    }
 }


### PR DESCRIPTION
## Changes proposed in this PR

- Parse a single Job from a `JSONObject`.
- Update `Builder.of(job)` to set constraints and disk.

## Why are we making these changes?
In Spark we want to allow users to pass a jobspec, `spark.cook.jobspec`, which we'll pass directly down to `Job.parseFromJson` for submission.

