### PR TITLE
Make /unscheduled endpoint redirect to leader.

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1080,7 +1080,7 @@ def unscheduled_jobs(cook_url, *job_uuids, partial=None):
     query_params = [('job', u) for u in job_uuids]
     if partial is not None:
         query_params.append(('partial', partial))
-    resp = session.get(f'{cook_url}/unscheduled_jobs?{urlencode(query_params)}')
+    resp = get_with_redirects(f'{cook_url}/unscheduled_jobs',params=query_params)
     job_reasons = resp.json() if resp.status_code == 200 else []
     return job_reasons, resp
 

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1080,7 +1080,7 @@ def unscheduled_jobs(cook_url, *job_uuids, partial=None):
     query_params = [('job', u) for u in job_uuids]
     if partial is not None:
         query_params.append(('partial', partial))
-    resp = get_with_redirects(f'{cook_url}/unscheduled_jobs',params=query_params)
+    resp = get_with_redirects(f'{cook_url}/unscheduled_jobs', params=query_params)
     job_reasons = resp.json() if resp.status_code == 200 else []
     return job_reasons, resp
 

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1874,10 +1874,13 @@
   {:can-post-to-gone?
    (constantly true)
 
+   ; Needs to be false when we're the leader or else the response code for when :exists?
+   ; is false is 410 GONE instead of 404 not-found.
+   ; Needs to be true when we're not the leader to trigger the redirection path.
    :existed?
-   (constantly true)
+   (fn [_] (not @leadership-atom))
 
-   ;; triggers path for moved-temporarily?
+   ;; Being false when not the leader triggers path for moved-temporarily?
    :exists? (fn [_] @leadership-atom)
 
    :handle-moved-temporarily
@@ -3138,15 +3141,20 @@
     representation))
 
 (defn read-unscheduled-handler
-  [conn is-authorized-fn]
+  [conn is-authorized-fn leadership-atom leader-selector]
   (base-cook-handler
-    {:allowed-methods [:get]
-     :exists? (partial retrieve-jobs conn)
-     :allowed? (partial job-request-allowed? conn is-authorized-fn)
-     :handle-ok (fn [ctx]
-                  (map (fn [job] {:uuid job
-                                  :reasons (job-reasons conn job)})
-                       (::jobs ctx)))}))
+    (merge
+      ;; only the leader handles unscheduled reasons
+      (redirect-to-leader leadership-atom leader-selector)
+      {:allowed-methods [:get]
+       ; liberator will not route requests to moved temporarily if exists is true, so make sure its
+       ; false if not leader.
+       :exists? (fn [ctx] (and @leadership-atom (retrieve-jobs conn ctx)))
+       :allowed? (partial job-request-allowed? conn is-authorized-fn)
+       :handle-ok (fn [ctx]
+                    (map (fn [job] {:uuid job
+                                    :reasons (job-reasons conn job)})
+                         (::jobs ctx)))})))
 
 ;;
 ;; /stats/instances
@@ -3839,7 +3847,7 @@
             {:produces ["application/json"],
              :get {:summary "Read reasons why a job isn't being scheduled."
                    :parameters {:query-params UnscheduledJobParams}
-                   :handler (read-unscheduled-handler conn is-authorized-fn)
+                   :handler (read-unscheduled-handler conn is-authorized-fn leadership-atom leader-selector)
                    :responses {200 {:schema UnscheduledJobResponse
                                     :description "Reasons the job isn't being scheduled."}
                                400 {:description "Invalid request format."}


### PR DESCRIPTION
## Changes proposed in this PR

- Make /unscheduled endpoint redirect to leader.
- Make the code around redirect-to-master more robust and backward compatible for code that uses :exists? handlers

## Why are we making these changes?

The /unscheduled endpoint must always redirect to leader to get appropriate data from Fenzo causes. This has been partially broken for a long time.
