### PR TITLE
Supports pluggable job-routing

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -3113,3 +3113,17 @@ class CookTest(util.CookTest):
         self.assertEqual('success', job['state'], job)
         self.assertLessEqual(1, len(job['instances']))
         self.assertIn('success', [i['status'] for i in job['instances']], job)
+
+    def test_benchmark_submit(self):
+        num_jobs = 500
+        self.logger.info(f'Submitting batch of {num_jobs} jobs')
+        jobspec = {'command': 'true', 'cpus': 0.01, 'mem': 32}
+        start_time = time.time()
+        job_uuids, response = util.submit_jobs(self.cook_url, jobspec, num_jobs)
+        elapsed_time = time.time() - start_time
+        try:
+            self.logger.info(f'Elapsed time: {elapsed_time}')
+            self.assertEqual(201, response.status_code, msg=response.content)
+            self.assertLess(elapsed_time, 10)
+        finally:
+            util.kill_jobs(self.cook_url, job_uuids, assert_response=False)

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -233,69 +233,70 @@ class MultiUserCookTest(util.CookTest):
     def test_job_mem_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
-        all_job_uuids = []
+        name = self.current_name()
         try:
             # User with no quota can't submit jobs
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, mem=0)
                 self.assertEqual(resp.status_code, 201, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url)
-                self.assertEqual(resp.status_code, 422, msg=resp.text)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url, name=name)[1],
+                    lambda r: r.status_code == 422)
             # User with tiny quota can't submit bigger jobs, but can submit tiny jobs
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, mem=10)
                 self.assertEqual(resp.status_code, 201, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url, mem=11)
-                self.assertEqual(resp.status_code, 422, msg=resp.text)
-                job_uuid, resp = util.submit_job(self.cook_url, mem=10)
-                self.assertEqual(resp.status_code, 201, msg=resp.text)
-                all_job_uuids.append(job_uuid)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url, mem=10, name=name)[1],
+                    lambda r: r.status_code == 201)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url, mem=11, name=name)[1],
+                    lambda r: r.status_code == 422)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
                 resp = util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
-                job_uuid, resp = util.submit_job(self.cook_url)
-                self.assertEqual(resp.status_code, 201, msg=resp.text)
-                all_job_uuids.append(job_uuid)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url, name=name)[1],
+                    lambda r: r.status_code == 201)
             # Can't set negative quota
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, mem=-128)
                 self.assertEqual(resp.status_code, 400, resp.text)
         finally:
             with admin:
-                util.kill_jobs(self.cook_url, all_job_uuids, assert_response=False)
                 util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
 
     def test_job_count_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
-        all_job_uuids = []
+        name = self.current_name()
         try:
             # User with no quota can't submit jobs
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, count=0)
                 self.assertEqual(resp.status_code, 201, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url)
-                self.assertEqual(resp.status_code, 422, msg=resp.text)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url, name=name)[1],
+                    lambda r: r.status_code == 422)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
                 resp = util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
-                job_uuid, resp = util.submit_job(self.cook_url)
-                self.assertEqual(resp.status_code, 201, msg=resp.text)
-                all_job_uuids.append(job_uuid)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url, name=name)[1],
+                    lambda r: r.status_code == 201)
             # Can't set negative quota
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, count=-1)
                 self.assertEqual(resp.status_code, 400, resp.text)
         finally:
             with admin:
-                util.kill_jobs(self.cook_url, all_job_uuids, assert_response=False)
                 util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
 
     def test_rate_limit_while_creating_job(self):

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -193,40 +193,40 @@ class MultiUserCookTest(util.CookTest):
     def test_job_cpu_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
-        all_job_uuids = []
         try:
             # User with no quota can't submit jobs
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, cpus=0)
                 self.assertEqual(resp.status_code, 201, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url)
-                self.assertEqual(resp.status_code, 422, msg=resp.text)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url)[1],
+                    lambda r: r.status_code == 422)
             # User with tiny quota can't submit bigger jobs, but can submit tiny jobs
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, cpus=0.25)
                 self.assertEqual(resp.status_code, 201, resp.text)
             with user:
