### PR TITLE
Prevents inactive pools from having a scheduling loop

### DIFF
--- a/scheduler/src/cook/pool.clj
+++ b/scheduler/src/cook/pool.clj
@@ -64,6 +64,11 @@
   [pool]
   (= :pool.state/active (:pool/state pool)))
 
+(defn schedules-jobs?
+  "Returns true if the given pool should schedule jobs"
+  [pool]
+  (= :pool.state/active (:pool/state pool)))
+
 (defn guard-invalid-default-pool
   "Throws if either of the following is true:
    - there are pools in the database, but no default pool is configured

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1947,7 +1947,7 @@
   (persist-mea-culpa-failure-limit! conn mea-culpa-failure-limit)
 
   (let [{:keys [match-trigger-chan rank-trigger-chan]} trigger-chans
-        pools (pool/all-pools (d/db conn))
+        pools (->> conn d/db pool/all-pools (filter pool/schedules-jobs?))
         pools' (if (-> pools count pos?)
                  pools
                  [{:pool/name "no-pool"}])

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2262,7 +2262,16 @@
           output-atom (atom [])]
       (with-redefs [sched/persist-mea-culpa-failure-limit! (fn [_ _])
                     d/db (fn [_])
-                    pool/all-pools (fn [_] [{:pool/name "pool 1"} {:pool/name "pool 2"} {:pool/name "pool 3"}])
+                    pool/all-pools
+                    (fn [_]
+                      [{:pool/name "pool 1"
+                        :pool/state :pool.state/active}
+                       {:pool/name "pool 2"
+                        :pool/state :pool.state/active}
+                       {:pool/name "pool 3"
+                        :pool/state :pool.state/active}
+                       {:pool/name "old pool"
+                        :pool/state :pool.state/inactive}])
                     sched/make-fenzo-scheduler (fn [_ _ _])
                     sched/make-offer-handler (fn [_ _ _ _ _ _ _ _ trigger-chan _ _ pool-name _ _]
                                                (tools/chime-at-ch


### PR DESCRIPTION
## Changes proposed in this PR

Only starting a scheduling loop for pools that are active.

## Why are we making these changes?

We don't want to waste CPU, mem, etc. on scheduling loops for pools that have been disabled.
