### PR TITLE
Separate lock shards per compute cluster.

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -498,17 +498,10 @@
                            (throw
                              (ex-info
                                "Please configure :controller-lock-num-shards to > 0 and < 32778 in your config file."
-                               kubernetes)))
-                         lock-objects
-                         (repeatedly
-                           controller-lock-num-shards
-                           #(ReentrantLock.))]
+                               kubernetes)))]
                      (merge {:autoscaling-scale-factor 1.0
                              :clobber-synthetic-pods false
                              :controller-lock-num-shards controller-lock-num-shards
-                             :controller-lock-objects (with-meta
-                                                        lock-objects
-                                                        {:json-value (str lock-objects)})
                              :default-workdir "/mnt/sandbox"
                              :max-jobs-for-autoscaling 1000
                              :pod-condition-containers-not-initialized-seconds 120

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -29,6 +29,7 @@
            (java.nio.charset StandardCharsets)
            (java.io ByteArrayInputStream File FileInputStream InputStreamReader)
            (java.util.concurrent Executors ExecutorService ScheduledExecutorService TimeUnit)
+           (java.util.concurrent.locks ReentrantLock)
            (java.util Base64 UUID)
            (okhttp3 OkHttpClient$Builder)))
 
@@ -318,7 +319,8 @@
                                      synthetic-pods-config node-blocklist-labels
                                      ^ExecutorService launch-task-executor-service
                                      cluster-definition state-atom state-locked?-atom dynamic-cluster-config?
-                                     compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name]
+                                     compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name
+                                     controller-lock-objects]
   cc/ComputeCluster
   (launch-tasks [this pool-name matches process-task-post-launch-fn]
     (let [task-metadata-seq (mapcat :task-metadata-seq matches)]
@@ -758,7 +760,8 @@
                                     use-token-refreshing-authenticator?)
         launch-task-executor-service (Executors/newFixedThreadPool launch-task-num-threads)
         compute-cluster-launch-rate-limiter (cook.rate-limit/create-compute-cluster-launch-rate-limiter name compute-cluster-launch-rate-limits)
-        compute-cluster (->KubernetesComputeCluster api-client 
+        lock-shard-count (:controller-lock-num-shards config/kubernetes)
+        compute-cluster (->KubernetesComputeCluster api-client
                                                     name
                                                     cluster-entity-id
                                                     exit-code-syncer-state
@@ -781,6 +784,8 @@
                                                     (atom state)
                                                     (atom state-locked?)
                                                     dynamic-cluster-config?
-                                                    compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name)]
+                                                    compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name
+                                                    (with-meta (repeatedly lock-shard-count #(ReentrantLock.))
+                                                        {:json-value (str "<count of " lock-shard-count " ReentrantLocks>")}))]
     (cc/register-compute-cluster! compute-cluster)
     compute-cluster))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -760,7 +760,7 @@
                                     use-token-refreshing-authenticator?)
         launch-task-executor-service (Executors/newFixedThreadPool launch-task-num-threads)
         compute-cluster-launch-rate-limiter (cook.rate-limit/create-compute-cluster-launch-rate-limiter name compute-cluster-launch-rate-limits)
-        lock-shard-count (:controller-lock-num-shards config/kubernetes)
+        lock-shard-count (:controller-lock-num-shards (config/kubernetes))
         compute-cluster (->KubernetesComputeCluster api-client
                                                     name
                                                     cluster-entity-id

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -46,6 +46,7 @@
            (io.kubernetes.client.custom Quantity Quantity$Format)
            (io.kubernetes.client.openapi.models V1Container V1Node V1NodeSpec V1NodeStatus V1ObjectMeta V1Pod V1PodSpec V1ResourceRequirements V1Taint)
            (java.util.concurrent Executors TimeUnit)
+           (java.util.concurrent.locks ReentrantLock)
            (java.util UUID)
            (org.apache.log4j ConsoleAppender Logger PatternLayout)))
 
@@ -645,4 +646,5 @@
                                     rate-limit/AllowAllRateLimiter
                                     "some-random-taint-A"
                                     "taint-prefix-1"
-                                    "some-random-label-A")))
+                                    "some-random-label-A"
+                                    (repeatedly 16 #(ReentrantLock.)))))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -367,7 +367,7 @@
   (testing "guards against inappropriate number of threads"
     (with-redefs [kcc/get-or-create-cluster-entity-id (constantly 1)
                   cc/register-compute-cluster! (constantly nil)
-                  config/kubernetes {:controller-lock-num-shards 5}]
+                  config/kubernetes (constantly {:controller-lock-num-shards 5})]
       (is (kcc/factory-fn {:use-google-service-account? false} nil))
       (is (kcc/factory-fn {:launch-task-num-threads 1
                            :use-google-service-account? false}

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -12,8 +12,7 @@
 
 (defn make-test-kubernetes-config
   []
-  {:controller-lock-num-shards 1
-   :controller-lock-objects [(ReentrantLock.)]})
+  {:controller-lock-num-shards 1})
 
 (deftest test-k8s-actual-state-equivalent?
   (testing "different states"
@@ -149,7 +148,8 @@
         mock-cc {:api-client nil
                  :cook-expected-state-map cook-expected-state-map
                  :k8s-actual-state-map k8s-actual-state-map
-                 :cook-starting-pods (atom {})}
+                 :cook-starting-pods (atom {})
+                 :controller-lock-objects [(ReentrantLock.)]}
         extract-cook-expected-state (fn []
                                       (:cook-expected-state (get @cook-expected-state-map pod-name {})))
         count-kill-pod (atom 0)]
@@ -272,7 +272,8 @@
 (deftest test-scan-process
   (testing "gracefully handles nil pod"
     (let [compute-cluster {:k8s-actual-state-map (atom {})
-                           :cook-expected-state-map (atom {})}
+                           :cook-expected-state-map (atom {})
+                           :controller-lock-objects [(ReentrantLock.)]}
           pod-name "test-pod"]
       (with-redefs [config/kubernetes make-test-kubernetes-config]
         (controller/scan-process compute-cluster pod-name)))))


### PR DESCRIPTION
## Changes proposed in this PR

- Separate lock shards per compute cluster. 

## Why are we making these changes?
Right now the set of lock shards is global across all of Cook, so one stuck thread can hold a lock shard which, via lock aliasing, can get another thread stuck which can cascade throughout the system. By splitting it, we can limit the blast radius of a stuck thread to the transitive closure of the related pools and the compute clusters that supply them. Even if a thread is stuck, we can at least make more progress before it cascades into everything freezing.

