### PR TITLE
Fix bug where we would fail to check for config-defined compute clusters in cs

### DIFF
--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -429,8 +429,8 @@ def get_compute_cluster_config(cluster, compute_cluster_name):
     """
     cook_cluster_settings = http.get(cluster, 'settings', params={}).json()
     cook_compute_clusters = http.get(cluster, 'compute-clusters', params={}).json()
-    rval = next(c['cluster-definition']['config'] for c in cook_compute_clusters['in-mem-configs'] if
-                c['name'] == compute_cluster_name)
+    rval = next((c['cluster-definition']['config'] for c in cook_compute_clusters['in-mem-configs'] if
+                 c['name'] == compute_cluster_name), None)
     if not rval:
         rval = next((c for c in (s['config'] for s in cook_cluster_settings['compute-clusters']) if
                      c['compute-cluster-name'] == compute_cluster_name), None)


### PR DESCRIPTION
## Changes proposed in this PR

- Fix a bug.

## Why are we making these changes?

If there are no dynamic compute clustes, we will get a StopIterationException instead of falling through to config-defined clusters, thus breaking cs for those clusters. Fix the that bug with a default None.
