### PR TITLE
Fix adding instances to cache bug

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -294,7 +294,7 @@
         new-cook-expected-state-dict {:cook-expected-state :cook-expected-state/starting
                                       :launch-pod {:pod pod}}]
     ; If a pod is not synthetic, cache a mapping of its instance-uuid to job-uuid in order to give all state machine passport events access to job-uuid
-    (when (api/synthetic-pod? pod-name)
+    (when-not (api/synthetic-pod? pod-name)
       (cache/put-cache! caches/instance-uuid->job-uuid identity pod-name (str (get-in task-metadata [:task-request :job :job/uuid]))))
     (try
       (controller/update-cook-expected-state compute-cluster pod-name new-cook-expected-state-dict)


### PR DESCRIPTION
## Changes proposed in this PR

- Fix bug that adds synthetic pods to the `instance-uuid->job-uuid` cache instead of normal pods

## Why are we making these changes?

We only want to add instance uuids for non-synthetic pods to that cache. Before this change, we were doing the opposite of that and only adding synthetic pods to the cache.
