### PR TITLE
Change cluster-name to compute-cluster

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1666,7 +1666,7 @@
                      "does not match pod name argument (" pod-name ")"))
         (log/info "In" compute-cluster-name "compute cluster, launching pod with name" pod-name "in namespace" namespace ":" (.serialize json pod))
         (let [event-map (assoc-uuids
-                          {:cluster-name compute-cluster-name
+                          {:compute-cluster compute-cluster-name
                            :event-type passport/pod-launching
                            :namespace namespace
                            :pod-name pod-name}

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -159,7 +159,7 @@
    {:keys [task-id state reason]}]
   (let [pod-name (task-id :value)
         event-map (api/assoc-uuids
-                    {:cluster-name name
+                    {:compute-cluster name
                      :event-type passport/pod-completed
                      :pod-name pod-name
                      :reason reason


### PR DESCRIPTION
## Changes proposed in this PR

- Change `:cluster-name` to `:compute-cluster` in passport logs

## Why are we making these changes?
`:compute-cluster` is a more clear name than `:cluster-name`, and this helps us differentiate between Cook cluster and compute cluster in the passport event logs.

