### PR TITLE
Treats prolonged ContainersNotReady condition as failure

### DIFF
--- a/scheduler/docs/reason-code
+++ b/scheduler/docs/reason-code
@@ -8,6 +8,7 @@
 01006: Scheduling failed on host
 01007: Container initialization timed out
 01008: Killed externally
+01009: Container readiness timed out
 
 02xxx: Job Misconfiguration
 02000: REASON_CONTAINER_LIMITATION

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -512,6 +512,7 @@
                              :default-workdir "/mnt/sandbox"
                              :max-jobs-for-autoscaling 1000
                              :pod-condition-containers-not-initialized-seconds 120
+                             :pod-condition-containers-not-ready-seconds 120
                              :pod-condition-unschedulable-seconds 60
                              :reconnect-delay-ms 60000
                              :set-container-cpu-limit? true

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1204,35 +1204,61 @@
                           (t/plus (t/seconds unschedulable-seconds))
                           (t/before? (t/now)))))))))
 
-(defn pod-containers-not-initialized?
-  "Returns true if the given pod status has an Initialized condition with status
-  False and reason ContainersNotInitialized, and the last transition was more than
-  pod-condition-containers-not-initialized-seconds seconds ago"
-  [pod-name ^V1PodStatus pod-status]
-  (let [{:keys [pod-condition-containers-not-initialized-seconds]} (config/kubernetes)
-        ^V1PodCondition pod-condition
+(defn pod-has-terminal-condition?
+  "Returns true if the given pod status has a pod condition that is deemed terminal,
+  meaning that it's been in some unready state for long enough that we assume it
+  will not recover, and we should fail the job instance altogether."
+  [pod-name ^V1PodStatus pod-status pod-condition-type pod-condition-reason pod-condition-seconds]
+  (let [^V1PodCondition pod-condition
         (some->> pod-status
                  .getConditions
                  (filter
-                   (fn pod-condition-containers-not-initialized?
+                   (fn pod-condition-of-interest?
                      [^V1PodCondition condition]
-                     (and (-> condition .getType (= "Initialized"))
+                     (and (-> condition .getType (= pod-condition-type))
                           (-> condition .getStatus (= "False"))
-                          (-> condition .getReason (= "ContainersNotInitialized")))))
+                          (-> condition .getReason (= pod-condition-reason)))))
                  first)]
     (when pod-condition
       (let [last-transition-time-plus-threshold-seconds
             (-> pod-condition
                 .getLastTransitionTime
-                (t/plus (t/seconds pod-condition-containers-not-initialized-seconds)))
+                (t/plus (t/seconds pod-condition-seconds)))
             now (t/now)
             threshold-passed? (t/before? last-transition-time-plus-threshold-seconds now)]
-        (log/info "Pod" pod-name "has containers that are not initialized"
+        (log/info "Pod" pod-name "has unready pod condition"
                   {:last-transition-time-plus-threshold-seconds last-transition-time-plus-threshold-seconds
                    :now now
                    :pod-condition pod-condition
+                   :pod-condition-reason pod-condition-reason
+                   :pod-condition-seconds pod-condition-seconds
+                   :pod-condition-type pod-condition-type
                    :threshold-passed? threshold-passed?})
         threshold-passed?))))
+
+(defn pod-containers-not-initialized?
+  "Returns true if the given pod status has an Initialized condition with status
+  False and reason ContainersNotInitialized, and the last transition was more than
+  pod-condition-containers-not-initialized-seconds seconds ago"
+  [pod-name ^V1PodStatus pod-status]
+  (pod-has-terminal-condition?
+    pod-name
+    pod-status
+    "Initialized"
+    "ContainersNotInitialized"
+    (:pod-condition-containers-not-initialized-seconds (config/kubernetes))))
+
+(defn pod-containers-not-ready?
+  "Returns true if the given pod status has a ContainersReady condition with status
+  False and reason ContainersNotReady, and the last transition was more than
+  pod-condition-containers-not-ready-seconds seconds ago"
+  [pod-name ^V1PodStatus pod-status]
+  (pod-has-terminal-condition?
+    pod-name
+    pod-status
+    "ContainersReady"
+    "ContainersNotReady"
+    (:pod-condition-containers-not-ready-seconds (config/kubernetes))))
 
 (defn pod->synthesized-pod-state
   "From a V1Pod object, determine the state of the pod, waiting running, succeeded, failed or unknown.
@@ -1269,18 +1295,27 @@
               (let [^V1ContainerState state (.getState job-status)]
                 (cond
                   (.getWaiting state)
-                  (if (pod-containers-not-initialized? pod-name pod-status)
+                  (cond
+                    (pod-containers-not-initialized? pod-name pod-status)
                     ; If the containers are not getting initialized,
                     ; then we should consider the pod failed. This
                     ; state can occur, for example, when volume
                     ; mounts fail.
                     {:state :pod/failed
                      :reason "ContainersNotInitialized"}
+
+                    (pod-containers-not-ready? pod-name pod-status)
+                    {:state :pod/failed
+                     :reason "ContainersNotReady"}
+
+                    :default
                     {:state :pod/waiting
                      :reason (-> state .getWaiting .getReason)})
+
                   (.getRunning state)
                   {:state :pod/running
                    :reason "Running"}
+
                   (.getTerminated state)
                   (let [exit-code (-> state .getTerminated .getExitCode)]
                     (if (= 0 exit-code)
@@ -1290,6 +1325,7 @@
                       {:state :pod/failed
                        :exit exit-code
                        :reason (-> state .getTerminated .getReason)}))
+
                   :default
                   {:state :pod/unknown
                    :reason "Unknown"}))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1204,8 +1204,8 @@
                           (t/plus (t/seconds unschedulable-seconds))
                           (t/before? (t/now)))))))))
 
