### PR TITLE
Refactor cs kubernetes commands

### DIFF
--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -429,9 +429,9 @@ def get_compute_cluster_config(cluster, compute_cluster_name):
     """
     cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
     cook_compute_clusters = http.get(cluster, 'compute-clusters', params={}).json()
-    rval = next((c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
-                c['compute-cluster-name'] == compute_cluster_name), None)
+    rval = next(c['cluster-definition']['config'] for c in cook_compute_clusters['in-mem-configs'] if
+                c['name'] == compute_cluster_name)
     if not rval:
-        rval = next(c['cluster-definition']['config'] for c in cook_compute_clusters['in-mem-configs'] if
-                    c['name'] == compute_cluster_name)
+        rval = next((c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
+                     c['compute-cluster-name'] == compute_cluster_name), None)
     return rval

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -6,7 +6,7 @@ from functools import partial
 
 from cook import plugins
 from cook.mesos import download_file
-from cook.querying import get_compute_cluster_config, parse_entity_refs, query_unique_and_run, parse_entity_ref
+from cook.querying import parse_entity_refs, query_unique_and_run, parse_entity_ref
 from cook.util import guard_no_cluster
 
 def cat_using_download_file(instance, sandbox_dir_fn, path):

--- a/cli/cook/subcommands/cat.py
+++ b/cli/cook/subcommands/cat.py
@@ -20,25 +20,23 @@ def cat_using_download_file(instance, sandbox_dir_fn, path):
         sys.stderr.close()
         logging.exception(bpe)
 
-def kubectl_cat_instance_file(instance_uuid, _, path):
+def kubectl_cat_instance_file(instance_uuid, path):
     os.execlp('kubectl', 'kubectl',
               'exec',
               '-c', os.getenv('COOK_CONTAINER_NAME_FOR_JOB', 'required-cook-job-container'),
               '-it', instance_uuid,
               '--', 'cat', path)
 
-def cat_for_instance(job, instance, sandbox_dir_fn, cluster, path):
+def cat_for_instance(_, instance, sandbox_dir_fn, __, path):
     """
     Outputs the contents of the Mesos sandbox path for the given instance.
     When using Kubernetes, calls the exec command of the kubectl cli.
     """
     compute_cluster = instance["compute-cluster"]
     compute_cluster_type = compute_cluster["type"]
-    compute_cluster_name = compute_cluster["name"]
     if compute_cluster_type == "kubernetes" and ("end_time" not in instance or instance["end_time"] is None):
-        kubectl_cat_instance_file_fn = plugins.get_fn('kubectl-cat-for-instance', kubectl_cat_instance_file)
-        compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
-        kubectl_cat_instance_file_fn(job["user"], instance["task_id"], compute_cluster_config, path)
+        kubernetes_cat_instance_file_fn = plugins.get_fn('kubernetes-cat-for-instance', kubectl_cat_instance_file)
+        kubernetes_cat_instance_file_fn(instance["task_id"], path)
     else:
         cat_using_download_file(instance, sandbox_dir_fn, path)
 

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -107,7 +107,7 @@ def ls_for_instance_from_mesos(instance, sandbox_dir_fn, path, long_format, as_j
         else:
             logging.info('the directory is empty')
 
-def kubectl_ls_for_instance(instance_uuid, _, path, long_format, as_json):
+def kubectl_ls_for_instance(instance_uuid, path, long_format, as_json):
     if as_json:
         working_dir = subprocess.run(['kubectl',
                                       'exec',
@@ -148,18 +148,16 @@ def kubectl_ls_for_instance(instance_uuid, _, path, long_format, as_json):
             args.append(path)
         os.execlp(*args)
 
-def ls_for_instance(job, instance, sandbox_dir_fn, cluster, path, long_format, as_json):
+def ls_for_instance(_, instance, sandbox_dir_fn, __, path, long_format, as_json):
     """
     Lists contents of the Mesos sandbox path for the given instance.
     When using Kubernetes, calls the exec command of the kubectl cli.
     """
     compute_cluster = instance["compute-cluster"]
     compute_cluster_type = compute_cluster["type"]
-    compute_cluster_name = compute_cluster["name"]
     if compute_cluster_type == "kubernetes" and ("end_time" not in instance or instance["end_time"] is None):
-        kubectl_ls_for_instance_fn = plugins.get_fn('kubectl-ls-for-instance', kubectl_ls_for_instance)
-        compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
-        kubectl_ls_for_instance_fn(job["user"], instance["task_id"], compute_cluster_config, path, long_format, as_json)
+        kubernetes_ls_for_instance_fn = plugins.get_fn('kubernetes-ls-for-instance', kubectl_ls_for_instance)
+        kubernetes_ls_for_instance_fn(instance["task_id"], path, long_format, as_json)
     else:
         ls_for_instance_from_mesos(instance, sandbox_dir_fn, path, long_format, as_json)
 

--- a/cli/cook/subcommands/ls.py
+++ b/cli/cook/subcommands/ls.py
@@ -9,7 +9,7 @@ from functools import partial
 from tabulate import tabulate
 
 from cook import http, mesos, terminal, plugins
-from cook.querying import get_compute_cluster_config, query_unique_and_run, parse_entity_refs
+from cook.querying import query_unique_and_run, parse_entity_refs
 from cook.util import guard_no_cluster
 
 

--- a/cli/cook/subcommands/ssh.py
+++ b/cli/cook/subcommands/ssh.py
@@ -8,7 +8,7 @@ from cook.querying import get_compute_cluster_config, query_unique_and_run, pars
 from cook.util import print_info, guard_no_cluster
 
 
-def kubectl_exec_to_instance(instance_uuid, _):
+def kubectl_exec_to_instance(_, instance_uuid, __, ___):
     os.execlp('kubectl', 'kubectl',
               'exec',
               '-c', os.getenv('COOK_CONTAINER_NAME_FOR_JOB', 'required-cook-job-container'),

--- a/cli/cook/subcommands/tail.py
+++ b/cli/cook/subcommands/tail.py
@@ -113,7 +113,7 @@ def tail_using_read_file(instance, sandbox_dir_fn, path, num_lines_to_print, fol
     if follow:
         tail_follow(file_size, read, follow_sleep_seconds)
 
-def kubectl_tail_instance_file(instance_uuid, _, path, num_lines_to_print, follow):
+def kubectl_tail_instance_file(instance_uuid, path, num_lines_to_print, follow):
     args = ['kubectl', 'kubectl',
             'exec',
             '-c', os.getenv('COOK_CONTAINER_NAME_FOR_JOB', 'required-cook-job-container'),
@@ -125,7 +125,7 @@ def kubectl_tail_instance_file(instance_uuid, _, path, num_lines_to_print, follo
     os.execlp(*args)
 
 
-def tail_for_instance(job, instance, sandbox_dir_fn, cluster, path, num_lines_to_print, follow, follow_sleep_seconds):
+def tail_for_instance(_, instance, sandbox_dir_fn, __, path, num_lines_to_print, follow, follow_sleep_seconds):
     """
     Tails the contents of the Mesos sandbox path for the given instance. If follow is truthy, it will
     try and read more data from the file until the user terminates. This assumes files will not shrink.
