### PR TITLE
Update test_basic.py

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2914,7 +2914,6 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, [job_uuid1, job_uuid2])
 
     @unittest.skipUnless(util.using_kubernetes() and util.in_cloud(), 'Test requires kubernetes')
-    @pytest.mark.xfail # Temporarily disable because of infrastructure issue. TODO: this should not exist past 20210312
     def test_kubernetes_checkpointing(self):
         docker_image = util.docker_image()
         container = {'type': 'docker',


### PR DESCRIPTION
## Changes proposed in this PR

- re-enable test_kubernetes_checkpointing

## Why are we making these changes?

Revert https://github.com/twosigma/Cook/pull/1812 because the failing dependency has been fixed
