### PR TITLE
Refactor VirtualMachineLeaseAdaptor to go through factory.

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -454,7 +454,7 @@
 ;;; API for matcher
 ;;; ===========================================================================
 
-(defrecord VirtualMachineLeaseAdapter [offer time]
+(defrecord VirtualMachineLeaseAdapter [offer time attr-map]
   VirtualMachineLease
   (cpuCores [_] (or (offer-resource-scalar offer "cpus") 0.0))
   ; We support disk but support different types of disk, so we set this metric to 0.0 and take care of binpacking disk in the disk-host-constraint
@@ -468,7 +468,7 @@
                 result))
             {}
             (:resources offer)))
-  (getAttributeMap [_] (get-offer-attr-map offer))
+  (getAttributeMap [_] attr-map)
   (getId [_] (-> offer :id :value))
   (getOffer [_] (throw (UnsupportedOperationException.)))
   (getOfferedTime [_] time)
@@ -480,6 +480,9 @@
                           (VirtualMachineLease$Range. begin end))
                         (offer-resource-ranges offer "ports"))))
 
+(defn offer->lease
+  [offer time]
+  (->VirtualMachineLeaseAdapter offer time (get-offer-attr-map offer)))
 
 (defrecord TaskRequestAdapter [job resources task-id assigned-resources guuid->considerable-cotask-ids constraints scalar-requests]
   TaskRequest
@@ -662,7 +665,7 @@
       (log/debug "In" pool-name "pool, tasks to scheduleOnce" considerable)
       (dl/update-cost-staleness-metric considerable)
       (let [t (System/currentTimeMillis)
-            leases (mapv #(->VirtualMachineLeaseAdapter % t) offers)
+            leases (mapv #(offer->lease % t) offers)
             considerable->task-id (plumbing.core/map-from-keys (fn [_] (str (d/squuid))) considerable)
             guuid->considerable-cotask-ids (tools/make-guuid->considerable-cotask-ids considerable->task-id)
             running-cotask-cache (atom (cache/fifo-cache-factory {} :threshold (max 1 (count considerable))))

--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -116,7 +116,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "GPU task on GPU host with too many GPUs should fail"))
       (is (not (.isSuccessful
@@ -126,7 +126,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "GPU task on GPU host with too little GPUs should fail"))
       (is (not (.isSuccessful
@@ -136,7 +136,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "GPU task on GPU host with correct number of GPUs but without correct GPU models should fail"))
       (is (.isSuccessful
@@ -146,7 +146,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-gpu-offer 0)))
+                         (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
                        nil))
           (str "GPU task on GPU host with the correct number of GPUs should succeed"))
       (is (not (.isSuccessful
@@ -156,7 +156,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [gpu-task-assignment])
-                              (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "We only allow one GPU job per VM. This VM already has a GPU job assigned to it, so it should not get any additional GPU tasks."))
       (is (not (.isSuccessful
@@ -166,7 +166,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "non GPU task on GPU host should fail"))
       (is (not (.isSuccessful
@@ -176,7 +176,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-non-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (sched/offer->lease k8s-non-gpu-offer 0)))
                             nil)))
           "GPU task on non GPU host should fail")
       (is (.isSuccessful
@@ -186,7 +186,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-non-gpu-offer 0)))
+                         (getCurrAvailableResources [_] (sched/offer->lease k8s-non-gpu-offer 0)))
                        nil))
           "non GPU task on non GPU host should succeed")
       (is (not (.isSuccessful
@@ -196,7 +196,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter mesos-gpu-job 0)))
+                              (getCurrAvailableResources [_] (sched/offer->lease mesos-gpu-job 0)))
                             nil)))
           "GPU task on mesos GPU host should fail")
       (is (.isSuccessful
@@ -206,7 +206,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter mesos-non-gpu-job 0)))
+                         (getCurrAvailableResources [_] (sched/offer->lease mesos-non-gpu-job 0)))
                        nil))
           "non GPU task on non GPU mesos host should succeed"))
     (is (.isSuccessful
@@ -216,7 +216,7 @@
                        (getHostname [_] "test-host")
                        (getRunningTasks [_] [])
                        (getTasksCurrentlyAssigned [_] [])
-                       (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter k8s-non-gpu-offer 0)))
+                       (getCurrAvailableResources [_] (sched/offer->lease k8s-non-gpu-offer 0)))
                      nil))
         "non GPU task on non GPU host should succeed")))
 
