### PR TITLE
Logs exceptions in deep-merge-with

### DIFF
--- a/scheduler/src/cook/util.clj
+++ b/scheduler/src/cook/util.clj
@@ -210,8 +210,13 @@
   -> {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}"
   [f & maps]
   (apply
-    (fn m [& maps]
-      (if (every? map? maps)
-        (apply merge-with m maps)
-        (apply f maps)))
+    (fn merge
+      [& args]
+      (try
+        (if (every? map? args)
+          (apply merge-with merge args)
+          (apply f args))
+        (catch Exception e
+          (log/error e "Encountered exception while merging" {:args args})
+          (throw e))))
     maps))

--- a/scheduler/test/cook/test/util.clj
+++ b/scheduler/test/cook/test/util.clj
@@ -37,3 +37,15 @@
                          :d {:d :d}}
                         {:a {:a :a}
                          :d {:d :e}}))))
+
+(deftest test-deep-merge-with
+  (is (= {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}
+         (deep-merge-with +
+                          {:a {:b {:c 1 :d {:x 1 :y 2}} :e 3} :f 4}
+                          {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})))
+  (is (= {"foo" 2}
+         (deep-merge-with - {"foo" 3} {"foo" 1})))
+  (is (thrown? NullPointerException
+               (deep-merge-with - {"foo" nil} {"foo" 1})))
+  (is (thrown? NullPointerException
+               (deep-merge-with - {"foo" 1} {"foo" nil}))))


### PR DESCRIPTION
## Changes proposed in this PR

Logging exceptions in `deep-merge-with`.

## Why are we making these changes?

Without this, it's not possible to understand which portion of the input maps is causing an exception.
