### PR TITLE
Supports synthetic pod inter-pod anti-affinity

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1131,7 +1131,8 @@
       ; We want to allow synthetic pods to be attracted to certain nodes via inter-pod affinity
       ; (https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)
       (let [{:keys [synthetic-pod-affinity-pod-label-key
-                    synthetic-pod-affinity-pod-label-value]}
+                    synthetic-pod-affinity-pod-label-value
+                    synthetic-pod-affinity-required?]}
             (config/kubernetes)]
         (when (and synthetic-pod-affinity-pod-label-key
                    synthetic-pod-affinity-pod-label-value)
@@ -1146,7 +1147,9 @@
                               synthetic-pod-affinity-pod-label-value})
             (.setLabelSelector pod-affinity-term label-selector)
             (.setTopologyKey pod-affinity-term k8s-hostname-label)
-            (.setRequiredDuringSchedulingIgnoredDuringExecution pod-affinity [pod-affinity-term])
+            (if synthetic-pod-affinity-required?
+              (.setRequiredDuringSchedulingIgnoredDuringExecution pod-affinity [pod-affinity-term])
+              (.setPreferredDuringSchedulingIgnoredDuringExecution pod-affinity [pod-affinity-term]))
             (.setPodAffinity affinity pod-affinity)
             (.setAffinity pod-spec affinity)))))
 

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -25,8 +25,8 @@
              CoreV1Event V1Affinity V1Container V1ContainerPort V1ContainerState V1ContainerStatus V1DeleteOptions
              V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1EnvVarSource V1HostPathVolumeSource
              V1HTTPGetAction V1LabelSelector V1ObjectFieldSelector V1Node V1NodeList V1NodeAffinity V1NodeSelector
-             V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodAffinity
-             V1PodAffinityTerm V1PodCondition V1PodSecurityContext V1PodSpec V1PodStatus V1Probe V1ResourceRequirements
+             V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodAffinityTerm
+             V1PodAntiAffinity V1PodCondition V1PodSecurityContext V1PodSpec V1PodStatus V1Probe V1ResourceRequirements
              V1Toleration V1Volume V1VolumeBuilder V1VolumeMount V1WeightedPodAffinityTerm)
            (io.kubernetes.client.util Watch)
            (java.net SocketTimeoutException)
@@ -1139,7 +1139,7 @@
           ; The synthetic pod pod-spec may or may not already have an affinity defined
           ; (see pod-hostnames-to-avoid above), so we need to allow for either case
           (let [affinity (or (.getAffinity pod-spec) (V1Affinity.))
-                pod-affinity (V1PodAffinity.)
+                pod-affinity (V1PodAntiAffinity.)
                 pod-affinity-term (V1PodAffinityTerm.)
                 label-selector (V1LabelSelector.)]
             (.setMatchLabels label-selector
@@ -1153,7 +1153,7 @@
                 (.setWeight weighted-pod-affinity-term (int 100))
                 (.setPodAffinityTerm weighted-pod-affinity-term pod-affinity-term)
                 (.setPreferredDuringSchedulingIgnoredDuringExecution pod-affinity [weighted-pod-affinity-term])))
