### PR TITLE
Logs watch response status field

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -142,7 +142,7 @@
         (process-watch-response! state-atom item type key-fn callbacks)
         (throw (ex-info "Encountered nil object on watch response"
                         {:watch-object item
-                         :watch-response watch-response
+                         :watch-status (.-status watch-response)
                          :watch-type type}))))))
 
 (defn get-pod-namespaced-key


### PR DESCRIPTION
## Changes proposed in this PR

Instead of logging the watch response, which does not have a `toString`, logging the `status` field, which does have a `toString`. Note that we're now logging all fields on the watch response (`object`, `status`, `type`): https://github.com/kubernetes-client/java/blob/fbf46529894c7f189cc5a604716aae50769d2caf/util/src/main/java/io/kubernetes/client/util/Watch.java#L48-L53.

## Why are we making these changes?

In order to understand the reasons we're seeing `ERROR` type responses on pod watches.
