### PR TITLE
Refactor the offer->lease code to a new file.

### DIFF
--- a/scheduler/src/cook/scheduler/offer.clj
+++ b/scheduler/src/cook/scheduler/offer.clj
@@ -1,0 +1,73 @@
+(ns cook.scheduler.offer
+  (:require [cook.compute-cluster :as cc])
+  (:import (com.netflix.fenzo
+             VirtualMachineLease VirtualMachineLease$Range)))
+
+  (defn offer-resource-values
+  [offer resource-name value-type]
+  (->> offer :resources (filter #(= (:name %) resource-name)) (map value-type)))
+
+(defn offer-resource-scalar
+  [offer resource-name]
+  (reduce + 0.0 (offer-resource-values offer resource-name :scalar)))
+
+(defn offer-resource-ranges
+  [offer resource-name]
+  (reduce into [] (offer-resource-values offer resource-name :ranges)))
+
+(defn offer-value-list-map
+  [value-list]
+  (->> value-list
+       (map #(vector (:name %) (case (:type %)
+                                 :value-scalar (:scalar %)
+                                 :value-ranges (:ranges %)
+                                 :value-set (:set %)
+                                 :value-text (:text %)
+                                 :value-text->scalar (:text->scalar %)
+                                 ; Default
+                                 (:value %))))
+       (into {})))
+
+(defn get-offer-attr-map
+  "Gets all the attributes from an offer and puts them in a simple, less structured map of the form
+   name->value"
+  [{:keys [attributes compute-cluster hostname resources] :as offer}]
+  (let [offer-attributes (offer-value-list-map attributes)
+        offer-resources (offer-value-list-map resources)
+        cook-attributes (cond->
+                          {"HOSTNAME" hostname}
+                          compute-cluster
+                          (assoc "COOK_MAX_TASKS_PER_HOST" (cc/max-tasks-per-host compute-cluster)
+                                 "COOK_NUM_TASKS_ON_HOST" (cc/num-tasks-on-host compute-cluster hostname)
+                                 "COOK_COMPUTE_CLUSTER_LOCATION" (cc/compute-cluster->location compute-cluster)))]
+    (merge offer-resources offer-attributes cook-attributes)))
+
+(defrecord VirtualMachineLeaseAdapter [offer time attr-map]
+  VirtualMachineLease
+  (cpuCores [_] (or (offer-resource-scalar offer "cpus") 0.0))
+  ; We support disk but support different types of disk, so we set this metric to 0.0 and take care of binpacking disk in the disk-host-constraint
+  (diskMB [_] 0.0)
+  (getScalarValue [_ name] (or (double (offer-resource-scalar offer name)) 0.0))
+  (getScalarValues [_]
+    (reduce (fn [result resource]
+              (if-let [value (:scalar resource)]
+                ;; Do not remove the following fnil--either arg to + can be nil!
+                (update-in result [(:name resource)] (fnil + 0.0 0.0) value)
+                result))
+            {}
+            (:resources offer)))
+  (getAttributeMap [_] attr-map)
+  (getId [_] (-> offer :id :value))
+  (getOffer [_] (throw (UnsupportedOperationException.)))
+  (getOfferedTime [_] time)
+  (getVMID [_] (-> offer :slave-id :value))
+  (hostname [_] (:hostname offer))
+  (memoryMB [_] (or (offer-resource-scalar offer "mem") 0.0))
+  (networkMbps [_] 0.0)
+  (portRanges [_] (mapv (fn [{:keys [begin end]}]
+                          (VirtualMachineLease$Range. begin end))
+                        (offer-resource-ranges offer "ports"))))
+
+(defn offer->lease
+  [offer time]
+  (->VirtualMachineLeaseAdapter offer time (get-offer-attr-map offer)))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -43,6 +43,7 @@
             [cook.scheduler.data-locality :as dl]
             [cook.scheduler.dru :as dru]
             [cook.scheduler.fenzo-utils :as fenzo]
+            [cook.scheduler.offer :as offer]
             [cook.scheduler.share :as share]
             [cook.task]
             [cook.task-stats :as task-stats]
@@ -67,44 +68,6 @@
   []
   (tc/to-date (time/now)))
 
