### PR TITLE
Add ability to convert JSON->Builder, set fields when JSONizing

### DIFF
--- a/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -171,6 +171,8 @@ final public class Job {
             setPool(job.getPool());
             setLabels(job.getLabels());
             setDatasets(job.getDatasets());
+            setStatus(job.getStatus());
+            setPriority(job.getPriority());
             setDisk(job.getDisk());
             addConstraint(job.getConstraints());
             if (job.isMeaCulpaRetriesDisabled()) {
@@ -1084,6 +1086,7 @@ final public class Job {
         if (job.getDisk().shouldIncludeInJSON()) {
             object.put("disk", job.getDisk().toJSONObject());
         }
+        object.put("status", job.getStatus().name());
         object.put("priority", job.getPriority());
         object.put("max_retries", job.getRetries());
         object.put("disable_mea_culpa_retries", job.isMeaCulpaRetriesDisabled());
@@ -1202,7 +1205,9 @@ final public class Job {
             jobBuilder.setExecutor(json.getString("executor"));
         }
         jobBuilder.setPriority(json.getInt("priority"));
-        jobBuilder.setStatus(Status.fromString(json.getString("status")));
+        if (json.has("status")){
+            jobBuilder.setStatus(Status.fromString(json.getString("status")));
+        }
         if (json.has("disable_mea_culpa_retries") && json.getBoolean("disable_mea_culpa_retries")) {
             jobBuilder.disableMeaCulpaRetries();
         } else {
@@ -1265,7 +1270,9 @@ final public class Job {
                 }
             }
         }
-        jobBuilder.addInstances(Instance.parseFromJSON(json.getJSONArray("instances"), decorator));
+        if (json.has("instances")) {
+            jobBuilder.addInstances(Instance.parseFromJSON(json.getJSONArray("instances"), decorator));
+        }
         if (json.has("application")) {
             JSONObject applicationJson = json.getJSONObject("application");
             jobBuilder.setApplication(Application.parseFromJSON(applicationJson));

--- a/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -1184,7 +1184,8 @@ final public class Job {
      * @return a single {@link Job}.
      * @throws JSONException
      */
-    public static Job parseFromJSON(JSONObject json, InstanceDecorator decorator){
+    public static Job parseFromJSON(JSONObject json, InstanceDecorator decorator)
+            throws JSONException {
         Builder jobBuilder = new Builder();
         jobBuilder.setUUID(UUID.fromString(json.getString("uuid")));
         jobBuilder.setMemory(json.getDouble("mem"));

--- a/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
+++ b/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
@@ -79,17 +79,6 @@ public class JobTest {
         jobBuilder.addCpuArchitectureConstraint("intel-cascade-lake");
     }
 
-    private JSONObject convertJobToJsonObject(Job basicJob) {
-        final JSONObject json = Job.jsonizeJob(basicJob);
-        if (!json.has("instances")) {
-            json.put("instances", new JSONArray());
-        }
-        if (!json.has("status")) {
-            json.put("status", "INITIALIZED");
-        }
-        return json;
-    }
-
     @Test
     public void testJsonizeJobBasic() throws JSONException {
         final Job.Builder jobBuilder = new Job.Builder();
@@ -136,7 +125,7 @@ public class JobTest {
         populateBuilder(jobBuilder);
         final Job basicJob = jobBuilder.build();
 
-        final JSONObject json = convertJobToJsonObject(basicJob);
+        final JSONObject json = Job.jsonizeJob(basicJob);
         json.put("pool", "dummy-pool");
         final String jsonString = new JSONArray().put(json).toString();
         final List<Job> jobs = Job.parseFromJSON(jsonString);
@@ -201,7 +190,7 @@ public class JobTest {
             populateBuilder(jobBuilder);
             jobBuilder.setExecutor(executor.displayName());
 
-            final JSONObject json = convertJobToJsonObject(jobBuilder.build());
+            final JSONObject json = Job.jsonizeJob(jobBuilder.build());
             final String jsonString = new JSONArray().put(json).toString();
             final List<Job> jobs = Job.parseFromJSON(jsonString);
             Assert.assertEquals(jobs.size(), 1);
@@ -234,7 +223,7 @@ public class JobTest {
         populateBuilder(jobBuilder);
         jobBuilder.setProgressOutputFile(progressOutputFile);
 
-        final JSONObject json = convertJobToJsonObject(jobBuilder.build());
+        final JSONObject json = Job.jsonizeJob(jobBuilder.build());
         final String jsonString = new JSONArray().put(json).toString();
         final List<Job> jobs = Job.parseFromJSON(jsonString);
         Assert.assertEquals(jobs.size(), 1);
@@ -266,7 +255,7 @@ public class JobTest {
         populateBuilder(jobBuilder);
         jobBuilder.setProgressRegexString(progressOutputFile);
 
-        final JSONObject json = convertJobToJsonObject(jobBuilder.build());
+        final JSONObject json = Job.jsonizeJob(jobBuilder.build());
         final String jsonString = new JSONArray().put(json).toString();
         final List<Job> jobs = Job.parseFromJSON(jsonString);
         Assert.assertEquals(jobs.size(), 1);
@@ -303,7 +292,7 @@ public class JobTest {
         populateBuilder(jobBuilder);
         jobBuilder.setDatasets(datasets);
 
-        final JSONObject json = convertJobToJsonObject(jobBuilder.build());
+        final JSONObject json = Job.jsonizeJob(jobBuilder.build());
         final String jsonString = new JSONArray().put(json).toString();
         final List<Job> jobs = Job.parseFromJSON(jsonString);
         Assert.assertEquals(jobs.size(), 1);
@@ -357,7 +346,7 @@ public class JobTest {
         jobBuilder1.setDiskRequest(10.0);
         jobBuilder1.setDiskType("pd-ssd");
 
-        final JSONObject json = convertJobToJsonObject(jobBuilder1.build());
+        final JSONObject json = Job.jsonizeJob(jobBuilder1.build());
         final String jsonString = new JSONArray().put(json).toString();
         final List<Job> jobs = Job.parseFromJSON(jsonString);
         Assert.assertEquals(jobs.size(), 1);
@@ -372,7 +361,7 @@ public class JobTest {
         populateBuilder(jobBuilder2);
         jobBuilder2.setDisk(diskEntry);
 
-        final JSONObject json2 = convertJobToJsonObject(jobBuilder2.build());
+        final JSONObject json2 = Job.jsonizeJob(jobBuilder2.build());
         final String jsonString2 = new JSONArray().put(json2).toString();
         final List<Job> jobs2 = Job.parseFromJSON(jsonString2);
         Assert.assertEquals(jobs2.size(), 1);
@@ -384,13 +373,13 @@ public class JobTest {
     }
 
     @Test
-    public void testParseFromJsonToBuilder() {
+    public void testParseFromJsonToBuilderOfJob() {
         final Job.Builder jobBuilder1 = new Job.Builder();
         populateBuilder(jobBuilder1);
         jobBuilder1.setDiskRequest(10.0);
         jobBuilder1.setDiskType("pd-ssd");
 
-        final JSONObject json = convertJobToJsonObject(jobBuilder1.build());
+        final JSONObject json = Job.jsonizeJob(jobBuilder1.build());
         final Job job1 = Job.parseFromJSON(json);
 
         final Job.Builder jobBuilder2 = new Job.Builder().of(job1);
@@ -398,6 +387,25 @@ public class JobTest {
 
         Assert.assertEquals(job1.getCommand(), job2.getCommand());
         Assert.assertEquals(job1.getEnv(), job2.getEnv());
+        Assert.assertEquals(job1.getDisk().getRequest(), job2.getDisk().getRequest(), EPSILON);
+        Assert.assertEquals(job1.getDisk().getType(), job2.getDisk().getType());
+        Assert.assertEquals(job1.getConstraints().size(), job2.getConstraints().size());
+    }
+
+    @Test
+    public void testParseFromJsonToBuilder() {
+        final Job.Builder jobBuilder1 = new Job.Builder();
+        populateBuilder(jobBuilder1);
+        jobBuilder1.setDiskRequest(10.0);
+        jobBuilder1.setDiskType("pd-ssd");
+        final Job job1 = jobBuilder1.build();
+
+        final JSONObject json = Job.jsonizeJob(jobBuilder1.build());
+        final Job.Builder jobBuilder2 = new Job.Builder().parseFromJSON(json);
+        final Job job2 = jobBuilder2.build();
+
+        Assert.assertEquals(job1.getCpus(), job2.getCpus());
+        Assert.assertEquals(job1.getMemory(), job2.getMemory());
         Assert.assertEquals(job1.getDisk().getRequest(), job2.getDisk().getRequest(), EPSILON);
         Assert.assertEquals(job1.getDisk().getType(), job2.getDisk().getType());
         Assert.assertEquals(job1.getConstraints().size(), job2.getConstraints().size());


### PR DESCRIPTION
## Changes proposed in this PR

- Add `throws JSONException` to `parseFromJSON`
- Set `status` and `priority` when creating a `Builder` object  from a `Job`.
- Allow users to create a `Builder` object from a `JSONObject`.

## Why are we making these changes?
Forgot to throw the exception up. Also if you create a Job from a JSON object or vice versa it's incomplete. It makes more sense from an API perspective to allow users to parse JSON -> `Builder`, then be able to make further changes to the builder object. You can't do that with the existing code since Job is effectively immutable after built.

