### PR TITLE
Bumps CLI version to v3.9.1

### DIFF
--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.9.0'
+VERSION = '3.9.1'


### PR DESCRIPTION
## Changes proposed in this PR

Bumping the CLI version.

## Why are we making these changes?

To release the CLI.
