### PR TITLE
Sends synthetic pod to same location as previous checkpoint

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -973,10 +973,11 @@
                                        {:job-uuid->reserved-host (apply dissoc job-uuid->reserved-host matched-job-uuids)
                                         :launched-job-uuids (into matched-job-uuids launched-job-uuids)})))
 
-(defn job->preferred-compute-clusters
+(defn job->acceptable-compute-clusters
   "Given a job and a collection of compute clusters, returns the
-  subset of compute clusters that the job would prefer to run
-  (and therefore, autoscale) on"
+  subset of compute clusters that the job would accept running
+  (and therefore, autoscaling) on. Note that this can return an
+  empty collection if no compute cluster is deemed acceptable."
   [{:keys [job/checkpoint job/instance]} compute-clusters]
   (if (and checkpoint instance)
     ; If checkpointing is enabled, we want to run the new instance in the
@@ -992,15 +993,19 @@
                :config
                :location)]
       (if-let [previous-location
-               (->> compute-clusters
-                    (filter #(= (:name %) cluster-name))
-                    first
-                    compute-cluster->location)]
+               (-> @cook.compute-cluster/cluster-name->compute-cluster-atom
+                   (get cluster-name)
+                   compute-cluster->location)]
+        ; We assume here that the number of compute clusters is small
+        ; (~10 or less); otherwise, we'd optimize this by pre-computing
+        ; the map of location -> (compute clusters in that location) and
+        ; passing that pre-computed map into this function
         (filter
-          #(= (compute-cluster->location %) previous-location)
+          #(= (compute-cluster->location %)
+              previous-location)
           compute-clusters)
         ; If the previous instance's compute cluster name is not
-        ; present in the list of compute clusters passed, there's
+        ; present in the dictionary of compute clusters, there's
         ; not much we can do
         compute-clusters))
     compute-clusters))
@@ -1008,18 +1013,27 @@
 (defn distribute-jobs-to-compute-clusters
   "Given a collection of pending jobs and a collection of
   compute clusters, distributes the jobs amongst the compute
-  clusters, using job->preferred-compute-clusters preferences,
+  clusters, using job->acceptable-compute-clusters preferences,
   along with a hash of the pending job's uuid. Returns a
   compute-cluster->jobs map. That is the API any future
   improvements need to stick to."
-  [pending-jobs compute-clusters]
-  (group-by (fn choose-compute-cluster-for-autoscaling
-              [{:keys [job/uuid] :as job}]
-              (let [preferred-compute-clusters
-                    (job->preferred-compute-clusters job compute-clusters)]
+  [pending-jobs pool-name compute-clusters]
+  (let [compute-cluster->jobs
+        (group-by
+          (fn choose-compute-cluster-for-autoscaling
+            [{:keys [job/uuid] :as job}]
+            (let [preferred-compute-clusters
+                  (job->acceptable-compute-clusters job compute-clusters)]
+              (if (empty? preferred-compute-clusters)
+                :no-acceptable-compute-cluster
                 (nth preferred-compute-clusters
-                     (-> uuid hash (mod (count preferred-compute-clusters))))))
-            pending-jobs))
+                     (-> uuid hash (mod (count preferred-compute-clusters)))))))
+          pending-jobs)]
+    (when-let [jobs (:no-acceptable-compute-cluster compute-cluster->jobs)]
+      (log/info "In" pool-name
+                "pool, there are jobs with no acceptable compute cluster for autoscaling"
+                {:first-10-jobs (take 10 jobs)}))
+    (dissoc compute-cluster->jobs :no-acceptable-compute-cluster)))
 
 (defn trigger-autoscaling!
   "Autoscales the given pool to satisfy the given pending jobs, if:
@@ -1033,7 +1047,7 @@
             num-autoscaling-compute-clusters (count autoscaling-compute-clusters)]
         (when (and (pos? num-autoscaling-compute-clusters) (seq pending-jobs))
           (let [compute-cluster->jobs (distribute-jobs-to-compute-clusters
-                                        pending-jobs autoscaling-compute-clusters)]
+                                        pending-jobs pool-name autoscaling-compute-clusters)]
             (log/info "In" pool-name "pool, starting autoscaling")
             (doseq [[compute-cluster jobs-for-cluster] compute-cluster->jobs]
               (cc/autoscale! compute-cluster pool-name jobs-for-cluster adjust-job-resources-for-pool-fn))

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2304,40 +2304,45 @@
                               {:resource/type :mem :resource/amount 45}
                               {:resource/type :disk :resource.disk/request 50 :resource.disk/limit 100}]}])))))
 
