### PR TITLE
Add support for node tenuring taint

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1079,10 +1079,11 @@
 
     (.addTolerationsItem pod-spec toleration-for-deletion-candidate-of-autoscaler)
     (.addTolerationsItem pod-spec (toleration-for-pool cook-pool-taint-name cook-pool-taint-prefix pool-name))
-    (.addTolerationsItem pod-spec toleration-tenured-node)
     ; We need to make sure synthetic pods --- which don't have a hostname set --- have a node selector
-    ; to run only in nodes labelled with the appropriate cook pool
-    (when-not hostname (add-node-selector pod-spec cook-pool-label-name pool-name))
+    ; to run only in nodes labelled with the appropriate cook pool and only in un-tenured nodes.
+    (when-not hostname
+      (add-node-selector pod-spec cook-pool-label-name pool-name)
+      (.addTolerationsItem pod-spec toleration-tenured-node))
 
     (when pod-constraints
       (doseq [{:keys [constraint/attribute

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1054,9 +1054,10 @@
       ; (https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
       ; from happening. We want this pod to preempt lower priority pods
       ; (e.g. synthetic pods).
-      (add-node-selector pod-spec k8s-hostname-label hostname)
-      ; Allow real pods to run on tenured nodes.
-      (.addTolerationsItem pod-spec toleration-tenured-node)
+      (do
+        (add-node-selector pod-spec k8s-hostname-label hostname)
+        ; Allow real pods to run on tenured nodes.
+        (.addTolerationsItem pod-spec toleration-tenured-node))
       (when (seq pod-hostnames-to-avoid)
         ; Use node "anti"-affinity to disallow scheduling on nodes with particular labels
         ; (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -51,7 +51,7 @@
 ; don't ignore it. Cook creates synthetic pods as a scaling signal. When they run on existing nodes,
 ; the signal we intend to send to the autoscaler is attenuated and we autoscale much less than intended.
 ;
-; We prefix the taint with the ignore-taint string so that the autoscaler won't use this when constructing exlempar new nodes.
+; We prefix the taint with the ignore-taint string so that the autoscaler won't use this when constructing exemplar new nodes.
 (def tenured-node-taint "ignore-taint.cluster-autoscaler.kubernetes.io/cook-node-tenured")
 
 (def default-shell

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1055,6 +1055,8 @@
       ; from happening. We want this pod to preempt lower priority pods
       ; (e.g. synthetic pods).
       (add-node-selector pod-spec k8s-hostname-label hostname)
+      ; Allow real pods to run on tenured nodes.
+      (.addTolerationsItem pod-spec toleration-tenured-node)
       (when (seq pod-hostnames-to-avoid)
         ; Use node "anti"-affinity to disallow scheduling on nodes with particular labels
         ; (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity)
@@ -1080,10 +1082,8 @@
     (.addTolerationsItem pod-spec toleration-for-deletion-candidate-of-autoscaler)
     (.addTolerationsItem pod-spec (toleration-for-pool cook-pool-taint-name cook-pool-taint-prefix pool-name))
     ; We need to make sure synthetic pods --- which don't have a hostname set --- have a node selector
-    ; to run only in nodes labelled with the appropriate cook pool and only in un-tenured nodes.
-    (when-not hostname
-      (add-node-selector pod-spec cook-pool-label-name pool-name)
-      (.addTolerationsItem pod-spec toleration-tenured-node))
+    ; to run only in nodes labelled with the appropriate cook pool
+    (when-not hostname (add-node-selector pod-spec cook-pool-label-name pool-name))
 
     (when pod-constraints
       (doseq [{:keys [constraint/attribute

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -50,7 +50,9 @@
 ; with this taint. Cook ignores it for scheduling purposes, but synthetic pods are configured so they
 ; don't ignore it. Cook creates synthetic pods as a scaling signal. When they run on existing nodes,
 ; the signal we intend to send to the autoscaler is attenuated and we autoscale much less than intended.
-(def tenured-node-taint "cook-node-tenured")
+;
+; We prefix the taint with the ignore-taint string so that the autoscaler won't use this when constructing exlempar new nodes.
+(def tenured-node-taint "ignore-taint.cluster-autoscaler.kubernetes.io/cook-node-tenured")
 
 (def default-shell
   "Default shell command used by our k8s scheduler to wrap and launch a job command


### PR DESCRIPTION
## Changes proposed in this PR

- Add support for node tenuring taint

## Why are we making these changes?
This lets us redirect synthetic pods toward the autoscaler instead of having them run on existing old nodes.
