### PR TITLE
Add memory limit job label

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -904,8 +904,7 @@ class CookTest(util.CookTest):
         job_uuid1, resp1 = util.submit_job(self.cook_url, mem=20, command=command)
 
         # job requests 20MB of memory, allows memory usage above request, and allocates 25MB of memory
-        if util.using_kubernetes():
-            job_uuid2, resp2 = util.submit_job(self.cook_url, mem=20, command=command, env={"ts.platform/memory.allow-usage-above-request": True})
+        job_uuid2, resp2 = util.submit_job(self.cook_url, mem=20, command=command, env={"ts.platform/memory.allow-usage-above-request": True})
 
         try:
             self.assertEqual(resp1.status_code, 201, msg=resp.content)
@@ -914,14 +913,13 @@ class CookTest(util.CookTest):
             self.assertEqual('failed', job1['instances'][0]['status'])
             self.assertEqual(2002, job1['instances'][0]['reason_code'])
 
-            if util.using_kubernetes():
-                self.assertEqual(resp2.status_code, 201, msg=resp.content)
-                job2 = util.wait_for_job(self.cook_url, job_uuid2, 'completed')
-                self.assertEqual('completed', job2['status'])
-                self.assertEqual('success', job2['instances'][0]['status'])
+            self.assertEqual(resp2.status_code, 201, msg=resp.content)
+            job2 = util.wait_for_job(self.cook_url, job_uuid2, 'completed')
+            self.assertEqual('completed', job2['status'])
+            self.assertEqual('success', job2['instances'][0]['status'])
 
         finally:
-            util.kill_jobs(self.cook_url, [job_uuid1], assert_response=False)
+            util.kill_jobs(self.cook_url, [job_uuid1, job_uuid2], assert_response=False)
 
     def test_get_job(self):
         # schedule a job

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -896,7 +896,7 @@ class CookTest(util.CookTest):
         command = self.memory_limit_script_command(count=2048)
         self.memory_limit_exceeded_helper(command, 'mesos', mem=32)
 
-    @unittest.skipUnless(util.using_kubernetes())
+    @unittest.skipUnless(util.using_kubernetes(), "Memory limit can only be removed on kubernetes")
     def test_memory_limit(self):
         command = "python -c 'MB = 1024 * 1024 ; a = \"a\" * (25 * MB)'"
 

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -904,7 +904,7 @@ class CookTest(util.CookTest):
         job_uuid1, resp1 = util.submit_job(self.cook_url, mem=20, command=command)
 
         # job requests 20MB of memory, allows memory usage above request, and allocates 25MB of memory
-        job_uuid2, resp2 = util.submit_job(self.cook_url, mem=20, command=command, env={"ts.platform/memory.allow-usage-above-request": True})
+        job_uuid2, resp2 = util.submit_job(self.cook_url, mem=20, command=command, labels={"ts.platform/memory.allow-usage-above-request": "True"})
 
         try:
             self.assertEqual(resp1.status_code, 201, msg=resp1.content)

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -907,13 +907,13 @@ class CookTest(util.CookTest):
         job_uuid2, resp2 = util.submit_job(self.cook_url, mem=20, command=command, env={"ts.platform/memory.allow-usage-above-request": True})
 
         try:
-            self.assertEqual(resp1.status_code, 201, msg=resp.content)
+            self.assertEqual(resp1.status_code, 201, msg=resp1.content)
             job1 = util.wait_for_job(self.cook_url, job_uuid1, 'completed')
             self.assertEqual('completed', job1['status'])
             self.assertEqual('failed', job1['instances'][0]['status'])
             self.assertEqual(2002, job1['instances'][0]['reason_code'])
 
-            self.assertEqual(resp2.status_code, 201, msg=resp.content)
+            self.assertEqual(resp2.status_code, 201, msg=resp2.content)
             job2 = util.wait_for_job(self.cook_url, job_uuid2, 'completed')
             self.assertEqual('completed', job2['status'])
             self.assertEqual('success', job2['instances'][0]['status'])

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -882,12 +882,7 @@ class CookTest(util.CookTest):
 
     @pytest.mark.memlimit
     def test_memory_limit_exceeded_mesos_python(self):
-        settings_dict = util.settings(self.cook_url)
-        set_memory_limit = settings_dict.get("kubernetes", {}).get("set-memory-limit?", True)
-        if util.using_kubernetes() and not set_memory_limit:
-            command = self.infinite_memory_python_command()
-        else:
-            command = self.memory_limit_python_command()
+        command = self.memory_limit_python_command()
         self.memory_limit_exceeded_helper(command, 'mesos')
 
     @pytest.mark.memlimit
@@ -898,12 +893,7 @@ class CookTest(util.CookTest):
 
     @pytest.mark.memlimit
     def test_memory_limit_exceeded_mesos_script(self):
-        settings_dict = util.settings(self.cook_url)
-        set_memory_limit = settings_dict.get("kubernetes", {}).get("set-memory-limit?", True)
-        if util.using_kubernetes() and not set_memory_limit:
-            command = self.infinite_memory_script_command(count=2048)
-        else:
-            command = self.memory_limit_script_command(count=2048)
+        command = self.memory_limit_script_command(count=2048)
         self.memory_limit_exceeded_helper(command, 'mesos', mem=32)
 
     def test_get_job(self):

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -86,6 +86,7 @@
               :disallowed-var-names #{"BADVAR"}
               :init-container {:command ["/bin/sh" "-c" "echo sample init container running"]
                                :image "byrnedo/alpine-curl:latest"}
