### PR TITLE
Takes only top X jobs when triggering autoscaling

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -508,6 +508,7 @@
                                                         lock-objects
                                                         {:json-value (str lock-objects)})
                              :default-workdir "/mnt/sandbox"
+                             :max-jobs-for-autoscaling 1000
                              :pod-condition-containers-not-initialized-seconds 120
                              :pod-condition-unschedulable-seconds 60
                              :reconnect-delay-ms 60000

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1045,8 +1045,10 @@
       (let [autoscaling-compute-clusters (filter #(cc/autoscaling? % pool-name) compute-clusters)
             num-autoscaling-compute-clusters (count autoscaling-compute-clusters)]
         (when (and (pos? num-autoscaling-compute-clusters) (seq pending-jobs))
-          (let [compute-cluster->jobs (distribute-jobs-to-compute-clusters
-                                        pending-jobs pool-name autoscaling-compute-clusters
+          (let [{:keys [max-jobs-for-autoscaling]} (config/kubernetes)
+                pending-jobs-for-autoscaling (take max-jobs-for-autoscaling pending-jobs)
+                compute-cluster->jobs (distribute-jobs-to-compute-clusters
+                                        pending-jobs-for-autoscaling pool-name autoscaling-compute-clusters
                                         job->acceptable-compute-clusters-fn)]
             (log/info "In" pool-name "pool, starting autoscaling")
             (doseq [[compute-cluster jobs-for-cluster] compute-cluster->jobs]


### PR DESCRIPTION
## Changes proposed in this PR

Before distributing pending jobs to compute clusters for autoscaling purposes, take the top X (where X is configurable and defaults to 1,000).

## Why are we making these changes?

Distributing jobs to compute clusters can require database lookups, and we shouldn't be doing this on the entire pending queue of jobs, which can grow to tens of thousands of jobs. We already limit the number of synthetic pods we submit in downstream code, so it doesn't make sense to calculate the distribution on the entire queue.
