### PR TITLE
Gracefully handles nodes with no pods in get-consumption

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -512,7 +512,9 @@
   (->> node-name->pods
        ; Keep those with non-nil node names
        (filter first)
-       ; Keep those with non-nil and non-empty pods
+       ; Keep those with non-nil and non-empty pods (in the wild, we occasionally see nodes at the
+       ; beginning of their lifetime come through this code path with no pods associated to them, and
+       ; when this happens, an exception is thrown in the calling code and no offers are generated)
        (filter #(-> % second seq))
        (pc/map-vals (fn [pods]
                       (->> pods

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -510,7 +510,10 @@
   See https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container"
   [clobber-synthetic-pods node-name->pods pool-name]
   (->> node-name->pods
-       (filter first) ; Keep those with non-nil node names.
+       ; Keep those with non-nil node names
+       (filter first)
+       ; Keep those with non-nil and non-empty pods
+       (filter #(-> % second seq))
        (pc/map-vals (fn [pods]
                       (->> pods
                            (remove #(and clobber-synthetic-pods (some-> % .getMetadata .getName synthetic-pod?)))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -184,7 +184,41 @@
                 {:name "cpus" :type :value-scalar :scalar 1.0}
                 {:name "disk" :type :value-text->scalar :text->scalar {"pd-standard" 255950.0}}
                 {:name "gpus" :type :value-text->scalar :text->scalar {}}]
-               (:resources offer)))))))
+               (:resources offer))))
+
+      (let [entire-node-a-capacity [{:name "mem"
+                                     :type :value-scalar
+                                     :scalar 1000.0}
+                                    {:name "cpus"
+                                     :type :value-scalar
+                                     :scalar 1.0}
+                                    {:name "disk"
+                                     :type :value-text->scalar
+                                     :text->scalar {}}
+                                    {:name "gpus"
+                                     :type :value-text->scalar
+                                     :text->scalar {"nvidia-tesla-p100" 10}}]]
+        (testing "graceful handling of node with empty pod list"
+          (let [offers
+                (kcc/generate-offers
+                  compute-cluster
+                  node-name->node
+                  (assoc node-name->pods "nodeA" [])
+                  "test-pool")
+                offer (first (filter #(= "nodeA" (:hostname %)) offers))]
+            (is offer)
+            (is (= entire-node-a-capacity (:resources offer)))))
+
+        (testing "graceful handling of node with nil pod list"
+          (let [offers
+                (kcc/generate-offers
+                  compute-cluster
+                  node-name->node
+                  (assoc node-name->pods "nodeA" nil)
+                  "test-pool")
+                offer (first (filter #(= "nodeA" (:hostname %)) offers))]
+            (is offer)
+            (is (= entire-node-a-capacity (:resources offer)))))))))
 
 (deftest determine-cook-expected-state
   ; TODO


### PR DESCRIPTION
## Changes proposed in this PR

- filtering out nodes with empty or `nil` pods in `get-consumption`

## Why are we making these changes?

In the wild, we occasionally see nodes at the beginning of their lifetime come through this code path with no pods associated to them. When this happens, an exception is thrown in the offer generation code and no offers are generated.