### PR TITLE
Validates job resources by node type

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -955,7 +955,7 @@ class CookTest(util.CookTest):
 
         request_body = {'jobs': [job_specs[0]]}
         resp = util.session.post('%s/rawscheduler' % self.cook_url, json=request_body)
-        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.status_code, 201, resp.text)
 
         time.sleep(5)
 

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -688,3 +688,7 @@
 (defn queue-limits
   []
   (-> config :settings :queue-limits))
+
+(defn job-resource-limits
+  []
+  (-> config :settings :job-resource-limits))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -691,4 +691,4 @@
 
 (defn job-resource-limits
   []
-  (-> config :settings :job-resource-limits))
+  (-> config :settings :plugins :job-shape-validation))

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -19,7 +19,7 @@
   (check-job-submission-default [this]
     "The default return value to use in check-job-submission if we've run out of time.")
 
-  (check-job-submission [this job-map]
+  (check-job-submission [this job-map pool-name]
     "Check a job submission for correctness at the time of submission. Returns a map with one of two possibilities:
       {:status :accepted}
       {:status :rejected}

--- a/scheduler/src/cook/plugins/demo_plugin.clj
+++ b/scheduler/src/cook/plugins/demo_plugin.clj
@@ -28,14 +28,14 @@
 (defrecord DemoValidateSubmission []
   chd/JobSubmissionValidator
   (chd/check-job-submission
-    [this {:keys [name] :as job-map}]
+    [this {:keys [name] :as job-map} _]
     (if (and name (str/starts-with? name "plugin_test.submit_fail"))
       (generate-result :rejected "Message1- Fail to submit")
       (generate-result :accepted "Message2"))))
 
 (defrecord DemoValidateSubmission2 []
   chd/JobSubmissionValidator
-  (chd/check-job-submission [this {:keys [name]}]
+  (chd/check-job-submission [this {:keys [name]} _]
     (if (and name (str/starts-with? name "plugin_test.submit_fail2"))
       (generate-result :rejected "Message5- Plugin2 failed")
       (generate-result :accepted "Message6"))))

--- a/scheduler/src/cook/plugins/submission.clj
+++ b/scheduler/src/cook/plugins/submission.clj
@@ -22,7 +22,7 @@
             [cook.config :as config]
             [cook.plugins.definitions :refer [check-job-submission check-job-submission-default JobSubmissionValidator]]
             [cook.plugins.util]
-            ;[cook.regexp-tools :as regexp-tools]
+            [cook.regexp-tools :as regexp-tools]
             [mount.core :as mount])
   (:import (com.google.common.cache Cache CacheBuilder)
            (java.util.concurrent TimeUnit)))
@@ -138,11 +138,10 @@
       {:status :accepted}
       (let [limits-config (config/job-resource-limits)
             node-type-lookup-map
-            {}
-            ;(regexp-tools/match-based-on-pool-name
-            ;  (:non-gpu-jobs limits-config)
-            ;  pool-name
-            ;  :node-type-lookup)
+            (regexp-tools/match-based-on-pool-name
+              (:non-gpu-jobs limits-config)
+              pool-name
+              :node-type-lookup)
             constraint-pattern-fn
             (fn [attribute-of-interest]
               (->> constraints

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2140,7 +2140,9 @@
                                              %
                                              :override-group-immutability?
                                              override-group-immutability?) jobs)
-                               {:keys [status message]} (submission-plugin/plugin-jobs-submission jobs)]
+                               {:keys [status message]} (submission-plugin/plugin-jobs-submission
+                                                          jobs
+                                                          effective-pool-name)]
                            ; Does the plugin accept the submission?
                            (if (= :accepted status)
                              [false {::groups groups

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -482,22 +482,22 @@
 ;; Accept or reject based on the name of the job.
 (def fake-submission-plugin
   (reify JobSubmissionValidator
-    (check-job-submission-default [this] {:status :rejected :message "Too slow"})
-    (check-job-submission [this {:keys [name] :as job-map}]
+    (check-job-submission-default [_] {:status :rejected :message "Too slow"})
+    (check-job-submission [_ {:keys [name]} _]
       (if (str/starts-with? name "accept")
         {:status :accepted :cache-expires-at (-> 1 t/seconds t/from-now)}
         {:status :rejected :cache-expires-at (-> 1 t/seconds t/from-now) :message "Explicitly rejected by plugin"}))))
 
 (def reject-submission-plugin
   (reify JobSubmissionValidator
-    (check-job-submission-default [this] {:status :rejected :message "Default Rejected"})
-    (check-job-submission [this _]
+    (check-job-submission-default [_] {:status :rejected :message "Default Rejected"})
+    (check-job-submission [_ _ _]
       {:status :rejected :message "Explicit-reject by test plugin"})))
 
 (def accept-submission-plugin
   (reify JobSubmissionValidator
-    (check-job-submission-default [this] {:status :rejected :message "Default Rejected"})
-    (check-job-submission [this _]
+    (check-job-submission-default [_] {:status :rejected :message "Default Rejected"})
+    (check-job-submission [_ _ _]
       {:status :accepted :message "Explicit-accept by test plugin"})))
 
 (def defer-launch-plugin

--- a/scheduler/test/cook/test/jobclient/jobclient.clj
+++ b/scheduler/test/cook/test/jobclient/jobclient.clj
@@ -16,7 +16,7 @@
 (ns cook.test.jobclient.jobclient
   (:require [clojure.core.async :as async]
             [clojure.test :refer :all]
-            [cook.test.testutil :refer [create-dummy-instance restore-fresh-database! with-test-server]]
+            [cook.test.testutil :refer [create-dummy-instance restore-fresh-database! setup with-test-server]]
             [datomic.api :as d])
   (:import (com.twosigma.cook.jobclient FetchableURI FetchableURI$Builder Group Group$Builder Group$Status GroupListener HostPlacement
                                         HostPlacement$Builder HostPlacement$Type Job Job$Builder Job$Status JobClient JobClient$Builder
@@ -102,6 +102,7 @@
       @(d/transact conn [[:instance/update-state inst :instance.status/success [:reason/name :unknown]]]))))
 
 (deftest jobclient-tester
+  (setup)
   ; Start a mock server for testing
   (let [conn (restore-fresh-database! "datomic:mem://jobclient")
         db (d/db conn)

--- a/scheduler/test/cook/test/plugins/submission.clj
+++ b/scheduler/test/cook/test/plugins/submission.clj
@@ -3,7 +3,8 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [cook.plugins.definitions :as plugins]
-            [cook.plugins.submission :as submit]))
+            [cook.plugins.submission :as submit]
+            [cook.config :as config]))
 
 
 
@@ -13,7 +14,7 @@
         no-a-plugin (reify plugins/JobSubmissionValidator
                       (plugins/check-job-submission-default [this]
                         {:status :accepted})
-                      (plugins/check-job-submission [this {:keys [job/name]}]
+                      (plugins/check-job-submission [this {:keys [job/name]} _]
                         (if (str/includes? name "a")
                           {:status :rejected
                            :message "Job name contained an a"
@@ -23,7 +24,7 @@
         no-b-plugin (reify plugins/JobSubmissionValidator
                       (plugins/check-job-submission-default [this]
                         {:status :accepted})
-                      (plugins/check-job-submission [this {:keys [job/name]}]
+                      (plugins/check-job-submission [this {:keys [job/name]} _]
                         (if (str/includes? name "b")
                           {:status :rejected
                            :message "Job name contained a b"
@@ -38,22 +39,122 @@
     (testing "both pass"
       (is (= {:status :accepted
               :cache-expires-at short-expiry}
-             (plugins/check-job-submission composite-plugin {:job/name "foo"}))))
+             (plugins/check-job-submission composite-plugin {:job/name "foo"} nil))))
 
     (testing "b plugin fails"
       (is (= {:status :rejected
               :message "Job name contained a b"
               :cache-expires-at short-expiry}
-             (plugins/check-job-submission composite-plugin {:job/name "b"}))))
+             (plugins/check-job-submission composite-plugin {:job/name "b"} nil))))
 
     (testing "a plugin fails"
       (is (= {:status :rejected
               :message "Job name contained an a"
               :cache-expires-at short-expiry}
-             (plugins/check-job-submission composite-plugin {:job/name "a"}))))
+             (plugins/check-job-submission composite-plugin {:job/name "a"} nil))))
 
     (testing "both plugins fail"
       (is (= {:status :rejected
               :message "Job name contained an a\nJob name contained a b"
               :cache-expires-at short-expiry}
-             (plugins/check-job-submission composite-plugin {:job/name "ab"}))))))
+             (plugins/check-job-submission composite-plugin {:job/name "ab"} nil))))))
+
+(deftest test-job-shape-validation-plugin
+  (let [plugin (submit/->JopShapeValidationPlugin)
+        limits-config
+        {:node-type->limits {"t1-test-1" {:max-cpus 1
+                                          :max-disk 2
+                                          :max-mem 3}
+                             "t2-test-1" {:max-cpus 4
+                                          :max-disk 5
+                                          :max-mem 6}
+                             "t3-test-1" {:max-cpus 7
+                                          :max-disk 8
+                                          :max-mem 9}
+                             "t3-test-2" {:max-cpus 10
+                                          :max-disk 11
+                                          :max-mem 12}
+                             "t4-test-1" {:max-cpus 13
+                                          :max-disk 14
+                                          :max-mem 15}}
+         :non-gpu-jobs [{:pool-regex "test-pool"
+                         :node-type-lookup {nil {nil {nil "t1-test-1"
+                                                      "foo-cpu-arch" "t2-test-1"}
+                                                 "t3" {nil "t3-test-1"
+                                                       "bar-cpu-arch" "t3-test-2"}}
+                                            "t4-test-1" {nil {nil "t4-test-1"}}}}]}]
+    (with-redefs [config/job-resource-limits (constantly limits-config)]
+      (is (= {:status :accepted}
+             (plugins/check-job-submission
+               plugin
+               {}
+               "test-pool")))
+      (is (= {:status :accepted}
+             (plugins/check-job-submission
+               plugin
+               {:cpus 1 :disk 2 :mem 3}
+               "test-pool")))
+      (is (= {:status :accepted}
+             (plugins/check-job-submission
+               plugin
+               {:constraints [["cpu-architecture" "EQUALS" "foo-cpu-arch"]]
+                :cpus 4
+                :disk 5
+                :mem 6}
+               "test-pool")))
+      (is (= {:status :accepted}
+             (plugins/check-job-submission
+               plugin
+               {:constraints [["node-family" "EQUALS" "t3"]]
+                :cpus 7
+                :disk 8
+                :mem 9}
+               "test-pool")))
+      (is (= {:status :accepted}
+             (plugins/check-job-submission
+               plugin
+               {:constraints [["node-family" "EQUALS" "t3"]
+                              ["cpu-architecture" "EQUALS" "bar-cpu-arch"]]
+                :cpus 10
+                :disk 11
+                :mem 12}
+               "test-pool")))
+      (is (= {:status :accepted}
+             (plugins/check-job-submission
+               plugin
+               {:constraints [["node-type" "EQUALS" "t4-test-1"]]
+                :cpus 13
+                :disk 14
+                :mem 15}
+               "test-pool")))
+      (is (= :rejected
+             (:status (plugins/check-job-submission
+                        plugin
+                        {:constraints [["node-type" "EQUALS" "t4-test-1"]]
+                         :cpus 14
+                         :disk 14
+                         :mem 15}
+                        "test-pool"))))
+      (is (= :rejected
+             (:status (plugins/check-job-submission
+                        plugin
+                        {:constraints [["node-type" "EQUALS" "t4-test-1"]]
+                         :cpus 13
+                         :disk 15
+                         :mem 15}
+                        "test-pool"))))
+      (is (= :rejected
+             (:status (plugins/check-job-submission
+                        plugin
+                        {:constraints [["node-type" "EQUALS" "t4-test-1"]]
+                         :cpus 13
+                         :disk 14
+                         :mem 16}
+                        "test-pool"))))
+      (is (= :rejected
+             (:status (plugins/check-job-submission
+                        plugin
+                        {:cpus 13
+                         :disk 14
+                         :mem 15}
+                        "test-pool")))))))

--- a/scheduler/test/cook/test/plugins/submission.clj
+++ b/scheduler/test/cook/test/plugins/submission.clj
@@ -92,14 +92,14 @@
       (is (= {:status :accepted}
              (plugins/check-job-submission
                plugin
-               {:cpus 1 :disk 2 :mem 3}
+               {:cpus 1 :disk {:request 2} :mem 3}
                "test-pool")))
       (is (= {:status :accepted}
              (plugins/check-job-submission
                plugin
                {:constraints [["cpu-architecture" "EQUALS" "foo-cpu-arch"]]
                 :cpus 4
-                :disk 5
+                :disk {:request 5}
                 :mem 6}
                "test-pool")))
       (is (= {:status :accepted}
@@ -107,7 +107,7 @@
                plugin
                {:constraints [["node-family" "EQUALS" "t3"]]
                 :cpus 7
-                :disk 8
+                :disk {:request 8}
                 :mem 9}
                "test-pool")))
       (is (= {:status :accepted}
@@ -116,7 +116,7 @@
                {:constraints [["node-family" "EQUALS" "t3"]
                               ["cpu-architecture" "EQUALS" "bar-cpu-arch"]]
                 :cpus 10
-                :disk 11
+                :disk {:request 11}
                 :mem 12}
                "test-pool")))
       (is (= {:status :accepted}
@@ -124,7 +124,7 @@
                plugin
                {:constraints [["node-type" "EQUALS" "t4-test-1"]]
                 :cpus 13
-                :disk 14
+                :disk {:request 14}
                 :mem 15}
                "test-pool")))
       (is (= :rejected
@@ -132,7 +132,7 @@
                         plugin
                         {:constraints [["node-type" "EQUALS" "t4-test-1"]]
                          :cpus 14
-                         :disk 14
+                         :disk {:request 14}
                          :mem 15}
                         "test-pool"))))
       (is (= :rejected
@@ -140,7 +140,7 @@
                         plugin
                         {:constraints [["node-type" "EQUALS" "t4-test-1"]]
                          :cpus 13
-                         :disk 15
+                         :disk {:request 15}
                          :mem 15}
                         "test-pool"))))
       (is (= :rejected
@@ -148,13 +148,13 @@
                         plugin
                         {:constraints [["node-type" "EQUALS" "t4-test-1"]]
                          :cpus 13
-                         :disk 14
+                         :disk {:request 14}
                          :mem 16}
                         "test-pool"))))
       (is (= :rejected
              (:status (plugins/check-job-submission
                         plugin
                         {:cpus 13
-                         :disk 14
+                         :disk {:request 14}
                          :mem 15}
                         "test-pool")))))))

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2393,7 +2393,8 @@
               ; We thus expect 5 to submit, and 5 to fail and get rejected by
               ; out-of-timeout by the check-job-submission-default which returns
               ; Reject for accept-accept-plugin.
-              (is true (str/starts-with? "Total of 5 errors. First 3 are " (:error body)))
+              (is (= "Total of 6 errors; first 3 are:\nDefault Rejected\nDefault Rejected\nDefault Rejected"
+                    (:error body)))
               (is (str/includes? body "Default Rejected"))))))
 
       (testing "pool mover plugin"

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2049,6 +2049,7 @@
     (is (= (:uuid response-1) (get (second (list-jobs-fn submit-ms-1 (inc submit-ms-2))) "uuid")))))
 
 (deftest test-list-jobs-include-custom-executor
+  (setup)
   (let [conn (restore-fresh-database! "datomic:mem://test-list-jobs-include-custom-executor")
         handler (basic-handler conn)
         before (t/now)


### PR DESCRIPTION
## Changes proposed in this PR

Adding a new submission plugin that validates resources across node types.

## Why are we making these changes?

So that Cook can apply different resource limits based on the node-type, node-family, and cpu-architecture constraints that users can specify.