-                _, resp = util.submit_job(self.cook_url, cpus=0.5)
-                self.assertEqual(resp.status_code, 422, msg=resp.text)
-                job_uuid, resp = util.submit_job(self.cook_url, cpus=0.25)
-                self.assertEqual(resp.status_code, 201, msg=resp.text)
-                all_job_uuids.append(job_uuid)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url, cpus=0.5)[1],
+                    lambda r: r.status_code == 422)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url, cpus=0.25)[1],
+                    lambda r: r.status_code == 201)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
                 resp = util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
-                job_uuid, resp = util.submit_job(self.cook_url)
-                self.assertEqual(resp.status_code, 201, msg=resp.text)
-                all_job_uuids.append(job_uuid)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url)[1],
+                    lambda r: r.status_code == 201)
             # Can't set negative quota
             with admin:
                 resp = util.set_limit(self.cook_url, 'quota', user.name, cpus=-4)
                 self.assertEqual(resp.status_code, 400, resp.text)
         finally:
             with admin:
-                util.kill_jobs(self.cook_url, all_job_uuids, assert_response=False)
                 util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
 
     def test_job_mem_quota(self):

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -193,6 +193,7 @@ class MultiUserCookTest(util.CookTest):
     def test_job_cpu_quota(self):
         admin = self.user_factory.admin()
         user = self.user_factory.new_user()
+        name = self.current_name()
         try:
             # User with no quota can't submit jobs
             with admin:
@@ -200,7 +201,7 @@ class MultiUserCookTest(util.CookTest):
                 self.assertEqual(resp.status_code, 201, resp.text)
             with user:
                 util.wait_until(
-                    lambda: util.submit_job(self.cook_url)[1],
+                    lambda: util.submit_job(self.cook_url, name=name)[1],
                     lambda r: r.status_code == 422)
             # User with tiny quota can't submit bigger jobs, but can submit tiny jobs
             with admin:
@@ -208,18 +209,18 @@ class MultiUserCookTest(util.CookTest):
                 self.assertEqual(resp.status_code, 201, resp.text)
             with user:
                 util.wait_until(
-                    lambda: util.submit_job(self.cook_url, cpus=0.5)[1],
-                    lambda r: r.status_code == 422)
-                util.wait_until(
-                    lambda: util.submit_job(self.cook_url, cpus=0.25)[1],
+                    lambda: util.submit_job(self.cook_url, cpus=0.25, name=name)[1],
                     lambda r: r.status_code == 201)
+                util.wait_until(
+                    lambda: util.submit_job(self.cook_url, cpus=0.5, name=name)[1],
+                    lambda r: r.status_code == 422)
             # Reset user's quota back to default, then user can submit jobs again
             with admin:
                 resp = util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name())
                 self.assertEqual(resp.status_code, 204, resp.text)
             with user:
                 util.wait_until(
-                    lambda: util.submit_job(self.cook_url)[1],
+                    lambda: util.submit_job(self.cook_url, name=name)[1],
                     lambda r: r.status_code == 201)
             # Can't set negative quota
             with admin:

--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -36,3 +36,6 @@
       ; We blocklist a given job from being autoscaled soon after a prior autoscaling.
       (.expireAfterWrite (:synthetic-pod-recency-seconds (config/kubernetes)) TimeUnit/SECONDS)
       (.build)))
+(mount/defstate ^Cache pool-name->exists?-cache :start (new-cache config/config))
+(mount/defstate ^Cache pool-name->accepts-submissions?-cache :start (new-cache config/config))
+(mount/defstate ^Cache pool-name->db-id-cache :start (new-cache config/config))

--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -39,3 +39,4 @@
 (mount/defstate ^Cache pool-name->exists?-cache :start (new-cache config/config))
 (mount/defstate ^Cache pool-name->accepts-submissions?-cache :start (new-cache config/config))
 (mount/defstate ^Cache pool-name->db-id-cache :start (new-cache config/config))
