### PR TITLE
constrain checkpointing to supported pools

### DIFF
--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -987,7 +987,15 @@
                  :job/instance [{:instance/reason {:reason/name :mesos-unknown}}
                                 {:instance/reason {:reason/name :mesos-unknown}}
                                 {:instance/reason {:reason/name :mesos-unknown}}]}]
-        (is (= nil (api/calculate-effective-checkpointing-config job 1)))))))
+        (is (= nil (api/calculate-effective-checkpointing-config job 1))))))
+  (testing "Don't checkpoint on unsupported pool"
+    (with-redefs [config/kubernetes (fn [] {:default-checkpoint-config {:supported-pools #{"good-pool"}}})]
+      (let [job {:job/checkpoint {:checkpoint/mode "auto"}}]
+        (is (= nil (api/calculate-effective-checkpointing-config job 1))))))
+  (testing "Checkpoint on supported pool"
+    (with-redefs [config/kubernetes (fn [] {:default-checkpoint-config {:supported-pools #{"good-pool"}}})]
+      (let [job {:job/checkpoint {:checkpoint/mode "auto"} :job/pool {:pool/name "good-pool"}}]
+        (is (= {:mode "auto" :supported-pools #{"good-pool"}} (api/calculate-effective-checkpointing-config job 1)))))))
 
 (deftest test-pod->sandbox-file-server-container-state
   (testing "file server not running"


### PR DESCRIPTION
## Changes proposed in this PR

- add functionality to be able to constrain checkpointing to supported pools

## Why are we making these changes?

We want to be able to submit a job that might be scheduled in various environments. Some environments might support checkpointing and others might not. So we want to know at pod submission time whether the environment will support checkpointing and if we should instrument the pod with checkpointing. We will make this decision based on the pool.

