### PR TITLE
Adds features to compute cluster

### DIFF
--- a/integration/tests/cook/test_dynamic_clusters.py
+++ b/integration/tests/cook/test_dynamic_clusters.py
@@ -170,9 +170,10 @@ class TestDynamicClusters(util.CookTest):
                             # Set state = draining
                             cluster_update['state'] = 'draining'
                             cluster_update['state-locked?'] = True
-                            # The location and cluster-definition fields cannot be sent in the update
+                            # The location, cluster-definition, and features fields cannot be sent in the update
                             cluster_update.pop('location', None)
                             cluster_update.pop('cluster-definition', None)
+                            cluster_update.pop('features', None)
                             self.logger.info(f'Trying to update cluster to draining: {cluster_update}')
                             util.wait_until(
                                 lambda: util.update_compute_cluster(self.cook_url, cluster_update)[1],
@@ -207,9 +208,10 @@ class TestDynamicClusters(util.CookTest):
                             # Set state = running
                             cluster_update['state'] = 'running'
                             cluster_update['state-locked?'] = False
-                            # The location and cluster-definition fields cannot be sent in the update
+                            # The location, cluster-definition, and features fields cannot be sent in the update
                             cluster_update.pop('location', None)
                             cluster_update.pop('cluster-definition', None)
+                            cluster_update.pop('features', None)
                             self.logger.info(f'Trying to update cluster to running: {cluster_update}')
                             util.wait_until(
                                 lambda: util.update_compute_cluster(self.cook_url, cluster_update)[1],

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -186,7 +186,8 @@
            compute-cluster-config/ca-cert
            compute-cluster-config/state
            compute-cluster-config/state-locked?
-           compute-cluster-config/location]}]
+           compute-cluster-config/location
+           compute-cluster-config/features]}]
   {:name name
    :template template
    :base-path base-path
@@ -196,11 +197,15 @@
             :compute-cluster-config.state/draining :draining
             :compute-cluster-config.state/deleted :deleted)
    :state-locked? state-locked?
