### PR TITLE
Fix time-until-waiting metric.

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -566,7 +566,7 @@
                                           :pod/waiting (do
                                                          (when waiting-metric-timer (timers/stop waiting-metric-timer))
                                                          ; Delete the timer so we only track the first time.
-                                                         (dissoc cook-expected-state-dict waiting-metric-timer)))
+                                                         (dissoc cook-expected-state-dict :waiting-metric-timer)))
 
                                         :missing
                                         (case pod-synthesized-state-modified


### PR DESCRIPTION
## Changes proposed in this PR

- We need to detach the timer so that we don't count waiting excessively for synthetic pods. We'll count each state revisit, not the first one where the pod shows as there.

## Why are we making these changes?
Make the metric correct.

