### PR TITLE
Specify that disk request and limit are in MiB

### DIFF
--- a/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Disk.java
+++ b/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Disk.java
@@ -5,8 +5,8 @@ import org.json.JSONObject;
 
 public class Disk {
     /**
-     *   request - disk space guaranteed for the job
-     *   limit - max disk space the job can use
+     *   request - disk space guaranteed for the job (MiB)
+     *   limit - max disk space the job can use (MiB)
      *   type - type of disk for the job
      */
     private Double _request;

--- a/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -470,7 +470,7 @@ final public class Job {
         }
 
         /**
-         * Set the disk request, specifying the disk space guaranteed, to the job.
+         * Set the disk request (MiB), specifying the disk space guaranteed, to the job.
          * @param diskRequest The disk request for this job
          * @return this builder
          */
@@ -480,7 +480,7 @@ final public class Job {
         }
 
         /**
-         * Set the disk limit, specifying the max usable disk space, to the job.
+         * Set the disk limit (MiB), specifying the max usable disk space, to the job.
          * @param diskLimit The disk limit for this job
          * @return this builder
          */


### PR DESCRIPTION
## Changes proposed in this PR

- Add that disk request and limit are in MiB in the docstrings

## Why are we making these changes?
- Clarification for users

