### PR TITLE
Update rebalancer to use guava cache and be per-pool selectable.

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -170,7 +170,7 @@
               :max-preemption 500.0
               :min-dru-diff 1.0
               :safe-dru-threshold 1.0
-              :rebalancer-pools "^.*alpha.*$"}
+              :pool-regex "^.*alpha.*$"}
  :sandbox-syncer {:sync-interval-ms 1000}
  :scheduler {:offer-incubate-ms 15000
              :task-constraints {:command-length-limit 5000

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -169,7 +169,8 @@
               :interval-seconds 30
               :max-preemption 500.0
               :min-dru-diff 1.0
-              :safe-dru-threshold 1.0}
+              :safe-dru-threshold 1.0
+              :rebalancer-pools "^.*alpha.*$"}
  :sandbox-syncer {:sync-interval-ms 1000}
  :scheduler {:offer-incubate-ms 15000
              :task-constraints {:command-length-limit 5000

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -102,7 +102,7 @@
                            good-enough-fitness hostname mea-culpa-failure-limit mesos-leader-path mesos-run-as-user
                            offer-incubate-time-ms optimizer rebalancer server-port task-constraints]
                           compute-clusters curator-framework mesos-datomic-mult leadership-atom
-                          mesos-agent-attributes-cache pool-name->pending-jobs-atom mesos-heartbeat-chan
+                          pool-name->pending-jobs-atom mesos-heartbeat-chan
                           trigger-chans]
 
                       ; We track queue limits on all nodes, not just the leader, because
@@ -134,7 +134,6 @@
                                  :leadership-atom leadership-atom
                                  :pool-name->pending-jobs-atom pool-name->pending-jobs-atom
                                  :mesos-run-as-user mesos-run-as-user
-                                 :agent-attributes-cache mesos-agent-attributes-cache
                                  :offer-incubate-time-ms offer-incubate-time-ms
                                  :optimizer-config optimizer
                                  :rebalancer-config rebalancer
@@ -332,12 +331,6 @@
                                      datomic/conn leadership-atom))
      :leadership-atom (fnk [] (atom false))
      :pool-name->pending-jobs-atom (fnk [] (atom {}))