-   :location location})
+   :location location
+   :features (map (fn [{:keys [compute-cluster-config.feature/key
+                               compute-cluster-config.feature/value]}]
+                    {:key key :value value})
+                  features)})
 
 (defn compute-cluster-config->compute-cluster-config-ent
   "Convert dynamic cluster configuration to a Datomic entity"
-  [{:keys [name template base-path ca-cert state state-locked? location]}]
+  [{:keys [name template base-path ca-cert state state-locked? location features]}]
   (cond->
     {:compute-cluster-config/name name
      :compute-cluster-config/template template
@@ -211,7 +216,13 @@
                                      :draining :compute-cluster-config.state/draining
                                      :deleted :compute-cluster-config.state/deleted)
      :compute-cluster-config/state-locked? state-locked?}
-    location (assoc :compute-cluster-config/location location)))
+    location (assoc :compute-cluster-config/location location)
+    features (assoc :compute-cluster-config/features
+                    (map (fn [{:keys [key value]}]
+                           {:compute-cluster-config.feature/key key
+                            :compute-cluster-config.feature/value value
+                            :db/id (d/tempid :db.part/user)})
+                         features))))
 
 (defn get-db-config-ents
   "Get the current dynamic cluster configuration entities from the database"
@@ -243,14 +254,15 @@
 (defn compute-cluster->compute-cluster-config
   "Calculate dynamic cluster configuration from a compute cluster"
   [{:keys [state-atom state-locked?-atom name]
-    {{:keys [template base-path ca-cert location]} :config} :cluster-definition}]
+    {{:keys [template base-path ca-cert location features]} :config} :cluster-definition}]
   {:name name
    :template template
    :base-path base-path
    :ca-cert ca-cert
    :state @state-atom
    :state-locked? @state-locked?-atom
-   :location location})
+   :location location
+   :features features})
 
 ;TODO: in the future all clusters will be dynamic and we shouldn't need this
 (defn get-dynamic-clusters
@@ -287,14 +299,15 @@
      (doseq [key both-keys]
        (let [current-db-config
              (get current-db-configs key)
-             {current-in-mem-location :location :as current-in-mem-config}
+             {current-in-mem-location :location current-in-mem-features :features :as current-in-mem-config}
              (get current-in-mem-configs key)
              keys-to-keep-synced
              (cond-> [:base-path :ca-cert :state]
                      ; The location field is treated specially when comparing db and in-mem configs --
                      ; since this is a new field, it can be nil in-memory and non-nil in the db for a
                      ; limited time after the db has been populated and before the leader is restarted.
-                     current-in-mem-location (conj :location))]
+                     current-in-mem-location (conj :location)
+                     current-in-mem-features (conj :features))]
          (when (not= (select-keys current-db-config keys-to-keep-synced)
                      (select-keys current-in-mem-config keys-to-keep-synced))
            (log/error keys-to-keep-synced "differ between in-memory and database cluster configurations."
@@ -343,17 +356,24 @@
    The location and state fields are special in this regard -- location can
    only transition from nil to non-nil, and state is validated in
    cluster-state-change-valid?."
-  [{current-location :location :as current-config}
-   {new-location :location :as new-config}]
-  (if (and (some? current-location)
-           (not= current-location new-location))
-    false
-    (let [dissoc-non-comparable-fields
-          #(-> %
-               (dissoc :state)
-               (dissoc :location))]
-      (= (dissoc-non-comparable-fields current-config)
-         (dissoc-non-comparable-fields new-config)))))
+  [{current-location :location current-features :features :as current-config}
+   {new-location :location new-features :features :as new-config}]
+  (cond (and (some? current-location)
+             (not= current-location new-location))
+        false
+
+        (and (some? current-features)
+             (not= current-features new-features))
+        false
+
+        :else
+        (let [dissoc-non-comparable-fields
+              #(-> %
+                   (dissoc :state)
+                   (dissoc :location)
+                   (dissoc :features))]
+          (= (dissoc-non-comparable-fields current-config)
+             (dissoc-non-comparable-fields new-config)))))
 
 (defn compute-config-update
   "Add validation info to a dynamic cluster configuration update."

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -364,7 +364,7 @@
           (log/warn "ZZZZZ location" current-location new-location)
           false)
 
