### PR TITLE
Enable local k8s

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3016,7 +3016,7 @@ class CookTest(util.CookTest):
         self.assertEqual('failed', job['instances'][0]['status'], job)
         self.assertEqual('Invalid task', job['instances'][0]['reason_string'], job)
 
-    @unittest.skipUnless(util.enable_unspecified_pool(), "Test disabled in this run as default image isn't appropriate for default pool.")
+    @unittest.skipUnless(util.disable_unspecified_pool_test(), "Test disabled in this run as default image isn't appropriate for default pool.")
     # This test should be enabled for only one compute cluster type, e.g., GKE, mesos, etc. Because we want to run the full set of
     # integration tests across multiple compute cluster types, if they accept different types of image formats in COOK_TEST_DOCKER_IMAGE,
     # this test can be active when the 'wrong' format is specified and the backend gets confused with the not-understood image format.

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3016,7 +3016,7 @@ class CookTest(util.CookTest):
         self.assertEqual('failed', job['instances'][0]['status'], job)
         self.assertEqual('Invalid task', job['instances'][0]['reason_string'], job)
 
-    @unittest.skipUnless(util.disable_unspecified_pool_test(), "Test disabled in this run as default image isn't appropriate for default pool.")
+    @unittest.skipIf(util.disable_unspecified_pool_test(), "Test disabled in this run as default image isn't appropriate for default pool.")
     # This test should be enabled for only one compute cluster type, e.g., GKE, mesos, etc. Because we want to run the full set of
     # integration tests across multiple compute cluster types, if they accept different types of image formats in COOK_TEST_DOCKER_IMAGE,
     # this test can be active when the 'wrong' format is specified and the backend gets confused with the not-understood image format.

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -404,7 +404,7 @@ class CookTest(util.CookTest):
                                 'parameters': [{'key': 'env', 'value': 'FOO=bar'},
                                                {'key': 'workdir', 'value': '/var/lib/pqr'}]},
                      'volumes': [{'mode': 'RW',
-                                  'host-path': '/var/lib/mno',
+                                  'host-path': '/lib/modules',
                                   'container-path': '/var/lib/pqr'}]}
         job_uuid, resp = util.submit_job(self.cook_url, container=container)
         try:
@@ -2896,7 +2896,7 @@ class CookTest(util.CookTest):
         finally:
             util.kill_jobs(self.cook_url, [job_uuid1, job_uuid2])
 
-    @unittest.skipUnless(util.using_kubernetes(), 'Test requires kubernetes')
+    @unittest.skipUnless(util.using_kubernetes() and util.in_cloud(), 'Test requires kubernetes')
     def test_kubernetes_checkpointing(self):
         docker_image = util.docker_image()
         container = {'type': 'docker',
@@ -3016,6 +3016,11 @@ class CookTest(util.CookTest):
         self.assertEqual('failed', job['instances'][0]['status'], job)
         self.assertEqual('Invalid task', job['instances'][0]['reason_string'], job)
 
+    @unittest.skipUnless(util.enable_unspecified_pool(), "Test disabled in this run as default image isn't appropriate for default pool.")
+    # This test should be enabled for only one compute cluster type, e.g., GKE, mesos, etc. Because we want to run the full set of
+    # integration tests across multiple compute cluster types, if they accept different types of image formats in COOK_TEST_DOCKER_IMAGE,
+    # this test can be active when the 'wrong' format is specified and the backend gets confused with the not-understood image format.
+    # If this test fails after changing the default pool, you need to change the image format to match the new default pool.
     def test_submit_pool_unspecified(self):
         job_uuid, resp = util.submit_job(self.cook_url, pool=util.POOL_UNSPECIFIED)
         self.assertEqual(resp.status_code, 201, resp.content)

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -461,8 +461,8 @@ def missing_docker_image():
     return os.getenv('COOK_TEST_MISSING_DOCKER_IMAGE')
 
 
-def enable_unspecified_pool():
-    return os.getenv('COOK_TEST_ENABLE_UNSPECIFIED_POOL', None) is not None
+def disable_unspecified_pool_test():
+    return os.getenv('COOK_TEST_DISABLE_UNSPECIFIED_POOL_TEST', None) is not None
 
 
 def docker_working_directory():

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -461,6 +461,10 @@ def missing_docker_image():
     return os.getenv('COOK_TEST_MISSING_DOCKER_IMAGE')
 
 
+def enable_unspecified_pool():
+    return os.getenv('COOK_TEST_ENABLE_UNSPECIFIED_POOL', None) is not None
+
+
 def docker_working_directory():
     return os.getenv('COOK_TEST_DOCKER_WORKING_DIRECTORY')
 
@@ -1744,6 +1748,11 @@ def using_mesos():
 
 def supports_exit_code():
     return using_kubernetes() or is_cook_executor_in_use()
+
+
+def in_cloud():
+    """Are we running tests in the cloud?"""
+    return os.getenv("COOK_TEST_RUNNING_IN_CLOUD", None) is not None
 
 
 def pool_quota_test_pool():

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -302,6 +302,9 @@
                           datomic-uri)
      :hostname (fnk [[:config {hostname (.getCanonicalHostName (InetAddress/getLocalHost))}]]
                  hostname)
+     ;; Ignore these group ID's when computing supplemental group IDs.
+     :ignore-supplemental-group-ids (fnk [[:config {ignore-supplemental-group-ids #{}}]]
+                                      ignore-supplemental-group-ids)
      :cluster-dns-name (fnk [[:config {cluster-dns-name nil}]]
                          cluster-dns-name)
      :scheduler-rest-url (fnk [cluster-dns-name hostname server-https-port server-port]

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -8,7 +8,6 @@
             [cook.kubernetes.metrics :as metrics]
             [cook.mesos.sandbox :as sandbox]
             [cook.scheduler.scheduler :as scheduler]
-            [cook.util :as util]
             [metrics.timers :as timers])
   (:import (clojure.lang IAtom)
            (io.kubernetes.client.openapi.models V1ContainerStatus V1Pod V1PodStatus)

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -72,8 +72,10 @@
 (let [user->group-ids-miss-fn
       (fn [user-name]
         (log/info "Retrieving group ids for" user-name)
-        {:cache-expires-at (-> 30 t/minutes t/from-now)
-         :system-ids (retrieve-system-ids "-G" user-name)})]
+        (let [ignore-group-ids (get-in config/config [:settings :ignore-supplemental-group-ids])
+              system-group-ids (retrieve-system-ids "-G" user-name)]
+          {:cache-expires-at (-> 30 t/minutes t/from-now)
+           :system-ids (remove ignore-group-ids system-group-ids)}))]
   (defn user->all-group-ids [user-name]
     "Retrieves the (potentially cached) collection
     of all group ids for the specified user"

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -135,7 +135,7 @@
               ^V1Pod pod (api/task-metadata->pod "test-namespace"
                                                  fake-cc-config
                                                  task-metadata)]
-          (is (nil? (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))))
+          (is (= [] (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))))
 
     (testing "creates pod from metadata"
       (with-redefs [config/kubernetes (constantly {:default-workdir "/mnt/sandbox"


### PR DESCRIPTION
## Changes proposed in this PR

- Various changes to enable local kubernetes operation.
- Support for a supplemental group ignore list for k8s.

## Why are we making these changes?
We need these changes for integration tests to pass in non-GKE environments.