+(mount/defstate ^Cache user-and-pool-name->quota :start (new-cache config/config))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -482,6 +482,12 @@
                              :age-out-first-seen-deadline-minutes 600
                              :age-out-seen-count 10}
                             job-launch-filter)
+                          ; The job-routing config has the following shape:
+                          ;
+                          ;   pool-name -> job-router-factory-fn
+                          ;
+                          ; where job-router-factory-fn must return
+                          ; something that satisfies the JobRouter protocol
                           :job-routing
                           (pc/map-vals
                             (fn [f]

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -57,3 +57,7 @@
 (defprotocol JobAdjuster
   (adjust-job [this job-map db]
     "Given a job-map, returns an adjusted job-map for downstream use"))
+
+(defprotocol JobRouter
+  (choose-pool-for-job [this job]
+    "Given a job submission, returns the initial pool selection for the job"))

--- a/scheduler/src/cook/plugins/submission.clj
+++ b/scheduler/src/cook/plugins/submission.clj
@@ -104,7 +104,7 @@
              (.build)))
 
 (defn plugin-jobs-submission
-  [job-pool-name-pairs]
+  [job-pool-name-maps]
   "Run the plugins for a set of jobs at submission time."
   (let [deadline (->> (config/batch-timeout-seconds-config)
                       ; One submission can include multiple jobs that must all be checked.
@@ -118,7 +118,7 @@
                                     ; Running out of time, do the default.
                                     (check-job-submission-default plugin-object))]
                        (or status default-accept)))
-        results (map do-one-job job-pool-name-pairs)
+        results (map do-one-job job-pool-name-maps)
         errors (filter #(= :rejected (:status %)) results)
         error-count (count errors)
         ; Collect a few errors to show in the response. (not every error)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2057,8 +2057,8 @@
           (let [miss-fn
                 (fn [{:keys [pool-name user]}]
                   (let [quota (quota/get-quota db user pool-name)]
-                    (log/info "In" pool-name "pool, queried user quota" user ":" quota)
-                    {:cache-expires-at (-> 1 t/minutes t/from-now)
+                    (log/debug "In" pool-name "pool, queried user quota" user ":" quota)
+                    {:cache-expires-at (-> 30 t/seconds t/from-now)
                      :quota quota}))]
             (:quota
               (ccache/lookup-cache-with-expiration!

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2058,7 +2058,7 @@
                 (fn [{:keys [pool-name user]}]
                   (let [quota (quota/get-quota db user pool-name)]
                     (log/info "In" pool-name "pool, queried user quota" user ":" quota)
-                    {:cache-expires-at (-> 5 t/minutes t/from-now)
+                    {:cache-expires-at (-> 1 t/minutes t/from-now)
                      :quota quota}))]
             (:quota
               (ccache/lookup-cache-with-expiration!

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2119,9 +2119,8 @@
 (defn pool-name->effective-pool-name
   "Given a pool name and job from a submission returns the effective pool name"
   [pool-name-from-submission job]
-  (if-let [{:keys [choose-pool-for-job-fn]}
-           (job-routing-pool-name? pool-name-from-submission)]
-    (choose-pool-for-job-fn job)
+  (if-let [job-router (job-routing-pool-name? pool-name-from-submission)]
+    (plugins/choose-pool-for-job job-router job)
     (or pool-name-from-submission (config/default-pool))))
 
 ;;; On POST; JSON blob that looks like:

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2031,9 +2031,10 @@
                      resource resource-keys
                      :let [job-usage (-> job (get resource 0) double)
                            user-quota (quota/get-quota db user (:pool/name pool))
-                           quota-val (-> user-quota (get resource) double)]
-                     :when (> job-usage quota-val)]
-                 (if (zero? (:count user-quota))
+                           quota-val (-> user-quota (get resource) double)
+                           zero-jobs? (-> user-quota :count zero?)]
+                     :when (or (> job-usage quota-val) zero-jobs?)]
+                 (if zero-jobs?
                    "User quota is set to zero jobs."
                    (format "Job %s exceeds quota for %s: %f > %f"
                            (:uuid job) (name resource) job-usage quota-val)))]

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2228,13 +2228,11 @@
                                       :pool-name effective-pool-name
                                       :pool-name-from-submission pool-name}))
                                  jobs)