-        (and (some? current-features)
+        (and (seq current-features)
              (not= current-features new-features))
         (do
           (log/warn "ZZZZZ features" current-features new-features)

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -303,8 +303,8 @@
              (get current-in-mem-configs key)
              keys-to-keep-synced
              (cond-> [:base-path :ca-cert :state]
-                     ; The location field is treated specially when comparing db and in-mem configs --
-                     ; since this is a new field, it can be nil in-memory and non-nil in the db for a
+                     ; The location and features fields are treated specially when comparing db and in-mem configs --
+                     ; since these are new fields, they can be nil in-memory and non-nil in the db for a
                      ; limited time after the db has been populated and before the leader is restarted.
                      current-in-mem-location (conj :location)
                      current-in-mem-features (conj :features))]
@@ -363,7 +363,7 @@
         false
 
         (and (seq current-features)
-             (not= current-features new-features))
+             (not= (set current-features) (set new-features)))
         false
 
         :else

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -360,11 +360,15 @@
    {new-location :location new-features :features :as new-config}]
   (cond (and (some? current-location)
              (not= current-location new-location))
-        false
+        (do
+          (log/warn "ZZZZZ location" current-location new-location)
+          false)
 
         (and (some? current-features)
              (not= current-features new-features))
-        false
+        (do
+          (log/warn "ZZZZZ features" current-features new-features)
+          false)
 
         :else
         (let [dissoc-non-comparable-fields
@@ -372,8 +376,13 @@
                    (dissoc :state)
                    (dissoc :location)
                    (dissoc :features))]
-          (= (dissoc-non-comparable-fields current-config)
-             (dissoc-non-comparable-fields new-config)))))
+          (do
+            (log/warn "ZZZZZ else current"
+                      (dissoc-non-comparable-fields current-config)
+                      "ZZZZZ new"
+                      (dissoc-non-comparable-fields new-config))
+            (= (dissoc-non-comparable-fields current-config)
+               (dissoc-non-comparable-fields new-config))))))
 
 (defn compute-config-update
   "Add validation info to a dynamic cluster configuration update."

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -360,15 +360,11 @@
    {new-location :location new-features :features :as new-config}]
   (cond (and (some? current-location)
              (not= current-location new-location))
-        (do
-          (log/warn "ZZZZZ location" current-location new-location)
-          false)
+        false
 
         (and (seq current-features)
              (not= current-features new-features))
-        (do
-          (log/warn "ZZZZZ features" current-features new-features)
-          false)
+        false
 
         :else
         (let [dissoc-non-comparable-fields
@@ -376,13 +372,8 @@
                    (dissoc :state)
                    (dissoc :location)
                    (dissoc :features))]
-          (do
-            (log/warn "ZZZZZ else current"
-                      (dissoc-non-comparable-fields current-config)
-                      "ZZZZZ new"
-                      (dissoc-non-comparable-fields new-config))
-            (= (dissoc-non-comparable-fields current-config)
-               (dissoc-non-comparable-fields new-config))))))
+          (= (dissoc-non-comparable-fields current-config)
+             (dissoc-non-comparable-fields new-config)))))
 
 (defn compute-config-update
   "Add validation info to a dynamic cluster configuration update."

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -406,6 +406,23 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db
     :db/doc "Location of compute cluster."}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :compute-cluster-config/features
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many
+    :db.install/_attribute :db.part/db
+    :db/doc "Features of compute cluster."}
+   ;; Compute Cluster features
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :compute-cluster-config.feature/key
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/ident :compute-cluster-config.feature/value
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
    ;; Container Attributes
    {:db/id (d/tempid :db.part/db)
     :db/doc "variant records based on container/type"

--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -1055,3 +1055,7 @@
                       :features [{:key "NVIDIA_DRIVER_VERSION"
                                   :value "450-80-02"}]}}
              (get-in-mem-configs))))))
+
+(deftest test-config=?
+  (testing "features can be in different orders"
+    (is (true? (config=? {:features [:a :b]} {:features [:b :a]})))))

--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -32,7 +32,9 @@
                 :ca-cert "ca-cert"
                 :state :running
                 :state-locked? true
-                :location "us-east1"}
+                :location "us-east1"
+                :features [{:key "NVIDIA_DRIVER_VERSION"
+                            :value "450-80-02"}]}
         config-ent (compute-cluster-config->compute-cluster-config-ent config)
         _ (is (= {:compute-cluster-config/name "name"
                   :compute-cluster-config/base-path "base-path"
@@ -40,7 +42,12 @@
                   :compute-cluster-config/state :compute-cluster-config.state/running
                   :compute-cluster-config/state-locked? true
                   :compute-cluster-config/template "template"
-                  :compute-cluster-config/location "us-east1"} config-ent))]
+                  :compute-cluster-config/location "us-east1"
+                  :compute-cluster-config/features [{:compute-cluster-config.feature/key "NVIDIA_DRIVER_VERSION"
+                                                     :compute-cluster-config.feature/value "450-80-02"}]}
+                 (update config-ent
+                         :compute-cluster-config/features
+                         #(map (fn [feature] (dissoc feature :db/id)) %))))]
     (is (= config (compute-cluster-config-ent->compute-cluster-config config-ent)))))
 
 (deftest test-db-config-ents
@@ -83,7 +90,9 @@
                                                :ca-cert "ca-cert"
                                                :state :running
                                                :state-locked? false
-                                               :location "us-east1"}}
+                                               :location "us-east1"
+                                               :features [{:key "NVIDIA_DRIVER_VERSION"
+                                                           :value "450-80-02"}]}}
                  :state-atom (atom :deleted)
                  :state-locked?-atom (atom true)}]
     (is (= {:base-path "base-path"
@@ -92,7 +101,9 @@
             :state :deleted
             :state-locked? true
             :template "template"
-            :location "us-east1"}
+            :location "us-east1"
+            :features [{:key "NVIDIA_DRIVER_VERSION"
+                        :value "450-80-02"}]}
            (compute-cluster->compute-cluster-config cluster)))))
 
 (def sample-in-mem-config
@@ -102,7 +113,9 @@
            :state :deleted
            :state-locked? true
            :template "template"
-           :location "us-east1"}})
+           :location "us-east1"
+           :features [{:key "NVIDIA_DRIVER_VERSION"
+                       :value "450-80-02"}]}})
 
 (def sample-clusters
   {"name" {:name "name"
@@ -113,7 +126,9 @@
                                          :ca-cert "ca-cert"
                                          :state :running
                                          :state-locked? false
-                                         :location "us-east1"}}
+                                         :location "us-east1"
+                                         :features [{:key "NVIDIA_DRIVER_VERSION"
+                                                     :value "450-80-02"}]}}
            :state-atom (atom :deleted)
            :state-locked?-atom (atom true)
            :dynamic-cluster-config? true}
