### PR TITLE
Introduces :pod/deleting state

### DIFF
--- a/scheduler/docs/kubernetes-state.dot
+++ b/scheduler/docs/kubernetes-state.dot
@@ -1,21 +1,21 @@
 # A graph showing valid transitions from expected states to expected states. Edges are annotated with
-# which kubernetes staes the system may be in when it makes the transition.
+# which kubernetes states the system may be in when it makes the transition.
 
 digraph g {
         Starting -> Starting [label=":waiting\n:missing"]
         Starting -> Running [label=":running"]
         // (Starting, missing) -> Completed happens for some failed pod submissions
-        Starting -> Completed [label=":succeeded\n:failed\n:unknown\n:missing"]
+        Starting -> Completed [label=":succeeded\n:failed\n:unknown\n:deleting"]
 
         Running -> Running [label=":running"]
-        Running -> Completed [label=":waiting\n:succeeded\n:failed\n:unknown\n:missing"]
+        Running -> Completed [label=":waiting\n:succeeded\n:failed\n:unknown\n:missing\n:deleting"]
 
         Completed -> Completed [label=":waiting\n:running\n:unknown\n:succeeded\n:failed"]
-        Completed -> Missing [label=":missing"]
+        Completed -> Missing [label=":missing\n:deleting"]
 
         Killed -> Killed [label=":waiting\n:running\n:unknown\n"]
-        Killed -> Completed [label=":succeeded\n:failed\n:missing"]
+        Killed -> Completed [label=":succeeded\n:failed\n:missing\n:deleting"]
 
         Missing [peripheries=2]
-        Missing -> Missing [label=":waiting\n:running\n:succeeded\n:failed\n:unknown\n:missing"]
+        Missing -> Missing [label=":waiting\n:running\n:succeeded\n:failed\n:unknown\n:missing\n:deleting"]
 }

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1337,12 +1337,8 @@
           pod-preempted-timestamp (some-> pod .getMetadata .getLabels (get (or (-> (config/kubernetes) :node-preempted-label) "node-preempted")))
           synthesized-pod-state
           (if (some-> pod .getMetadata .getDeletionTimestamp)
-            ; If a pod has been ordered deleted, treat it as if it was gone, It's being async removed.
-            ; Note that we distinguish between this explicit :missing, and not being there at all when processing
-            ; (:cook-expected-state/killed, :missing) in cook.kubernetes.controller/process
-            {:state :missing
-             :reason "Pod was explicitly deleted"
-             :pod-deleted? true}
+            {:state :pod/deleting
+             :reason "Pod was explicitly deleted"}
             ; If pod isn't being async removed, then look at the containers inside it.
             (if job-status
               (let [^V1ContainerState state (.getState job-status)]

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -499,9 +499,12 @@
                                               ; sure to write the status to datomic. Recall we're in kubernetes state missing.
                                               (handle-pod-killed compute-cluster pod-name))
                                             (do
+                                              ; This shouldn't occur except in cases of extreme
+                                              ; staleness (if we miss the deleting intermediate states)
                                               (log-weird-state compute-cluster pod-name
                                                                cook-expected-state-dict k8s-actual-state-dict)
                                               (handle-pod-killed compute-cluster pod-name)))
+                                          ; This is an expected transition in the deletion path
                                           :pod/deleting
                                           (do
                                             (log/info "In compute cluster" name ", pod" pod-name


### PR DESCRIPTION
## Changes proposed in this PR

- Introducing a new k8s state, `:pod/deleting`, which until now has been captured by the combination of (`:missing` + `:pod-deleted? true`).
- Adding entries to the state machine for `:pod/deleting`, but (mostly) without changing behavior (in this PR).
- The one behavior change introduced here is that prior to this change, the state machine is sometimes generating two kill requests within 100ms of each other due to the fact that pods with a deletion timestamp are being treated the same as pods that are completely missing from k8s. The "opportunistic killing" code is there to avoid a race where the kill request enters the state machine before it's become aware of the pod's existence from the pod watch. This code makes sense, but only for the "actually missing from k8s" scenario, not for the "has a pod deletion timestamp" scenario. This PR avoids the "double kill" in the `:pod/deleting` case.

## Why are we making these changes?

This is a preparatory change for another PR which will hard-delete pods if they've been in the `:pod/deleting` state for too long.