-                               jobs (map :job job-pool-name-maps)
                                {:keys [status message]}
                                (submission-plugin/plugin-jobs-submission job-pool-name-maps)]
                            ; Does the plugin accept the submission?
                            (if (= :accepted status)
                              [false {::groups groups
-                                     ::jobs jobs
                                      ::job-pool-name-maps job-pool-name-maps}]
                              [true {::error message}])))
                        (catch Exception e
@@ -2243,7 +2241,7 @@
      :allowed? (partial job-create-allowed? is-authorized-fn)
      :exists? (fn [ctx]
                 (let [db (d/db conn)
-                      existing (filter (partial job-exists? db) (map :uuid (::jobs ctx)))]
+                      existing (filter (partial job-exists? db) (->> ctx ::job-pool-name-maps (map :job) (map :uuid)))]
                   [(seq existing) {::existing existing}]))
      :processable? (partial job-create-processable? conn)
      ;; To ensure compatibility with existing clients,

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2052,6 +2052,9 @@
   where \"...\" is a detailed error string describing the quota bounds exceeded."
   [conn {:keys [::job-pool-name-maps] :as ctx}]
   (let [db (db conn)
+        ; We cache quota by (user, pool) here because JobRouting plugins can result in
+        ; different jobs in a single batch submission getting routed to different pools,
+        ; and we don't want to query the database for quota for every single job.
         get-quota
         (fn [db user pool-name]
           (let [miss-fn

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -197,7 +197,10 @@
   (.invalidateAll caches/job-ent->pool-cache)
   (.invalidateAll caches/task-ent->user-cache)
   (.invalidateAll caches/task->feature-vector-cache)
-  (.invalidateAll caches/job-ent->user-cache))
+  (.invalidateAll caches/job-ent->user-cache)
+  (.invalidateAll caches/pool-name->exists?-cache)
+  (.invalidateAll caches/pool-name->accepts-submissions?-cache)
+  (.invalidateAll caches/pool-name->db-id-cache))
 
 (defn restore-fresh-database!
   "Completely delete all data, start a fresh database and apply transactions if

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -139,7 +139,8 @@
                            #'caches/recent-synthetic-pod-job-uuids
                            #'caches/pool-name->exists?-cache
                            #'caches/pool-name->accepts-submissions?-cache
-                           #'caches/pool-name->db-id-cache)))
+                           #'caches/pool-name->db-id-cache
+                           #'caches/user-and-pool-name->quota)))
 
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."
@@ -200,7 +201,8 @@
   (.invalidateAll caches/job-ent->user-cache)
   (.invalidateAll caches/pool-name->exists?-cache)
   (.invalidateAll caches/pool-name->accepts-submissions?-cache)
-  (.invalidateAll caches/pool-name->db-id-cache))
+  (.invalidateAll caches/pool-name->db-id-cache)
+  (.invalidateAll caches/user-and-pool-name->quota))
 
 (defn restore-fresh-database!
   "Completely delete all data, start a fresh database and apply transactions if

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -136,7 +136,10 @@
                            #'caches/job-ent->user-cache
                            #'cook.quota/per-user-per-pool-launch-rate-limiter
                            #'caches/user->group-ids-cache
-                           #'caches/recent-synthetic-pod-job-uuids)))
+                           #'caches/recent-synthetic-pod-job-uuids
+                           #'caches/pool-name->exists?-cache
+                           #'caches/pool-name->accepts-submissions?-cache
+                           #'caches/pool-name->db-id-cache)))
 
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."

--- a/scheduler/test/cook/test/monitor.clj
+++ b/scheduler/test/cook/test/monitor.clj
@@ -56,7 +56,7 @@
     (is (= 0 (counter ["hungry" "users"])))
     (is (= 0 (counter ["satisfied" "users"])))
 
-    (testutil/create-jobs! conn {::api/jobs [job1 job2]})
+    (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job1} {:job job2}]})
 
     (monitor/set-stats-counters! (db conn) stats-atom
                                  (queries/get-pending-job-ents (db conn))
@@ -218,7 +218,7 @@
     (is (= 0 (counter ["hungry" "users"])))
     (is (= 0 (counter ["satisfied" "users"])))
 
-    (testutil/create-jobs! conn {::api/jobs [job3]})
+    (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job3}]})
     (with-redefs [share/get-share (constantly {:cpus 0 :mem 0})]
 
       (monitor/set-stats-counters! (db conn) stats-atom

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2775,3 +2775,20 @@
           (let [{:keys [status] :as response} (handler request)]
             (is (= 422 status) (-> response response->body-data str))
             (is (= (str "Compute cluster with name " name " does not exist") (-> response response->body-data (get-in ["error" "message"]))))))))))
