### PR TITLE
Updates java jobclient to v0.8.1

### DIFF
--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -3,7 +3,7 @@
   <groupId>twosigma</groupId>
   <artifactId>cook-jobclient</artifactId>
   <packaging>jar</packaging>
-  <version>0.8.1</version>
+  <version>0.8.2-SNAPSHOT</version>
   <name>cook-jobclient</name>
   <description>A Java API for connecting to the Cook scheduler, submitting, and monitoring jobs.</description>
   <licenses>

--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -3,7 +3,7 @@
   <groupId>twosigma</groupId>
   <artifactId>cook-jobclient</artifactId>
   <packaging>jar</packaging>
-  <version>0.7.2-SNAPSHOT</version>
+  <version>0.8.1</version>
   <name>cook-jobclient</name>
   <description>A Java API for connecting to the Cook scheduler, submitting, and monitoring jobs.</description>
   <licenses>

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -191,7 +191,7 @@
    {:dependencies [[criterium "0.4.4"]
                    [org.clojure/test.check "0.6.1"]
                    [org.mockito/mockito-core "1.10.19"]
-                   [twosigma/cook-jobclient "0.7.2-SNAPSHOT"]]}
+                   [twosigma/cook-jobclient "0.8.2-SNAPSHOT"]]}
 
    :test-console
    [:test {:jvm-opts ["-Dcook.test.logging.console"]}]


### PR DESCRIPTION
### Please Rebase and merge to preserve the two commits

## Changes proposed in this PR

- bumping the version

## Why are we making these changes?

To release the library.