-            (.setPodAffinity affinity pod-affinity)
+            (.setPodAntiAffinity affinity pod-affinity)
             (.setAffinity pod-spec affinity)))))
 
     pod))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1150,7 +1150,7 @@
             (if synthetic-pod-affinity-required?
               (.setRequiredDuringSchedulingIgnoredDuringExecution pod-affinity [pod-affinity-term])
               (let [weighted-pod-affinity-term (V1WeightedPodAffinityTerm.)]
-                (.setWeight weighted-pod-affinity-term 100)
+                (.setWeight weighted-pod-affinity-term (int 100))
                 (.setPodAffinityTerm weighted-pod-affinity-term pod-affinity-term)
                 (.setPreferredDuringSchedulingIgnoredDuringExecution pod-affinity [weighted-pod-affinity-term])))
             (.setPodAffinity affinity pod-affinity)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -22,11 +22,12 @@
            (io.kubernetes.client.openapi ApiClient ApiException JSON)
            (io.kubernetes.client.openapi.apis CoreV1Api)
            (io.kubernetes.client.openapi.models
-             V1Affinity V1Container V1ContainerPort V1ContainerState V1ContainerStatus V1DeleteOptions
-             V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1EnvVarSource CoreV1Event V1HostPathVolumeSource
-             V1HTTPGetAction V1ObjectFieldSelector V1Node V1NodeList V1NodeAffinity V1NodeSelector V1NodeSelectorRequirement
-             V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodCondition V1PodSecurityContext V1PodSpec
-             V1PodStatus V1Probe V1ResourceRequirements V1Toleration V1Volume V1VolumeBuilder V1VolumeMount)
+             CoreV1Event V1Affinity V1Container V1ContainerPort V1ContainerState V1ContainerStatus V1DeleteOptions
+             V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1EnvVarSource V1HostPathVolumeSource
+             V1HTTPGetAction V1LabelSelector V1ObjectFieldSelector V1Node V1NodeList V1NodeAffinity V1NodeSelector
+             V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodAffinityTerm
+             V1PodAntiAffinity V1PodCondition V1PodSecurityContext V1PodSpec V1PodStatus V1Probe V1ResourceRequirements
+             V1Toleration V1Volume V1VolumeBuilder V1VolumeMount)
            (io.kubernetes.client.util Watch)
            (java.net SocketTimeoutException)
            (java.util.concurrent Executors ExecutorService)))
@@ -1120,12 +1121,34 @@
     (.setMetadata pod metadata)
     (.setSpec pod pod-spec)
 
-    ; We want to allow synthetic pods to have a non-default (typically 0) termination grace period,
-    ; so that they can be deleted quickly to free up space on nodes for real job pods. The default
-    ; grace period of 30 seconds can cause real job pods to be deemed unschedulable and fail.
     (when (synthetic-pod? pod-name)
+      ; We want to allow synthetic pods to have a non-default (typically 0) termination grace period,
+      ; so that they can be deleted quickly to free up space on nodes for real job pods. The default
+      ; grace period of 30 seconds can cause real job pods to be deemed unschedulable and fail.
       (when-let [{:keys [synthetic-pod-termination-grace-period-seconds]} (config/kubernetes)]
-        (.setTerminationGracePeriodSeconds pod-spec synthetic-pod-termination-grace-period-seconds)))
+        (.setTerminationGracePeriodSeconds pod-spec synthetic-pod-termination-grace-period-seconds))
+
+      ; We want to allow synthetic pods to be repelled from certain nodes via inter-pod anti-affinity
+      ; (https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)
+      (let [{:keys [synthetic-pod-anti-affinity-pod-label-key
+                    synthetic-pod-anti-affinity-pod-label-value]}
+            (config/kubernetes)]
+        (when (and synthetic-pod-anti-affinity-pod-label-key
+                   synthetic-pod-anti-affinity-pod-label-value)
+          ; The synthetic pod pod-spec may or may not already have an affinity defined
+          ; (see pod-hostnames-to-avoid above), so we need to allow for either case
+          (let [affinity (or (.getAffinity pod-spec) (V1Affinity.))
+                pod-anti-affinity (V1PodAntiAffinity.)
+                pod-anti-affinity-term (V1PodAffinityTerm.)
+                label-selector (V1LabelSelector.)]
+            (.setMatchLabels label-selector
+                             {synthetic-pod-anti-affinity-pod-label-key
+                              synthetic-pod-anti-affinity-pod-label-value})
+            (.setLabelSelector pod-anti-affinity-term label-selector)
+            (.setTopologyKey pod-anti-affinity-term k8s-hostname-label)
+            (.setRequiredDuringSchedulingIgnoredDuringExecution pod-anti-affinity [pod-anti-affinity-term])
+            (.setPodAntiAffinity affinity pod-anti-affinity)
+            (.setAffinity pod-spec affinity)))))
 
     pod))
 

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -25,8 +25,8 @@
              CoreV1Event V1Affinity V1Container V1ContainerPort V1ContainerState V1ContainerStatus V1DeleteOptions
              V1DeleteOptionsBuilder V1EmptyDirVolumeSource V1EnvVar V1EnvVarSource V1HostPathVolumeSource
              V1HTTPGetAction V1LabelSelector V1ObjectFieldSelector V1Node V1NodeList V1NodeAffinity V1NodeSelector
