### PR TITLE
Support longer pod names

### DIFF
--- a/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
+++ b/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
@@ -22,7 +22,7 @@ public class WatchHelper {
     public static Watch<V1Node> createNodeWatch(ApiClient apiClient, String resourceVersion) throws ApiException {
         CoreV1Api api = new CoreV1Api(apiClient);
         return Watch.createWatch(apiClient,
-                api.listNodeCall(null, null, null,null, null,null, resourceVersion, null, null, true, null),
+                api.listNodeCall(null, null, null, null, null, null, resourceVersion, null, null, true, null),
                 new TypeToken<Watch.Response<V1Node>>() {}.getType());
     }
 

--- a/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
+++ b/scheduler/java/com/twosigma/cook/kubernetes/WatchHelper.java
@@ -4,7 +4,7 @@ import com.google.common.reflect.TypeToken;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.openapi.models.V1Event;
+import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.V1Node;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.util.Watch;
@@ -15,23 +15,22 @@ public class WatchHelper {
         CoreV1Api api = new CoreV1Api(apiClient);
         return Watch.createWatch(apiClient,
                 api.listPodForAllNamespacesCall(null, null, null, null, null, null,
-                        resourceVersion, null, true, null),
+                        resourceVersion, null, null, true, null),
                 new TypeToken<Watch.Response<V1Pod>>() {}.getType());
     }
 
     public static Watch<V1Node> createNodeWatch(ApiClient apiClient, String resourceVersion) throws ApiException {
         CoreV1Api api = new CoreV1Api(apiClient);
         return Watch.createWatch(apiClient,
-                api.listNodeCall(null, null, null, null, null,
-                        null, resourceVersion, null, true, null),
+                api.listNodeCall(null, null, null,null, null,null, resourceVersion, null, null, true, null),
                 new TypeToken<Watch.Response<V1Node>>() {}.getType());
     }
 
-    public static Watch<V1Event> createEventWatch(ApiClient apiClient, String resourceVersion) throws ApiException {
+    public static Watch<CoreV1Event> createEventWatch(ApiClient apiClient, String resourceVersion) throws ApiException {
         CoreV1Api api = new CoreV1Api(apiClient);
         return Watch.createWatch(apiClient,
-                api.listEventForAllNamespacesCall(null, null, null, null,
-                        null, null, resourceVersion, null, true, null),
-                new TypeToken<Watch.Response<V1Event>>() {}.getType());
+                api.listEventForAllNamespacesCall(null, null, null, null, null,
+                        null, resourceVersion, null, null, true, null),
+                new TypeToken<Watch.Response<CoreV1Event>>() {}.getType());
     }
 }

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -114,7 +114,7 @@
                  [mount "0.1.12"]
 
                  ;; Kubernetes
-                 [io.kubernetes/client-java "7.0.0"]
+                 [io.kubernetes/client-java "11.0.0"]
                  [com.google.auth/google-auth-library-oauth2-http "0.16.2"]]
 
   :repositories {"maven2" {:url "https://files.couchbase.com/maven2/"}

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1294,7 +1294,7 @@
           nil ; pretty
           nil ; dryRun
           nil ; gracePeriodSeconds
-          nil ; oprphanDependents
+          nil ; orphanDependents
           nil ; propagationPolicy
           deleteOptions
           )

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -921,6 +921,7 @@
     (when pod-annotations
       (.setAnnotations metadata pod-annotations))
 
+    (.setHostnameAsFQDN pod-spec false)
     ; container
     (.setName container cook-container-name-for-job)
     (.setCommand container

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -23,8 +23,8 @@
            (io.kubernetes.client.openapi.apis CoreV1Api)
            (io.kubernetes.client.openapi.models
              V1Affinity V1Container V1ContainerPort V1ContainerState V1ContainerStatus V1DeleteOptions
-             V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1EnvVarSource V1Event V1HostPathVolumeSource
-             V1HTTPGetAction V1ObjectFieldSelector V1Node V1NodeAffinity V1NodeSelector V1NodeSelectorRequirement
+             V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1EnvVarSource CoreV1Event V1HostPathVolumeSource
+             V1HTTPGetAction V1ObjectFieldSelector V1Node V1NodeList V1NodeAffinity V1NodeSelector V1NodeSelectorRequirement
              V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodCondition V1PodSecurityContext V1PodSpec
              V1PodStatus V1Probe V1ResourceRequirements V1Toleration V1Volume V1VolumeBuilder V1VolumeMount)
            (io.kubernetes.client.util Watch)
@@ -141,6 +141,7 @@
   (timers/time! (metrics/timer "get-all-pods" compute-cluster-name)
     (let [api (CoreV1Api. api-client)
           current-pods (.listPodForAllNamespaces api
+                                                 nil ; allowWatchBookmarks
                                                  nil ; continue
                                                  nil ; fieldSelector
                                                  nil ; includeUninitialized
@@ -264,16 +265,17 @@
   "Help creating node watch. Returns a new watch Callable"
   [{:keys [^ApiClient api-client current-nodes-atom pool->node-name->node cook-pool-taint-name cook-pool-taint-prefix] compute-cluster-name :name :as compute-cluster}]
   (let [api (CoreV1Api. api-client)
-        current-nodes-raw
+        ^V1NodeList current-nodes-raw
         (timers/time! (metrics/timer "get-all-nodes" compute-cluster-name)
           (.listNode api
-                     nil ; includeUninitialized
                      nil ; pretty
+                     nil ; allowWatchBookmarks
                      nil ; continue
                      nil ; fieldSelector
                      nil ; labelSelector
                      nil ; limit
                      nil ; resourceVersion
+                     nil ; resourceVersionMatch
                      nil ; timeoutSeconds
                      nil ; watch
                      ))
@@ -342,7 +344,7 @@
           (log/info "In" compute-cluster-name "compute cluster, handling event watch updates")
           (while (.hasNext watch)
             (let [watch-response (.next watch)
-                  ^V1Event event (.-object watch-response)]
+                  ^CoreV1Event event (.-object watch-response)]
               (when event
                 (let [^V1ObjectReference involved-object (.getInvolvedObject event)]
                   (when (and involved-object (= (.getKind involved-object) "Pod"))


### PR DESCRIPTION
## Changes proposed in this PR

- Upgrade kubernetes-java to 11.0.0 to support setHostnameAsFQDN
- setHostnameAsFQDN to false so that we can support longer pod name default paths.

## Why are we making these changes?
Support longer podname paths.

