### PR TITLE
Skips inactive pools when ranking

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1750,7 +1750,7 @@
         pool-name->pending-task-ents (pc/map-vals #(map tools/create-task-ent %1) pool-name->pending-job-ents)
         pool-name->running-task-ents (group-by (comp cached-queries/job->pool-name :job/_instance)
                                                (tools/get-running-task-ents unfiltered-db))
-        pools (pool/all-pools unfiltered-db)
+        pools (->> unfiltered-db pool/all-pools (filter pool/schedules-jobs?))
         using-pools? (-> pools count pos?)
         pool-name->user->dru-divisors (if using-pools?
                                         (pool-map pools (fn [{:keys [pool/name]}]


### PR DESCRIPTION
## Changes proposed in this PR

Filtering out inactive pools when ranking jobs.

## Why are we making these changes?

1. There's no need to run the ranking code on inactive pools.
1. The map returned by the ranking function is used by the rebalancer, and when the rebalancer encounters an inactive pool, it throws an NPE when it calls `view-incubating-offers` with that inactive pool, because that code path is already filtering out inactive pools.