### PR TITLE
Split metrics for synthetic pods and normal pods for time until run and time until waiting

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -180,9 +180,10 @@
   (if (api/launch-pod api-client name cook-expected-state-dict pod-name)
     ; These metrics only measure the happy paths to avoid wide variations from error rates changing.
     ; k8s-response-time-until-waiting helps us characterize watch latency
-    (merge {:waiting-metric-timer (timers/start (metrics/timer "k8s-response-time-until-waiting" name))
-            :running-metric-timer (timers/start (metrics/timer "k8s-response-time-until-running" name))}
-           cook-expected-state-dict)
+    (let [metric-suffix (if (api/synthetic-pod? pod-name) "-synthetic" "")]
+    (merge {:waiting-metric-timer (timers/start (metrics/timer (str "k8s-response-time-until-waiting" metric-suffix) name))
+            :running-metric-timer (timers/start (metrics/timer (str "k8s-response-time-until-running" metric-suffix) name))}
+           cook-expected-state-dict))
     (handle-pod-submission-failed compute-cluster pod-name)))
 
 (defn update-or-delete!


### PR DESCRIPTION
## Changes proposed in this PR

- Collect metrics for time until waiting and running for synthetic pods and regular pods separately.

## Why are we making these changes?
We think that these will have different responsivenesses, so track them separately.