@@ -133,11 +133,9 @@ def tail_for_instance(job, instance, sandbox_dir_fn, cluster, path, num_lines_to
     """
     compute_cluster = instance["compute-cluster"]
     compute_cluster_type = compute_cluster["type"]
-    compute_cluster_name = compute_cluster["name"]
     if compute_cluster_type == "kubernetes" and ("end_time" not in instance or instance["end_time"] is None):
-        kubectl_tail_instance_file_fn = plugins.get_fn('kubectl-tail-instance-file', kubectl_tail_instance_file)
-        compute_cluster_config = get_compute_cluster_config(cluster, compute_cluster_name)
-        kubectl_tail_instance_file_fn(job["user"], instance["task_id"], compute_cluster_config, path, num_lines_to_print, follow)
+        kubernetes_tail_instance_file_fn = plugins.get_fn('kubernetes-tail-instance-file', kubectl_tail_instance_file)
+        kubernetes_tail_instance_file_fn(instance["task_id"], path, num_lines_to_print, follow)
     else:
         tail_using_read_file(instance, sandbox_dir_fn, path, num_lines_to_print, follow, follow_sleep_seconds)
 

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.5.1'
+VERSION = '3.6.0'


### PR DESCRIPTION
## Changes proposed in this PR

- don't assume kubectl for cat, ls, tail on running job on kubernetes

## Why are we making these changes?

Make the plugin functions for ls, cat, tail be able to work without using kubectl when on kubernetes