@@ -265,7 +265,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter offer 0)))
+                         (getCurrAvailableResources [_] (sched/offer->lease offer 0)))
                        nil))
           (str "Disk task on host with enough disk and correct type should succeed"))
       (is (.isSuccessful
@@ -275,7 +275,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter offer 0)))
+                         (getCurrAvailableResources [_] (sched/offer->lease offer 0)))
                        nil))
           (str "Disk task on host with enough disk and correct type should succeed"))
       (is (not (.isSuccessful
@@ -285,7 +285,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter offer 0)))
+                              (getCurrAvailableResources [_] (sched/offer->lease offer 0)))
                             nil)))
           (str "Disk task on host without enough disk should fail"))
       (is (not (.isSuccessful
@@ -295,7 +295,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/->VirtualMachineLeaseAdapter offer 0)))
+                              (getCurrAvailableResources [_] (sched/offer->lease offer 0)))
                             nil)))
           (str "Disk task on host without correct disk type should fail"))
       (is (nil? (constraints/build-disk-host-constraint disk-request-job-5))))))
@@ -337,7 +337,7 @@
                            (getHostname [_] "hostB")
                            (getRunningTasks [_] [])
                            (getTasksCurrentlyAssigned [_] [])
-                           (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter hostB-offer 0)))
+                           (getCurrAvailableResources [_]  (sched/offer->lease hostB-offer 0)))
                          nil))))
     (is (.isSuccessful
          (.evaluate constraint
@@ -346,7 +346,7 @@
                       (getHostname [_] "hostA")
                       (getRunningTasks [_] [])
                       (getTasksCurrentlyAssigned [_] [])
-                      (getCurrAvailableResources [_]  (sched/->VirtualMachineLeaseAdapter hostA-offer 0)))
+                      (getCurrAvailableResources [_]  (sched/offer->lease hostA-offer 0)))
                     nil)))))
 
 

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -159,7 +159,7 @@
 
 (defn make-mesos-vm-offer
   [framework-id host offer-id & {:keys [attrs cpus mem disk] :or {attrs {} cpus 100.0 mem 100000.0 disk 100000.0}}]
-  (sched/->VirtualMachineLeaseAdapter
+  (sched/offer->lease
     (make-mesos-offer offer-id framework-id "test-slave" host
                       :cpus cpus :mem mem :disk disk :attrs attrs) 0))
 
@@ -176,7 +176,7 @@
 
 (defn make-k8s-vm-offer
   [framework-id host offer-id & {:keys [attrs cpus mem gpus disk] :or {attrs {} cpus 100.0 mem 100000.0 gpus {} disk 100000.0}}]
-  (sched/->VirtualMachineLeaseAdapter
+  (sched/offer->lease
     (make-k8s-offer offer-id framework-id "test-slave" host
                     :cpus cpus :mem mem :gpus gpus :disk disk :attrs attrs) 0))
 
@@ -791,7 +791,7 @@
                                                  #mesomatic.types.Resource{:name "gpus", :type :value-scalar :scalar 2.0 :role "*"}],
                                      :attributes [],
                                      :executor-ids []}
-        adapter (sched/->VirtualMachineLeaseAdapter offer now)]
+        adapter (sched/offer->lease offer now)]
 
     (is (= (.getId adapter) "my-offer-id"))
     (is (= (.cpuCores adapter) 40.0))
@@ -818,7 +818,7 @@
                            {:name "gpus", :type :value-text->scalar :text->scalar {"nvidia-tesla-p100" 2} :role "*"}],
                :attributes [],
                :executor-ids []}
-        adapter (sched/->VirtualMachineLeaseAdapter offer now)]
+        adapter (sched/offer->lease offer now)]
 
     (is (= (.getId adapter) "my-offer-id"))
     (is (= (.cpuCores adapter) 40.0))


### PR DESCRIPTION
## Changes proposed in this PR

- Refactor VirtualMachineLeaseAdaptor constructor to go through factory.

## Why are we making these changes?
This is the first on a set of refactors to compute VirtualMachineLeaseAdaptor.getAttributes more efficiently at construction time instead of at query time. In particular, get-attr-map can be calcualted much more efficiently on a set of offers in bulk instead of individually. That is the long term goal of these refactors.

