### PR TITLE
Hard deletes pods that have been deleting for too long

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1334,11 +1334,25 @@
           ; * A job may have additional containers with the name aux-*
           job-status (first (filter (fn [c] (= cook-container-name-for-job (.getName c)))
                                     container-statuses))
-          pod-preempted-timestamp (some-> pod .getMetadata .getLabels (get (or (-> (config/kubernetes) :node-preempted-label) "node-preempted")))
+          {:keys [node-preempted-label pod-deletion-timeout-seconds]}
+          (config/kubernetes)
+          pod-metadata (some-> pod .getMetadata)
+          pod-preempted-timestamp
+          (some-> pod-metadata
+                  .getLabels
+                  (get (or node-preempted-label "node-preempted")))
+          pod-deletion-timestamp (some-> pod-metadata .getDeletionTimestamp)
           synthesized-pod-state
-          (if (some-> pod .getMetadata .getDeletionTimestamp)
-            {:state :pod/deleting
-             :reason "Pod was explicitly deleted"}
+          (if pod-deletion-timestamp
+            (if (and pod-deletion-timeout-seconds
+                     (-> pod-deletion-timestamp
+                         (t/plus (t/seconds pod-deletion-timeout-seconds))
+                         (t/before? (t/now))))
+              {:state :pod/deleting
+               :reason "Pod deletion timed out"
+               :hard-delete? true}
+              {:state :pod/deleting
+               :reason "Pod was explicitly deleted"})
             ; If pod isn't being async removed, then look at the containers inside it.
             (if job-status
               (let [^V1ContainerState state (.getState job-status)]
@@ -1433,9 +1447,13 @@
 
 (defn delete-pod
   "Kill this kubernetes pod. This is the same as deleting it."
-  [^ApiClient api-client compute-cluster-name ^V1Pod pod]
+  [^ApiClient api-client compute-cluster-name ^V1Pod pod & {:keys [grace-period-seconds]}]
   (let [api (CoreV1Api. api-client)
-        ^V1DeleteOptions deleteOptions (-> (V1DeleteOptionsBuilder.) (.withPropagationPolicy "Background") .build)
+        delete-options-builder
+        (cond-> (V1DeleteOptionsBuilder.)
+                true (.withPropagationPolicy "Background")
+                grace-period-seconds (.withGracePeriodSeconds grace-period-seconds))
+        ^V1DeleteOptions deleteOptions (.build delete-options-builder)
         pod-name (-> pod .getMetadata .getName)
         pod-namespace (-> pod .getMetadata .getNamespace)]
     ; TODO: This likes to noisily throw NotFound multiple times as we delete away from kubernetes.

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -589,7 +589,9 @@
                                         (case pod-synthesized-state-modified
                                           :missing nil
                                           :pod/deleting
-                                          (if (:hard-delete? synthesized-state)
+                                          (if (api/has-old-deletion-timestamp? pod)
+                                            ; If the pod has an "old" deletion timestamp, then we should
+                                            ; stop waiting and submit a hard-kill (grace period sec = 0)
                                             (kill-pod-hard compute-cluster pod-name k8s-actual-state-dict)
                                             nil)
                                           ; We shouldn't hit these unless we get a database rollback.

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -136,7 +136,14 @@
   circumstances, we want to give processes a chance to properly handle SIGTERM."
   [{:keys [api-client name]} pod-name {:keys [pod]}]
   (log/info "In compute cluster" name ", pod" pod-name "needs to be hard-killed")
-  (kill-pod api-client name nil pod :grace-period-seconds 0))
+  (kill-pod
+    api-client
+    name
+    ; It's ok to pass nil for cook-expected-state-dict because we only use this
+    ; code path when the cook-expected-state-dict is already nil (aka :missing)
+    nil
+    pod
+    :grace-period-seconds 0))
 
 (defn write-status-to-datomic
   "Helper function for calling scheduler/write-status-to-datomic"

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -8,7 +8,7 @@
             [cook.test.testutil :as tu]
             [metrics.timers :as timers])
   (:import (io.kubernetes.client.openapi ApiException)
-           (io.kubernetes.client.openapi.models V1PodCondition V1PodStatus)
+           (io.kubernetes.client.openapi.models V1ObjectMeta V1Pod V1PodCondition V1PodStatus)
            (java.util.concurrent.locks ReentrantLock)))
 
 (defn make-test-kubernetes-config
@@ -33,10 +33,12 @@
         do-process-full-state (fn [cook-expected-state k8s-actual-state & {:keys [create-namespaced-pod-fn
                                                                                   ^V1PodCondition pod-condition
                                                                                   custom-test-state
-                                                                                  force-nil-pod?]
+                                                                                  force-nil-pod?
+                                                                                  ^V1ObjectMeta pod-metadata]
                                                                            :or {create-namespaced-pod-fn (constantly true)
                                                                                 custom-test-state nil
-                                                                                force-nil-pod? false}}]
+                                                                                force-nil-pod? false
+                                                                                pod-metadata nil}}]
                                 (reset! reason nil)
                                 (with-redefs [controller/delete-pod (fn [_ _ cook-expected-state-dict _]
                                                                       cook-expected-state-dict)
@@ -48,10 +50,11 @@
                                                                                    (reset! reason (:reason status)))
                                               api/create-namespaced-pod create-namespaced-pod-fn
                                               cc/compute-cluster-name (constantly "compute-cluster-name")]
-                                  (let [pod (tu/pod-helper name "hostA" {:cpus 1.0 :mem 100.0})
+                                  (let [^V1Pod pod (tu/pod-helper name "hostA" {:cpus 1.0 :mem 100.0})
                                         pod-status (V1PodStatus.)
                                         _ (when pod-condition (.addConditionsItem pod-status pod-condition))
                                         _ (.setStatus pod pod-status)
+                                        _ (when pod-metadata (.setMetadata pod pod-metadata))
                                         cook-expected-state-map
                                         (atom {name {:cook-expected-state cook-expected-state
                                                      :launch-pod {:pod pod}
@@ -67,15 +70,18 @@
         do-process (fn [cook-expected-state k8s-actual-state & {:keys [create-namespaced-pod-fn
                                                                        ^V1PodCondition pod-condition
                                                                        custom-test-state
-                                                                       force-nil-pod?]
+                                                                       force-nil-pod?
+                                                                       ^V1ObjectMeta pod-metadata]
                                                                 :or {create-namespaced-pod-fn (constantly true)
                                                                      custom-test-state nil
-                                                                     force-nil-pod? false}}]
+                                                                     force-nil-pod? false
+                                                                     pod-metadata nil}}]
                      (:cook-expected-state (do-process-full-state cook-expected-state k8s-actual-state
                                                                   :create-namespaced-pod-fn create-namespaced-pod-fn
                                                                   :pod-condition pod-condition
                                                                   :custom-test-state custom-test-state
-                                                                  :force-nil-pod? force-nil-pod?)))]
+                                                                  :force-nil-pod? force-nil-pod?
+                                                                  :pod-metadata pod-metadata)))]
 
     (is (nil? (do-process :cook-expected-state/completed :missing)))
     (is (nil? (do-process :cook-expected-state/completed :pod/deleting)))
@@ -163,14 +169,21 @@
       (is (not (nil? (:waiting-metric-timer (do-process-full-state :cook-expected-state/starting :missing))))))
 
     (is (nil? (do-process :missing :missing)))
