### PR TITLE
Allow disk request/limit to be an int

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -1932,7 +1932,7 @@ class CookTest(util.CookTest):
                     self.assertNotIn("limit", job["disk"])
                     self.assertNotIn("type", job["disk"])
 
-                    # Valid job submission with disk request, size, and type
+                    # Valid job submission with disk request, limit, and type
                     job_uuid, resp = util.submit_job(
                         self.cook_url,
                         pool=pool_name,
@@ -1941,6 +1941,20 @@ class CookTest(util.CookTest):
                               'type': expected_type})
                     self.assertEqual(resp.status_code, 201, resp.text)
                     job = util.load_job(self.cook_url, job_uuid)
+                    self.assertEqual(job["disk"]["request"], expected_request)
+                    self.assertEqual(job["disk"]["limit"], expected_limit)
+                    self.assertEqual(job["disk"]["type"], expected_type)
+
+                    # Valid job submission with disk request and limit as int
+                    job_uuid, resp = util.submit_job(
+                        self.cook_url,
+                        pool=pool_name,
+                        disk={'request': int(expected_request),
+                              'limit': int(expected_limit),
+                              'type': expected_type})
+                    self.assertEqual(resp.status_code, 201, resp.text)
+                    job = util.load_job(self.cook_url, job_uuid)
+                    # disk request and limit are converted to doubles when entering into database
                     self.assertEqual(job["disk"]["request"], expected_request)
                     self.assertEqual(job["disk"]["limit"], expected_limit)
                     self.assertEqual(job["disk"]["type"], expected_type)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -795,7 +795,7 @@
                                 (let [disk-id (d/tempid :db.part/user)
                                       params {:db/id disk-id
                                               :resource/type :resource.type/disk
-                                              :resource.disk/request (:request disk)}]
+                                              :resource.disk/request (some-> disk :request double)}]
                                   [[:db/add db-id :job/resource disk-id]
                                    (reduce-kv
                                      ;; This only adds the optional params to the DB if they were explicitly set
@@ -804,7 +804,7 @@
                                          (assoc txn-map k v)
                                          txn-map))
                                      params
-                                     {:resource.disk/limit (:limit disk)
+                                     {:resource.disk/limit (some-> disk :limit double)
                                       :resource.disk/type (:type disk)})]))
                               (when (and gpus (not (zero? gpus)))
                                 (let [gpus-id (d/tempid :db.part/user)]

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -470,6 +470,14 @@
                              :headers {"Content-Type" "application/json"}
                              :authorization/user "dgrnbrg"
                              :body-params {"jobs" [(job {"request" 2.5})] "pool" "test-pool"}})))))
+      (testing "Int request of disk valid"
+        (is (= 201
+               (:status (h {:request-method :post
+                            :scheme :http
+                            :uri "/jobs"
+                            :headers {"Content-Type" "application/json"}
+                            :authorization/user "dgrnbrg"
+                            :body-params {"jobs" [(job {"request" 20.0})] "pool" "test-pool"}})))))
       (testing "Request of disk greater than max size invalid"
         (is (= 400
                (:status (h {:request-method :post

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -477,7 +477,7 @@
                             :uri "/jobs"
                             :headers {"Content-Type" "application/json"}
                             :authorization/user "dgrnbrg"
-                            :body-params {"jobs" [(job {"request" 20.0})] "pool" "test-pool"}})))))
+                            :body-params {"jobs" [(job {"request" 20})] "pool" "test-pool"}})))))
       (testing "Request of disk greater than max size invalid"
         (is (= 400
                (:status (h {:request-method :post


### PR DESCRIPTION
## Changes proposed in this PR

- Accept int values for disk request and limit

## Why are we making these changes?

- Improve user experience since people may want to just specify int values for disk request and limit

