### PR TITLE
Marks reason correctly for pod failures from preemption

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -307,8 +307,8 @@
   [{:keys [name] :as compute-cluster} pod-name {:keys [synthesized-state] :as k8s-actual-state-dict}]
   (if (some-> synthesized-state :pod-preempted-timestamp)
     (do
-      (log/info "In compute cluster" name ", pod" pod-name
-                "failed, seemingly due to preemption")
+      (log/info "In compute cluster" name ", pod" pod-name "failed and has"
+                ":pod-preempted-timestamp, so is being treated as preempted")
       (handle-pod-preemption compute-cluster pod-name))
     (handle-pod-completed compute-cluster pod-name k8s-actual-state-dict)))
 

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -97,6 +97,12 @@
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/succeeded)))
     (is (= :reason-normal-exit @reason))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/failed)))
+    (is (= :unknown @reason))
+    (is (= :cook-expected-state/completed
+           (do-process :cook-expected-state/running
+                       nil
+                       :custom-test-state {:pod-preempted-timestamp 1 :state :pod/failed})))
+    (is (= :reason-slave-removed @reason))
     (is (= :cook-expected-state/running (do-process :cook-expected-state/running :pod/running)))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/unknown)))
     (is (= :cook-expected-state/completed (do-process :cook-expected-state/running :pod/waiting)))


### PR DESCRIPTION
## Changes proposed in this PR

Making pods that fail and have a `:pod-preempted-timestamp` go down the `handle-pod-preemption` path so that they get the appropriate `Agent removed` failure reason.

## Why are we making these changes?

Currently, pod failures from node preemption result in the confusing and misleading `Unknown mesos reason`.
