### PR TITLE
Fix NPE bug for sidecar mem limit

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -94,7 +94,8 @@
                         :port 23906
                         :resource-requirements {:cpu-request 0.1
                                                 :cpu-limit 0.1
-                                                :memory-request 128.0}}
+                                                :memory-request 128.0
+                                                :memory-limit 128.0}}
               :set-memory-limit? true}
  :log {:file #config/env "COOK_LOG_FILE"
        :levels {"datomic.db" :warn


### PR DESCRIPTION
## Changes proposed in this PR

- Add back sidecar memory limit to prevent NPE in open source

## Why are we making these changes?
- Prevent NPE