-             V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodAffinityTerm
-             V1PodAntiAffinity V1PodCondition V1PodSecurityContext V1PodSpec V1PodStatus V1Probe V1ResourceRequirements
+             V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodAffinity
+             V1PodAffinityTerm V1PodCondition V1PodSecurityContext V1PodSpec V1PodStatus V1Probe V1ResourceRequirements
              V1Toleration V1Volume V1VolumeBuilder V1VolumeMount)
            (io.kubernetes.client.util Watch)
            (java.net SocketTimeoutException)
@@ -1128,26 +1128,26 @@
       (when-let [{:keys [synthetic-pod-termination-grace-period-seconds]} (config/kubernetes)]
         (.setTerminationGracePeriodSeconds pod-spec synthetic-pod-termination-grace-period-seconds))
 
-      ; We want to allow synthetic pods to be repelled from certain nodes via inter-pod anti-affinity
+      ; We want to allow synthetic pods to be attracted to certain nodes via inter-pod affinity
       ; (https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)
-      (let [{:keys [synthetic-pod-anti-affinity-pod-label-key
-                    synthetic-pod-anti-affinity-pod-label-value]}
+      (let [{:keys [synthetic-pod-affinity-pod-label-key
+                    synthetic-pod-affinity-pod-label-value]}
             (config/kubernetes)]
-        (when (and synthetic-pod-anti-affinity-pod-label-key
-                   synthetic-pod-anti-affinity-pod-label-value)
+        (when (and synthetic-pod-affinity-pod-label-key
+                   synthetic-pod-affinity-pod-label-value)
           ; The synthetic pod pod-spec may or may not already have an affinity defined
           ; (see pod-hostnames-to-avoid above), so we need to allow for either case
           (let [affinity (or (.getAffinity pod-spec) (V1Affinity.))
-                pod-anti-affinity (V1PodAntiAffinity.)
-                pod-anti-affinity-term (V1PodAffinityTerm.)
+                pod-affinity (V1PodAffinity.)
+                pod-affinity-term (V1PodAffinityTerm.)
                 label-selector (V1LabelSelector.)]
             (.setMatchLabels label-selector
-                             {synthetic-pod-anti-affinity-pod-label-key
-                              synthetic-pod-anti-affinity-pod-label-value})
-            (.setLabelSelector pod-anti-affinity-term label-selector)
-            (.setTopologyKey pod-anti-affinity-term k8s-hostname-label)
-            (.setRequiredDuringSchedulingIgnoredDuringExecution pod-anti-affinity [pod-anti-affinity-term])
-            (.setPodAntiAffinity affinity pod-anti-affinity)
+                             {synthetic-pod-affinity-pod-label-key
+                              synthetic-pod-affinity-pod-label-value})
+            (.setLabelSelector pod-affinity-term label-selector)
+            (.setTopologyKey pod-affinity-term k8s-hostname-label)
+            (.setRequiredDuringSchedulingIgnoredDuringExecution pod-affinity [pod-affinity-term])
+            (.setPodAffinity affinity pod-affinity)
             (.setAffinity pod-spec affinity)))))
 
     pod))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -27,7 +27,7 @@
              V1HTTPGetAction V1LabelSelector V1ObjectFieldSelector V1Node V1NodeList V1NodeAffinity V1NodeSelector
              V1NodeSelectorRequirement V1NodeSelectorTerm V1ObjectMeta V1ObjectReference V1Pod V1PodAffinity
              V1PodAffinityTerm V1PodCondition V1PodSecurityContext V1PodSpec V1PodStatus V1Probe V1ResourceRequirements
-             V1Toleration V1Volume V1VolumeBuilder V1VolumeMount)
+             V1Toleration V1Volume V1VolumeBuilder V1VolumeMount V1WeightedPodAffinityTerm)
            (io.kubernetes.client.util Watch)
            (java.net SocketTimeoutException)
            (java.util.concurrent Executors ExecutorService)))