-     :mesos-agent-attributes-cache (fnk [[:settings {agent-attributes-cache nil}]]
-                                     (when agent-attributes-cache
-                                       (log/info "Agent attributes cache max size =" (:max-size agent-attributes-cache))
-                                       (-> {}
-                                           (cache/lru-cache-factory :threshold (:max-size agent-attributes-cache))
-                                           atom)))
      :curator-framework curator-framework}))
 
 (defn -main

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -420,7 +420,8 @@
                    (when (:min-utilization-threshold rebalancer)
                      (log/warn "The :min-utilization-threshold configuration field is no longer used"))
                    (merge {:interval-seconds 300
-                           :dru-scale 1.0}
+                           :dru-scale 1.0
+                           :rebalancer-pools ".*"}
                           rebalancer))
 
      :optimizer (fnk [[:config {optimizer nil}]]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -421,7 +421,7 @@
                      (log/warn "The :min-utilization-threshold configuration field is no longer used"))
                    (merge {:interval-seconds 300
                            :dru-scale 1.0
-                           :rebalancer-pools ".*"}
+                           :pool-regex ".*"}
                           rebalancer))
 
      :optimizer (fnk [[:config {optimizer nil}]]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -346,11 +346,6 @@
      :offer-incubate-time-ms (fnk [[:config {scheduler nil}]]
                                (when scheduler
                                  (or (:offer-incubate-ms scheduler) 15000)))
-     :agent-attributes-cache (fnk [[:config {scheduler nil}]]
-                               (when scheduler
-                                 (merge
-                                   {:max-size 2000}
-                                   (:offer-cache scheduler))))
      :mea-culpa-failure-limit (fnk [[:config {scheduler nil}]]
                                 (:mea-culpa-failure-limit scheduler))
      :max-over-quota-jobs (fnk [[:config {scheduler nil}]]

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -176,7 +176,7 @@
    fenzo-config                  -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details
    sandbox-syncer-state          -- map, representing the sandbox syncer object"
   [{:keys [curator-framework fenzo-config mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult
-           mesos-heartbeat-chan leadership-atom pool-name->pending-jobs-atom mesos-run-as-user agent-attributes-cache
+           mesos-heartbeat-chan leadership-atom pool-name->pending-jobs-atom mesos-run-as-user
            offer-incubate-time-ms optimizer-config rebalancer-config server-config task-constraints trigger-chans
            zk-prefix]}]
   (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
@@ -195,7 +195,10 @@
                           ;clojure.lang.Agent/pooledExecutor
                           (reify LeaderSelectorListener
                             (takeLeadership [_ client]
-                              (let [{:keys [pool-name->fenzo-state view-incubating-offers] :as scheduler}
+                              (let [agent-attributes-cache (-> {}
+                                                               (cache/fifo-cache-factory :threshold 100000)
+                                                               atom)
+                                    {:keys [pool-name->fenzo-state view-incubating-offers] :as scheduler}
                                     (sched/create-datomic-scheduler
                                       {:conn mesos-datomic-conn
                                        :cluster-name->compute-cluster-atom cook.compute-cluster/cluster-name->compute-cluster-atom

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -202,7 +202,7 @@
                                         ;; When we check it in the rebalancer, we only visit nodes that have
                                         ;; running jobs on them.
                                         ;; So, set a 2 hour timeout; if we've not seen a node in 2 hours, or our
-                                        ;; offer processing is *that* slow, its OK to be broken.
+                                        ;; offer processing is *that* slow, losing the state won't make things any worse.
                                         (.expireAfterAccess 2 TimeUnit/HOURS)
                                         (.expireAfterWrite 2 TimeUnit/HOURS)
                                         ; *ALWAYS* prevent runaway.

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -39,7 +39,9 @@
             [metrics.counters :as counters]
             [plumbing.core :refer [map-from-keys]]
             [swiss.arrows :refer :all])
-  (:import (org.apache.curator.framework.recipes.leader LeaderSelector LeaderSelectorListener)
+  (:import (com.google.common.cache CacheBuilder)
+           (java.util.concurrent TimeUnit)
+           (org.apache.curator.framework.recipes.leader LeaderSelector LeaderSelectorListener)
            (org.apache.curator.framework.state ConnectionState)))
 
 ;; ============================================================================
@@ -168,7 +170,6 @@
                                     see scheduler/docs/configuration.adoc for more details
    task-constraints              -- map, constraints on task. See scheduler/docs/configuration.adoc for more details
    pool-name->pending-jobs-atom  -- atom, Populate (and update) map from pool name to list of pending jobs into atom
-   agent-attributes-cache        -- atom, map from agent id to most recent agent attributes
    gpu-enabled?                  -- boolean, whether cook will schedule gpus
    rebalancer-config             -- map, config for rebalancer. See scheduler/docs/rebalancer-config.adoc for details
    progress-config               -- map, config for progress publishing. See scheduler/docs/configuration.adoc
@@ -195,9 +196,18 @@
                           ;clojure.lang.Agent/pooledExecutor
                           (reify LeaderSelectorListener
                             (takeLeadership [_ client]
-                              (let [agent-attributes-cache (-> {}
-                                                               (cache/fifo-cache-factory :threshold 100000)
-                                                               atom)
+                              (let [agent-attributes-cache
+                                    (-> (CacheBuilder/newBuilder)
+                                        ;; When we store in this cache, we only visit nodes with offers.
+                                        ;; When we check it in the rebalancer, we only visit nodes that have
+                                        ;; running jobs on them.
+                                        ;; So, set a 2 hour timeout; if we've not seen a node in 2 hours, or our
+                                        ;; offer processing is *that* slow, its OK to be broken.
+                                        (.expireAfterAccess 2 TimeUnit/HOURS)
+                                        (.expireAfterWrite 2 TimeUnit/HOURS)
+                                        ; *ALWAYS* prevent runaway.
+                                        (.maximumSize 1000000)
+                                        (.build))
                                     {:keys [pool-name->fenzo-state view-incubating-offers] :as scheduler}
                                     (sched/create-datomic-scheduler
                                       {:conn mesos-datomic-conn

--- a/scheduler/src/cook/rebalancer.clj
+++ b/scheduler/src/cook/rebalancer.clj
@@ -551,32 +551,37 @@
       trigger-chan
       (fn trigger-rebalance-iteration []
         (log/info "Rebalance cycle starting")
-        (let [{:keys [max-preemption] :as params} (read-datomic-params conn)]
+        (let [{:keys [max-preemption] :as params} (read-datomic-params conn)
+              rebalancer-pools-pattern (-> config
+                                           :rebalancer-pools
+                                           re-pattern)]
           (if (seq params)
             (do
               (run!
                 (fn [[pool pending-jobs]]
-                  (let [host->spare-resources (->> (view-incubating-offers pool)
-                                                   (map (fn [v]
-                                                          [(:hostname v)
-                                                           (select-keys (keywordize-keys (:resources v))
-                                                                        [:cpus :mem :gpus])]))
-                                                   (into {}))
-                        pool-ent (if (= "no-pool" pool)
-                                   {:pool/name pool
-                                    :pool/dru-mode :pool.dru-mode/default}
-                                   (d/entity (d/db conn) [:pool/name pool]))
-                        db (mt/db conn)
-                        jobs-to-make-room-for (->> pending-jobs
-                                                   (filter (partial util/job-allowed-to-start? db))
-                                                   (take max-preemption))
-                        init-state (init-state db (util/get-running-task-ents db) jobs-to-make-room-for
-                                               host->spare-resources pool-ent)]
-                    (log/info "Rebalancing for pool" pool)
-                    (rebalance! db conn agent-attributes-cache rebalancer-reservation-atom
-                                params init-state jobs-to-make-room-for (:pool/name pool-ent))))
-                @pool-name->pending-jobs-atom)
-              (log/info "Rebalance cycle ended"))
-            (log/info "Skipping rebalancing because it's not cofigured"))))
+                  (if (re-find rebalancer-pools-pattern pool)
+                    (let [host->spare-resources (->> (view-incubating-offers pool)
+                                                     (map (fn [v]
+                                                            [(:hostname v)
+                                                             (select-keys (keywordize-keys (:resources v))
+                                                                          [:cpus :mem :gpus])]))
+                                                     (into {}))
+                          pool-ent (if (= "no-pool" pool)
+                                     {:pool/name pool
+                                      :pool/dru-mode :pool.dru-mode/default}
+                                     (d/entity (d/db conn) [:pool/name pool]))
+                          db (mt/db conn)
+                          jobs-to-make-room-for (->> pending-jobs
+                                                     (filter (partial util/job-allowed-to-start? db))
+                                                     (take max-preemption))
+                          init-state (init-state db (util/get-running-task-ents db) jobs-to-make-room-for
+                                                 host->spare-resources pool-ent)]
+                      (log/info "Rebalancing for pool" pool)
+                      (rebalance! db conn agent-attributes-cache rebalancer-reservation-atom
+                                  params init-state jobs-to-make-room-for (:pool/name pool-ent)))
+                    (log/info "Skip rebalancing for pool" pool)))
+                  @pool-name->pending-jobs-atom)
+                (log/info "Rebalance cycle ended"))
+              (log/info "Skipping rebalancing because it's not cofigured"))))
       {:error-handler (fn [ex] (log/error ex "Rebalance failed"))})
     #(async/close! trigger-chan)))

--- a/scheduler/src/cook/rebalancer.clj
+++ b/scheduler/src/cook/rebalancer.clj
@@ -553,7 +553,7 @@
         (log/info "Rebalance cycle starting")
         (let [{:keys [max-preemption] :as params} (read-datomic-params conn)
               rebalancer-pools-pattern (-> config
-                                           :rebalancer-pools
+                                           :pool-regex
                                            re-pattern)]
           (if (seq params)
             (do

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -432,6 +432,7 @@
             true
             ""))))))
 
+; Note that these constraints are used by the rebalancer.
 (def job-constraint-constructors [build-novel-host-constraint
                                   build-gpu-host-constraint
                                   build-disk-host-constraint
@@ -462,12 +463,13 @@
         (ConstraintEvaluator$Result. passes? reason)))))
 
 (defn make-fenzo-job-constraints
-  "Returns a sequence of all the constraints for 'job', in Fenzo-compatible format."
+  "Returns a sequence of all the constraints for 'job', in Fenzo-compatible format for use by Fenzo."
   [job]
   (conj (->> job-constraint-constructors
              (map (fn [constructor] (constructor job)))
              (remove nil?)
              (map fenzoize-job-constraint))
+        ; This constraint, which accesses the number of pods on a machine, is not visible to rebalancer.
         (build-max-tasks-per-host-constraint)))
 
 (defn build-rebalancer-reservation-constraint

--- a/scheduler/src/cook/scheduler/offer.clj
+++ b/scheduler/src/cook/scheduler/offer.clj
@@ -38,6 +38,9 @@
                           {"HOSTNAME" hostname}
                           compute-cluster
                           (assoc "COOK_MAX_TASKS_PER_HOST" (cc/max-tasks-per-host compute-cluster)
+                                 ; Note that this is dynamic and can change from moment to moment.
+                                 ; This could be a problem in the agent-attributes-cache..... However,
+                                 ; the rebalancer ignores this constraint, so its safe to cache this.
                                  "COOK_NUM_TASKS_ON_HOST" (cc/num-tasks-on-host compute-cluster hostname)
                                  "COOK_COMPUTE_CLUSTER_LOCATION" (cc/compute-cluster->location compute-cluster)))]
     (merge offer-resources offer-attributes cook-attributes)))

--- a/scheduler/src/cook/scheduler/offer.clj
+++ b/scheduler/src/cook/scheduler/offer.clj
@@ -39,8 +39,8 @@
                           compute-cluster
                           (assoc "COOK_MAX_TASKS_PER_HOST" (cc/max-tasks-per-host compute-cluster)
                                  ; Note that this is dynamic and can change from moment to moment.
-                                 ; This could be a problem in the agent-attributes-cache..... However,
-                                 ; the rebalancer ignores this constraint, so its safe to cache this.
+                                 ; This could be a problem in the agent-attributes-cache. However,
+                                 ; the rebalancer ignores this constraint, so it's safe to cache this.
                                  "COOK_NUM_TASKS_ON_HOST" (cc/num-tasks-on-host compute-cluster hostname)
                                  "COOK_COMPUTE_CLUSTER_LOCATION" (cc/compute-cluster->location compute-cluster)))]
     (merge offer-resources offer-attributes cook-attributes)))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1325,8 +1325,9 @@
                             ; Cache offers for rebalancer so it can use job constraints when doing preemption decisions.
                             ; Computing get-offer-attr-map is pretty expensive because it includes calculating
                             ; currently running pods, so we have to union the set of pods k8s says are there and
