### PR TITLE
don't override existing job groups

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1994,10 +1994,10 @@
                                distinct
                                (remove #(contains? group-uuids %))
                                (map make-default-group))
-          groups (into (vec implicit-groups) groups)
+          db (d/db conn)
+          groups (filter (fn [group] (not (group-exists? db (:uuid group)))) (into (vec implicit-groups) groups))
           job-asserts (map (fn [j] [:entity/ensure-not-exists [:job/uuid (:uuid j)]]) jobs)
           [commit-latch-id commit-latch] (make-commit-latch)
-          db (d/db conn)
           job-txns (mapcat
                      (fn [job-pool-name-map]
                        (make-job-txn job-pool-name-map commit-latch-id db))

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1995,6 +1995,7 @@
                                (remove #(contains? group-uuids %))
                                (map make-default-group))
           db (d/db conn)
+          ; don't replace an existing group with an implicit group
           groups (filter (fn [group] (not (group-exists? db (:uuid group)))) (into (vec implicit-groups) groups))
           job-asserts (map (fn [j] [:entity/ensure-not-exists [:job/uuid (:uuid j)]]) jobs)
           [commit-latch-id commit-latch] (make-commit-latch)


### PR DESCRIPTION
## Changes proposed in this PR

- don't override existing job groups


## Why are we making these changes?

If you add a job to a group currently you will override the existing group with an implicit group