-    (let [hard-kill-atom (atom false)]
+    (let [hard-kill-atom (atom false)
+          pod-metadata (V1ObjectMeta.)]
       (with-redefs [controller/kill-pod-hard
                     (fn [_ _ _]
                       (reset! hard-kill-atom true)
-                      nil)]
-        (is (nil? (do-process :missing :pod/deleting)))
+                      nil)
+                    config/kubernetes
+                    (constantly {:pod-deletion-timeout-seconds (* 60 15)})]
+        ; Recent deletion timestamp
+        (.setDeletionTimestamp pod-metadata (t/now))
+        (is (nil? (do-process :missing :pod/deleting :pod-metadata pod-metadata)))
         (is (false? @hard-kill-atom))
-        (is (nil? (do-process :missing nil :custom-test-state {:state :pod/deleting :hard-delete? true})))
+        ; Old deletion timestamp
+        (.setDeletionTimestamp pod-metadata (t/epoch))
+        (is (nil? (do-process :missing :pod/deleting :pod-metadata pod-metadata)))
         (is (true? @hard-kill-atom))))
     (is (nil? (do-process :missing :pod/succeeded)))
     (is (nil? (do-process :missing :pod/failed)))


### PR DESCRIPTION
## Changes proposed in this PR

If a pod has a deletion timestamp older than a configurable amount of time (e.g. 15 minutes), Cook will hard-delete the pod (with grace period = 0).

## Why are we making these changes?

Without this, Cook will assume any pod with a deletion timestamp is already deleted, which is sometimes not the case.