-                            ; the set of pods we're trying to put on the node. Even though its not used by
-                            ; rebalancer (and not needed). So only do it if this is a new node.
+                            ; the set of pods we're trying to put on the node. Even though it's not used by
+                            ; rebalancer (and not needed). So it's OK if it's stale, so we do not need to refresh
+                            ; and only store if it is a new node.
                             (when-not (ccache/get-if-present agent-attributes-cache identity slave-id)
                               (ccache/put-cache! agent-attributes-cache identity slave-id (offer/get-offer-attr-map offer))))
                         using-pools? (not (nil? (config/default-pool)))

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -426,7 +426,7 @@
       ;; When we check it in the rebalancer, we only visit nodes that have
       ;; running jobs on them.
       ;; So, set a 2 hour timeout; if we've not seen a node in 2 hours, or our
-      ;; offer processing is *that* slow, its OK to be broken.
+      ;; offer processing is *that* slow, losing the state won't make things any worse.
       (.expireAfterAccess 2 TimeUnit/HOURS)
       (.expireAfterWrite 2 TimeUnit/HOURS)
       ; *ALWAYS* prevent runaway.

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -681,7 +681,7 @@
 (defn get-slave-attrs-from-cache
   "Looks up a slave property (properties are a union of the slave's attributes and its hostname) in the provided cache"
   [agent-attributes-cache-atom slave-id]
-  (cache/lookup @agent-attributes-cache-atom slave-id))
+  (ccache/get-if-present agent-attributes-cache-atom identity slave-id))
 
 (defn clear-uncommitted-jobs
   "Retracts entities that have not been committed as of now and were submitted before

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -74,7 +74,7 @@
                                 :safe-dru-threshold 1.0
                                 :min-dru-diff 0.5
                                 :max-preemption 100.0
-                                :rebalancer-pools ".*"})
+                                :pool-regex ".*"})
 
 (def default-fenzo-config {:fenzo-max-jobs-considered 2000
                            :fenzo-scaleback 0.95

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -73,7 +73,8 @@
                                 :dru-scale 1.0
                                 :safe-dru-threshold 1.0
                                 :min-dru-diff 0.5
-                                :max-preemption 100.0})
+                                :max-preemption 100.0
+                                :rebalancer-pools ".*"})
 
 (def default-fenzo-config {:fenzo-max-jobs-considered 2000
                            :fenzo-scaleback 0.95

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -95,10 +95,6 @@
                          (async/mult (async/chan)))
          pool-name->pending-jobs-atom# (or (:pool-name->pending-jobs-atom ~scheduler-config)
                                            (atom {}))
