### PR TITLE
cook: pass decorator through to List<Job> parseFromJSON

### DIFF
--- a/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
+++ b/jobclient/java/src/main/java/com/twosigma/cook/jobclient/Job.java
@@ -1401,7 +1401,7 @@ final public class Job {
         List<Job> jobs = new ArrayList<Job>(jsonArray.length());
         for (int i = 0; i < jsonArray.length(); ++i) {
             JSONObject json = jsonArray.getJSONObject(i);
-            jobs.add(parseFromJSON(json));
+            jobs.add(parseFromJSON(json, decorator));
         }
         return jobs;
     }


### PR DESCRIPTION
## Changes proposed in this PR

- Pass `decorator down`

## Why are we making these changes?
My bad.