@@ -125,7 +140,9 @@
                                                   :ca-cert "ca-cert"
                                                   :state :running
                                                   :state-locked? false
-                                                  :location "us-east1"}}}})
+                                                  :location "us-east1"
+                                                  :features [{:key "NVIDIA_DRIVER_VERSION"
+                                                              :value "450-80-02"}]}}}})
 
 (deftest test-in-mem-configs
   (reset! cluster-name->compute-cluster-atom {})
@@ -165,7 +182,10 @@
                   :state :deleted
                   :state-locked? true
                   :template "template"
-                  :location "us-east1"}} (compute-current-configs {} sample-in-mem-config)))
+                  :location "us-east1"
+                  :features [{:key "NVIDIA_DRIVER_VERSION"
+                              :value "450-80-02"}]}}
+         (compute-current-configs {} sample-in-mem-config)))
   (is (= {:a {:location "us-east1"}}
          (compute-current-configs
            {:a {:location "us-east1"}}
@@ -560,7 +580,9 @@
                 :ca-cert "ca-cert"
                 :state :running
                 :state-locked? true
-                :location "us-east1"})))
+                :location "us-east1"
+                :features [{:key "NVIDIA_DRIVER_VERSION"
+                            :value "450-80-02"}]})))
       (is (= ["name"] @initialize-cluster-fn-invocations-atom))
       (is (= {"name" {:base-path "base-path"
                       :ca-cert "ca-cert"
@@ -568,7 +590,9 @@
                       :state :running
                       :state-locked? true
                       :template "template1"
-                      :location "us-east1"}}
+                      :location "us-east1"
+                      :features [{:key "NVIDIA_DRIVER_VERSION"
+                                  :value "450-80-02"}]}}
              (get-in-mem-configs))))
 
     (testing "exception"
@@ -602,7 +626,9 @@
                                     :ca-cert "ca-cert"
                                     :state :running
                                     :state-locked? true
-                                    :location "us-east1"}
+                                    :location "us-east1"
+                                    :features [{:key "NVIDIA_DRIVER_VERSION"
+                                                :value "450-80-02"}]}
                                    :valid? true
                                    :differs? true
                                    :active? true})))
@@ -613,7 +639,9 @@
                   :state :running
                   :state-locked? true
                   :template "template1"
-                  :location "us-east1"}
+                  :location "us-east1"
+                  :features [{:key "NVIDIA_DRIVER_VERSION"
+                              :value "450-80-02"}]}
                  (-> (get-db-config-ents (d/db conn)) (get "name") compute-cluster-config-ent->compute-cluster-config)))
           (is (= {"name" {:base-path "base-path"
                           :ca-cert "ca-cert"
@@ -621,7 +649,10 @@
                           :state :running
                           :state-locked? true
                           :template "template1"
-                          :location "us-east1"}} (get-in-mem-configs))))
+                          :location "us-east1"
+                          :features [{:key "NVIDIA_DRIVER_VERSION"
+                                      :value "450-80-02"}]}}
+                 (get-in-mem-configs))))
 
         (testing "normal update - differs? is false but cluster not in memory; cluster is created"
           ; no change update with missing cluster
@@ -637,7 +668,9 @@
                                     :ca-cert "ca-cert"
                                     :state :running
                                     :state-locked? true
-                                    :location "us-east1"}
+                                    :location "us-east1"
+                                    :features [{:key "NVIDIA_DRIVER_VERSION"
+                                                :value "450-80-02"}]}
                                    :valid? true
                                    :differs? false
                                    :active? true})))