-         agent-attributes-cache# (or (:mesos-agent-attributes-cache ~scheduler-config)
-                                     (-> {}
-                                         (cache/fifo-cache-factory :threshold 100)
-                                         atom))
          zk-prefix# (or (:zk-prefix ~scheduler-config)
                         "/cook")
          offer-incubate-time-ms# (or (:offer-incubate-time-ms ~scheduler-config)
@@ -177,7 +173,6 @@
             :leadership-atom leadership-atom#
             :pool-name->pending-jobs-atom pool-name->pending-jobs-atom#
             :mesos-run-as-user nil
-            :agent-attributes-cache agent-attributes-cache#
             :offer-incubate-time-ms offer-incubate-time-ms#
             :optimizer-config optimizer-config#
             :rebalancer-config rebalancer-config#


### PR DESCRIPTION
## Changes proposed in this PR

- Add comments about a particular wart in the agent attribute cache.
- Refactor agent-attrbute-cache to happen lower down than in components.
- Change agent-attribute-cache to use guava cache instead of clojure cache.
- Make the rebalancer selectable by pool regexp.

## Why are we making these changes?
Rebalancer can be something we need for a fixed size k8s cluster. We've also seen it show up, occasionally, as a scaling bottleneck, running for excessive time in Mesos, and k8s lets us go to a higher scale. So, get rid of the O(n) cache it uses and replace with guava cache. In addition, we may only want it active for some pools, not all pools, so make this selectable.
