### PR TITLE
[DRAFT] Add instance-uuid->job-uuid cache and update kubernetes/controller tests

### DIFF
--- a/scheduler/src/cook/cached_queries.clj
+++ b/scheduler/src/cook/cached_queries.clj
@@ -20,7 +20,7 @@
   [job-ent]
   (caches/lookup-cache-datomic-entity! caches/job-ent->user-cache :job/user job-ent))
 
-(defn instance-uuid->job-uuid
+(defn instance-uuid->job-uuid-datomic-query
   "Queries for the job uuid from an instance uuid.
    Returns nil if the instance uuid doesn't correspond
    to a job"
@@ -31,7 +31,7 @@
 
 (let [miss-fn
       (fn [instance-uuid]
-        (instance-uuid->job-uuid (d/db datomic/conn) instance-uuid))]
+        (instance-uuid->job-uuid-datomic-query (d/db datomic/conn) instance-uuid))]
   (defn instance-uuid->job-uuid-cache-lookup
     "Get value from cache if it is present, else search datomic for it"
     [instance-uuid]

--- a/scheduler/src/cook/cached_queries.clj
+++ b/scheduler/src/cook/cached_queries.clj
@@ -1,6 +1,9 @@
 (ns cook.cached-queries
-  (:require [cook.caches :as caches]
-            [cook.config :as config]))
+  (:require [cook.cache :as ccache]
+            [cook.caches :as caches]
+            [cook.config :as config]
+            [cook.datomic :as datomic]
+            [datomic.api :as d :refer [q]]))
 
 (let [miss-fn
       (fn [{:keys [job/pool]}]
@@ -16,3 +19,20 @@
   "Given a job entity, return the user the job runs as."
   [job-ent]
   (caches/lookup-cache-datomic-entity! caches/job-ent->user-cache :job/user job-ent))
+
+(defn instance-uuid->job-uuid
+  "Queries for the job uuid from an instance uuid.
+   Returns nil if the instance uuid doesn't correspond
+   to a job"
+  [db instance-uuid]
+  (->> (d/entity db [:instance/task-id (str instance-uuid)])
+       :job/_instance
+       :job/uuid))
+
+(let [miss-fn
+      (fn [instance-uuid]
+        (instance-uuid->job-uuid (d/db datomic/conn) instance-uuid))]
+  (defn instance-uuid->job-uuid-cache-lookup
+    "Get value from cache if it is present, else search datomic for it"
+    [instance-uuid]
+    (ccache/lookup-cache! caches/instance-uuid->job-uuid identity miss-fn instance-uuid)))

--- a/scheduler/src/cook/cached_queries.clj
+++ b/scheduler/src/cook/cached_queries.clj
@@ -31,7 +31,7 @@
 
 (let [miss-fn
       (fn [instance-uuid]
-        (instance-uuid->job-uuid-datomic-query (d/db datomic/conn) instance-uuid))]
+        (str (instance-uuid->job-uuid-datomic-query (d/db datomic/conn) instance-uuid)))]
   (defn instance-uuid->job-uuid-cache-lookup
     "Get value from cache if it is present, else search datomic for it"
     [instance-uuid]

--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -40,3 +40,8 @@
 (mount/defstate ^Cache pool-name->accepts-submissions?-cache :start (new-cache config/config))
 (mount/defstate ^Cache pool-name->db-id-cache :start (new-cache config/config))
 (mount/defstate ^Cache user-and-pool-name->quota :start (new-cache config/config))
+(mount/defstate ^Cache instance-uuid->job-uuid :start
+  (-> (CacheBuilder/newBuilder)
+    (.maximumSize (get-in config/config [:settings :cache-working-set-size])) ;1million
+    (.expireAfterAccess (get-in config/config [:settings :passport :instance-uuid->job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
+    (.build)))

--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -42,6 +42,6 @@
 (mount/defstate ^Cache user-and-pool-name->quota :start (new-cache config/config))
 (mount/defstate ^Cache instance-uuid->job-uuid :start
   (-> (CacheBuilder/newBuilder)
-    (.maximumSize (get-in config/config [:settings :cache-working-set-size])) ;1million
+    (.maximumSize (get-in config/config [:settings :cache-working-set-size]))
     (.expireAfterAccess (get-in config/config [:settings :passport :instance-uuid->job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
     (.build)))

--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -42,6 +42,6 @@
 (mount/defstate ^Cache user-and-pool-name->quota :start (new-cache config/config))
 (mount/defstate ^Cache instance-uuid->job-uuid :start
   (-> (CacheBuilder/newBuilder)
-    (.maximumSize (get-in config/config [:settings :cache-working-set-size]))
-    (.expireAfterAccess (get-in config/config [:settings :passport :instance-uuid->job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
+    (.maximumSize (get-in config/config [:settings :passport :job-uuid-cache-set-size]))
+    (.expireAfterAccess (get-in config/config [:settings :passport :job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
     (.build)))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -512,8 +512,8 @@
                                   :default-pool "no-pool"}
                                  pool-selection)})))
      :passport (fnk [[:config {passport {}}]]
-                 (merge passport
-                        {:instance-uuid->job-uuid-cache-expiry-time-hours 24}))
+                 (merge {:instance-uuid->job-uuid-cache-expiry-time-hours 24}
+                        passport))
      :kubernetes (fnk [[:config {kubernetes {}}]]
                    (let [{:keys [controller-lock-num-shards
                                  telemetry-tags-key-invalid-char-pattern]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -512,7 +512,8 @@
                                   :default-pool "no-pool"}
                                  pool-selection)})))
      :passport (fnk [[:config {passport {}}]]
-                 passport)
+                 (merge passport
+                        {:instance-uuid->job-uuid-cache-expiry-time-hours 24}))
      :kubernetes (fnk [[:config {kubernetes {}}]]
                    (let [{:keys [controller-lock-num-shards
                                  telemetry-tags-key-invalid-char-pattern]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -512,7 +512,8 @@
                                   :default-pool "no-pool"}
                                  pool-selection)})))
      :passport (fnk [[:config {passport {}}]]
-                 (merge {:instance-uuid->job-uuid-cache-expiry-time-hours 24}
+                 (merge {:job-uuid-cache-expiry-time-hours 24
+                         :job-uuid-cache-set-size 1000000}
                         passport))
      :kubernetes (fnk [[:config {kubernetes {}}]]
                    (let [{:keys [controller-lock-num-shards

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -70,7 +70,7 @@
   [pod-name]
   (str/starts-with? pod-name cook-synthetic-pod-name-prefix))
 
-(defn synthetic-pod-name->job-uuid
+(defn pod-name->job-uuid
   "If a pod is synthetic, return the uuid of the job it was created for"
   [pod-name]
   (when (synthetic-pod? pod-name)
@@ -86,10 +86,8 @@
   "Returns event-map with added fields :job-uuid (based on pod-name) and :instance-uuid (if pod is not synthetic)"
   [event-map pod-name]
   (let [instance-uuid (pod-name->instance-uuid pod-name)
-        synthetic-pod-job-uuid (synthetic-pod-name->job-uuid pod-name)
-        job-uuid (if synthetic-pod-job-uuid
-                   synthetic-pod-job-uuid
-                   (tools/instance-uuid->job-uuid-cache-lookup instance-uuid))]
+        job-uuid (or (pod-name->job-uuid pod-name)
+                     (tools/instance-uuid->job-uuid-cache-lookup instance-uuid))]
     (cond->
       event-map
       instance-uuid (assoc :instance-uuid instance-uuid)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -87,7 +87,7 @@
   [event-map pod-name]
   (let [instance-uuid (pod-name->instance-uuid pod-name)
         job-uuid (or (pod-name->job-uuid pod-name)
-                     (tools/instance-uuid->job-uuid-cache-lookup instance-uuid))]
+                     (cached-queries/instance-uuid->job-uuid-cache-lookup instance-uuid))]
     (cond->
       event-map
       instance-uuid (assoc :instance-uuid instance-uuid)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -293,6 +293,7 @@
         ^V1Pod pod (api/task-metadata->pod pod-namespace compute-cluster task-metadata)
         new-cook-expected-state-dict {:cook-expected-state :cook-expected-state/starting
                                       :launch-pod {:pod pod}}]
+    ; If a pod is not synthetic, cache a mapping of its instance-uuid to job-uuid in order to give all state machine passport events access to job-uuid
     (when (api/synthetic-pod? pod-name)
       (cache/put-cache! caches/instance-uuid->job-uuid identity pod-name (get-in task-metadata [:task-request :job :job/uuid])))
     (try

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -6,6 +6,8 @@
             [clojure.set :as set]
             [clojure.tools.logging :as log]
             [clojure.walk :as walk]
+            [cook.cache :as cache]
+            [cook.caches :as caches]
             [cook.compute-cluster :as cc]
             [cook.compute-cluster.metrics :as ccmetrics]
             [cook.config :as config]
@@ -13,6 +15,7 @@
             [cook.kubernetes.controller :as controller]
             [cook.kubernetes.metrics :as metrics]
             [cook.monitor :as monitor]
+            [cook.passport :as passport]
             [cook.pool]
             [cook.scheduler.constraints :as constraints]
             [cook.tools :as tools]
@@ -290,6 +293,8 @@
         ^V1Pod pod (api/task-metadata->pod pod-namespace compute-cluster task-metadata)
         new-cook-expected-state-dict {:cook-expected-state :cook-expected-state/starting
                                       :launch-pod {:pod pod}}]
+    (when (api/synthetic-pod? pod-name)
+      (cache/put-cache! caches/instance-uuid->job-uuid identity pod-name (get-in task-metadata [:task-request :job :job/uuid])))
     (try
       (controller/update-cook-expected-state compute-cluster pod-name new-cook-expected-state-dict)
       (.stop timer-context)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -295,7 +295,7 @@
                                       :launch-pod {:pod pod}}]
     ; If a pod is not synthetic, cache a mapping of its instance-uuid to job-uuid in order to give all state machine passport events access to job-uuid
     (when (api/synthetic-pod? pod-name)
-      (cache/put-cache! caches/instance-uuid->job-uuid identity pod-name (get-in task-metadata [:task-request :job :job/uuid])))
+      (cache/put-cache! caches/instance-uuid->job-uuid identity pod-name (str (get-in task-metadata [:task-request :job :job/uuid]))))
     (try
       (controller/update-cook-expected-state compute-cluster pod-name new-cook-expected-state-dict)
       (.stop timer-context)

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -158,7 +158,7 @@
   [{:keys [name]}
    {:keys [task-id state reason]}]
   (let [pod-name (task-id :value)
-        event-map (api/assoc-uuid
+        event-map (api/assoc-uuids
                     {:cluster-name name
                      :event-type passport/pod-completed
                      :pod-name pod-name

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1429,7 +1429,7 @@
   (let [jobs (wrap-seq (get-in ctx [:request :query-params :job]))
         instances (wrap-seq (get-in ctx [:request :query-params :instance]))
         allow-partial-results (get-in ctx [:request :query-params :partial])
-        instance-uuid->job-uuid #(cached-queries/instance-uuid->job-uuid (d/db conn) %)
+        instance-uuid->job-uuid #(cached-queries/instance-uuid->job-uuid-datomic-query (d/db conn) %)
         instance-jobs (mapv instance-uuid->job-uuid instances)
         exists? #(job-exists? (db conn) %)
         existing-jobs (filter exists? jobs)]
@@ -1481,7 +1481,7 @@
   cluster, and get back the data for those that do match."
   (let [uuids (wrap-seq (::instances ctx))
         allow-partial-results? (::allow-partial-results? ctx)
-        instance-uuid->job-uuid #(cached-queries/instance-uuid->job-uuid (d/db conn) %)
+        instance-uuid->job-uuid #(cached-queries/instance-uuid->job-uuid-datomic-query (d/db conn) %)
         job-uuids (mapv instance-uuid->job-uuid uuids)]
     (cond
       (every? some? job-uuids)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1429,7 +1429,7 @@
   (let [jobs (wrap-seq (get-in ctx [:request :query-params :job]))
         instances (wrap-seq (get-in ctx [:request :query-params :instance]))
         allow-partial-results (get-in ctx [:request :query-params :partial])
-        instance-uuid->job-uuid #(util/instance-uuid->job-uuid (d/db conn) %)
+        instance-uuid->job-uuid #(cached-queries/instance-uuid->job-uuid (d/db conn) %)
         instance-jobs (mapv instance-uuid->job-uuid instances)
         exists? #(job-exists? (db conn) %)
         existing-jobs (filter exists? jobs)]
@@ -1481,7 +1481,7 @@
   cluster, and get back the data for those that do match."
   (let [uuids (wrap-seq (::instances ctx))
         allow-partial-results? (::allow-partial-results? ctx)
-        instance-uuid->job-uuid #(util/instance-uuid->job-uuid (d/db conn) %)
+        instance-uuid->job-uuid #(cached-queries/instance-uuid->job-uuid (d/db conn) %)
         job-uuids (mapv instance-uuid->job-uuid uuids)]
     (cond
       (every? some? job-uuids)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1397,15 +1397,6 @@
         (update-in [:host-placement :type] util/without-ns)
         (update-in [:straggler-handling :type] util/without-ns))))
 
-(defn instance-uuid->job-uuid
-  "Queries for the job uuid from an instance uuid.
-   Returns nil if the instance uuid doesn't correspond
-   a job"
-  [db instance-uuid]
-  (->> (d/entity db [:instance/task-id (str instance-uuid)])
-       :job/_instance
-       :job/uuid))
-
 (defn- wrap-seq
   "Returns:
    - [v] if v is not nil and not sequential
@@ -1438,7 +1429,7 @@
   (let [jobs (wrap-seq (get-in ctx [:request :query-params :job]))
         instances (wrap-seq (get-in ctx [:request :query-params :instance]))
         allow-partial-results (get-in ctx [:request :query-params :partial])
-        instance-uuid->job-uuid #(instance-uuid->job-uuid (d/db conn) %)
+        instance-uuid->job-uuid #(util/instance-uuid->job-uuid (d/db conn) %)
         instance-jobs (mapv instance-uuid->job-uuid instances)
         exists? #(job-exists? (db conn) %)
         existing-jobs (filter exists? jobs)]
@@ -1490,7 +1481,7 @@
   cluster, and get back the data for those that do match."
   (let [uuids (wrap-seq (::instances ctx))
         allow-partial-results? (::allow-partial-results? ctx)
-        instance-uuid->job-uuid #(instance-uuid->job-uuid (d/db conn) %)
+        instance-uuid->job-uuid #(util/instance-uuid->job-uuid (d/db conn) %)
         job-uuids (mapv instance-uuid->job-uuid uuids)]
     (cond
       (every? some? job-uuids)

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -140,7 +140,8 @@
                            #'caches/pool-name->exists?-cache
                            #'caches/pool-name->accepts-submissions?-cache
                            #'caches/pool-name->db-id-cache
-                           #'caches/user-and-pool-name->quota)))
+                           #'caches/user-and-pool-name->quota
+                           #'caches/instance-uuid->job-uuid)))
 
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."
@@ -202,7 +203,8 @@
   (.invalidateAll caches/pool-name->exists?-cache)
   (.invalidateAll caches/pool-name->accepts-submissions?-cache)
   (.invalidateAll caches/pool-name->db-id-cache)
-  (.invalidateAll caches/user-and-pool-name->quota))
+  (.invalidateAll caches/user-and-pool-name->quota)
+  (.invalidateAll caches/instance-uuid->job-uuid))
 
 (defn restore-fresh-database!
   "Completely delete all data, start a fresh database and apply transactions if

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -1038,22 +1038,3 @@
   "Get submit-time for a job. due to a bug, submit time may not exist for some jobs"
   [job]
   (when (:job/submit-time job) (.getTime (:job/submit-time job))))
-
-(defn instance-uuid->job-uuid
-  "Queries for the job uuid from an instance uuid.
-   Returns nil if the instance uuid doesn't correspond
-   a job"
-  [db instance-uuid]
-  (->> (d/entity db [:instance/task-id (str instance-uuid)])
-       :job/_instance
-       :job/uuid))
-
-(defn instance-uuid->job-uuid-cache-miss
-  "Wrapper function that passes in a DB to the instance-uuid->job-uuid function. Used for cache misses by the instance-uuid->job-uuid cache"
-  [instance-uuid]
-  (instance-uuid->job-uuid (d/db datomic/conn) instance-uuid))
-
-(defn instance-uuid->job-uuid-cache-lookup
-  "Gets value from cache if it is present, else search datomic for it"
-  [instance-uuid]
-  (ccache/lookup-cache! caches/instance-uuid->job-uuid identity instance-uuid->job-uuid-cache-miss instance-uuid))

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -28,7 +28,6 @@
             [cook.cached-queries :as cached-queries]
             [cook.caches :as caches]
             [cook.config :as config]
-            [cook.datomic :as datomic]
             [cook.pool :as pool]
             [cook.queries :as queries]
             [cook.quota :as quota]

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -28,6 +28,7 @@
             [cook.cached-queries :as cached-queries]
             [cook.caches :as caches]
             [cook.config :as config]
+            [cook.datomic :as datomic]
             [cook.pool :as pool]
             [cook.queries :as queries]
             [cook.quota :as quota]
@@ -1037,3 +1038,22 @@
   "Get submit-time for a job. due to a bug, submit time may not exist for some jobs"
   [job]
   (when (:job/submit-time job) (.getTime (:job/submit-time job))))
+
+(defn instance-uuid->job-uuid
+  "Queries for the job uuid from an instance uuid.
+   Returns nil if the instance uuid doesn't correspond
+   a job"
+  [db instance-uuid]
+  (->> (d/entity db [:instance/task-id (str instance-uuid)])
+       :job/_instance
+       :job/uuid))
+
+(defn instance-uuid->job-uuid-cache-miss
+  "Wrapper function that passes in a DB to the instance-uuid->job-uuid function. Used for cache misses by the instance-uuid->job-uuid cache"
+  [instance-uuid]
+  (instance-uuid->job-uuid (d/db datomic/conn) instance-uuid))
+
+(defn instance-uuid->job-uuid-cache-lookup
+  "Gets value from cache if it is present, else search datomic for it"
+  [instance-uuid]
+  (ccache/lookup-cache! caches/instance-uuid->job-uuid identity instance-uuid->job-uuid-cache-miss instance-uuid))

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -1,6 +1,7 @@
 (ns cook.test.kubernetes.controller
   (:require [clj-time.core :as t]
             [clojure.test :refer :all]
+            [cook.cached-queries :as cached-queries]
             [cook.compute-cluster :as cc]
             [cook.config :as config]
             [cook.kubernetes.api :as api]
@@ -29,7 +30,7 @@
              (controller/container-status->failure-reason {:name "test-cluster"} "12345"
                                                           pod-status container-status))))))
 (deftest test-process
-  (with-redefs [tools/instance-uuid->job-uuid-cache-lookup (constantly "placeholder-job-uuid")]
+  (with-redefs [cached-queries/instance-uuid->job-uuid-cache-lookup (constantly nil)]
     (let [name "TestPodName"
           reason (atom nil)
           do-process-full-state (fn [cook-expected-state k8s-actual-state & {:keys [create-namespaced-pod-fn
@@ -261,7 +262,7 @@
       (is (= 1 @count-delete-pod)))))
 
 (deftest test-handle-pod-completed
-  (with-redefs [tools/instance-uuid->job-uuid-cache-lookup (constantly "placeholder-job-uuid")]
+  (with-redefs [cached-queries/instance-uuid->job-uuid-cache-lookup (constantly nil)]
     (testing "graceful handling of lack of exit code"
       (let [pod (tu/pod-helper "podA" "hostA" {})
             pod-status (V1PodStatus.)]

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -5,8 +5,8 @@
             [cook.config :as config]
             [cook.kubernetes.api :as api]
             [cook.kubernetes.controller :as controller]
-            [cook.tools :as tools]
             [cook.test.testutil :as tu]
+            [cook.tools :as tools]
             [metrics.timers :as timers])
   (:import (io.kubernetes.client.openapi ApiException)
            (io.kubernetes.client.openapi.models V1ObjectMeta V1Pod V1PodCondition V1PodStatus)


### PR DESCRIPTION
## Changes proposed in this PR

- Add a cache mapping `instance-uuid` to `job-uuid`
- Update `assoc-uuids` function to get `job-uuid`s from cache when needed and append them to passport event maps
- Add `with-redefs` logic to spoof cache hits in `cook.test.kubernetes.controller` tests

## Why are we making these changes?

- Adding this cache gives us the ability to log `job-uuid` for all Passport events in the state machine where `job-uuid` is not immediately visible
- These changes will give us a way to associate `instance-uuid` with `job-uuid` without querying datomic each time we want to access it