@@ -648,7 +681,9 @@
                   :state :running
                   :state-locked? true
                   :template "template1"
-                  :location "us-east1"}
+                  :location "us-east1"
+                  :features [{:key "NVIDIA_DRIVER_VERSION"
+                              :value "450-80-02"}]}
                  (-> (get-db-config-ents (d/db conn)) (get "name") compute-cluster-config-ent->compute-cluster-config)))
           (is (= {"name" {:base-path "base-path"
                           :ca-cert "ca-cert"
@@ -656,7 +691,10 @@
                           :state :running
                           :state-locked? true
                           :template "template1"
-                          :location "us-east1"}} (get-in-mem-configs)))))
+                          :location "us-east1"
+                          :features [{:key "NVIDIA_DRIVER_VERSION"
+                                      :value "450-80-02"}]}}
+                 (get-in-mem-configs)))))
       (let [conn (restore-fresh-database! uri)]
         (testing "normal update - insert then update"
           (testing "insert"
@@ -672,7 +710,9 @@
                                                    :ca-cert "ca-cert"
                                                    :state :running
                                                    :state-locked? true
-                                                   :location "us-east1"}
+                                                   :location "us-east1"
+                                                   :features [{:key "NVIDIA_DRIVER_VERSION"
+                                                               :value "450-80-02"}]}
                                      :valid? true
                                      :differs? true
                                      :active? true})))
@@ -683,7 +723,9 @@
                     :state :running
                     :state-locked? true
                     :template "template1"
