### PR TITLE
Adds location to compute cluster

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -339,11 +339,10 @@
     false))
 
 (defn config=?
-  "Returns true if we can consider current-config and
-  new-config to be equal. The location and state
-  fields are special in this regard -- location can
-  only transition from nil to non-nil, and state is
-  validated in cluster-state-change-valid?."
+  "Returns true if we can consider current-config and new-config to be equal.
+   The location and state fields are special in this regard -- location can
+   only transition from nil to non-nil, and state is validated in
+   cluster-state-change-valid?."
   [{current-location :location :as current-config}
    {new-location :location :as new-config}]
   (if (and (some? current-location)

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -394,6 +394,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db.install/_attribute :db.part/db
     :db/doc "If true, the state value can't be changed unless forced when calling update function.
              The background dynamic cluster update process does not force changes."}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :compute-cluster-config/location
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db
+    :db/doc "Location of compute cluster."}
    ;; Container Attributes
    {:db/id (d/tempid :db.part/db)
     :db/doc "variant records based on container/type"

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -312,8 +312,7 @@
                      start-time (java.util.Date.)
                      task-id (str (str (UUID/randomUUID)))} :as cfg}]
 
-  (let [unittest-compute-cluster (setup-fake-test-compute-cluster conn)
-        id (d/tempid :db.part/user)
+  (let [id (d/tempid :db.part/user)
         val @(d/transact conn [(cond->
                                  {:db/id id
                                   :instance/executor-id executor-id
@@ -327,7 +326,8 @@
                                   :job/_instance job
                                   :instance/compute-cluster
                                   (cc/db-id
-                                    (or compute-cluster unittest-compute-cluster))}
+                                    (or compute-cluster
+                                        (setup-fake-test-compute-cluster conn)))}
                                  cancelled (assoc :instance/cancelled true)
                                  end-time (assoc :instance/end-time end-time)
                                  executor (assoc :instance/executor executor)

--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -165,7 +165,11 @@
                   :state :deleted
                   :state-locked? true
                   :template "template"
-                  :location "us-east1"}} (compute-current-configs {} sample-in-mem-config))))
+                  :location "us-east1"}} (compute-current-configs {} sample-in-mem-config)))
+  (is (= {:a {:location "us-east1"}}
+         (compute-current-configs
+           {:a {:location "us-east1"}}
+           {:a {}}))))
 
 (deftest test-get-job-instance-ids-for-cluster-name
   (let [uri "datomic:mem://test-compute-cluster-config"


### PR DESCRIPTION
## Changes proposed in this PR

- adding a `location` field to the compute cluster

## Why are we making these changes?

To eventually support constraining job instances to specific locations, e.g. specific cloud regions.
