### PR TITLE
Saves the submitted pool name

### DIFF
--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -206,6 +206,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/valueType :db.type/instant
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/doc "The pool name that was specified on the job submission"
+    :db/ident :job/submit-pool-name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
    ;; Group attributes
    {:db/id (d/tempid :db.part/db)
     :db/ident :group/uuid


### PR DESCRIPTION
## Changes proposed in this PR

- saving the pool name that was specified on the job submission
- returning it in the job query response

## Why are we making these changes?

Job routing plugins can convert a "special" pool name provided at submission time to a real pool, and it's useful to be able to know when this happened.
