### PR TITLE
fix memory request value sent to pod

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -911,8 +911,10 @@
                    ;; preserving compatibility with Meosos + Cook Executor.
                    (not progress-file-path)
                    (assoc progress-file-var (str workdir "/" task-id ".progress"))
+                   mem
+                   (assoc "COOK_USER_MEMORY_REQUEST_BYTES" (* memory-multiplier mem))
                    computed-mem
-                   (assoc "COOK_MEMORY_REQUEST_BYTES" (* memory-multiplier mem)))
+                   (assoc "COOK_MEMORY_REQUEST_BYTES" (* memory-multiplier computed-mem)))
         main-env-vars (make-filtered-env-vars main-env)]
 
     ; metadata

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -197,6 +197,7 @@
                     "COOK_POOL"
                     "COOK_SANDBOX"
                     "COOK_SCHEDULER_REST_URL"
+                    "COOK_USER_MEMORY_REQUEST_BYTES"
                     "EXECUTOR_PROGRESS_OUTPUT_FILE"
                     "FOO"
                     "HOME"


### PR DESCRIPTION
## Changes proposed in this PR

- change the COOK_MEMORY_REQUEST_BYTES pod environment variable to be the actual pod memory request


## Why are we making these changes?


