### PR TITLE
Add support for defaulting the environmental variables as a function of the pool

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -138,7 +138,12 @@
          [{:pool-regex "^k8s-.*"
            :default-constraints [{:constraint/attribute "node-type"
                                   :constraint/operator :constraint.operator/equals
-                                  :constraint/pattern "g1-small"}]}]}
+                                  :constraint/pattern "g1-small"}]}]
+         :default-env
+         [{:pool-regex "unused" :env {"foo" "bar"}}
+                       {:pool-regex ".*" :env
+                        {"SAMPLE_DEFAULT_ENV_KEY" "SAMPLE_DEFAULT_ENV_VAL"}}]}
+
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"
        :keystore-path #config/env "COOK_KEYSTORE_PATH"

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -462,6 +462,8 @@
                            (update :pool-regex re-pattern)))
                 (not (:default-containers pools))
                 (assoc :default-containers [])
+                (not (:default-env pools))
+                (assoc :default-env [])
                 (not (:quotas pools))
                 (assoc :quotas [])))
      :api-only? (fnk [[:config {api-only? false}]]

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -115,7 +115,9 @@
     (is (= value (.getValue variable)))))
 
 (deftest test-task-metadata->pod
-  (tu/setup)
+  (tu/setup :config {:pools {:default-env [{:pool-regex "unused" :env {"foo" "bar"}}
+                                           {:pool-regex ".*" :env
+                                            {"SAMPLE_DEFAULT_ENV_KEY" "SAMPLE_DEFAULT_ENV_VAL"}}]}})
   (let [fake-cc-config {:name "test-compute-cluster" :cook-pool-taint-name "test-taint" :cook-pool-taint-prefix ""}]
     (testing "supplemental group ids"
       (with-redefs [sh/sh (constantly {:exit 0 :out "12 34 56 78"})]
@@ -208,6 +210,7 @@
                     "HOST_IP"
                     "MESOS_DIRECTORY"
                     "MESOS_SANDBOX"
+                    "SAMPLE_DEFAULT_ENV_KEY"
                     "SIDECAR_WORKDIR"]
                    (->> container-env (map #(.getName %)) sort)))
             (is (= "/mnt/sandbox" (.getWorkingDir container)))
@@ -218,6 +221,7 @@
               (is (= "/mnt/sandbox" (.getMountPath cook-sandbox-mount))))
 
             (assert-env-var-value container "FOO" "BAR")
+            (assert-env-var-value container "SAMPLE_DEFAULT_ENV_KEY" "SAMPLE_DEFAULT_ENV_VAL")
             (assert-env-var-value container "HOME" (.getWorkingDir container))
             (assert-env-var-value container "MESOS_SANDBOX" (.getWorkingDir container))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Let us make a predefined environment in the config variable so that Cook can inject environmental variables an a per-pool basis. 
- 
- 

## Why are we making these changes?
So that we can have runtime wrapper scripts properly configured as a function of the pool name.

