### PR TITLE
Improves several integration tests

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -522,8 +522,8 @@ if __name__ == '__main__':
             # waiting
             cp, jobs = self.list_jobs(name, user, ['waiting'])
             self.assertEqual(0, cp.returncode, cp.stderr)
-            self.assertEqual(1, len(jobs))
-            self.assertEqual(waiting_uuid, jobs[0]['uuid'])
+            self.assertLessEqual(1, len(jobs), jobs)
+            self.assertIn(waiting_uuid, [job['uuid'] for job in jobs])
 
             # running
             def running_jobs():

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1493,9 +1493,7 @@ if __name__ == '__main__':
                                                                                f'--name {self.current_name()} '
                                                                                f'--max-retries 5')
         self.assertEqual(0, cp.returncode, cp.stderr)
-        cp = cli.wait(uuids, self.cook_url)
-        self.assertEqual(0, cp.returncode, cp.stderr)
-        cp, jobs = cli.show_jobs(uuids, self.cook_url)
+        jobs = util.wait_for_jobs(self.cook_url, uuids, 'completed')
         self.assertEqual('FOO=0; exit ${FOO:-1}', jobs[0]['command'])
         self.assertEqual('success', jobs[0]['state'])
 
@@ -1506,9 +1504,7 @@ if __name__ == '__main__':
             cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, flags=flags,
                                    submit_flags=f'--name {self.current_name()}')
             self.assertEqual(0, cp.returncode, cp.stderr)
-            cp = cli.wait(uuids, self.cook_url)
-            self.assertEqual(0, cp.returncode, cp.stderr)
-            cp, jobs = cli.show_jobs(uuids, self.cook_url)
+            jobs = util.wait_for_jobs(self.cook_url, uuids, 'completed')
             self.assertEqual('exit ${FOO:-1}', jobs[0]['command'])
             self.assertEqual('failed', jobs[0]['state'])
 
@@ -1519,9 +1515,7 @@ if __name__ == '__main__':
             cp, uuids = cli.submit('"exit ${FOO:-1}"', self.cook_url, flags=flags,
                                    submit_flags=f'--name {self.current_name()} --max-retries 5')
             self.assertEqual(0, cp.returncode, cp.stderr)
-            cp = cli.wait(uuids, self.cook_url)
-            self.assertEqual(0, cp.returncode, cp.stderr)
-            cp, jobs = cli.show_jobs(uuids, self.cook_url)
+            jobs = util.wait_for_jobs(self.cook_url, uuids, 'completed')
             self.assertEqual('export FOO=0; exit ${FOO:-1}', jobs[0]['command'])
             self.assertEqual('success', jobs[0]['state'])
 

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -532,11 +532,11 @@ if __name__ == '__main__':
             def running_jobs():
                 _cp, _jobs = self.list_jobs(name, user, ['running'])
                 assert 0 == _cp.returncode, _cp.stderr
+                self.logger.info(f'Running jobs: {_jobs}')
                 return _jobs
 
             def one_running_job(_jobs):
-                assert 1 == len(_jobs)
-                assert running_uuid == _jobs[0]['uuid']
+                return 1 == len(_jobs) and running_uuid == _jobs[0]['uuid']
 
             util.wait_until(running_jobs, one_running_job)
 

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -432,10 +432,7 @@ if __name__ == '__main__':
     def test_quoting(self):
         cp, uuids = cli.submit('echo "Hello; exit 1"', self.cook_url, submit_flags=f'--max-retries 5')
         self.assertEqual(0, cp.returncode, cp.stderr)
-        cp = cli.wait(uuids, self.cook_url)
-        self.assertEqual(0, cp.returncode, cp.stderr)
-        cp, jobs = cli.show_jobs(uuids, self.cook_url)
-        self.assertEqual(0, cp.returncode, cp.stderr)
+        jobs = util.wait_for_jobs(self.cook_url, uuids, 'completed')
         self.assertEqual('completed', jobs[0]['status'])
         self.assertEqual('success', jobs[0]['state'])
 


### PR DESCRIPTION
## Changes proposed in this PR

- making `test_list_by_state` more reliable
- `cli.wait` -> `util.wait_for_jobs` in a few places
- several formatting-only changes

## Why are we making these changes?

To make failures less likely and/or easier to diagnose.