-(defn offer-resource-values
-  [offer resource-name value-type]
-  (->> offer :resources (filter #(= (:name %) resource-name)) (map value-type)))
-
-(defn offer-resource-scalar
-  [offer resource-name]
-  (reduce + 0.0 (offer-resource-values offer resource-name :scalar)))
-
-(defn offer-resource-ranges
-  [offer resource-name]
-  (reduce into [] (offer-resource-values offer resource-name :ranges)))
-
-(defn offer-value-list-map
-  [value-list]
-  (->> value-list
-       (map #(vector (:name %) (case (:type %)
-                                 :value-scalar (:scalar %)
-                                 :value-ranges (:ranges %)
-                                 :value-set (:set %)
-                                 :value-text (:text %)
-                                 :value-text->scalar (:text->scalar %)
-                                 ; Default
-                                 (:value %))))
-       (into {})))
-
-(defn get-offer-attr-map
-  "Gets all the attributes from an offer and puts them in a simple, less structured map of the form
-   name->value"
-  [{:keys [attributes compute-cluster hostname resources] :as offer}]
-  (let [offer-attributes (offer-value-list-map attributes)
-        offer-resources (offer-value-list-map resources)
-        cook-attributes (cond->
-                          {"HOSTNAME" hostname}
-                          compute-cluster
-                          (assoc "COOK_MAX_TASKS_PER_HOST" (cc/max-tasks-per-host compute-cluster)
-                                 "COOK_NUM_TASKS_ON_HOST" (cc/num-tasks-on-host compute-cluster hostname)
-                                 "COOK_COMPUTE_CLUSTER_LOCATION" (cc/compute-cluster->location compute-cluster)))]
-    (merge offer-resources offer-attributes cook-attributes)))
 
 (timers/deftimer [cook-mesos scheduler handle-status-update-duration])
 (timers/deftimer [cook-mesos scheduler handle-framework-message-duration])
@@ -454,36 +417,6 @@
 ;;; API for matcher
 ;;; ===========================================================================
 
-(defrecord VirtualMachineLeaseAdapter [offer time attr-map]
-  VirtualMachineLease
-  (cpuCores [_] (or (offer-resource-scalar offer "cpus") 0.0))
-  ; We support disk but support different types of disk, so we set this metric to 0.0 and take care of binpacking disk in the disk-host-constraint
-  (diskMB [_] 0.0)
-  (getScalarValue [_ name] (or (double (offer-resource-scalar offer name)) 0.0))
-  (getScalarValues [_]
-    (reduce (fn [result resource]
-              (if-let [value (:scalar resource)]
-                ;; Do not remove the following fnil--either arg to + can be nil!
-                (update-in result [(:name resource)] (fnil + 0.0 0.0) value)
-                result))
-            {}
-            (:resources offer)))
-  (getAttributeMap [_] attr-map)
-  (getId [_] (-> offer :id :value))
-  (getOffer [_] (throw (UnsupportedOperationException.)))
-  (getOfferedTime [_] time)
-  (getVMID [_] (-> offer :slave-id :value))
-  (hostname [_] (:hostname offer))
-  (memoryMB [_] (or (offer-resource-scalar offer "mem") 0.0))
-  (networkMbps [_] 0.0)
-  (portRanges [_] (mapv (fn [{:keys [begin end]}]
-                          (VirtualMachineLease$Range. begin end))
-                        (offer-resource-ranges offer "ports"))))
-
-(defn offer->lease
-  [offer time]
-  (->VirtualMachineLeaseAdapter offer time (get-offer-attr-map offer)))
-
 
 ; job and resources appear to be unused, but they are used. Other code paths destructure job and resource out.
 (defrecord TaskRequestAdapter [job resources cpus mem ports uuid task-id assigned-resources guuid->considerable-cotask-ids constraints scalar-requests]
@@ -672,7 +605,7 @@
       (log/debug "In" pool-name "pool, tasks to scheduleOnce" considerable)
       (dl/update-cost-staleness-metric considerable)
       (let [t (System/currentTimeMillis)
-            leases (mapv #(offer->lease % t) offers)
+            leases (mapv #(offer/offer->lease % t) offers)
             considerable->task-id (plumbing.core/map-from-keys (fn [_] (str (d/squuid))) considerable)
             guuid->considerable-cotask-ids (tools/make-guuid->considerable-cotask-ids considerable->task-id)
             running-cotask-cache (atom (cache/fifo-cache-factory {} :threshold (max 1 (count considerable))))
@@ -1392,7 +1325,7 @@
                             (swap! agent-attributes-cache (fn [c]
                                                             (if (cache/has? c slave-id)
                                                               (cache/hit c slave-id)
-                                                              (cache/miss c slave-id (get-offer-attr-map offer))))))
+                                                              (cache/miss c slave-id (offer/get-offer-attr-map offer))))))
                         using-pools? (not (nil? (config/default-pool)))
                         user->quota (quota/create-user->quota-fn (d/db conn) (if using-pools? pool-name nil))
                         matched-head? (handle-resource-offers! conn fenzo-state pool-name->pending-jobs-atom

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -5,7 +5,7 @@
             [clojure.test :refer :all]
             [cook.compute-cluster :as cc]
             [cook.mesos.task :as task]
-            [cook.scheduler.scheduler :as sched]
+            [cook.scheduler.offer :as offer]
             [cook.test.testutil :as tu]
             [datomic.api :as d]
             [mesomatic.types :as mtypes])
@@ -159,11 +159,11 @@
 
         (testing "resources"
           ;; offers have the same resources structure as tasks so we can reuse (offer-resource-values)
-          (is (= (sched/offer-resource-scalar msg "mem") (-> task :resources :mem)))
-          (is (= (sched/offer-resource-scalar msg "cpus") (-> task :resources :cpus)))
-          (is (= (->> (sched/offer-resource-ranges msg "ports") first :begin)
+          (is (= (offer/offer-resource-scalar msg "mem") (-> task :resources :mem)))
+          (is (= (offer/offer-resource-scalar msg "cpus") (-> task :resources :cpus)))
+          (is (= (->> (offer/offer-resource-ranges msg "ports") first :begin)
                  (-> task :resources :ports first :begin)))
-          (is (= (->> (sched/offer-resource-ranges msg "ports") first :end)
+          (is (= (->> (offer/offer-resource-ranges msg "ports") first :end)
                  (-> task :resources :ports first :end)))
           (is (= (->> msg :resources (map :role))
                  (map :role (into (:scalar-resource-messages task)
@@ -334,6 +334,7 @@
               (is (= expected-container (->> container-executor-task task-info->mesos-message-wrap :executor :container))))))))))
 
 (deftest test-job->task-metadata
+  (tu/setup)
   (let [uri "datomic:mem://test-job-task-metadata"
         conn (tu/restore-fresh-database! uri)
         executor {:command "./cook-executor"

--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -22,6 +22,7 @@
             [cook.config :as config]
             [cook.scheduler.constraints :as constraints]
             [cook.scheduler.data-locality :as dl]
+            [cook.scheduler.offer :as offer]
             [cook.scheduler.scheduler :as sched]
             [cook.test.testutil :as testutil
              :refer [create-dummy-group create-dummy-instance create-dummy-job create-dummy-job-with-instances create-pool
@@ -116,7 +117,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (offer/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "GPU task on GPU host with too many GPUs should fail"))
       (is (not (.isSuccessful
@@ -126,7 +127,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (offer/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "GPU task on GPU host with too little GPUs should fail"))
       (is (not (.isSuccessful
@@ -136,7 +137,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (offer/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "GPU task on GPU host with correct number of GPUs but without correct GPU models should fail"))
       (is (.isSuccessful
@@ -146,7 +147,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
+                         (getCurrAvailableResources [_] (offer/offer->lease k8s-gpu-offer 0)))
                        nil))
           (str "GPU task on GPU host with the correct number of GPUs should succeed"))
       (is (not (.isSuccessful
@@ -156,7 +157,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [gpu-task-assignment])
-                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (offer/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "We only allow one GPU job per VM. This VM already has a GPU job assigned to it, so it should not get any additional GPU tasks."))
       (is (not (.isSuccessful
@@ -166,7 +167,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/offer->lease k8s-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (offer/offer->lease k8s-gpu-offer 0)))
                             nil)))
           (str "non GPU task on GPU host should fail"))
       (is (not (.isSuccessful
@@ -176,7 +177,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/offer->lease k8s-non-gpu-offer 0)))
+                              (getCurrAvailableResources [_] (offer/offer->lease k8s-non-gpu-offer 0)))
                             nil)))
           "GPU task on non GPU host should fail")
       (is (.isSuccessful
@@ -186,7 +187,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/offer->lease k8s-non-gpu-offer 0)))
+                         (getCurrAvailableResources [_] (offer/offer->lease k8s-non-gpu-offer 0)))
                        nil))
           "non GPU task on non GPU host should succeed")
       (is (not (.isSuccessful
@@ -196,7 +197,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/offer->lease mesos-gpu-job 0)))
+                              (getCurrAvailableResources [_] (offer/offer->lease mesos-gpu-job 0)))
                             nil)))
           "GPU task on mesos GPU host should fail")
       (is (.isSuccessful
@@ -206,7 +207,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/offer->lease mesos-non-gpu-job 0)))
+                         (getCurrAvailableResources [_] (offer/offer->lease mesos-non-gpu-job 0)))
                        nil))
           "non GPU task on non GPU mesos host should succeed"))
     (is (.isSuccessful
@@ -216,7 +217,7 @@
                        (getHostname [_] "test-host")
                        (getRunningTasks [_] [])
                        (getTasksCurrentlyAssigned [_] [])
-                       (getCurrAvailableResources [_] (sched/offer->lease k8s-non-gpu-offer 0)))
+                       (getCurrAvailableResources [_] (offer/offer->lease k8s-non-gpu-offer 0)))
                      nil))
         "non GPU task on non GPU host should succeed")))
 