-                    :location "us-east1"}
+                    :location "us-east1"
+                    :features [{:key "NVIDIA_DRIVER_VERSION"
+                                :value "450-80-02"}]}
                    (-> (get-db-config-ents (d/db conn)) (get "name") compute-cluster-config-ent->compute-cluster-config)))
             (is (= {"name" {:base-path "base-path"
                             :ca-cert "ca-cert"
@@ -691,7 +733,10 @@
                             :state :running
                             :state-locked? true
                             :template "template1"
-                            :location "us-east1"}} (get-in-mem-configs))))
+                            :location "us-east1"
+                            :features [{:key "NVIDIA_DRIVER_VERSION"
+                                        :value "450-80-02"}]}}
+                   (get-in-mem-configs))))
 
           (testing "update - state updates in db and in mem. base-path only updates in db"
             (is (= {:update-succeeded true}
@@ -713,7 +758,9 @@
                     :state :draining
                     :state-locked? true
                     :template "template1"
-                    :location "us-east1"}
+                    :location "us-east1"
+                    :features [{:key "NVIDIA_DRIVER_VERSION"
+                                :value "450-80-02"}]}
                    (-> (get-db-config-ents (d/db conn)) (get "name") compute-cluster-config-ent->compute-cluster-config)))
             (is (= {"name" {:base-path "base-path"
                             :ca-cert "ca-cert"
@@ -721,7 +768,10 @@
                             :state :draining
                             :state-locked? true
                             :template "template1"
-                            :location "us-east1"}} (get-in-mem-configs))))))
+                            :location "us-east1"
+                            :features [{:key "NVIDIA_DRIVER_VERSION"
+                                        :value "450-80-02"}]}}
+                   (get-in-mem-configs))))))
       (let [conn (restore-fresh-database! uri)]
         (testing "exceptions"
           (reset! cluster-name->compute-cluster-atom {})
@@ -862,7 +912,10 @@
                                                     :compute-cluster-config/state :compute-cluster-config.state/running
                                                     :compute-cluster-config/state-locked? true
                                                     :compute-cluster-config/template "template"
-                                                    :compute-cluster-config/location "us-east1"}})
+                                                    :compute-cluster-config/location "us-east1"
+                                                    :compute-cluster-config/features
+                                                    [{:compute-cluster-config.feature/key "NVIDIA_DRIVER_VERSION"
+                                                      :compute-cluster-config.feature/value "450-80-02"}]}})
                 get-dynamic-clusters (constantly (->> [(sample-clusters "name")] (map-from-vals #(-> % :name))))]
     (is (= {:db-configs '({:base-path "base-path"
                            :ca-cert "ca-cert"
@@ -870,7 +923,9 @@
                            :state :running
                            :state-locked? true
                            :template "template"
-                           :location "us-east1"})
+                           :location "us-east1"
+                           :features [{:key "NVIDIA_DRIVER_VERSION"
+                                       :value "450-80-02"}]})
             :in-mem-configs '({:base-path "base-path"
                                :ca-cert "ca-cert"
                                :name "name"
@@ -878,6 +933,8 @@
                                :state-locked? true
                                :template "template"
                                :location "us-east1"
+                               :features [{:key "NVIDIA_DRIVER_VERSION"
+                                           :value "450-80-02"}]
                                :cluster-definition {:factory-fn cook.kubernetes.compute-cluster/factory-fn
                                                     :config {:base-path "base-path"
                                                              :ca-cert "ca-cert"
@@ -885,7 +942,9 @@
                                                              :state :running
                                                              :state-locked? false
                                                              :template "template"
-                                                             :location "us-east1"}}})}
+                                                             :location "us-east1"
+                                                             :features [{:key "NVIDIA_DRIVER_VERSION"
+                                                                         :value "450-80-02"}]}}})}
            (get-compute-clusters nil)))))
 
 (deftest test-delete-compute-cluster
@@ -931,7 +990,9 @@
                      :ca-cert "ca-cert"
                      :state :running
                      :state-locked? true
-                     :location "us-east1"}
+                     :location "us-east1"
+                     :features [{:key "NVIDIA_DRIVER_VERSION"
+                                 :value "450-80-02"}]}
         ent (compute-cluster-config->compute-cluster-config-ent new-cluster)
         new-cluster-2 {:name "name-2"
                        :template "template1"
@@ -939,7 +1000,9 @@
                        :ca-cert "ca-cert"
                        :state :deleted
                        :state-locked? true
-                       :location "us-east1"}
+                       :location "us-east1"
+                       :features [{:key "NVIDIA_DRIVER_VERSION"
+                                   :value "450-80-02"}]}
         ent-2 (compute-cluster-config->compute-cluster-config-ent new-cluster-2)]
     (is (= {} (get-in-mem-configs)))
     (is (= {} (get-db-config-ents (d/db conn))))
@@ -961,7 +1024,9 @@
                                 :state :running
                                 :state-locked? true
                                 :template "template1"
-                                :location "us-east1"}
+                                :location "us-east1"
+                                :features [{:key "NVIDIA_DRIVER_VERSION"
+                                            :value "450-80-02"}]}
                   :update-result {:update-succeeded true}
                   :valid? true}
                  {:active? false
@@ -973,7 +1038,9 @@
                                 :state :deleted
                                 :state-locked? true
                                 :template "template1"
-                                :location "us-east1"}
+                                :location "us-east1"
+                                :features [{:key "NVIDIA_DRIVER_VERSION"
+                                            :value "450-80-02"}]}
                   :update-result {:update-succeeded true}
                   :valid? true}))
              (set (update-compute-clusters conn (get-db-configs (d/db conn)) false))))
@@ -984,5 +1051,7 @@
                       :state :running
                       :state-locked? true
                       :template "template1"
-                      :location "us-east1"}}
+                      :location "us-east1"
+                      :features [{:key "NVIDIA_DRIVER_VERSION"
+                                  :value "450-80-02"}]}}
              (get-in-mem-configs))))))


### PR DESCRIPTION
## Changes proposed in this PR

Adding a `features` field to the compute cluster.

## Why are we making these changes?

To eventually support constraining job instances to specific compute clusters based on the features those compute clusters support, e.g. specific NVIDIA driver versions.
