### PR TITLE
Bumps python jobclient to v0.4.0

### DIFF
--- a/jobclient/python/cookclient/__init__.py
+++ b/jobclient/python/cookclient/__init__.py
@@ -28,7 +28,7 @@ from . import util
 from .containers import AbstractContainer
 from .jobs import Application, Disk, Job
 
-CLIENT_VERSION = '0.3.1'
+CLIENT_VERSION = '0.4.0'
 
 _LOG = logging.getLogger(__name__)
 _LOG.addHandler(logging.StreamHandler())


### PR DESCRIPTION
## Changes proposed in this PR

- bumping the version

## Why are we making these changes?

To release the library.
