### PR TITLE
Adds pool source to job submission passport stamp

### DIFF
--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -9,6 +9,7 @@
   (when (:enabled? (config/passport))
     (log/log config/passport-logger-ns :info nil (json/write-str log-data))))
 
+(def api-job-creation :api-job-creation)
 (def api-job-submission :api-job-submission)
 (def pod-launching :pod-launching)
 (def pod-completed :pod-completed)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1980,7 +1980,7 @@
                      (update job-pool-name-map :job #(dissoc % :command)))
                    job-pool-name-maps))
     (doseq [{{:keys [uuid, user]} :job} job-pool-name-maps]
-      (passport/log-event {:event-type passport/api-job-submission
+      (passport/log-event {:event-type passport/api-job-creation
                            :job-uuid (str uuid)
                            :user user}))
     (let [jobs (map :job job-pool-name-maps)
@@ -2178,11 +2178,26 @@
                          groups (get params :groups)
                          user (get-in ctx [:request :authorization/user])
                          override-group-immutability? (boolean (get params :override-group-immutability))
-                         pool-name (or (get params :pool) (get headers "x-cook-pool"))
+                         pool-param (get params :pool)
+                         pool-header (get headers "x-cook-pool")
+                         pool-name (or pool-param pool-header)
                          uuid->count (pc/map-vals count (group-by :uuid jobs))
                          time-until-out-of-debt (rate-limit/time-until-out-of-debt-millis! rate-limit/job-submission-rate-limiter user)
                          in-debt? (not (zero? time-until-out-of-debt))]
                      (try
+                       (doseq [{:keys [uuid]} jobs]
+                         (passport/log-event
+                           {:event-type passport/api-job-submission
+                            :job-uuid (str uuid)
+                            :pool pool-name
+                            :pool-header pool-header
+                            :pool-param pool-param
+                            :pool-source
+                            (cond
+                              pool-param :request-parameter
+                              pool-header :x-cook-pool-header
+                              :else :unspecified)
+                            :user user}))
                        (when in-debt?
                          (log/info (str "User " user " is inserting too quickly (will be out of debt in "
                                         (/ time-until-out-of-debt 1000.0) " seconds).")))


### PR DESCRIPTION
## Changes proposed in this PR

- adding a new passport event type, `:api-job-creation`
- changing the existing stamp in `create-jobs!` to use `:api-job-creation`
- stamping with `:api-job-submission` from the `malformed?` check (earlier in the request flow)
- adding how the pool was sourced (request parameter vs. `x-cook-pool` header) to `:api-job-submission` 

## Why are we making these changes?

We want to be able to distinguish between jobs that landed in a pool via the request parameter and those that landed in a pool via the `x-cook-pool` request header. This change also allows for a passport event to be logged earlier in the request flow, before all of the validation checks have run.
