### PR TITLE
Optimize novel-host-constraint

### DIFF
--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -69,9 +69,8 @@
   (job-constraint-name [this] (get-class-name this))
   (job-constraint-evaluate
     [this _ vm-attributes]
-    (let [job (:job this)
-          target-hostname (get vm-attributes "HOSTNAME")]
-      [(not-any? #(= target-hostname %) previous-hosts)
+    (let [target-hostname (get vm-attributes "HOSTNAME")]
+      [(not (get previous-hosts target-hostname))
        "Already ran on host"]))
   (job-constraint-evaluate
     [this _ vm-attributes _]
@@ -90,7 +89,7 @@
   "Constructs a novel-host-constraint.
   The constraint prevents the job from running on hosts it has already run on"
   [job]
-  (let [previous-hosts (job->previous-hosts-to-avoid job)]
+  (let [previous-hosts (set (job->previous-hosts-to-avoid job))]
     (->novel-host-constraint job previous-hosts)))
 
 (defn job->gpu-model-requested


### PR DESCRIPTION
## Changes proposed in this PR

- Optimize novel-host-constraint time by ~10%.

## Why are we making these changes?
This check is run whenever trying to see if a job can run on a prospective host. Use a hashset instead of list traversal for membership testing. This is about 10% of total runtime.

