### PR TITLE
Updates java jobclient version to 0.8.3

### DIFF
--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -3,7 +3,7 @@
   <groupId>twosigma</groupId>
   <artifactId>cook-jobclient</artifactId>
   <packaging>jar</packaging>
-  <version>0.8.3</version>
+  <version>0.8.4-SNAPSHOT</version>
   <name>cook-jobclient</name>
   <description>A Java API for connecting to the Cook scheduler, submitting, and monitoring jobs.</description>
   <licenses>

--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -3,7 +3,7 @@
   <groupId>twosigma</groupId>
   <artifactId>cook-jobclient</artifactId>
   <packaging>jar</packaging>
-  <version>0.8.3-SNAPSHOT</version>
+  <version>0.8.3</version>
   <name>cook-jobclient</name>
   <description>A Java API for connecting to the Cook scheduler, submitting, and monitoring jobs.</description>
   <licenses>

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -191,7 +191,7 @@
    {:dependencies [[criterium "0.4.4"]
                    [org.clojure/test.check "0.6.1"]
                    [org.mockito/mockito-core "1.10.19"]
-                   [twosigma/cook-jobclient "0.8.3-SNAPSHOT"]]}
+                   [twosigma/cook-jobclient "0.8.4-SNAPSHOT"]]}
 
    :test-console
    [:test {:jvm-opts ["-Dcook.test.logging.console"]}]


### PR DESCRIPTION
### Please Rebase and merge to preserve the two commits

## Changes proposed in this PR

- bumping the version

## Why are we making these changes?

To release the library.
