### PR TITLE
Ignores the space used by synthetic pods

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -33,7 +33,7 @@
                               :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                               :max-pods-outstanding 128
                               :user #config/env "USER"
-                              :command "exit 0"
+                              :command "sleep 300"
                               :pools #{"k8s-alpha" "k8s-gamma"}}
              :node-blocklist-labels ["blocklist-nodes-with-this-label-key"]
              :use-google-service-account? false
@@ -51,7 +51,7 @@
              :synthetic-pods {:image "gcr.io/google-containers/alpine-with-bash:1.0"
                               :max-pods-outstanding 128
                               :user #config/env "USER"
-                              :command "exit 0"
+                              :command "sleep 300"
                               :pools #{"k8s-alpha"}}
              :node-blocklist-labels ["blocklist-nodes-with-this-label-key-1" "blocklist-nodes-with-this-label-key-2"]
              :use-google-service-account? false

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -504,6 +504,7 @@
                            controller-lock-num-shards
                            #(ReentrantLock.))]
                      (merge {:autoscaling-scale-factor 1.0
+                             :clobber-synthetic-pods false
                              :controller-lock-num-shards controller-lock-num-shards
                              :controller-lock-objects (with-meta
                                                         lock-objects

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -505,6 +505,7 @@
        (filter first) ; Keep those with non-nil node names.
        (pc/map-vals (fn [pods]
                       (->> pods
+                           (remove #(some-> % .getMetadata .getName synthetic-pod?))
                            (map (fn [^V1Pod pod]
                                   (let [containers (some-> pod .getSpec .getContainers)
                                         container-requests (map (fn [^V1Container c]

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -500,12 +500,12 @@
   Ignores pods that do not have an assigned node.
   When accounting for resources, we use resource requests to determine how much is used, not limits.
   See https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container"
-  [node-name->pods pool-name]
+  [clobber-synthetic-pods node-name->pods pool-name]
   (->> node-name->pods
        (filter first) ; Keep those with non-nil node names.
        (pc/map-vals (fn [pods]
                       (->> pods
-                           (remove #(some-> % .getMetadata .getName synthetic-pod?))
+                           (remove #(and clobber-synthetic-pods (some-> % .getMetadata .getName synthetic-pod?)))
                            (map (fn [^V1Pod pod]
                                   (let [containers (some-> pod .getSpec .getContainers)
                                         container-requests (map (fn [^V1Container c]

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -57,7 +57,8 @@
 (defn generate-offers
   "Given a compute cluster and maps with node capacity and existing pods, return a map from pool to offers."
   [compute-cluster node-name->node node-name->pods pool-name]
-  (let [compute-cluster-name (cc/compute-cluster-name compute-cluster)
+  (let [clobber-synthetic-pods (:clobber-synthetic-pods (config/kubernetes))
+        compute-cluster-name (cc/compute-cluster-name compute-cluster)
         node-name->capacity (api/get-capacity node-name->node pool-name)
         ; node-name->node map, used to calculate node-name->capacity includes nodes from the one pool,
         ; gotten via the pools->node-name->node map.
@@ -72,7 +73,7 @@
         ; If we have consumption calculation on a node that doesn't have a capacity calculated, there's not not much
         ; point in further computation on it. We won't make an offer in any case. So we filter them out.
         ; This also cleanly avoids the logged ERROR.
-        node-name->consumed (->> (api/get-consumption node-name->pods pool-name)
+        node-name->consumed (->> (api/get-consumption clobber-synthetic-pods node-name->pods pool-name)
                                  (filter #(node-name->capacity (first %)))
                                  (into {}))
         node-name->available (util/deep-merge-with - node-name->capacity node-name->consumed)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -447,7 +447,7 @@
               total-pods (-> @all-pods-atom keys count)
               total-nodes (-> @current-nodes-atom keys count)
               {:keys [image user command max-pods-outstanding max-total-pods max-total-nodes]
-               :or {command "exit 0" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config]
+               :or {command "sleep 300" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config]
 
           (when (>= total-pods max-total-pods)
             (log/warn "In" name "compute cluster, total pods are maxed out"

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -448,7 +448,7 @@
               total-pods (-> @all-pods-atom keys count)
               total-nodes (-> @current-nodes-atom keys count)
               {:keys [image user command max-pods-outstanding max-total-pods max-total-nodes]
-               :or {command "sleep 300" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config]
+               :or {command "exit 0" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config]
 
           (when (>= total-pods max-total-pods)
             (log/warn "In" name "compute cluster, total pods are maxed out"


### PR DESCRIPTION
## Changes proposed in this PR

- Have synthetic pods sleep for a while after starting so that the space
cannot be reused for other synthetic pods. 
- In addition, have Cook ignore
the space used by synthetic pods, so that Cook will barge in and take
those resources away.

## Why are we making these changes?
Improve autoscaling. At present, an empty node can have synthetic pods sequentially match on it, attenuating the autoscaling signal Cook is intending to send.