### PR TITLE
Allows namespace to be added to synthetic pod anti-affinity

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1134,7 +1134,8 @@
       ; have been up and running for a certain amount of time. Without this, synthetic pods will often
       ; run on nodes that have been alive for a while (tenured nodes) when job pods complete and free
       ; up space, causing those synthetic pods to not serve their purpose of triggering scale-up.
-      (let [{:keys [synthetic-pod-anti-affinity-pod-label-key
+      (let [{:keys [synthetic-pod-anti-affinity-namespace
+                    synthetic-pod-anti-affinity-pod-label-key
                     synthetic-pod-anti-affinity-pod-label-value]}
             (config/kubernetes)]
         (when (and synthetic-pod-anti-affinity-pod-label-key
@@ -1150,6 +1151,8 @@
                               synthetic-pod-anti-affinity-pod-label-value})
             (.setLabelSelector pod-affinity-term label-selector)
             (.setTopologyKey pod-affinity-term k8s-hostname-label)
+            (when synthetic-pod-anti-affinity-namespace
+              (.addNamespacesItem pod-affinity-term synthetic-pod-anti-affinity-namespace))
             (.setRequiredDuringSchedulingIgnoredDuringExecution pod-anti-affinity [pod-affinity-term])
             (.setPodAntiAffinity affinity pod-anti-affinity)
             (.setAffinity pod-spec affinity)))))


### PR DESCRIPTION
## Changes proposed in this PR

Allowing a namespace to be specified on the synthetic pod anti-affinity.

## Why are we making these changes?

> because pods are namespaced (and therefore the labels on pods are implicitly namespaced), a label selector over pod labels must specify which namespaces the selector should apply to

(https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)