+
+(deftest test-make-job-txn
+  (setup)
+  (testing "job schema type hint"
+    (is (api/make-job-txn {:job {}} nil nil))
+    (is (thrown? ExceptionInfo (s/with-fn-validation (api/make-job-txn {:job {}} nil nil))))
+    (let [valid-job
+          {:command "true"
+           :cpus 0.1
+           :max-retries 2
+           :max-runtime 1
+           :mem 128.
+           :name "test-job"
+           :priority 100
+           :user "test-user"
+           :uuid (UUID/randomUUID)}]
+      (is (s/with-fn-validation (api/make-job-txn {:job valid-job} nil nil))))))

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -1475,7 +1475,7 @@
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
                 {:keys [uuid] :as job} (minimal-job)]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (dissoc (api/fetch-job-map (db conn) uuid) :submit_time)))))
 
@@ -1483,10 +1483,10 @@
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
                 {:keys [uuid] :as job} (minimal-job)]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (thrown-with-msg? ExecutionException
                                   (re-pattern (str ".*:job/uuid.*" uuid ".*already exists"))
-                                  (testutil/create-jobs! conn {::api/jobs [job]})))))
+                                  (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))))
 
         (testing "should work with datasets"
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1498,7 +1498,7 @@
                                                                                        {"begin" "20180301"
                                                                                         "end" "20180401"}}}})]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (dissoc (api/fetch-job-map (db conn) uuid) :submit_time)))))
 
@@ -1507,7 +1507,7 @@
                 application {:name "foo-app", :version "0.1.0"}
                 {:keys [uuid] :as job} (assoc (minimal-job) :application application)]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (dissoc (api/fetch-job-map (db conn) uuid) :submit_time)))))
 
@@ -1516,7 +1516,7 @@
                 checkpoint {:mode "auto"}
                 {:keys [uuid] :as job} (assoc (minimal-job) :checkpoint checkpoint)]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (dissoc (api/fetch-job-map (db conn) uuid) :submit_time)))))
 
@@ -1527,7 +1527,7 @@
                             :periodic-options {:period-sec 777}}
                 {:keys [uuid] :as job} (assoc (minimal-job) :checkpoint checkpoint)]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (dissoc (api/fetch-job-map (db conn) uuid) :submit_time)))))
 
@@ -1535,7 +1535,7 @@
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
                 {:keys [uuid] :as job} (assoc (minimal-job) :expected-runtime 1)]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (-> (api/fetch-job-map (db conn) uuid)
                        (dissoc :submit_time))))))
@@ -1544,7 +1544,7 @@
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
                 {:keys [uuid] :as job} (assoc (minimal-job) :disable-mea-culpa-retries true)]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (-> (api/fetch-job-map (db conn) uuid)
                        (dissoc :submit_time))))))
