### PR TITLE
Update passport event types with cook-scheduler source and namespace

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1667,7 +1667,7 @@
         (log/info "In" compute-cluster-name "compute cluster, launching pod with name" pod-name "in namespace" namespace ":" (.serialize json pod))
         (let [event-map (assoc-uuids
                           {:compute-cluster compute-cluster-name
-                           :event-type passport/pod-launching
+                           :event-type passport/pod-launched
                            :namespace namespace
                            :pod-name pod-name}
                           pod-name)]

--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -5,13 +5,13 @@
 
 (defn log-event
   "Log event to cook-passport log file"
-  [log-data]
+  [{:keys [event-type] :as log-data}]
   (when (:enabled? (config/passport))
     (log/log config/passport-logger-ns :info nil (json/write-str
                                                    (assoc
                                                      log-data
                                                      :source :cook-scheduler
-                                                     :event-type (str "cook-scheduler/" (name (log-data :event-type))))))))
+                                                     :event-type (str "cook-scheduler/" (name event-type)))))))
 
 (def job-created :job-created)
 (def job-submitted :job-submitted)

--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -7,9 +7,13 @@
   "Log event to cook-passport log file"
   [log-data]
   (when (:enabled? (config/passport))
-    (log/log config/passport-logger-ns :info nil (json/write-str log-data))))
+    (log/log config/passport-logger-ns :info nil (json/write-str
+                                                   (assoc
+                                                     log-data
+                                                     :source :cook-scheduler
+                                                     :event-type (str "cook-scheduler/" (name (log-data :event-type))))))))
 
-(def api-job-creation :api-job-creation)
-(def api-job-submission :api-job-submission)
-(def pod-launching :pod-launching)
+(def job-created :job-created)
+(def job-submitted :job-submitted)
+(def pod-launched :pod-launched)
 (def pod-completed :pod-completed)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1971,7 +1971,7 @@
                      (update job-pool-name-map :job #(dissoc % :command)))
                    job-pool-name-maps))
     (doseq [{{:keys [uuid, user]} :job} job-pool-name-maps]
-      (passport/log-event {:event-type passport/api-job-creation
+      (passport/log-event {:event-type passport/job-created
                            :job-uuid (str uuid)
                            :user user}))
     (let [jobs (map :job job-pool-name-maps)
@@ -2179,7 +2179,7 @@
                      (try
                        (doseq [{:keys [uuid]} jobs]
                          (passport/log-event
-                           {:event-type passport/api-job-submission
+                           {:event-type passport/job-submitted
                             :job-uuid (str uuid)
                             :pool pool-name
                             :pool-header pool-header


### PR DESCRIPTION
## Changes proposed in this PR

- Update names for passport event types
- Add cook-scheduler namespace on event-type strings
- Add `source` field with value `cook-scheduler`

## Why are we making these changes?
These changes keep our `event-type` strings up to date with our design document and provide us with `source` information in every log.

