### PR TITLE
Gracefully handles nil watch objects

### DIFF
--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -932,12 +932,3 @@
       (.addContainerStatusesItem pod-status container-status)
       (.setStatus pod pod-status)
       (= :not-running (api/pod->sandbox-file-server-container-state pod)))))
-
-(deftest test-process-watch-response!
-  (testing "graceful handling of nil watch object"
-    (api/process-watch-response!
-      (atom nil)
-      nil
-      "ADDED"
-      #(when (nil? %) (throw (ex-info "nil key" {})))
-      nil)))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -932,3 +932,12 @@
       (.addContainerStatusesItem pod-status container-status)
       (.setStatus pod pod-status)
       (= :not-running (api/pod->sandbox-file-server-container-state pod)))))
+
+(deftest test-process-watch-response!
+  (testing "graceful handling of nil watch object"
+    (api/process-watch-response!
+      (atom nil)
+      nil
+      "ADDED"
+      #(when (nil? %) (throw (ex-info "nil key" {})))
+      nil)))


### PR DESCRIPTION
## Changes proposed in this PR

- logging a warning instead of causing an exception to be thrown when the watch object is `nil`

## Why are we making these changes?

In the wild, we occasionally see `nil` watch objects come through the watch.