-(deftest test-job->preferred-compute-clusters
-  (let [compute-cluster-1-name "test-compute-cluster-1"
-        compute-cluster-2-name "test-compute-cluster-2"
-        compute-cluster-3-name "test-compute-cluster-3"
-        location-a "test-location-a"
-        location-b "test-location-b"
-        compute-cluster-1 {:cluster-definition
-                           {:config {:location location-a}}
-                           :name compute-cluster-1-name}
-        compute-cluster-2 {:cluster-definition
-                           {:config {:location location-b}}
-                           :name compute-cluster-2-name}
-        compute-cluster-3 {:cluster-definition
-                           {:config {:location location-a}}
-                           :name compute-cluster-3-name}
-        instance-first {:instance/compute-cluster
-                        {:compute-cluster/cluster-name
-                         compute-cluster-2-name}
-                        :instance/start-time 1}
-        instance-second {:instance/compute-cluster
-                         {:compute-cluster/cluster-name
-                          compute-cluster-1-name}
-                         :instance/start-time 2}
-        instances [instance-second instance-first]]
+(let [compute-cluster-1-name "test-compute-cluster-1"
+      compute-cluster-2-name "test-compute-cluster-2"
+      compute-cluster-3-name "test-compute-cluster-3"
+      location-a "test-location-a"
+      location-b "test-location-b"
+      compute-cluster-1 {:cluster-definition
+                         {:config {:location location-a}}
+                         :name compute-cluster-1-name}
+      compute-cluster-2 {:cluster-definition
+                         {:config {:location location-b}}
+                         :name compute-cluster-2-name}
+      compute-cluster-3 {:cluster-definition
+                         {:config {:location location-a}}
+                         :name compute-cluster-3-name}
+      instance-first {:instance/compute-cluster
+                      {:compute-cluster/cluster-name
+                       compute-cluster-2-name}
+                      :instance/start-time 1}
+      instance-second {:instance/compute-cluster
+                       {:compute-cluster/cluster-name
+                        compute-cluster-1-name}
+                       :instance/start-time 2}
+      instances [instance-second instance-first]]
+
+  (deftest test-job->preferred-compute-clusters
+    (reset! cook.compute-cluster/cluster-name->compute-cluster-atom
+            {compute-cluster-1-name compute-cluster-1
+             compute-cluster-2-name compute-cluster-2
+             compute-cluster-3-name compute-cluster-3})
     (is (= [compute-cluster-1
             compute-cluster-3]
-           (sched/job->preferred-compute-clusters
+           (sched/job->acceptable-compute-clusters
              {:job/checkpoint true
               :job/instance instances}
              [compute-cluster-1
               compute-cluster-2
               compute-cluster-3])))
     (is (= [compute-cluster-2]
-           (sched/job->preferred-compute-clusters
+           (sched/job->acceptable-compute-clusters
              {:job/checkpoint true
               :job/instance [instance-first]}
              [compute-cluster-1
@@ -2346,7 +2351,7 @@
     (is (= [compute-cluster-1
             compute-cluster-2
             compute-cluster-3]
-           (sched/job->preferred-compute-clusters
+           (sched/job->acceptable-compute-clusters
              {:job/checkpoint true
               :job/instance []}
              [compute-cluster-1
@@ -2355,9 +2360,29 @@
     (is (= [compute-cluster-1
             compute-cluster-2
             compute-cluster-3]
-           (sched/job->preferred-compute-clusters
+           (sched/job->acceptable-compute-clusters
              {:job/checkpoint false
               :job/instance instances}
              [compute-cluster-1
               compute-cluster-2
-              compute-cluster-3])))))
+              compute-cluster-3]))))
+
+  (deftest test-distribute-jobs-to-compute-clusters
+    (reset! cook.compute-cluster/cluster-name->compute-cluster-atom
+            {compute-cluster-1-name compute-cluster-1
+             compute-cluster-2-name compute-cluster-2
+             compute-cluster-3-name compute-cluster-3})
+    (let [job {:job/checkpoint true
+               :job/instance instances}]
+      (is (= {compute-cluster-1 [job]}
+             (sched/distribute-jobs-to-compute-clusters
+               [job]
+               "test-pool"
+               [compute-cluster-1
+                compute-cluster-2
+                compute-cluster-3])))
+      (is (= {}
+             (sched/distribute-jobs-to-compute-clusters
+               [job]
+               "test-pool"
+               [compute-cluster-2]))))))


### PR DESCRIPTION
## Changes proposed in this PR

If checkpointing is enabled, sending the synthetic pod for a new instance to the same location (e.g. region) as the checkpointed instance.

## Why are we making these changes?

To take advantage of data locality for the checkpoint data.

## What's not in this PR?

This PR only affects synthetic pods, not the actual matching constraint to enforce where the real job pods run. That will come in a subsequent patch.
