### PR TITLE
make straggler kill mea culpa

### DIFF
--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -1413,7 +1413,7 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :reason/code 2004
     :reason/string "Task was a straggler"
     :reason/name :straggler
-    :reason/mea-culpa? false}
+    :reason/mea-culpa? true}
 
    {:db/id (d/tempid :db.part/user)
     :reason/code 3000


### PR DESCRIPTION
## Changes proposed in this PR

- make straggler kill mea culpa

## Why are we making these changes?

Consider straggler kill as something that is not a property of the job. Allow it to re-run