-(defn pod-has-terminal-condition?
-  "Returns true if the given pod status has a pod condition that is deemed terminal,
+(defn pod-has-stuck-condition?
+  "Returns true if the given pod status has a pod condition that is deemed stuck,
   meaning that it's been in some unready state for long enough that we assume it
   will not recover, and we should fail the job instance altogether."
   [pod-name ^V1PodStatus pod-status pod-condition-type pod-condition-reason pod-condition-seconds]
@@ -1241,7 +1241,7 @@
   False and reason ContainersNotInitialized, and the last transition was more than
   pod-condition-containers-not-initialized-seconds seconds ago"
   [pod-name ^V1PodStatus pod-status]
-  (pod-has-terminal-condition?
+  (pod-has-stuck-condition?
     pod-name
     pod-status
     "Initialized"
@@ -1253,7 +1253,7 @@
   False and reason ContainersNotReady, and the last transition was more than
   pod-condition-containers-not-ready-seconds seconds ago"
   [pod-name ^V1PodStatus pod-status]
-  (pod-has-terminal-condition?
+  (pod-has-stuck-condition?
     pod-name
     pod-status
     "ContainersReady"

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -227,6 +227,11 @@
         (log/info "In compute cluster" name ", encountered containers not initialized in pod" instance-id)
         :reason-container-initialization-timed-out)
 
+      (api/pod-containers-not-ready? instance-id pod-status)
+      (do
+        (log/info "In compute cluster" name ", encountered containers not ready in pod" instance-id)
+        :reason-container-readiness-timed-out)
+
       :default
       (do
         (log/warn "In compute cluster" name ", unable to determine failure reason for" instance-id

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -1379,6 +1379,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :reason/name :killed-externally
     :reason/mea-culpa? true
     :reason/mesos-reason :reason-killed-externally}
+   {:db/id (d/tempid :db.part/user)
+    :reason/code 1009
+    :reason/string "Container readiness timed out"
+    :reason/name :container-readiness-timed-out
+    :reason/mea-culpa? true
+    :reason/mesos-reason :reason-container-readiness-timed-out}
 
    {:db/id (d/tempid :db.part/user)
     :reason/code 2000


### PR DESCRIPTION
Similar to PR #1489, but for a different pod condition.

## Changes proposed in this PR

- adding a new failure reason "Container readiness timed out"
- fast-failing jobs using this new reason when they get into the `ContainersNotReady` condition for a prolonged (configurable) amount of time

## Why are we making these changes?

Without this, pods can remain in the `ContainersNotReady` state forever, and their jobs stay in the `Running` state forever, despite not actually having started running the user's workload.
