### PR TITLE
Hard deletes pods that won't go away

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1334,15 +1334,32 @@
           ; * A job may have additional containers with the name aux-*
           job-status (first (filter (fn [c] (= cook-container-name-for-job (.getName c)))
                                     container-statuses))
-          pod-preempted-timestamp (some-> pod .getMetadata .getLabels (get (or (-> (config/kubernetes) :node-preempted-label) "node-preempted")))
+          pod-metadata (some-> pod .getMetadata)
+          {:keys [node-preempted-label pod-deletion-timeout-seconds]} (config/kubernetes)
+          pod-preempted-timestamp
+          (some-> pod-metadata
+                  .getLabels
+                  (get (or node-preempted-label "node-preempted")))
+          pod-deletion-timestamp (some-> pod-metadata .getDeletionTimestamp)
           synthesized-pod-state
-          (if (some-> pod .getMetadata .getDeletionTimestamp)
-            ; If a pod has been ordered deleted, treat it as if it was gone, It's being async removed.
-            ; Note that we distinguish between this explicit :missing, and not being there at all when processing
-            ; (:cook-expected-state/killed, :missing) in cook.kubernetes.controller/process
-            {:state :missing
-             :reason "Pod was explicitly deleted"
-             :pod-deleted? true}
+          (if pod-deletion-timestamp
+            ; If a pod has been ordered deleted, treat it as if it were gone, unless too
+            ; long (pod-deletion-timeout-seconds) has passed since its deletion timestamp
+            (let [missing-state
+                  {:pod-deleted? true
+                   :reason "Pod was explicitly deleted"
+                   :state :missing}]
+              (if pod-deletion-timeout-seconds
+                (let [pod-deletion-timed-out?
+                      (-> pod-deletion-timestamp
+                          (t/plus (t/seconds pod-deletion-timeout-seconds))
+                          (t/before? (t/now)))]
+                  (if pod-deletion-timed-out?
+                    {:hard-delete? true
+                     :reason "Pod deletion timed out"
+                     :state :pod/unknown}
+                    missing-state))
+                missing-state))
             ; If pod isn't being async removed, then look at the containers inside it.
             (if job-status
               (let [^V1ContainerState state (.getState job-status)]
@@ -1437,9 +1454,13 @@
 
 (defn delete-pod
   "Kill this kubernetes pod. This is the same as deleting it."
-  [^ApiClient api-client compute-cluster-name ^V1Pod pod]
+  [^ApiClient api-client compute-cluster-name ^V1Pod pod & {:keys [grace-period-seconds]}]
   (let [api (CoreV1Api. api-client)
-        ^V1DeleteOptions deleteOptions (-> (V1DeleteOptionsBuilder.) (.withPropagationPolicy "Background") .build)
+        delete-options-builder
+        (cond-> (V1DeleteOptionsBuilder.)
+                true (.withPropagationPolicy "Background")
+                grace-period-seconds (.withGracePeriodSeconds grace-period-seconds))
+        ^V1DeleteOptions deleteOptions (.build delete-options-builder)
         pod-name (-> pod .getMetadata .getName)
         pod-namespace (-> pod .getMetadata .getNamespace)]
     ; TODO: This likes to noisily throw NotFound multiple times as we delete away from kubernetes.
@@ -1455,8 +1476,7 @@
           nil ; gracePeriodSeconds
           nil ; orphanDependents
           nil ; propagationPolicy
-          deleteOptions
-          )
+          deleteOptions)
         (catch JsonSyntaxException e
           ; Silently gobble this exception.
           ;

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -80,8 +80,8 @@
   Delete is used for completed pods that we're done with.
   Kill is used for possibly running pods we want to kill so that they fail.
   Returns the cook-expected-state-dict passed in."
-  [api-client compute-cluster-name cook-expected-state-dict pod]
-  (api/delete-pod api-client compute-cluster-name pod)
+  [api-client compute-cluster-name cook-expected-state-dict pod & {:keys [grace-period-seconds]}]
+  (api/delete-pod api-client compute-cluster-name pod :grace-period-seconds grace-period-seconds)
   cook-expected-state-dict)
 
 (defn prepare-cook-expected-state-dict-for-logging
@@ -128,6 +128,12 @@
   [{:keys [api-client name] :as compute-cluster} pod-name cook-expected-state-dict {:keys [pod] :as k8s-actual-state-dict}]
   (log-weird-state compute-cluster pod-name cook-expected-state-dict k8s-actual-state-dict)
   (kill-pod api-client name cook-expected-state-dict pod))
+
+(defn kill-pod-hard
+  "Kills the pod with a grace period of 0"
+  [{:keys [api-client name]} pod-name {:keys [pod]}]
+  (log/info "In compute cluster" name ", pod" pod-name "needs to be hard-killed")
+  (kill-pod api-client name nil pod :grace-period-seconds 0))
 
 (defn write-status-to-datomic
   "Helper function for calling scheduler/write-status-to-datomic"
@@ -584,8 +590,11 @@
                                           :pod/succeeded (kill-pod-in-weird-state compute-cluster pod-name
                                                                                   nil k8s-actual-state-dict)
                                           ; Unlike the other :pod/unknown states, no datomic state to update.
-                                          :pod/unknown (kill-pod-in-weird-state compute-cluster pod-name
-                                                                                nil k8s-actual-state-dict)
+                                          :pod/unknown
+                                          (if (:hard-delete? synthesized-state)
+                                            (kill-pod-hard compute-cluster pod-name k8s-actual-state-dict)
+                                            (kill-pod-in-weird-state compute-cluster pod-name
+                                                                     nil k8s-actual-state-dict))
                                           ; This can occur in testing when you're e.g., blowing away the database.
                                           ; It will go through :missing,:missing and then be deleted from the map.
                                           ; TODO: May be evidence of a bug where we process pod changes when we're starting up.


### PR DESCRIPTION
## Changes proposed in this PR

If a pod has a deletion timestamp older than a configurable amount of time (e.g. 15 minutes), Cook will hard-delete the pod (grace period = 0).

## Why are we making these changes?

Without this, Cook will assume any pod with a deletion timestamp is already deleted, which is sometimes not the case.