@@ -1553,7 +1553,7 @@
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
                 {:keys [uuid] :as job} (assoc (minimal-job) :executor "cook")]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (-> (api/fetch-job-map (db conn) uuid)
                        (dissoc :submit_time)
@@ -1563,7 +1563,7 @@
           (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
                 {:keys [uuid] :as job} (assoc (minimal-job) :executor "mesos")]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (-> (api/fetch-job-map (db conn) uuid)
                        (dissoc :submit_time)
@@ -1573,7 +1573,7 @@
           (let [conn (restore-fresh-database! "datomic:mem://data-locality-submit")
                 {:keys [uuid] :as job} (assoc (minimal-job) :supports_data_locality true)]
             (is (= {::api/results (str "submitted jobs " uuid)}
-                   (testutil/create-jobs! conn {::api/jobs [job]})))
+                   (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
             (is (= (expected-job-map job)
                    (-> (api/fetch-job-map (db conn) uuid)
                        (dissoc :submit_time))))))
@@ -1591,7 +1591,7 @@
                       parameters []
                       {:keys [uuid] :as job} (assoc-in basic-docker-job [:container :docker :parameters] parameters)]
                   (is (= {::api/results (str "submitted jobs " uuid)}
-                         (testutil/create-jobs! conn {::api/jobs [job]})))
+                         (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
                   (is (= (assoc (expected-job-map job)
                            :container (assoc-in docker-container
                                                 [:docker :parameters]
@@ -1606,7 +1606,7 @@
                   (with-redefs [util/retrieve-system-id (fn [& args] (str/join "" (reverse args)))]
                     (is (thrown-with-msg? ExceptionInfo
                                           #"user parameter must match uid and gid of user submitting"
-                                          (testutil/create-jobs! conn {::api/jobs [job]}))))))
+                                          (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]}))))))
 
               (testing "user parameter provided"
                 (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
@@ -1615,7 +1615,7 @@
                                   {:key "user" :value "1234:2345"}]
                       {:keys [uuid] :as job} (assoc-in basic-docker-job [:container :docker :parameters] parameters)]
                   (is (= {::api/results (str "submitted jobs " uuid)}
-                         (testutil/create-jobs! conn {::api/jobs [job]})))
+                         (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
                   (is (= (assoc (expected-job-map job)
                            :container (assoc-in docker-container
                                                 [:docker :parameters]
@@ -1632,7 +1632,7 @@
                                   {:key "tee" :value "tie"}]
                       {:keys [uuid] :as job} (assoc-in basic-docker-job [:container :docker :parameters] parameters)]
                   (is (= {::api/results (str "submitted jobs " uuid)}
-                         (testutil/create-jobs! conn {::api/jobs [job]})))
+                         (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
                   (is (= (assoc (expected-job-map job)
                            :container (assoc-in docker-container
                                                 [:docker :parameters]
@@ -1651,7 +1651,7 @@
         (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")
               {:keys [uuid] :as job} (minimal-job)]
           (is (= {::api/results (str "submitted jobs " uuid)}
-                 (testutil/create-jobs! conn {::api/jobs [job]})))
+                 (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})))
           (is (= (assoc (expected-job-map job) :framework_id "unsupported")
                  (dissoc (api/fetch-job-map (db conn) uuid) :submit_time))))))))
 
@@ -1701,7 +1701,7 @@
         handler (api/destroy-jobs-handler conn is-authorized-fn)]
     (testing "should be able to destroy own jobs"
       (let [{:keys [uuid user] :as job} (minimal-job)
-            _ (testutil/create-jobs! conn {::api/jobs [job]})
+            _ (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})
             resp (handler {:request-method :delete
                            :authorization/user user
                            :query-params {:job uuid}})]
@@ -1709,7 +1709,7 @@
 
     (testing "should not be able to destroy another user's job"
       (let [{:keys [uuid] :as job} (assoc (minimal-job) :user "creator")
-            _ (testutil/create-jobs! conn {::api/jobs [job]})
+            _ (testutil/create-jobs! conn {::api/job-pool-name-maps [{:job job}]})
             resp (handler {:request-method :delete
                            :authorization/user "destroyer"
                            :query-params {:job uuid}})]


### PR DESCRIPTION
## Changes proposed in this PR

Adding support for configurable job-routing to a Cook pool based on a "special" (configurable) pool name.

## Why are we making these changes?

In order to support intelligent job routing within Cook, e.g. choosing the most appropriate of multiple possible pools for a job.
