### PR TITLE
Adds pod label prefix to workload labels

### DIFF
--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -449,7 +449,7 @@
                                                fake-cc-config
                                                task-metadata)
             pod-labels (-> pod .getMetadata .getLabels)]
-        (is (= "cook-job" (get pod-labels "workload-class")))
+        (is (= "undefined" (get pod-labels "workload-class")))
         (is (= "bar" (get pod-labels "workload-id")))
         (is (= "baz" (get pod-labels "workload-details"))))
 
@@ -463,7 +463,7 @@
                                                task-metadata)
             pod-labels (-> pod .getMetadata .getLabels)]
         (is (= "foo" (get pod-labels "workload-class")))
-        (is (= "unspecified" (get pod-labels "workload-id")))
+        (is (= "undefined" (get pod-labels "workload-id")))
         (is (= "baz" (get pod-labels "workload-details"))))
 
       ; No workload-details specified
@@ -477,7 +477,7 @@
             pod-labels (-> pod .getMetadata .getLabels)]
         (is (= "foo" (get pod-labels "workload-class")))
         (is (= "bar" (get pod-labels "workload-id")))
-        (is (= "none" (get pod-labels "workload-details"))))
+        (is (= "undefined" (get pod-labels "workload-details"))))
 
       ; No workload- fields specified
       (let [task-metadata {:command {:user "test-user"}
@@ -487,9 +487,9 @@
                                                fake-cc-config
                                                task-metadata)
             pod-labels (-> pod .getMetadata .getLabels)]
-        (is (= "cook-job" (get pod-labels "workload-class")))
-        (is (= "unspecified" (get pod-labels "workload-id")))
-        (is (= "none" (get pod-labels "workload-details")))))
+        (is (= "undefined" (get pod-labels "workload-class")))
+        (is (= "undefined" (get pod-labels "workload-id")))
+        (is (= "undefined" (get pod-labels "workload-details")))))
 
     (testing "synthetic pod anti-affinity"
       (with-redefs [config/kubernetes (constantly {:synthetic-pod-anti-affinity-namespace "test-namespace"


### PR DESCRIPTION
## Changes proposed in this PR

- adding the configured pod label prefix to the `workload-*` labels
- changing the defaults to `undefined` for the `workload-*` labels

## Why are we making these changes?

So that the `workload-*` labels are consistent with the other pod labels that are passed through from job labels due to their prefix.
