### PR TITLE
Numerous autoscaling improvements

### DIFF
--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -30,3 +30,9 @@
 (mount/defstate ^Cache task->feature-vector-cache :start (new-cache config/config))
 (mount/defstate ^Cache job-uuid->dataset-maps-cache :start (new-cache config/config))
 (mount/defstate ^Cache user->group-ids-cache :start (new-cache config/config))
+(mount/defstate ^Cache autoscale-retry-blacklist :start
+  (-> (CacheBuilder/newBuilder)
+      (.maximumSize 50000)
+      ; We blocklist a given job from being autoscaled soon after a prior autoscaling.
+      (.expireAfterWrite (:autoscale-blocklist-seconds (config/kubernetes)) TimeUnit/SECONDS)
+      (.build)))

--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -30,9 +30,9 @@
 (mount/defstate ^Cache task->feature-vector-cache :start (new-cache config/config))
 (mount/defstate ^Cache job-uuid->dataset-maps-cache :start (new-cache config/config))
 (mount/defstate ^Cache user->group-ids-cache :start (new-cache config/config))
-(mount/defstate ^Cache autoscale-retry-blacklist :start
+(mount/defstate ^Cache recent-synthetic-pod-job-uuids :start
   (-> (CacheBuilder/newBuilder)
-      (.maximumSize 50000)
+      (.maximumSize (:synthetic-pod-recency-size (config/kubernetes)))
       ; We blocklist a given job from being autoscaled soon after a prior autoscaling.
-      (.expireAfterWrite (:autoscale-blocklist-seconds (config/kubernetes)) TimeUnit/SECONDS)
+      (.expireAfterWrite (:synthetic-pod-recency-seconds (config/kubernetes)) TimeUnit/SECONDS)
       (.build)))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -503,8 +503,7 @@
                          (repeatedly
                            controller-lock-num-shards
                            #(ReentrantLock.))]
-                     (merge {
-                             :autoscaling-scale-factor 1.0
+                     (merge {:autoscaling-scale-factor 1.0
                              :controller-lock-num-shards controller-lock-num-shards
                              :controller-lock-objects (with-meta
                                                         lock-objects

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -503,28 +503,30 @@
                          (repeatedly
                            controller-lock-num-shards
                            #(ReentrantLock.))]
-                     (merge {:controller-lock-num-shards controller-lock-num-shards
+                     (merge {
+                             :autoscaling-scale-factor 1.0
+                             :controller-lock-num-shards controller-lock-num-shards
                              :controller-lock-objects (with-meta
                                                         lock-objects
                                                         {:json-value (str lock-objects)})
                              :default-workdir "/mnt/sandbox"
                              :max-jobs-for-autoscaling 1000
-                             :synthetic-pod-recency-size 50000
-                             :synthetic-pod-recency-seconds 240 ; Should be greater than the time to start a node and have it accept workloads.
-                             :autoscaling-scale-factor 1.0
                              :pod-condition-containers-not-initialized-seconds 120
                              :pod-condition-unschedulable-seconds 60
                              :reconnect-delay-ms 60000
                              :set-container-cpu-limit? true
+                             :set-memory-limit? true
                              :synthetic-pod-condition-unschedulable-seconds 900
-                             :set-memory-limit? true}
+                             :synthetic-pod-recency-size 50000
+                             :synthetic-pod-recency-seconds 120 ; Should be greater than the time to start a node and have it accept workloads.
+                             }
                             kubernetes)))
      :offer-matching (fnk [[:config {offer-matching {}}]]
-                       (merge {:global-min-match-interval-millis 100
+                       (merge {:considerable-job-threshold-to-collect-job-match-statistics 20
+                               :global-min-match-interval-millis 100
                                :target-per-pool-match-interval-millis 3000
                                :unmatched-cycles-warn-threshold 500
-                               :unmatched-fraction-warn-threshold 0.5
-                               :considerable-job-threshold-to-collect-job-match-statistics 20}
+                               :unmatched-fraction-warn-threshold 0.5}
                               offer-matching))
      :queue-limits (fnk [[:config {queue-limits {}}]]
                      (merge {:update-interval-seconds 180}

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -523,7 +523,8 @@
                        (merge {:global-min-match-interval-millis 100
                                :target-per-pool-match-interval-millis 3000
                                :unmatched-cycles-warn-threshold 500
-                               :unmatched-fraction-warn-threshold 0.5}
+                               :unmatched-fraction-warn-threshold 0.5
+                               :considerable-job-threshold-to-collect-job-match-statistics 20}
                               offer-matching))
      :queue-limits (fnk [[:config {queue-limits {}}]]
                      (merge {:update-interval-seconds 180}

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -509,6 +509,8 @@
                                                         {:json-value (str lock-objects)})
                              :default-workdir "/mnt/sandbox"
                              :max-jobs-for-autoscaling 1000
+                             :autoscale-blocklist-seconds 240 ; Should be greater than the time to start a pod and have it accept workloads.
+                             :autoscaling-scale-factor 1.0
                              :pod-condition-containers-not-initialized-seconds 120
                              :pod-condition-unschedulable-seconds 60
                              :reconnect-delay-ms 60000

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -509,7 +509,8 @@
                                                         {:json-value (str lock-objects)})
                              :default-workdir "/mnt/sandbox"
                              :max-jobs-for-autoscaling 1000
-                             :autoscale-blocklist-seconds 240 ; Should be greater than the time to start a pod and have it accept workloads.
+                             :synthetic-pod-recency-size 50000
+                             :synthetic-pod-recency-seconds 240 ; Should be greater than the time to start a node and have it accept workloads.
                              :autoscaling-scale-factor 1.0
                              :pod-condition-containers-not-initialized-seconds 120
                              :pod-condition-unschedulable-seconds 60

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -531,9 +531,8 @@
                          (take max-launchable))
                     num-synthetic-pods-to-launch (count task-metadata-seq)]
                 (meters/mark! (metrics/meter "cc-synthetic-pod-submit-rate" name) num-synthetic-pods-to-launch)
-                (when (pos? num-synthetic-pods-to-launch)
-                  (log/info "In" name "compute cluster, launching" num-synthetic-pods-to-launch
-                            "synthetic pod(s) in" synthetic-task-pool-name "pool"))
+                (log/info "In" name "compute cluster, launching" num-synthetic-pods-to-launch
+                          "synthetic pod(s) in" synthetic-task-pool-name "pool")
                 (let [timer-context-launch-tasks (timers/start (metrics/timer "cc-synthetic-pod-launch-tasks" name))]
                   (cc/launch-tasks this
                                    synthetic-task-pool-name

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -485,7 +485,7 @@
                          (map (fn [{:keys [job/user job/uuid job/environment] :as job}]
                                 (let [pool-specific-resources
                                       ((adjust-job-resources-for-pool-fn pool-name) job (tools/job-ent->resources job))]
-                                  (.put cook.caches/autoscale-retry-blacklist uuid uuid)
+                                  (.put cook.caches/recent-synthetic-pod-job-uuids uuid uuid)
                                   {:command {:user (or user-from-synthetic-pods-config user)
                                              :value command}
                                    :container {:docker {:image image}}

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -482,6 +482,7 @@
                     user-from-synthetic-pods-config user
                     task-metadata-seq
                     (->> new-jobs
+                         (take max-launchable)
                          (map (fn [{:keys [job/user job/uuid job/environment] :as job}]
                                 (let [pool-specific-resources
                                       ((adjust-job-resources-for-pool-fn pool-name) job (tools/job-ent->resources job))]
@@ -527,8 +528,7 @@
                                                   :job {:job/pool {:pool/name synthetic-task-pool-name}
                                                         :job/environment environment}
                                                   ; Need to pass in resources to task-metadata->pod for gpu count
-                                                  :resources pool-specific-resources}})))
-                         (take max-launchable))
+                                                  :resources pool-specific-resources}}))))
                     num-synthetic-pods-to-launch (count task-metadata-seq)]
                 (meters/mark! (metrics/meter "cc-synthetic-pod-submit-rate" name) num-synthetic-pods-to-launch)
                 (log/info "In" name "compute cluster, launching" num-synthetic-pods-to-launch

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1260,7 +1260,7 @@
                                        (tools/filter-pending-jobs-for-quota pool-name (atom {}) (atom {})
                                                                             user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name))
                                        (take number-for-autoscaling))
-                filtered-autoscalable-jobs (remove #(.getIfPresent caches/autoscale-retry-blacklist (:job/uuid %)) autoscalable-jobs)]
+                filtered-autoscalable-jobs (remove #(.getIfPresent caches/recent-synthetic-pod-job-uuids (:job/uuid %)) autoscalable-jobs)]
             ; When we have at least 20 jobs being looked at, metric which fraction have matched.
             (when (> number-total 20)
               (histograms/update! (histograms/histogram (metric-title "fraction-unmatched" pool-name)) fraction-unmatched))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1265,17 +1265,18 @@
                                                                             user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name))
                                        (take max-jobs-for-autoscaling-scaled))
                 filtered-autoscalable-jobs (remove #(.getIfPresent caches/recent-synthetic-pod-job-uuids (:job/uuid %)) autoscalable-jobs)]
-            ; When we have at least a minimum jobs being looked at, metric which fraction have matched. This lets us measure how well we're matching on existing resources.
-            ; We only measure when there's a minimum jobs being considered so that our measurements are less noisy.
+            ; When we have at least a minimum number of jobs being looked at, metric which fraction have matched.
+            ; This lets us measure how well we're matching on existing resources.
+            ; We only measure when there's a minimum number of jobs being considered so that our measurements are less noisy.
             (when (> number-considerable-jobs (:considerable-job-threshold-to-collect-job-match-statistics (config/offer-matching)))
               (histograms/update! (histograms/histogram (metric-title "fraction-unmatched-jobs" pool-name)) fraction-unmatched-jobs))
             (when (pos? number-considerable-jobs)
               (log/info "In" pool-name "pool, autoscaling variables" {:autoscalable-jobs (count autoscalable-jobs)
-                                                                :filtered-autoscalable-jobs (count filtered-autoscalable-jobs)
-                                                                :fraction-unmatched-jobs fraction-unmatched-jobs
-                                                                :max-jobs-for-autoscaling-scaled max-jobs-for-autoscaling-scaled
-                                                                :number-considerable-jobs number-considerable-jobs
-                                                                :number-unmatched-jobs number-unmatched-jobs})
+                                                                      :filtered-autoscalable-jobs (count filtered-autoscalable-jobs)
+                                                                      :fraction-unmatched-jobs fraction-unmatched-jobs
+                                                                      :max-jobs-for-autoscaling-scaled max-jobs-for-autoscaling-scaled
+                                                                      :number-considerable-jobs number-considerable-jobs
+                                                                      :number-unmatched-jobs number-unmatched-jobs})
               ;; This call needs to happen *after* launch-matched-tasks!
               ;; in order to avoid autoscaling tasks taking up available
               ;; capacity that was already matched for real Cook tasks.

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -25,6 +25,7 @@
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
             [cook.cached-queries :as cached-queries]
+            [cook.caches :as caches]
             [cook.compute-cluster :as cc]
             [cook.config :as config]
             [cook.datomic :as datomic]
@@ -1016,7 +1017,7 @@
   along with a hash of the pending job's uuid. Returns a
   compute-cluster->jobs map. That is the API any future
   improvements need to stick to."
-  [pending-jobs pool-name compute-clusters job->acceptable-compute-clusters-fn]
+  [autoscalable-jobs pool-name compute-clusters job->acceptable-compute-clusters-fn]
   (let [compute-cluster->jobs
         (group-by
           (fn choose-compute-cluster-for-autoscaling
@@ -1027,7 +1028,7 @@
                 :no-acceptable-compute-cluster
                 (nth preferred-compute-clusters
                      (-> uuid hash (mod (count preferred-compute-clusters)))))))
-          pending-jobs)]
+          autoscalable-jobs)]
     (when-let [jobs (:no-acceptable-compute-cluster compute-cluster->jobs)]
       (log/info "In" pool-name
                 "pool, there are jobs with no acceptable compute cluster for autoscaling"
@@ -1038,22 +1039,25 @@
   "Autoscales the given pool to satisfy the given pending jobs, if:
   - There is at least one pending job
   - There is at least one compute cluster configured to do autoscaling"
-  [pending-jobs pool-name compute-clusters job->acceptable-compute-clusters-fn]
+  [pending-jobs-for-autoscaling pool-name compute-clusters job->acceptable-compute-clusters-fn]
   (timers/time!
     (timers/timer (metric-title "trigger-autoscaling!-duration" pool-name))
     (try
       (let [autoscaling-compute-clusters (filter #(cc/autoscaling? % pool-name) compute-clusters)
             num-autoscaling-compute-clusters (count autoscaling-compute-clusters)]
-        (when (and (pos? num-autoscaling-compute-clusters) (seq pending-jobs))
-          (let [{:keys [max-jobs-for-autoscaling]} (config/kubernetes)
-                pending-jobs-for-autoscaling (take max-jobs-for-autoscaling pending-jobs)
-                compute-cluster->jobs (distribute-jobs-to-compute-clusters
+        (when (and (pos? num-autoscaling-compute-clusters) (seq pending-jobs-for-autoscaling))
+          (log/info "In" pool-name "pool, preparing for autoscaling")
+          (let [compute-cluster->jobs (distribute-jobs-to-compute-clusters
                                         pending-jobs-for-autoscaling pool-name autoscaling-compute-clusters
                                         job->acceptable-compute-clusters-fn)]
             (log/info "In" pool-name "pool, starting autoscaling")
-            (doseq [[compute-cluster jobs-for-cluster] compute-cluster->jobs]
-              (cc/autoscale! compute-cluster pool-name jobs-for-cluster adjust-job-resources-for-pool-fn))
-            (log/info "In" pool-name "pool, done autoscaling"))))
+            (->> compute-cluster->jobs
+                 (map
+                   (fn [[compute-cluster jobs-for-cluster]]
+                     (future (cc/autoscale! compute-cluster pool-name jobs-for-cluster adjust-job-resources-for-pool-fn))))
+                 doall
+                 (run! deref)))
+          (log/info "In" pool-name "pool, done autoscaling")))
       (catch Throwable e
         (log/error e "In" pool-name "pool, encountered error while triggering autoscaling")))))
 
@@ -1099,15 +1103,17 @@
                                                           frequencies)
               user->number-total-considerable-jobs (->> considerable-jobs
                                                         (map cached-queries/job-ent->user)
-                                                        frequencies)]
+                                                        frequencies)
+              number-matched (count matched-job-uuids)
+              number-total (count considerable-jobs)
+              number-unmatched (- number-total number-matched)]
 
           (log/info "In" pool-name "pool, matching offers to considerable jobs"
                     {:jobs-considerable {:head-matched? matched-considerable-jobs-head?
                                          :head-resources first-considerable-job-resources
-                                         :number-matched (count matched-job-uuids)
-                                         :number-total (count considerable-jobs)
-                                         :number-unmatched (- (count considerable-jobs)
-                                                              (count matched-job-uuids))
+                                         :number-matched number-matched
+                                         :number-total number-total
+                                         :number-unmatched number-unmatched
                                          :stats (jobs->stats considerable-jobs)
                                          :user->number-matched user->number-matched-considerable-jobs
                                          :user->number-total user->number-total-considerable-jobs
@@ -1232,16 +1238,43 @@
                     (launch-matched-tasks! matches conn db fenzo mesos-run-as-user pool-name)
                     (update-host-reservations! rebalancer-reservation-atom matched-job-uuids)
                     matched-considerable-jobs-head?))
+                ; Absolute maximum jobs we will consider autoscaling to.
+                {:keys [max-jobs-for-autoscaling autoscaling-scale-factor]} (config/kubernetes)
+                ; The fraction of jobs we tried to match that actually matched.
+                fraction-unmatched (if (pos? number-total) (/ (float number-unmatched) number-total) 0)
+                ; We want to autoscale any unmatched job, or
+                ; We want to scale our max-jobs-for-autoscaling by the fraction of the jobs we just matched.
+                ; E.g. If we matched 20% of the queue, then we want to autoscale to 20% of max-jobs-for-autoscaling)
+                ; We include a scale factor however, so that if we match 20$ and scale factor is 2.5, we'll generate
+                ; pods for 50% of max-jobs-for-autoscaling.
+                number-for-autoscaling (-> fraction-unmatched
+                                           (* autoscaling-scale-factor)
+                                           (min 1) ; Can't match more than 100% of max-jobs-for-autoscaling.
+                                           (* max-jobs-for-autoscaling)
+                                           int
+                                           (max number-unmatched)) ; Autoscale at least the pods that failed to match.
                 ;; We need to filter pending jobs based on quota so that we don't
                 ;; trigger autoscaling beyond what users have quota to actually run
                 autoscalable-jobs (->> pool-name
                                        (get @pool-name->pending-jobs-atom)
                                        (tools/filter-pending-jobs-for-quota pool-name (atom {}) (atom {})
-                                         user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name)))]
+                                                                            user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name))
+                                       (take number-for-autoscaling))
+                filtered-autoscalable-jobs (remove #(.getIfPresent caches/autoscale-retry-blacklist (:job/uuid %)) autoscalable-jobs)]
+            ; When we have at least 20 jobs being looked at, metric which fraction have matched.
+            (when (> number-total 20)
+              (histograms/update! (histograms/histogram (metric-title "fraction-unmatched" pool-name)) fraction-unmatched))
+            (when (pos? number-total)
+              (log/info "In" pool-name "autoscaling variables" {:number-total number-total
+                                                                :fraction-unmatched fraction-unmatched
+                                                                :number-for-autoscaling number-for-autoscaling
+                                                                :autoscalable-jobs (count autoscalable-jobs)
+                                                                :filtered-autoscalable-jobs (count filtered-autoscalable-jobs)
+                                                                :number-unmatched number-unmatched}))
             ;; This call needs to happen *after* launch-matched-tasks!
             ;; in order to avoid autoscaling tasks taking up available
             ;; capacity that was already matched for real Cook tasks.
-            (trigger-autoscaling! autoscalable-jobs pool-name compute-clusters job->acceptable-compute-clusters-fn)
+            (trigger-autoscaling! filtered-autoscalable-jobs pool-name compute-clusters job->acceptable-compute-clusters-fn)
             matched-head-or-no-matches?))
         (catch Throwable t
           (meters/mark! handle-resource-offer!-errors)

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -112,6 +112,7 @@
                       :nrepl {}
                       :port 80
                       :scheduler {}
+                      :kubernetes {:autoscale-blocklist-seconds 1 :max-jobs-for-autoscaling 1000 :autoscaling-scale-factor 1000.0}
                       :unhandled-exceptions {}
                       :zookeeper {:local? true}}]
   (defn setup
@@ -133,7 +134,8 @@
                            #'caches/task->feature-vector-cache
                            #'caches/job-ent->user-cache
                            #'cook.quota/per-user-per-pool-launch-rate-limiter
-                           #'caches/user->group-ids-cache)))
+                           #'caches/user->group-ids-cache
+                           #'caches/autoscale-retry-blacklist)))
 
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -112,7 +112,7 @@
                       :nrepl {}
                       :port 80
                       :scheduler {}
-                      :kubernetes {:autoscale-blocklist-seconds 1 :max-jobs-for-autoscaling 1000 :autoscaling-scale-factor 1000.0}
+                      :kubernetes {:synthetic-pod-recency-seconds 1 :max-jobs-for-autoscaling 1000 :autoscaling-scale-factor 1000.0}
                       :unhandled-exceptions {}
                       :zookeeper {:local? true}}]
   (defn setup
@@ -135,7 +135,7 @@
                            #'caches/job-ent->user-cache
                            #'cook.quota/per-user-per-pool-launch-rate-limiter
                            #'caches/user->group-ids-cache
-                           #'caches/autoscale-retry-blacklist)))
+                           #'caches/recent-synthetic-pod-job-uuids)))
 
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2436,14 +2436,14 @@
                     :job/instance instances}]
       (let [uuid (UUID/randomUUID)
             job1 (assoc base-job :job/uuid uuid)]
-        (is (= {compute-cluster-1 [job1]}
-               (sched/distribute-jobs-to-compute-clusters
-                 [job1]
-                 "test-pool"
-                 [compute-cluster-1
-                  compute-cluster-2
-                  compute-cluster-3]
-                 sched/job->acceptable-compute-clusters))))
+        (is (= (list [job1])
+               (vals (sched/distribute-jobs-to-compute-clusters
+                       [job1]
+                       "test-pool"
+                       [compute-cluster-1
+                        compute-cluster-2
+                        compute-cluster-3]
+                       sched/job->acceptable-compute-clusters)))))
       (testing "max-jobs-for-autoscaling=0"
         (let [job (assoc base-job :job/uuid (UUID/randomUUID))]
           (is (= {}


### PR DESCRIPTION
* Parallel synthetic pod launching across compute clusters
* Launch synthetic pods proportional to queue length
* Don't launch synthetic pods for the same job too frequently

## Changes proposed in this PR

* Parallel synthetic pod launching across compute clusters
* Launch synthetic pods proportional to queue length
* Don't launch synthetic pods for the same job too frequently

## Why are we making these changes?
Reduce the overheads of autoscaling.