@@ -265,7 +266,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/offer->lease offer 0)))
+                         (getCurrAvailableResources [_] (offer/offer->lease offer 0)))
                        nil))
           (str "Disk task on host with enough disk and correct type should succeed"))
       (is (.isSuccessful
@@ -275,7 +276,7 @@
                          (getHostname [_] "test-host")
                          (getRunningTasks [_] [])
                          (getTasksCurrentlyAssigned [_] [])
-                         (getCurrAvailableResources [_] (sched/offer->lease offer 0)))
+                         (getCurrAvailableResources [_] (offer/offer->lease offer 0)))
                        nil))
           (str "Disk task on host with enough disk and correct type should succeed"))
       (is (not (.isSuccessful
@@ -285,7 +286,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/offer->lease offer 0)))
+                              (getCurrAvailableResources [_] (offer/offer->lease offer 0)))
                             nil)))
           (str "Disk task on host without enough disk should fail"))
       (is (not (.isSuccessful
@@ -295,7 +296,7 @@
                               (getHostname [_] "test-host")
                               (getRunningTasks [_] [])
                               (getTasksCurrentlyAssigned [_] [])
-                              (getCurrAvailableResources [_] (sched/offer->lease offer 0)))
+                              (getCurrAvailableResources [_] (offer/offer->lease offer 0)))
                             nil)))
           (str "Disk task on host without correct disk type should fail"))
       (is (nil? (constraints/build-disk-host-constraint disk-request-job-5))))))
