### PR TITLE
 Update cook-client-api version to 0.3.3

### DIFF
--- a/jobclient/python/cookclient/__init__.py
+++ b/jobclient/python/cookclient/__init__.py
@@ -28,7 +28,7 @@ from . import util
 from .containers import AbstractContainer
 from .jobs import Application, Disk, Job
 
-CLIENT_VERSION = '0.3.2'
+CLIENT_VERSION = '0.3.3'
 
 _LOG = logging.getLogger(__name__)
 _LOG.addHandler(logging.StreamHandler())


### PR DESCRIPTION
## Changes proposed in this PR

- Upgrade cook-client-api-version to 0.3.3

## Why are we making these changes?
Publish the new version to pypi

