### PR TITLE
Allows getting /usage for all users

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -3455,6 +3455,7 @@
                          GroupResponse (partial pc/map-keys ->snake_case)
                          UserUsageResponse (partial pc/map-keys ->snake_case)
                          UsageInPool (partial pc/map-keys ->snake_case)
+                         UserUsageInPool (partial pc/map-keys ->snake_case)
                          UsageGroupInfo (partial pc/map-keys ->snake_case)
                          JobsUsageResponse (partial pc/map-keys ->snake_case)
                          s/Uuid str})]

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2762,15 +2762,15 @@
    (s/optional-key :grouped) [{:group UsageGroupInfo, :usage UsageInfo}]
    (s/optional-key :ungrouped) JobsUsageResponse})
 
-(def UsageInPool
-  "Schema for a usage within a particular pool."
-  (assoc UserUsageInPool
-    (s/optional-key :users) {s/Str UserUsageInPool}))
-
 (def UserUsageResponse
   "Schema for a usage response."
-  (assoc UsageInPool
-    (s/optional-key :pools) {s/Str UsageInPool}))
+  (assoc UserUsageInPool
+    (s/optional-key :pools) {s/Str UserUsageInPool}))
+
+(def UsageResponse
+  "Schema for a usage response."
+  (assoc UserUsageResponse
+    (s/optional-key :users) {s/Str UserUsageResponse}))
 
 (def zero-usage
   "Resource usage map 'zero' value"
@@ -3454,7 +3454,6 @@
                          JobResponse (partial pc/map-keys ->snake_case)
                          GroupResponse (partial pc/map-keys ->snake_case)
                          UserUsageResponse (partial pc/map-keys ->snake_case)
-                         UsageInPool (partial pc/map-keys ->snake_case)
                          UserUsageInPool (partial pc/map-keys ->snake_case)
                          UsageGroupInfo (partial pc/map-keys ->snake_case)
                          JobsUsageResponse (partial pc/map-keys ->snake_case)
@@ -3639,7 +3638,7 @@
           "/usage" []
           (c-api/resource
             {:produces ["application/json"],
-             :responses {200 {:schema UserUsageResponse
+             :responses {200 {:schema UsageResponse
                               :description "User's usage calculated."}
                          400 {:description "Invalid request format."}
                          401 {:description "Not authorized to read usage."}}

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -3453,6 +3453,7 @@
                         {JobResponseDeprecated (partial pc/map-keys ->snake_case)
                          JobResponse (partial pc/map-keys ->snake_case)
                          GroupResponse (partial pc/map-keys ->snake_case)
+                         UsageResponse (partial pc/map-keys ->snake_case)
                          UserUsageResponse (partial pc/map-keys ->snake_case)
                          UserUsageInPool (partial pc/map-keys ->snake_case)
                          UsageGroupInfo (partial pc/map-keys ->snake_case)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2760,16 +2760,17 @@
   "Schema for a user's usage within a particular pool."
   {(s/optional-key :total_usage) UsageInfo
    (s/optional-key :grouped) [{:group UsageGroupInfo, :usage UsageInfo}]
-   (s/optional-key :ungrouped) JobsUsageResponse
-   (s/optional-key :users)
-   {s/Str {:total_usage UsageInfo
-           (s/optional-key :grouped) [{:group UsageGroupInfo, :usage UsageInfo}]
-           (s/optional-key :ungrouped) JobsUsageResponse}}})
+   (s/optional-key :ungrouped) JobsUsageResponse})
+
+(def UsageInPool
+  "Schema for a usage within a particular pool."
+  (assoc UserUsageInPool
+    (s/optional-key :users) {s/Str UserUsageInPool}))
 
 (def UserUsageResponse
   "Schema for a usage response."
-  (assoc UserUsageInPool
-    (s/optional-key :pools) {s/Str UserUsageInPool}))
+  (assoc UsageInPool
+    (s/optional-key :pools) {s/Str UsageInPool}))
 
 (def zero-usage
   "Resource usage map 'zero' value"
@@ -3453,7 +3454,7 @@
                          JobResponse (partial pc/map-keys ->snake_case)
                          GroupResponse (partial pc/map-keys ->snake_case)
                          UserUsageResponse (partial pc/map-keys ->snake_case)
-                         UserUsageInPool (partial pc/map-keys ->snake_case)
+                         UsageInPool (partial pc/map-keys ->snake_case)
                          UsageGroupInfo (partial pc/map-keys ->snake_case)
                          JobsUsageResponse (partial pc/map-keys ->snake_case)
                          s/Uuid str})]

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -27,6 +27,7 @@
             [compojure.api.middleware :as c-mw]
             [compojure.api.sweet :as c-api]
             [compojure.core :refer [ANY GET POST routes]]
+            [cook.cached-queries :as cached-queries]
             [cook.compute-cluster :as cc]
             [cook.config :as config]
             [cook.datomic :as datomic]
@@ -2844,13 +2845,12 @@
             (util/get-running-job-ents db)
             pool (filter
                    #(= pool
-                       (or (-> % :job/pool :pool/name)
-                           (config/default-pool))))))]
+                       (cached-queries/job->pool-name %)))))]
     (if user
       (usage db pool with-group-breakdown? running-jobs)
       {:users
        (->> running-jobs
-            (group-by :job/user)
+            (group-by cached-queries/job-ent->user)
             (pc/map-vals
               #(usage db pool with-group-breakdown? %)))})))
 


### PR DESCRIPTION
## Changes proposed in this PR

- removing the requirement to pass `user` on `/usage` requests
- when `user` is not passed, making `/usage` return usage for all users that have running jobs

## Why are we making these changes?

It's useful to know usage for all users, e.g. when troubleshooting scheduling issues. The existing `/running` endpoint is not sufficient for this because it returns individual running tasks, and there can be thousands of running tasks on some clusters.