### PR TITLE
Allows cluster features to be dynamic

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -303,11 +303,10 @@
              (get current-in-mem-configs key)
              keys-to-keep-synced
              (cond-> [:base-path :ca-cert :state]
-                     ; The location and features fields are treated specially when comparing db and in-mem configs --
-                     ; since these are new fields, they can be nil in-memory and non-nil in the db for a
+                     ; The location field is treated specially when comparing db and in-mem configs --
+                     ; since this is a new field, it can be nil in-memory and non-nil in the db for a
                      ; limited time after the db has been populated and before the leader is restarted.
-                     current-in-mem-location (conj :location)
-                     current-in-mem-features (conj :features))]
+                     current-in-mem-location (conj :location))]
          (when (not= (select-keys current-db-config keys-to-keep-synced)
                      (select-keys current-in-mem-config keys-to-keep-synced))
            (log/error keys-to-keep-synced "differ between in-memory and database cluster configurations."

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -356,14 +356,10 @@
    The location and state fields are special in this regard -- location can
    only transition from nil to non-nil, and state is validated in
    cluster-state-change-valid?."
-  [{current-location :location current-features :features :as current-config}
-   {new-location :location new-features :features :as new-config}]
+  [{current-location :location :as current-config}
+   {new-location :location :as new-config}]
   (cond (and (some? current-location)
              (not= current-location new-location))
-        false
-
-        (and (seq current-features)
-             (not= (set current-features) (set new-features)))
         false
 
         :else

--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -1058,4 +1058,16 @@
 
 (deftest test-config=?
   (testing "features can be in different orders"
-    (is (true? (config=? {:features [:a :b]} {:features [:b :a]})))))
+    (is (true? (config=? {:features [:a :b]} {:features [:b :a]}))))
+
+  (testing "features can be completely dynamic"
+    (is (true? (config=? {:features [:a :b]} {})))
+    (is (true? (config=? {:features [:a :b]} {:features nil})))
+    (is (true? (config=? {:features [:a :b]} {:features []})))
+    (is (true? (config=? {:features [:a :b]} {:features [:a]})))
+    (is (true? (config=? {:features [:a :b]} {:features [:c]})))
+    (is (true? (config=? {} {:features [:a :b]})))
+    (is (true? (config=? {:features nil} {:features [:a :b]})))
+    (is (true? (config=? {:features []} {:features [:a :b]})))
+    (is (true? (config=? {:features [:a]} {:features [:a :b]})))
+    (is (true? (config=? {:features [:c]} {:features [:a :b]})))))


### PR DESCRIPTION
## Changes proposed in this PR

Allowing cluster features to change on an existing cluster.

## Why are we making these changes?

We want to support updating cluster features after the initial cluster creation.
