### PR TITLE
Do fenzo unassign in batches outside of the fenzo lock

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -82,6 +82,7 @@
                                :factory-fn "cook.plugins.demo-plugin/launch-factory"}}
  :hostname #config/env "COOK_HOSTNAME"
  :kubernetes {:add-job-label-to-pod-prefix "platform/"
+              :clobber-synthetic-pods true
               :disallowed-container-paths #{"/mnt/bad"}
               :disallowed-var-names #{"BADVAR"}
               :init-container {:command ["/bin/sh" "-c" "echo sample init container running"]

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -62,7 +62,7 @@
   (db-id [this]
     "Get a database entity-id for this compute cluster (used for putting it into a task structure).")
 
-  (initialize-cluster [this pool->fenzo]
+  (initialize-cluster [this pool-name->fenzo-state]
     "Initializes the cluster. Returns a channel that will be delivered on when the cluster loses leadership.
      We expect Cook to give up leadership when a compute cluster loses leadership, so leadership is not expected to be regained.
      The channel result will be an exception if an error occurred, or a status message if leadership was lost normally.")
@@ -453,9 +453,9 @@
       (check-for-unique-constraint-violations resulting-active-configs :base-path)
       (check-for-unique-constraint-violations resulting-active-configs :ca-cert))))
 
-; we need to save pool->fenzo and exit-code-syncer so that clusters created later have access to them
+; we need to save pool-name->fenzo-state and exit-code-syncer so that clusters created later have access to them
 (def exit-code-syncer-state-atom (atom nil))
-(def pool-name->fenzo-atom (atom nil))
+(def pool-name->fenzo-state-atom (atom nil))
 
 (defn initialize-cluster!
   "Create and initialize a ComputeCluster"
@@ -471,7 +471,7 @@
                             {:template template})))
         full-cluster-config (-> (:config cluster-definition-template) (merge config) (assoc :dynamic-cluster-config? true))
         cluster (resolved full-cluster-config {:exit-code-syncer-state @exit-code-syncer-state-atom})]
