### PR TITLE
Conj the smaller set into the bigger set in update-host-reservation

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1005,7 +1005,7 @@
   [rebalancer-reservation-atom matched-job-uuids]
   (swap! rebalancer-reservation-atom (fn [{:keys [job-uuid->reserved-host launched-job-uuids]}]
                                        {:job-uuid->reserved-host (apply dissoc job-uuid->reserved-host matched-job-uuids)
-                                        :launched-job-uuids (into matched-job-uuids launched-job-uuids)})))
+                                        :launched-job-uuids (into launched-job-uuids matched-job-uuids)})))
 
 (defn job->acceptable-compute-clusters
   "Given a job and a collection of compute clusters, returns the

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1989,7 +1989,8 @@
               job-1-uuid (d/squuid)
               job-2-uuid (d/squuid)
               initial-reservation-state {:job-uuid->reserved-host {job-1-uuid (:hostname offer-9)
-                                                                   job-2-uuid (:hostname offer-9)}}
+                                                                   job-2-uuid (:hostname offer-9)}
+                                         :launched-job-uuids #{}}
               rebalancer-reservation-atom (atom initial-reservation-state)]
           (is (run-handle-resource-offers! num-considerable offers "test-pool" :rebalancer-reservation-atom rebalancer-reservation-atom
                                            :job-name->uuid {"job-1" job-1-uuid "job-2" job-2-uuid}))


### PR DESCRIPTION
## Changes proposed in this PR

- Conj matched-job-uuids into launch-job-uuids in update-host-reservation instead of the other way around.

## Why are we making these changes?
This data is used by the rebalancer. 
Maunched-job-uuids is the much bigger set. Its more efficient to add the matches to this much larger set than the reverse.
I estimate cook slows down about 2%/day in the matching loop as this set grows. 

