### PR TITLE
Add passport logger and json passport log events

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -511,6 +511,8 @@
                           (merge {:attribute-name "cook-pool"
                                   :default-pool "no-pool"}
                                  pool-selection)})))
+     :passport (fnk [[:config {passport {}}]]
+                 passport)
      :kubernetes (fnk [[:config {kubernetes {}}]]
                    (let [{:keys [controller-lock-num-shards
                                  telemetry-tags-key-invalid-char-pattern]
@@ -692,6 +694,10 @@
 (defn compute-cluster-templates
   []
   (:compute-cluster-templates (compute-cluster-options)))
+
+(defn passport
+  []
+  (get-in config [:settings :passport]))
 
 (defn kubernetes
   []

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -16,7 +16,6 @@
 (ns cook.config
   (:require [clj-logging-config.log4j :as log4j-conf]
             [clj-time.core :as t]
-            [clojure.data.json :as json]
             [clojure.edn :as edn]
             [clojure.stacktrace :as stacktrace]
             [clojure.string :as str]
@@ -56,10 +55,6 @@
 
 (def passport-logger-ns "passport-logger")
 
-(defn log-passport-event
-  [log-data]
-  (log/log passport-logger-ns :info nil (json/write-str log-data)))
-
 (defn init-logger
   ([] (init-logger {:levels {"datomic.db" :warn
                              "datomic.peer" :warn
@@ -88,7 +83,7 @@
          {:out (DailyRollingFileAppender.
                  (PatternLayout.
                    "%d{ISO8601} %-5p %c [%t] - %m%n")
-                 "log/passport.log"
+                 "log/cook-passport.log"
                  "'.'yyyy-MM-dd")
           :level default}))
      (catch Throwable t

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -8,6 +8,7 @@
             [cook.cached-queries :as cached-queries]
             [cook.config :as config]
             [cook.kubernetes.metrics :as metrics]
+            [cook.passport :as passport]
             [cook.regexp-tools :as regexp-tools]
             [cook.rest.api :as api]
             [cook.scheduler.constraints :as constraints]
@@ -1641,10 +1642,11 @@
                 (str "Pod name from pod (" pod-name-from-pod ") "
                      "does not match pod name argument (" pod-name ")"))
         (log/info "In" compute-cluster-name "compute cluster, launching pod with name" pod-name "in namespace" namespace ":" (.serialize json pod))
-        (cook.config/log-passport-event {"pod-name" pod-name
-                                         "namespace" namespace
-                                         "cluster-name" compute-cluster-name
-                                         "event-type" "Launching Pod"})
+        (passport/log-passport-event {"pod-name" pod-name
+                                      "instance-uuid" pod-name
+                                      "namespace" namespace
+                                      "cluster-name" compute-cluster-name
+                                      "event-type" passport/pod-launching})
         (try
           (timers/time! (metrics/timer "launch-pod" compute-cluster-name)
                         (create-namespaced-pod api namespace pod))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1642,11 +1642,10 @@
                 (str "Pod name from pod (" pod-name-from-pod ") "
                      "does not match pod name argument (" pod-name ")"))
         (log/info "In" compute-cluster-name "compute cluster, launching pod with name" pod-name "in namespace" namespace ":" (.serialize json pod))
-        (passport/log-passport-event {"pod-name" pod-name
-                                      "instance-uuid" pod-name
-                                      "namespace" namespace
-                                      "cluster-name" compute-cluster-name
-                                      "event-type" passport/pod-launching})
+        (passport/log-passport-event {:pod-name pod-name
+                                      :namespace namespace
+                                      :cluster-name compute-cluster-name
+                                      :event-type passport/pod-launching})
         (try
           (timers/time! (metrics/timer "launch-pod" compute-cluster-name)
                         (create-namespaced-pod api namespace pod))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1641,6 +1641,10 @@
                 (str "Pod name from pod (" pod-name-from-pod ") "
                      "does not match pod name argument (" pod-name ")"))
         (log/info "In" compute-cluster-name "compute cluster, launching pod with name" pod-name "in namespace" namespace ":" (.serialize json pod))
+        (cook.config/log-passport-event {"pod-name" pod-name
+                                         "namespace" namespace
+                                         "cluster-name" compute-cluster-name
+                                         "event-type" "Launching Pod"})
         (try
           (timers/time! (metrics/timer "launch-pod" compute-cluster-name)
                         (create-namespaced-pod api namespace pod))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -82,13 +82,13 @@
   (when-not (synthetic-pod? pod-name)
     pod-name))
 
-(defn create-uuid-map
-  "Return a map with :job-uuid and/or :instance-uuid based on pod-name"
-  [pod-name]
+(defn assoc-uuid
+  "Return a map with :job-uuid or :instance-uuid based on pod-name"
+  [event-map pod-name]
   (let [instance-uuid (pod-name->instance-uuid pod-name)
         job-uuid (pod-name->job-uuid pod-name)]
     (cond->
-      {}
+      event-map
       instance-uuid (assoc :instance-uuid instance-uuid)
       job-uuid (assoc :job-uuid job-uuid))))
 
@@ -1664,12 +1664,12 @@
                 (str "Pod name from pod (" pod-name-from-pod ") "
                      "does not match pod name argument (" pod-name ")"))
         (log/info "In" compute-cluster-name "compute cluster, launching pod with name" pod-name "in namespace" namespace ":" (.serialize json pod))
-        (let [event-map (merge
+        (let [event-map (assoc-uuid
                           {:cluster-name compute-cluster-name
                            :event-type passport/pod-launching
                            :namespace namespace
                            :pod-name pod-name}
-                          (create-uuid-map pod-name))]
+                          pod-name)]
           (passport/log-event event-map))
         (try
           (timers/time! (metrics/timer "launch-pod" compute-cluster-name)

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -157,12 +157,18 @@
   "Helper function for logging completed job status to cook passport"
   [{:keys [name]}
    {:keys [task-id state reason]}]
-  (let [pod-name (task-id :value)]
-    (passport/log-passport-event {:pod-name pod-name
-                                  :cluster-name name
-                                  :state state
-                                  :reason reason
-                                  :event-type passport/pod-completed})))
+  (let [pod-name (task-id :value)
+        event-map {:pod-name pod-name
+                   :cluster-name name
+                   :state state
+                   :reason reason
+                   :event-type passport/pod-completed}
+        instance-uuid (api/pod-name->instance-uuid pod-name)
+        job-uuid (api/pod-name->job-uuid pod-name)
+        event-map (cond
+                    instance-uuid (assoc event-map :instance-uuid instance-uuid)
+                    job-uuid (assoc event-map :job-uuid job-uuid))]
+    (passport/log-passport-event event-map)))
 
 (defn handle-pod-submission-failed
   "Marks the corresponding job instance as failed in the database and

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -158,17 +158,14 @@
   [{:keys [name]}
    {:keys [task-id state reason]}]
   (let [pod-name (task-id :value)
-        event-map {:pod-name pod-name
-                   :cluster-name name
-                   :state state
-                   :reason reason
-                   :event-type passport/pod-completed}
-        instance-uuid (api/pod-name->instance-uuid pod-name)
-        job-uuid (api/pod-name->job-uuid pod-name)
-        event-map (cond
-                    instance-uuid (assoc event-map :instance-uuid instance-uuid)
-                    job-uuid (assoc event-map :job-uuid job-uuid))]
-    (passport/log-passport-event event-map)))
+        event-map (merge
+                    {:cluster-name name
+                     :event-type passport/pod-completed
+                     :pod-name pod-name
+                     :reason reason
+                     :state state}
+                    (api/create-uuid-map pod-name))]
+    (passport/log-event event-map)))
 
 (defn handle-pod-submission-failed
   "Marks the corresponding job instance as failed in the database and

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -158,13 +158,13 @@
   [{:keys [name]}
    {:keys [task-id state reason]}]
   (let [pod-name (task-id :value)
-        event-map (merge
+        event-map (api/assoc-uuid
                     {:cluster-name name
                      :event-type passport/pod-completed
                      :pod-name pod-name
                      :reason reason
                      :state state}
-                    (api/create-uuid-map pod-name))]
+                    pod-name)]
     (passport/log-event event-map)))
 
 (defn handle-pod-submission-failed

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -7,6 +7,7 @@
             [cook.kubernetes.api :as api]
             [cook.kubernetes.metrics :as metrics]
             [cook.mesos.sandbox :as sandbox]
+            [cook.passport :as passport]
             [cook.scheduler.scheduler :as scheduler]
             [metrics.timers :as timers])
   (:import (clojure.lang IAtom)
@@ -156,12 +157,13 @@
   "Helper function for logging completed job status to cook passport"
   [{:keys [name]}
    {:keys [task-id state reason]}]
-  (let [job-uuid (task-id :value)]
-    (cook.config/log-passport-event {"pod-name" job-uuid
-                                     "cluster-name" name
-                                     "state" state
-                                     "reason" reason
-                                     "event-type" "Pod Completed"})))
+  (let [instance-uuid (task-id :value)]
+    (passport/log-passport-event {"pod-name" instance-uuid
+                                  "instance-uuid" instance-uuid
+                                  "cluster-name" name
+                                  "state" state
+                                  "reason" reason
+                                  "event-type" passport/pod-completed})))
 
 (defn handle-pod-submission-failed
   "Marks the corresponding job instance as failed in the database and

--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -6,7 +6,8 @@
 (defn log-event
   "Log event to cook-passport log file"
   [log-data]
-  (log/log config/passport-logger-ns :info nil (json/write-str log-data)))
+  (when (:enabled? (config/passport))
+    (log/log config/passport-logger-ns :info nil (json/write-str log-data))))
 
 (def api-job-submission :api-job-submission)
 (def pod-launching :pod-launching)

--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -1,0 +1,15 @@
+(ns cook.passport
+  (:require [clojure.data.json :as json]
+            [clojure.tools.logging :as log]
+            [congestion.limits :refer [RateLimit]]
+            [cook.config :as config]
+            [cook.rest.impersonation :refer [impersonation-authorized-wrapper]]
+            [plumbing.core :refer [fnk]]))
+
+(defn log-passport-event
+  [log-data]
+  (log/log config/passport-logger-ns :info nil (json/write-str log-data)))
+
+(def api-job-submission "raw-api-job-submission")
+(def pod-launching "pod-launching")
+(def pod-completed "pod-completed")

--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -3,10 +3,11 @@
             [clojure.tools.logging :as log]
             [cook.config :as config]))
 
-(defn log-passport-event
+(defn log-event
+  "Log event to cook-passport log file"
   [log-data]
   (log/log config/passport-logger-ns :info nil (json/write-str log-data)))
 
-(def api-job-submission "api-job-submission")
-(def pod-launching "pod-launching")
-(def pod-completed "pod-completed")
+(def api-job-submission :api-job-submission)
+(def pod-launching :pod-launching)
+(def pod-completed :pod-completed)

--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -1,15 +1,12 @@
 (ns cook.passport
   (:require [clojure.data.json :as json]
             [clojure.tools.logging :as log]
-            [congestion.limits :refer [RateLimit]]
-            [cook.config :as config]
-            [cook.rest.impersonation :refer [impersonation-authorized-wrapper]]
-            [plumbing.core :refer [fnk]]))
+            [cook.config :as config]))
 
 (defn log-passport-event
   [log-data]
   (log/log config/passport-logger-ns :info nil (json/write-str log-data)))
 
-(def api-job-submission "raw-api-job-submission")
+(def api-job-submission "api-job-submission")
 (def pod-launching "pod-launching")
 (def pod-completed "pod-completed")

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1979,10 +1979,10 @@
                       (update job-pool-name-map :job #(dissoc % :command)))
                     job-pool-name-maps)]
       (log/info "Submitting jobs through raw api:" jobs)
-      (doseq [job jobs]
-        (passport/log-passport-event {"job-uuid" (str (:uuid job))
-                                      "user" (:user job)
-                                      "event-type" passport/api-job-submission})))
+      (doseq [{{:keys [uuid, user]} :job} jobs]
+        (passport/log-passport-event {:job-uuid (str uuid)
+                                      :user user
+                                      :event-type passport/api-job-submission})))
     (let [jobs (map :job job-pool-name-maps)
           group-uuids (set (map :uuid groups))
           group-asserts (map (fn [guuid] [:entity/ensure-not-exists [:group/uuid guuid]])

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1975,14 +1975,14 @@
   ::jobs and ::groups, which specify the jobs and job groups."
   [conn {:keys [::groups ::job-pool-name-maps] :as ctx}]
   (try
-    (let [jobs (map (fn [job-pool-name-map]
-                      (update job-pool-name-map :job #(dissoc % :command)))
-                    job-pool-name-maps)]
-      (log/info "Submitting jobs through raw api:" jobs)
-      (doseq [{{:keys [uuid, user]} :job} jobs]
-        (passport/log-event {:event-type passport/api-job-submission
-                             :job-uuid (str uuid)
-                             :user user})))
+    (log/info "Submitting jobs through raw api:"
+              (map (fn [job-pool-name-map]
+                     (update job-pool-name-map :job #(dissoc % :command)))
+                   job-pool-name-maps))
+    (doseq [{{:keys [uuid, user]} :job} job-pool-name-maps]
+      (passport/log-event {:event-type passport/api-job-submission
+                           :job-uuid (str uuid)
+                           :user user}))
     (let [jobs (map :job job-pool-name-maps)
           group-uuids (set (map :uuid groups))
           group-asserts (map (fn [guuid] [:entity/ensure-not-exists [:group/uuid guuid]])

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1975,14 +1975,14 @@
   ::jobs and ::groups, which specify the jobs and job groups."
   [conn {:keys [::groups ::job-pool-name-maps] :as ctx}]
   (try
-    (log/info "Submitting jobs through raw api:"
-              (map (fn [job-pool-name-map]
-                     (update job-pool-name-map :job #(dissoc % :command)))
-                   job-pool-name-maps))
-    (doseq [job jobs]
-      (passport/log-passport-event {"job-uuid" (str (:uuid job))
-                                    "user" (:user job)
-                                    "event-type" passport/api-job-submission}))
+    (let [jobs (map (fn [job-pool-name-map]
+                      (update job-pool-name-map :job #(dissoc % :command)))
+                    job-pool-name-maps)]
+      (log/info "Submitting jobs through raw api:" jobs)
+      (doseq [job jobs]
+        (passport/log-passport-event {"job-uuid" (str (:uuid job))
+                                      "user" (:user job)
+                                      "event-type" passport/api-job-submission})))
     (let [jobs (map :job job-pool-name-maps)
           group-uuids (set (map :uuid groups))
           group-asserts (map (fn [guuid] [:entity/ensure-not-exists [:group/uuid guuid]])

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1980,7 +1980,7 @@
                     job-pool-name-maps)]
       (log/info "Submitting jobs through raw api:" jobs)
       (doseq [{{:keys [uuid, user]} :job} jobs]
-        (passport/log-passport-event {:job-uuid (str uuid)
+        (passport/log-event {:job-uuid (str uuid)
                                       :user user
                                       :event-type passport/api-job-submission})))
     (let [jobs (map :job job-pool-name-maps)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -36,6 +36,7 @@
             [cook.datomic :as datomic]
             [cook.mesos]
             [cook.mesos.reason :as reason]
+            [cook.passport :as passport]
             [cook.plugins.adjustment :as adjustment]
             [cook.plugins.definitions :as plugins]
             [cook.plugins.file :as file-plugin]
@@ -1979,9 +1980,9 @@
                      (update job-pool-name-map :job #(dissoc % :command)))
                    job-pool-name-maps))
     (doseq [job jobs]
-      (cook.config/log-passport-event {"job-uuid" (str (:uuid job))
-                                       "user" (:user job)
-                                       "event-type" "Submitting job from raw api"}))
+      (passport/log-passport-event {"job-uuid" (str (:uuid job))
+                                    "user" (:user job)
+                                    "event-type" passport/api-job-submission}))
     (let [jobs (map :job job-pool-name-maps)
           group-uuids (set (map :uuid groups))
           group-asserts (map (fn [guuid] [:entity/ensure-not-exists [:group/uuid guuid]])

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1978,6 +1978,10 @@
               (map (fn [job-pool-name-map]
                      (update job-pool-name-map :job #(dissoc % :command)))
                    job-pool-name-maps))
+    (doseq [job jobs]
+      (cook.config/log-passport-event {"job-uuid" (str (:uuid job))
+                                       "user" (:user job)
+                                       "event-type" "Submitting job from raw api"}))
     (let [jobs (map :job job-pool-name-maps)
           group-uuids (set (map :uuid groups))
           group-asserts (map (fn [guuid] [:entity/ensure-not-exists [:group/uuid guuid]])

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1980,9 +1980,9 @@
                     job-pool-name-maps)]
       (log/info "Submitting jobs through raw api:" jobs)
       (doseq [{{:keys [uuid, user]} :job} jobs]
-        (passport/log-event {:job-uuid (str uuid)
-                                      :user user
-                                      :event-type passport/api-job-submission})))
+        (passport/log-event {:event-type passport/api-job-submission
+                             :job-uuid (str uuid)
+                             :user user})))
     (let [jobs (map :job job-pool-name-maps)
           group-uuids (set (map :uuid groups))
           group-asserts (map (fn [guuid] [:entity/ensure-not-exists [:group/uuid guuid]])


### PR DESCRIPTION
## Changes proposed in this PR

- Adding a new logger that logs Cook passport events to a passport-only log file
- Adding a structured logging wrapper to log passport events as json
- Adding passport logging for the following events:
  - Job submission through raw API
  - Pod submission
  - Pod completion

## Why are we making these changes?

- Having structured passport logging makes it easier to work with and filter logs
