### PR TITLE
Fixes the names for synthetic pod workload labels

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -36,8 +36,6 @@
 
 (def cook-pod-label "twosigma.com/cook-scheduler-job")
 (def cook-synthetic-pod-job-uuid-label "twosigma.com/cook-scheduler-synthetic-pod-job-uuid")
-(def workload-class-label "workload-class")
-(def workload-id-label "workload-id")
 (def resource-owner-label "resource-owner")
 (def cook-sandbox-volume-name "cook-sandbox-volume")
 (def cook-job-pod-priority-class "cook-workload")
@@ -88,10 +86,25 @@
 ; and MiB back to bytes when submitting to k8s.
 (def memory-multiplier (* 1024 1024))
 
+(defn pod-label-prefix
+  "Returns the prefix to use for application-related pod labels"
+  []
+  (:add-job-label-to-pod-prefix (config/kubernetes)))
+
+(defn workload-class-label
+  "Returns the full pod label for workload-class"
+  []
+  (str (pod-label-prefix) "application.workload-class"))
+
+(defn workload-id-label
+  "Returns the full pod label for workload-id"
+  []
+  (str (pod-label-prefix) "application.workload-id"))
+
 (defn pod-labels-defaults
   "Returns a map with default pod labels"
   []
-  (let [prefix (:add-job-label-to-pod-prefix (config/kubernetes))]
+  (let [prefix (pod-label-prefix)]
     {(str prefix "application.name") "undefined"
      (str prefix "application.version") "undefined"
      (str prefix "application.workload-class") "undefined"

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -512,8 +512,8 @@
                                    ; also want to label the workload as infrastructure
                                    ; and associate the user as the resource owner.
                                    :pod-labels {api/cook-synthetic-pod-job-uuid-label (str uuid)
-                                                api/workload-class-label "infrastructure"
-                                                api/workload-id-label "synthetic-pod"
+                                                (api/workload-class-label) "infrastructure"
+                                                (api/workload-id-label) "synthetic-pod"
                                                 api/resource-owner-label user}
                                    ; We need to give synthetic pods a lower priority than
                                    ; actual job pods so that the job pods can preempt them


### PR DESCRIPTION
## Changes proposed in this PR

Adding the configured label prefix and `application.` to the workload label keys for synthetic pods.

## Why are we making these changes?

To make them consistent with the labels for real job pods.
