### PR TITLE
reduce default job disk size

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -127,7 +127,7 @@
            :max-size 256000.0
            :valid-types #{"standard", "pd-ssd"}
            :default-type "standard"
-           :default-request 10000.0
+           :default-request 256.0
            :type-map {"standard" "pd-standard"}
            :enable-constraint? true
            :disk-node-label "cloud.google.com/gke-boot-disk"}]


### PR DESCRIPTION
## Changes proposed in this PR

- reduce default job disk size

## Why are we making these changes?

So that a default job will fit on test cluster