@@ -337,7 +338,7 @@
                            (getHostname [_] "hostB")
                            (getRunningTasks [_] [])
                            (getTasksCurrentlyAssigned [_] [])
-                           (getCurrAvailableResources [_]  (sched/offer->lease hostB-offer 0)))
+                           (getCurrAvailableResources [_]  (offer/offer->lease hostB-offer 0)))
                          nil))))
     (is (.isSuccessful
          (.evaluate constraint
@@ -346,7 +347,7 @@
                       (getHostname [_] "hostA")
                       (getRunningTasks [_] [])
                       (getTasksCurrentlyAssigned [_] [])
-                      (getCurrAvailableResources [_]  (sched/offer->lease hostA-offer 0)))
+                      (getCurrAvailableResources [_]  (offer/offer->lease hostA-offer 0)))
                     nil)))))
 
 

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -39,6 +39,7 @@
             [cook.quota :as quota]
             [cook.rate-limit :as rate-limit]
             [cook.scheduler.data-locality :as dl]
+            [cook.scheduler.offer :as offer]
             [cook.scheduler.scheduler :as sched]
             [cook.scheduler.share :as share]
             [cook.test.testutil :as testutil
@@ -159,7 +160,7 @@
 
 (defn make-mesos-vm-offer
   [framework-id host offer-id & {:keys [attrs cpus mem disk] :or {attrs {} cpus 100.0 mem 100000.0 disk 100000.0}}]
-  (sched/offer->lease
+  (offer/offer->lease
     (make-mesos-offer offer-id framework-id "test-slave" host
                       :cpus cpus :mem mem :disk disk :attrs attrs) 0))
 
@@ -176,7 +177,7 @@
 
 (defn make-k8s-vm-offer
   [framework-id host offer-id & {:keys [attrs cpus mem gpus disk] :or {attrs {} cpus 100.0 mem 100000.0 gpus {} disk 100000.0}}]
-  (sched/offer->lease
+  (offer/offer->lease
     (make-k8s-offer offer-id framework-id "test-slave" host
                     :cpus cpus :mem mem :gpus gpus :disk disk :attrs attrs) 0))
 
@@ -791,7 +792,7 @@
                                                  #mesomatic.types.Resource{:name "gpus", :type :value-scalar :scalar 2.0 :role "*"}],
                                      :attributes [],
                                      :executor-ids []}
-        adapter (sched/offer->lease offer now)]
+        adapter (offer/offer->lease offer now)]
 
     (is (= (.getId adapter) "my-offer-id"))
     (is (= (.cpuCores adapter) 40.0))
@@ -818,7 +819,7 @@
                            {:name "gpus", :type :value-text->scalar :text->scalar {"nvidia-tesla-p100" 2} :role "*"}],
                :attributes [],
                :executor-ids []}
-        adapter (sched/offer->lease offer now)]
+        adapter (offer/offer->lease offer now)]
 
     (is (= (.getId adapter) "my-offer-id"))
     (is (= (.cpuCores adapter) 40.0))


### PR DESCRIPTION
## Changes proposed in this PR

- Refactor the offer and lease->offer code to a new file.
- No functionality change

## Why are we making these changes?

Prepare for VirtualMachineLease calculations to happen behind the compute cluster API layer.  Gets this code into a file with a lot less dependencies than cook.scheduler.scheduler

