### PR TITLE
Make the lock vector a vector, not a sequence.

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -785,6 +785,7 @@
                                                     (atom state-locked?)
                                                     dynamic-cluster-config?
                                                     compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name
+                                                    ; Vector instead of seq for O(1) access.
                                                     (with-meta (vec (repeatedly lock-shard-count #(ReentrantLock.)))
                                                         {:json-value (str "<count of " lock-shard-count " ReentrantLocks>")}))]
     (cc/register-compute-cluster! compute-cluster)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -785,7 +785,7 @@
                                                     (atom state-locked?)
                                                     dynamic-cluster-config?
                                                     compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name
-                                                    (with-meta (repeatedly lock-shard-count #(ReentrantLock.))
+                                                    (with-meta (vec (repeatedly lock-shard-count #(ReentrantLock.)))
                                                         {:json-value (str "<count of " lock-shard-count " ReentrantLocks>")}))]
     (cc/register-compute-cluster! compute-cluster)
     compute-cluster))


### PR DESCRIPTION
## Changes proposed in this PR

- Make the lock vector a vector, not a sequence.

## Why are we making these changes?
So we can get access to locks with O(1) instead of O(n).