-    (initialize-cluster cluster @pool-name->fenzo-atom)))
+    (initialize-cluster cluster @pool-name->fenzo-state-atom)))
 
 (defn execute-update!
   "Attempt to execute a valid cluster configuration update.

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -133,7 +133,7 @@
   "Helper function for calling scheduler/write-status-to-datomic"
   [compute-cluster mesos-status]
   (scheduler/write-status-to-datomic datomic/conn
-                                     @(:pool->fenzo-atom compute-cluster)
+                                     @(:pool-name->fenzo-state-atom compute-cluster)
                                      mesos-status))
 
 (defn handle-pod-submission-failed

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -195,7 +195,7 @@
                           ;clojure.lang.Agent/pooledExecutor
                           (reify LeaderSelectorListener
                             (takeLeadership [_ client]
-                              (let [{:keys [pool-name->fenzo view-incubating-offers] :as scheduler}
+                              (let [{:keys [pool-name->fenzo-state view-incubating-offers] :as scheduler}
                                     (sched/create-datomic-scheduler
                                       {:conn mesos-datomic-conn
                                        :cluster-name->compute-cluster-atom cook.compute-cluster/cluster-name->compute-cluster-atom
@@ -213,10 +213,10 @@
                                        :rebalancer-reservation-atom rebalancer-reservation-atom
                                        :task-constraints task-constraints
                                        :trigger-chans trigger-chans})]
-                                ; we need to make sure to initialize cc/pool-name->fenzo-atom before we take leadership
-                                ; after we take leadership, we should be able to create dynamic clusters, so cc/pool-name->fenzo-atom
+                                ; we need to make sure to initialize cc/pool-name->fenzo-state-atom before we take leadership
+                                ; after we take leadership, we should be able to create dynamic clusters, so cc/pool-name->fenzo-state-atom
                                 ; needs to be set
-                                (reset! cc/pool-name->fenzo-atom (:pool-name->fenzo scheduler))
+                                (reset! cc/pool-name->fenzo-state-atom (:pool-name->fenzo-state scheduler))
                                 (dynamic-compute-cluster-configurations-setup mesos-datomic-conn (config/compute-cluster-options))
                                 (log/warn "Taking leadership")
                                 (reset! leadership-atom true)
@@ -229,7 +229,7 @@
                                                                          (map (fn [[compute-cluster-name compute-cluster]]
                                                                                 (try
                                                                                   (cc/initialize-cluster compute-cluster
-                                                                                                         pool-name->fenzo)
+                                                                                                         pool-name->fenzo-state)
                                                                                   (catch Throwable t
                                                                                     (log/error t "Error launching compute cluster" compute-cluster-name)
                                                                                     ; Return a chan that never gets a message on it.

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -60,7 +60,7 @@
   (:import (com.netflix.fenzo
              TaskAssignmentResult TaskRequest TaskScheduler TaskScheduler$Builder VirtualMachineCurrentState
              VirtualMachineLease VirtualMachineLease$Range)
-           (com.netflix.fenzo.functions Action1 Func1)
+           (com.netflix.fenzo.functions Action1 Action2 Func1)
            (java.util LinkedList)))
 
 (defn now
@@ -236,7 +236,7 @@
 
 (defn write-status-to-datomic
   "Takes a status update from mesos."
-  [conn pool->fenzo status]
+  [conn pool-name->fenzo-state status]
   (log/info "Instance status is:" status)
   (timers/time!
     handle-status-update-duration
@@ -275,21 +275,12 @@
                                    (.getTime (or (:instance/start-time instance-ent) current-time)))
                job-resources (tools/job-ent->resources job-ent)
                pool-name (cached-queries/job->pool-name job-ent)
-               ^TaskScheduler fenzo (get pool->fenzo pool-name)]
+               unassign-task-set (some-> (pool-name->fenzo-state pool-name) :unassign-task-set)]
            (when (#{:instance.status/success :instance.status/failed} instance-status)
-             (if fenzo
-               (try
-                 (log/debug "In" pool-name "pool, unassigning task"
-                            task-id "from" (:instance/hostname instance-ent))
-                 (locking fenzo
-                   (.. fenzo
-                       (getTaskUnAssigner)
-                       (call task-id (:instance/hostname instance-ent))))
-                 (catch Exception e
-                   (log/error e "In" pool-name "pool, failed to unassign task"
-                              task-id "from" (:instance/hostname instance-ent))))
+             (if unassign-task-set
+               (swap! unassign-task-set conj [task-id (:instance/hostname instance-ent)])
                (log/error "In" pool-name "pool, unable to unassign task" task-id "from"
-                          (:instance/hostname instance-ent) "because fenzo is nil:" pool->fenzo)))
+                          (:instance/hostname instance-ent) "because fenzo is nil:" (keys pool-name->fenzo-state))))
            (when (= instance-status :instance.status/success)
              (handle-throughput-metrics job-resources instance-runtime :succeeded pool-name)
              (handle-throughput-metrics job-resources instance-runtime :completed pool-name))
@@ -641,7 +632,7 @@
 
    Returns {:matches (list of tasks that got matched to the offer)
             :failures (list of unmatched tasks, and why they weren't matched)}"
-  [db ^TaskScheduler fenzo considerable offers rebalancer-reservation-atom pool-name]
+  [db {:keys [^TaskScheduler fenzo unassign-task-set]} considerable offers rebalancer-reservation-atom pool-name]
   (if (and (-> considerable count zero?)
            (-> offers count pos?)
            (every? :reject-after-match-attempt offers))
@@ -673,7 +664,17 @@
             ;; Need to lock on fenzo when accessing scheduleOnce because scheduleOnce and
             ;; task assigner can not be called at the same time.
             ;; task assigner may be called when reconciling
+            to-unassign (util/set-atom! unassign-task-set #{})
+            ^Action2 unassigner (.getTaskUnAssigner fenzo)
             result (locking fenzo
+                     (doseq [[task-id hostname] to-unassign]
+                       (try
+                         (log/debug "In" pool-name "pool, unassigning task"
+                                    task-id "from" hostname)
+                         (.call unassigner task-id hostname)
+                         (catch Exception e
+                           (log/error e "In" pool-name "pool, failed to unassign task"
+                                      task-id "from" hostname))))
                      (timers/time!
                        (timers/timer (metric-title "fenzo-schedule-once-duration" pool-name))
                        (.scheduleOnce fenzo requests leases)))
@@ -1066,7 +1067,7 @@
 (defn handle-resource-offers!
   "Gets a list of offers from mesos. Decides what to do with them all--they should all
    be accepted or rejected at the end of the function."
-  [conn ^TaskScheduler fenzo pool-name->pending-jobs-atom mesos-run-as-user
+  [conn fenzo-state pool-name->pending-jobs-atom mesos-run-as-user
    user->usage user->quota num-considerable offers rebalancer-reservation-atom pool-name compute-clusters
    job->acceptable-compute-clusters-fn]
   (log/debug "In" pool-name "pool, invoked handle-resource-offers!")
@@ -1085,7 +1086,7 @@
               ; matches is a vector of maps of {:hostname .. :leases .. :tasks}
               {:keys [matches failures]} (timers/time!
                                            (timers/timer (metric-title "handle-resource-offer!-match-duration" pool-name))
-                                           (match-offer-to-schedule db fenzo considerable-jobs offers
+                                           (match-offer-to-schedule db fenzo-state considerable-jobs offers
                                                                     rebalancer-reservation-atom pool-name))
               matches (filter-matches-for-ratelimit matches)
               _ (log/debug "In" pool-name "pool, got matches after rate limit:" matches)
@@ -1235,7 +1236,7 @@
                     (log/debug "In" pool-name
                                "pool, updated pool-name->pending-jobs-atom:"
                                @pool-name->pending-jobs-atom)
-                    (launch-matched-tasks! matches conn db fenzo mesos-run-as-user pool-name)
+                    (launch-matched-tasks! matches conn db (:fenzo fenzo-state) mesos-run-as-user pool-name)
                     (update-host-reservations! rebalancer-reservation-atom matched-job-uuids)
                     matched-considerable-jobs-head?))
                 ; Absolute maximum jobs we will consider autoscaling to.
@@ -1314,10 +1315,11 @@
 
 (defn make-offer-handler
   "Make the core scheduling loop for a pool"
-  [conn fenzo pool-name->pending-jobs-atom agent-attributes-cache max-considerable scaleback
+  [conn fenzo-state pool-name->pending-jobs-atom agent-attributes-cache max-considerable scaleback
    floor-iterations-before-warn floor-iterations-before-reset trigger-chan rebalancer-reservation-atom
    mesos-run-as-user pool-name cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn]
-  (let [resources-atom (atom (view-incubating-offers fenzo))]
+  (let [fenzo (:fenzo fenzo-state)
+        resources-atom (atom (view-incubating-offers fenzo))]
     (reset! fenzo-num-considerable-atom max-considerable)
     (tools/chime-at-ch
       trigger-chan
@@ -1368,7 +1370,7 @@
                                                               (cache/miss c slave-id (get-offer-attr-map offer))))))
                         using-pools? (not (nil? (config/default-pool)))
                         user->quota (quota/create-user->quota-fn (d/db conn) (if using-pools? pool-name nil))
-                        matched-head? (handle-resource-offers! conn fenzo pool-name->pending-jobs-atom
+                        matched-head? (handle-resource-offers! conn fenzo-state pool-name->pending-jobs-atom
                                                                mesos-run-as-user @user->usage-future user->quota
                                                                num-considerable offers
                                                                rebalancer-reservation-atom pool-name compute-clusters
@@ -1432,7 +1434,7 @@
 ;; TODO test that this fenzo recovery system actually works
 (defn reconcile-tasks
   "Finds all non-completed tasks, and has Mesos let us know if any have changed."
-  [db compute-cluster driver pool->fenzo]
+  [db compute-cluster driver pool-name->fenzo-state]
   (let [running-tasks (q '[:find ?task-id ?status ?slave-id
                            :in $ [?status ...] ?compute-cluster-id
                            :where
@@ -1456,10 +1458,20 @@
                                    (when-let [job (tools/job-ent->map (:job/_instance task-ent))]
                                      (let [pool-name (cached-queries/job->pool-name job)
                                            task-request (make-task-request db job pool-name :task-id task-id)
-                                           ^TaskScheduler fenzo (pool->fenzo pool-name)]
+                                           {:keys [^TaskScheduler fenzo unassign-task-set]} (pool-name->fenzo-state pool-name)
+                                           to-unassign (util/set-atom! unassign-task-set #{})
+                                           ^Action2 unassigner (.getTaskUnAssigner fenzo)]
                                        ;; Need to lock on fenzo when accessing taskAssigner because taskAssigner and
                                        ;; scheduleOnce can not be called at the same time.
                                        (locking fenzo
+                                         (doseq [[task-id hostname] to-unassign]
+                                           (try
+                                             (log/debug "In" pool-name "pool, unassigning task"
+                                                        task-id "from" hostname)
+                                             (.call unassigner task-id hostname)
+                                             (catch Exception e
+                                               (log/error e "In" pool-name "pool, failed to unassign task"
+                                                          task-id "from" hostname))))
                                          (.. fenzo
                                              (getTaskAssigner)
                                              (call task-request hostname)))
@@ -1838,26 +1850,30 @@
 (meters/defmeter [cook-mesos scheduler mesos-error])
 (meters/defmeter [cook-mesos scheduler offer-chan-full-error])
 
-(defn make-fenzo-scheduler
+(defn make-fenzo-state
+  "Make a fenzo scheduler state. This consists of the fenzo scheduler itself and a set of tasks that
+  should be unassigned the next iteration through."
   [offer-incubate-time-ms fitness-calculator good-enough-fitness]
-  (.. (TaskScheduler$Builder.)
-      (disableShortfallEvaluation) ;; We're not using the autoscaling features
-      (withLeaseOfferExpirySecs (max (-> offer-incubate-time-ms time/millis time/in-seconds) 1)) ;; should be at least 1 second
-      (withRejectAllExpiredOffers)
-      (withFitnessCalculator (config/fitness-calculator fitness-calculator))
-      (withFitnessGoodEnoughFunction (reify Func1
-                                       (call [_ fitness]
-                                         (> fitness good-enough-fitness))))
-      (withLeaseRejectAction (reify Action1
-                               (call [_ lease]
-                                 (let [offer (:offer lease)
-                                       id (:id offer)]
-                                   (log/debug "Fenzo is declining offer" offer)
-                                   (try
-                                     (decline-offers (:compute-cluster offer) [id])
-                                     (catch Exception e
-                                       (log/error e "Unable to decline fenzos rejected offers")))))))
-      (build)))
+  {:unassign-task-set (atom #{})
+   :fenzo
+   (.. (TaskScheduler$Builder.)
+       (disableShortfallEvaluation) ;; We're not using the autoscaling features
+       (withLeaseOfferExpirySecs (max (-> offer-incubate-time-ms time/millis time/in-seconds) 1)) ;; should be at least 1 second
+       (withRejectAllExpiredOffers)
+       (withFitnessCalculator (config/fitness-calculator fitness-calculator))
+       (withFitnessGoodEnoughFunction (reify Func1
+                                        (call [_ fitness]
+                                          (> fitness good-enough-fitness))))
+       (withLeaseRejectAction (reify Action1
+                                (call [_ lease]
+                                  (let [offer (:offer lease)
+                                        id (:id offer)]
+                                    (log/debug "Fenzo is declining offer" offer)
+                                    (try
+                                      (decline-offers (:compute-cluster offer) [id])
+                                      (catch Exception e
+                                        (log/error e "Unable to decline fenzos rejected offers")))))))
+       (build))})
 
 (defn persist-mea-culpa-failure-limit!
   "The Datomic transactor needs to be able to access this part of the
@@ -1951,8 +1967,8 @@
         pools' (if (-> pools count pos?)
                  pools
                  [{:pool/name "no-pool"}])
-        pool-name->fenzo (pool-map pools' (fn [_] (make-fenzo-scheduler offer-incubate-time-ms
-                                                                        fenzo-fitness-calculator good-enough-fitness)))
+        pool-name->fenzo-state (pool-map pools' (fn [_] (make-fenzo-state offer-incubate-time-ms
+                                                                          fenzo-fitness-calculator good-enough-fitness)))
         pool->match-trigger-chan (pool-map pools' (fn [_] (async/chan (async/sliding-buffer 1))))
         pool-names-linked-list (LinkedList. (map :pool/name pools'))
         job->acceptable-compute-clusters-fn
@@ -1964,7 +1980,8 @@
                                pools'
                                (fn [{:keys [pool/name]}]
                                  (make-offer-handler
-                                   conn (pool-name->fenzo name) pool-name->pending-jobs-atom agent-attributes-cache
+                                   conn (get pool-name->fenzo-state name)
+                                   pool-name->pending-jobs-atom agent-attributes-cache
                                    fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn
                                    fenzo-floor-iterations-before-reset (get pool->match-trigger-chan name)
                                    rebalancer-reservation-atom mesos-run-as-user name
@@ -1980,8 +1997,8 @@
             (log/error e "Exception in match-trigger-chan chime handler")
             (throw e)))
         (recur)))
-    (log/info "Pool name to fenzo scheduler map:" pool-name->fenzo)
+    (log/info "Pool name to fenzo scheduler map:" (keys pool-name->fenzo-state))
     (start-jobs-prioritizer! conn pool-name->pending-jobs-atom task-constraints rank-trigger-chan)
-    {:pool-name->fenzo pool-name->fenzo
+    {:pool-name->fenzo-state pool-name->fenzo-state
      :view-incubating-offers (fn get-resources-atom [p]
                                (deref (get pool->resources-atom p)))}))

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -632,7 +632,7 @@
                                     (atom {}) ; cook-expected-state-map
                                     (atom {}) ; cook-starting-pods
                                     (atom {}) ; k8s-actual-state-map
-                                    (atom nil) ; pool->fenzo-atom
+                                    (atom nil) ; pool-name->fenzo-state-atom
                                     {:kind :per-user} ; namespace-config
                                     nil ; scan-frequency-seconds-config
                                     nil ; max-pods-per-node

--- a/scheduler/src/cook/util.clj
+++ b/scheduler/src/cook/util.clj
@@ -220,3 +220,11 @@
           (log/error e "Encountered exception while merging" {:args args})
           (throw e))))
     maps))
+
+(defn set-atom!
+  "Atomically set the atom to the new value, return the old val"
+  [atom newval]
+  (loop []
+    (let [old-val @atom
+          swap-happened (compare-and-set! atom old-val newval)]
+      (if swap-happened old-val (recur)))))

--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -522,7 +522,7 @@
            dynamic-cluster-config?]
     :as compute-cluster-config} _]
   (when (= "fail" (:name compute-cluster-config)) (throw (ex-info "fail" {})))
-  (reset! pool-name->fenzo-atom {:pool-name :fenzo})
+  (reset! pool-name->fenzo-state-atom {:pool-name {:fenzo :fenzo}})
   (let [backing-map {:name name
                      :dynamic-cluster-config? dynamic-cluster-config?
                      :state-atom (atom state)
@@ -530,8 +530,8 @@
                      :cluster-definition {:factory-fn 'cook.kubernetes.compute-cluster/factory-fn :config compute-cluster-config}}
         compute-cluster (reify ComputeCluster
                           (compute-cluster-name [cluster] (:name cluster))
-                          (initialize-cluster [cluster pool->fenzo]
-                            (is (= {:pool-name :fenzo} pool->fenzo))
+                          (initialize-cluster [cluster pool-name->fenzo-state]
+                            (is (= {:pool-name {:fenzo :fenzo}} pool-name->fenzo-state))
                             (swap! initialize-cluster-fn-invocations-atom conj (:name cluster)))
                           java.util.Map
                           (get [_ val] (backing-map val))

--- a/scheduler/test/cook/test/util.clj
+++ b/scheduler/test/cook/test/util.clj
@@ -49,3 +49,11 @@
                (deep-merge-with - {"foo" nil} {"foo" 1})))
   (is (thrown? NullPointerException
                (deep-merge-with - {"foo" 1} {"foo" nil}))))
+
+
+(deftest test-set-atom!
+  (let [state (atom {})]
+    (is (= @state {}))
+    (is (= (set-atom! state "a") {}))
+    (is (= (set-atom! state {:a :b}) "a"))
+    (is (= @state {:a :b}))))


### PR DESCRIPTION
## Changes proposed in this PR

- Do unassignments asyncronously, adding to a list, and later unassigning just before matching.

## Why are we making these changes?
This avoids the fenzo lock being held when processing the k8s state machine, which would otherwise cause all pod completions to get stuck waiting for that lock.