@@ -1149,7 +1149,10 @@
             (.setTopologyKey pod-affinity-term k8s-hostname-label)
             (if synthetic-pod-affinity-required?
               (.setRequiredDuringSchedulingIgnoredDuringExecution pod-affinity [pod-affinity-term])
-              (.setPreferredDuringSchedulingIgnoredDuringExecution pod-affinity [pod-affinity-term]))
+              (let [weighted-pod-affinity-term (V1WeightedPodAffinityTerm.)]
+                (.setWeight weighted-pod-affinity-term 100)
+                (.setPodAffinityTerm weighted-pod-affinity-term pod-affinity-term)
+                (.setPreferredDuringSchedulingIgnoredDuringExecution pod-affinity [weighted-pod-affinity-term])))
             (.setPodAffinity affinity pod-affinity)
             (.setAffinity pod-spec affinity)))))
 

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -8,9 +8,9 @@
             [cook.test.testutil :as tu]
             [datomic.api :as d])
   (:import (io.kubernetes.client.openapi.models V1Container V1ContainerState V1ContainerStateWaiting V1ContainerStatus
-                                                V1EnvVar V1ListMeta V1Node V1NodeSpec V1ObjectMeta V1Pod V1PodCondition
-                                                V1PodList V1PodSpec V1PodStatus V1ResourceRequirements V1Taint V1Volume
-                                                V1VolumeMount)))
+                                                V1EnvVar V1ListMeta V1Node V1NodeSpec V1ObjectMeta V1Pod
+                                                V1PodAffinityTerm V1PodCondition V1PodList V1PodSpec V1PodStatus
+                                                V1ResourceRequirements V1Taint V1Volume V1VolumeMount)))
 
 (deftest test-get-consumption
   (testing "correctly computes consumption for a single pod without gpus"
@@ -490,15 +490,22 @@
         (is (= "unspecified" (get pod-labels "workload-id")))
         (is (= "none" (get pod-labels "workload-details")))))
 
-    (testing "synthetic pod affinity"
-      (let [task-metadata {:command {:user "test-user"}
-                           :task-id "synthetic"
-                           :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}]
-        (with-redefs [config/kubernetes (constantly {:synthetic-pod-affinity-pod-label-key "foo"
-                                                     :synthetic-pod-affinity-pod-label-value "bar"})]
-          (api/task-metadata->pod "test-namespace" fake-cc-config task-metadata)))
-      ; TODO: Assert that the pod has the expected affinity
-      )))
+    (testing "synthetic pod anti-affinity"
+      (with-redefs [config/kubernetes (constantly {:synthetic-pod-anti-affinity-pod-label-key "test-key"
+                                                   :synthetic-pod-anti-affinity-pod-label-value "test-value"})]
+        (let [task-metadata {:command {:user "test-user"}
+                             :task-id "synthetic"
+                             :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
+              pod (api/task-metadata->pod "test-namespace" fake-cc-config task-metadata)
+              ^V1PodAffinityTerm pod-affinity-term (-> pod
+                                                       .getSpec
+                                                       .getAffinity
+                                                       .getPodAntiAffinity
+                                                       .getRequiredDuringSchedulingIgnoredDuringExecution
+                                                       first)]
+          (is pod-affinity-term)
+          (is (= api/k8s-hostname-label (.getTopologyKey pod-affinity-term)))
+          (is (= {"test-key" "test-value"} (-> pod-affinity-term .getLabelSelector .getMatchLabels))))))))
 
 (defn- k8s-volume->clj [^V1Volume volume]
   {:name (.getName volume)

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -488,7 +488,17 @@
             pod-labels (-> pod .getMetadata .getLabels)]
         (is (= "cook-job" (get pod-labels "workload-class")))
         (is (= "unspecified" (get pod-labels "workload-id")))
-        (is (= "none" (get pod-labels "workload-details")))))))
+        (is (= "none" (get pod-labels "workload-details")))))
+
+    (testing "synthetic pod affinity"
+      (let [task-metadata {:command {:user "test-user"}
+                           :task-id "synthetic"
+                           :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}]
+        (with-redefs [config/kubernetes (constantly {:synthetic-pod-affinity-pod-label-key "foo"
+                                                     :synthetic-pod-affinity-pod-label-value "bar"})]
+          (api/task-metadata->pod "test-namespace" fake-cc-config task-metadata)))
+      ; TODO: Assert that the pod has the expected affinity
+      )))
 
 (defn- k8s-volume->clj [^V1Volume volume]
   {:name (.getName volume)


### PR DESCRIPTION
## Changes proposed in this PR

Allowing (optionally) synthetic pods to have inter-pod anti-affinity to a configurable pod label.

## Why are we making these changes?

In order to repel synthetic pods from tenured nodes, e.g. by running a "repeller" pod on nodes that have been up and running for a certain amount of time.