+              :memory-limit-job-label-name "platform/memory.allow-usage-above-request"
               :sidecar {;; Note that Cook automatically appends the :port given below 
                         ;; as the last argument in this :command vector.
                         :command ["cook-sidecar" "--file-server-port"]

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -944,7 +944,8 @@
     (.setStdin container true)
 
     ; add memory limit if user sets job label to allow memory usage above request to True
-    (set-mem-cpu-resources resources computed-mem (when-not (get labels (:memory-limit-job-label-name (config/kubernetes)) false) computed-mem) cpus cpus)
+    (let [allow-memory-usage-above-request (get labels (:memory-limit-job-label-name (config/kubernetes)) false)]
+      (set-mem-cpu-resources resources computed-mem (when-not allow-memory-usage-above-request computed-mem) cpus cpus))
 
     (when (pos? gpus)
       (.putLimitsItem resources "nvidia.com/gpu" (double->quantity gpus))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -943,8 +943,8 @@
     (.setTty container true)
     (.setStdin container true)
 
-    ; add memory limit if config flag set-memory-limit? is True
-    (set-mem-cpu-resources resources computed-mem (when (:set-memory-limit? (config/kubernetes)) computed-mem) cpus cpus)
+    ; add memory limit if user sets job label to allow memory usage above request to True
+    (set-mem-cpu-resources resources computed-mem (when-not (get labels (:memory-limit-job-label-name (config/kubernetes)) false) computed-mem) cpus cpus)
 
     (when (pos? gpus)
       (.putLimitsItem resources "nvidia.com/gpu" (double->quantity gpus))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -943,8 +943,8 @@
     (.setTty container true)
     (.setStdin container true)
 
-    ; add memory limit if user sets job label to allow memory usage above request to True
-    (let [allow-memory-usage-above-request (get labels (:memory-limit-job-label-name (config/kubernetes) "ts.platform/memory.allow-usage-above-request") false)]
+    ; add memory limit if user sets job label to allow memory usage above request to "true"
+    (let [allow-memory-usage-above-request (= "true" (some-> (get labels (:memory-limit-job-label-name (config/kubernetes) "ts.platform/memory.allow-usage-above-request")) (clojure.string/lower-case )) )]
       (set-mem-cpu-resources resources computed-mem (when-not allow-memory-usage-above-request computed-mem) cpus cpus))
 
     (when (pos? gpus)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -944,7 +944,7 @@
     (.setStdin container true)
 
     ; add memory limit if user sets job label to allow memory usage above request to True
-    (let [allow-memory-usage-above-request (get labels (:memory-limit-job-label-name (config/kubernetes) "ts.platform/allow-usage-above-request") false)]
+    (let [allow-memory-usage-above-request (get labels (:memory-limit-job-label-name (config/kubernetes) "ts.platform/memory.allow-usage-above-request") false)]
       (set-mem-cpu-resources resources computed-mem (when-not allow-memory-usage-above-request computed-mem) cpus cpus))
 
     (when (pos? gpus)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -944,7 +944,7 @@
     (.setStdin container true)
 
     ; add memory limit if user sets job label to allow memory usage above request to True
-    (let [allow-memory-usage-above-request (get labels (:memory-limit-job-label-name (config/kubernetes)) false)]
+    (let [allow-memory-usage-above-request (get labels (:memory-limit-job-label-name (config/kubernetes) "ts.platform/allow-usage-above-request") false)]
       (set-mem-cpu-resources resources computed-mem (when-not allow-memory-usage-above-request computed-mem) cpus cpus))
 
     (when (pos? gpus)

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -155,7 +155,7 @@
                                                               "cpus" 1.0}
                                             :job {:job/pool {:pool/name "fake-pool-12"}
                                                   :job/label [{:label/key "platform/memory.allow-usage-above-request"
-                                                               :label/value true}]}}
+                                                               :label/value "True"}]}}
                              :hostname "kubehost"}
               pod (api/task-metadata->pod "cook" {:name "testing-cluster" :cook-pool-taint-name "test-taint" :cook-pool-taint-prefix "taint-prefix-"} task-metadata)]
           (is (= "my-task" (-> pod .getMetadata .getName)))
@@ -164,7 +164,7 @@
           (is (= "kubehost" (-> pod .getSpec .getNodeSelector (get api/k8s-hostname-label))))
           (is (= 1 (count (-> pod .getSpec .getContainers))))
           (is (= "testing-cluster" (-> pod .getMetadata .getLabels (get api/cook-pod-label))))
-          (is (true? (-> pod .getMetadata .getLabels (get (:memory-limit-job-label-name (config/kubernetes))))))
+          (is (= "True" (-> pod .getMetadata .getLabels (get (:memory-limit-job-label-name (config/kubernetes))))))
           (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))
           (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Let users set on configurable job label if they want to allow memory usage above memory request


## Why are we making these changes?
- We found use cases of memory limit

