### PR TITLE
Use add over set when parsing JSON.

### DIFF
--- a/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -165,11 +165,11 @@ final public class Job {
             setGpus(job.getGpus());
             setRetries(job.getRetries());
             setMaxRuntime(job.getMaxRuntime());
-            setEnv(job.getEnv());
+            addEnv(job.getEnv());
             setUris(job.getUris());
             setContainer(job.getContainer());
             setPool(job.getPool());
-            setLabels(job.getLabels());
+            addLabels(job.getLabels());
             setDatasets(job.getDatasets());
             setStatus(job.getStatus());
             setPriority(job.getPriority());
@@ -799,23 +799,19 @@ final public class Job {
             }
             if (json.has("env")) {
                 JSONObject envJson = json.getJSONObject("env");
-                Map<String, String> envMap = new HashMap<>();
                 if (envJson.length() > 0) {
                     for (String varName : JSONObject.getNames(envJson)) {
-                        envMap.put(varName, envJson.getString(varName));
+                        addEnv(varName, envJson.getString(varName));
                     }
                 }
-                setEnv(envMap);
             }
             if (json.has("labels")) {
                 JSONObject labelsJson = json.getJSONObject("labels");
-                Map<String, String> labelsMap = new HashMap<>();
                 if (labelsJson.length() > 0) {
                     for (String varName : JSONObject.getNames(labelsJson)) {
-                        labelsMap.put(varName, labelsJson.getString(varName));
+                        addLabel(varName, labelsJson.getString(varName));
                     }
                 }
-                setLabels(labelsMap);
             }
             JSONArray urisJson = json.optJSONArray("uris");
             if (urisJson != null) {

--- a/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
+++ b/jobclient/java/src/test/java/com/twosigma/cook/jobclient/JobTest.java
@@ -402,6 +402,8 @@ public class JobTest {
 
         final JSONObject json = Job.jsonizeJob(jobBuilder1.build());
         final Job.Builder jobBuilder2 = new Job.Builder().parseFromJSON(json);
+        jobBuilder2.addEnv("foo", "bar");
+        jobBuilder2.addLabel("foo", "bar");
         final Job job2 = jobBuilder2.build();
 
         Assert.assertEquals(job1.getCpus(), job2.getCpus());
@@ -409,5 +411,7 @@ public class JobTest {
         Assert.assertEquals(job1.getDisk().getRequest(), job2.getDisk().getRequest(), EPSILON);
         Assert.assertEquals(job1.getDisk().getType(), job2.getDisk().getType());
         Assert.assertEquals(job1.getConstraints().size(), job2.getConstraints().size());
+        // Added an extra label to job1.
+        Assert.assertEquals(job2.getLabels().size(), job1.getLabels().size() + 1);
     }
 }


### PR DESCRIPTION
## Changes proposed in this PR

- Uses `addLabel`/`addEnv` over `setLabel`/`setEnv`.

## Why are we making these changes?
Since the `Builder` object is not immutable, when you call `setLabels`, it sets it to an `ImmutableMap`, which prevents the user from being able to call `addLabel` afterwards.
