### PR TITLE
Supports replacing invalid characters from telemetry tag keys

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -490,7 +490,8 @@
                                   :default-pool "no-pool"}
                                  pool-selection)})))
      :kubernetes (fnk [[:config {kubernetes {}}]]
-                   (let [{:keys [controller-lock-num-shards]
+                   (let [{:keys [controller-lock-num-shards
+                                 telemetry-tags-key-invalid-char-pattern]
                           :or {controller-lock-num-shards 4095}}
                          kubernetes
                          _
@@ -514,7 +515,10 @@
                              :synthetic-pod-recency-size 50000
                              :synthetic-pod-recency-seconds 120 ; Should be greater than the time to start a node and have it accept workloads.
                              }
-                            kubernetes)))
+                            (cond-> kubernetes
+                                    telemetry-tags-key-invalid-char-pattern
+                                    (assoc :telemetry-tags-key-invalid-char-pattern
+                                           (re-pattern telemetry-tags-key-invalid-char-pattern))))))
      :offer-matching (fnk [[:config {offer-matching {}}]]
                        (merge {:considerable-job-threshold-to-collect-job-match-statistics 20
                                :global-min-match-interval-millis 100

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -953,6 +953,7 @@
         {:keys [volumes volume-mounts sandbox-volume-mount-fn]} (make-volumes volumes sandbox-dir)
         {:keys [custom-shell init-container sidecar telemetry-agent-host-var-name telemetry-env-var-name
                 telemetry-env-value telemetry-service-var-name telemetry-tags-entry-separator
+                telemetry-tags-key-invalid-char-pattern telemetry-tags-key-invalid-char-replacement
                 telemetry-tags-key-value-separator telemetry-tags-var-name telemetry-version-var-name]}
         (config/kubernetes)
         checkpoint (calculate-effective-checkpointing-config job task-id)
@@ -1021,7 +1022,15 @@
                          (assoc telemetry-tags-var-name
                                 (->> pod-labels
                                      (map (fn [[k v]]
-                                            (str k telemetry-tags-key-value-separator v)))
+                                            (str (if (and telemetry-tags-key-invalid-char-pattern
+                                                          telemetry-tags-key-invalid-char-replacement)
+                                                   (str/replace
+                                                     k
+                                                     telemetry-tags-key-invalid-char-pattern
+                                                     telemetry-tags-key-invalid-char-replacement)
+                                                   k)
+                                                 telemetry-tags-key-value-separator
+                                                 v)))
                                      (str/join telemetry-tags-entry-separator)))
 
                          telemetry-version-var-name

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1026,7 +1026,7 @@
                                                           telemetry-tags-key-invalid-char-replacement)
                                                    (str/replace
                                                      k
-                                                     telemetry-tags-key-invalid-char-pattern
+                                                     (re-pattern telemetry-tags-key-invalid-char-pattern)
                                                      telemetry-tags-key-invalid-char-replacement)
                                                    k)
                                                  telemetry-tags-key-value-separator

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1026,7 +1026,7 @@
                                                           telemetry-tags-key-invalid-char-replacement)
                                                    (str/replace
                                                      k
-                                                     (re-pattern telemetry-tags-key-invalid-char-pattern)
+                                                     telemetry-tags-key-invalid-char-pattern
                                                      telemetry-tags-key-invalid-char-replacement)
                                                    k)
                                                  telemetry-tags-key-value-separator

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -520,7 +520,7 @@
                                                    :telemetry-env-value "test-env"
                                                    :telemetry-service-var-name "TEST_SERVICE"
                                                    :telemetry-tags-entry-separator " "
-                                                   :telemetry-tags-key-invalid-char-pattern "[^a-zA-Z0-9-]"
+                                                   :telemetry-tags-key-invalid-char-pattern (re-pattern "[^a-zA-Z0-9-]")
                                                    :telemetry-tags-key-invalid-char-replacement "."
                                                    :telemetry-tags-key-value-separator ":"
                                                    :telemetry-tags-var-name "TEST_TAGS"

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -520,7 +520,7 @@
                                                    :telemetry-env-value "test-env"
                                                    :telemetry-service-var-name "TEST_SERVICE"
                                                    :telemetry-tags-entry-separator " "
-                                                   :telemetry-tags-key-invalid-char-pattern #"[^a-zA-Z0-9-]"
+                                                   :telemetry-tags-key-invalid-char-pattern "[^a-zA-Z0-9-]"
                                                    :telemetry-tags-key-invalid-char-replacement "."
                                                    :telemetry-tags-key-value-separator ":"
                                                    :telemetry-tags-var-name "TEST_TAGS"

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -520,6 +520,8 @@
                                                    :telemetry-env-value "test-env"
                                                    :telemetry-service-var-name "TEST_SERVICE"
                                                    :telemetry-tags-entry-separator " "
+                                                   :telemetry-tags-key-invalid-char-pattern #"[^a-zA-Z0-9-]"
+                                                   :telemetry-tags-key-invalid-char-replacement "."
                                                    :telemetry-tags-key-value-separator ":"
                                                    :telemetry-tags-var-name "TEST_TAGS"
                                                    :telemetry-version-var-name "TEST_VERSION"})]
@@ -544,11 +546,11 @@
           (assert-env-var-value container "TEST_ENV" "test-env")
           (assert-env-var-value container "TEST_SERVICE" "test-name")
           (assert-env-var-value container "TEST_TAGS"
-                                (str "test-prefix/application.name:test-name "
-                                     "test-prefix/application.version:test-version "
-                                     "test-prefix/application.workload-class:foo "
-                                     "test-prefix/application.workload-id:bar "
-                                     "test-prefix/application.workload-details:baz"))
+                                (str "test-prefix.application.name:test-name "
+                                     "test-prefix.application.version:test-version "
+                                     "test-prefix.application.workload-class:foo "
+                                     "test-prefix.application.workload-id:bar "
+                                     "test-prefix.application.workload-details:baz"))
           (assert-env-var-value container "TEST_VERSION" "test-version"))))))
 
 (defn- k8s-volume->clj [^V1Volume volume]


### PR DESCRIPTION
## Changes proposed in this PR

Adding optional support for replacing characters from telemetry tag keys.

## Why are we making these changes?

Some telemetry sinks don't support certain characters in tag keys.