### PR TITLE
Fix Location header of redirects to include request parameters

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -1255,6 +1255,10 @@ def request_with_redirects(method, url, allow_redirects=True, **kwargs):
     # (when redirecting to primary node), and requests strips and does not re-apply
     # auth when redirects cross domains.
     response = session.request(method, url, allow_redirects=False, **kwargs)
+    # Should not re-include the params in subsequent redirects. Cook's Location response
+    # header should include them if they're needed (it does)
+    if 'params' in kwargs:
+        del kwargs['params']
     if allow_redirects and response.is_redirect:
         for _ in range(10):
             response = session.request(method, response.headers['Location'], allow_redirects=False, **kwargs)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1896,8 +1896,10 @@
      [ctx]
      ;; the client is expected to cache the redirect location
      (if-let [leader-url (::leader-url ctx)]
-       (let [request-path (get-in ctx [:request :uri])]
-         [true {:location (str leader-url request-path)}])
+       (let [request-path (get-in ctx [:request :uri])
+             request-param (get-in ctx [:request :query-string])]
+         ; Include the request parameters in the location header response, if needed.
+         [true {:location (str leader-url request-path (when request-param (str "?" request-param)))}])
        [false {}]))
 
    :service-available?

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1897,9 +1897,9 @@
      ;; the client is expected to cache the redirect location
      (if-let [leader-url (::leader-url ctx)]
        (let [request-path (get-in ctx [:request :uri])
-             request-param (get-in ctx [:request :query-string])]
+             query-string (get-in ctx [:request :query-string])]
          ; Include the request parameters in the location header response, if needed.
-         [true {:location (str leader-url request-path (when request-param (str "?" request-param)))}])
+         [true {:location (str leader-url request-path (when query-string (str "?" query-string)))}])
        [false {}]))
 
    :service-available?


### PR DESCRIPTION
**This is an API change.**

## Changes proposed in this PR

- Fixes two bugs that mostly compensated for each other. 
- When we generate Location: headers for redirect-to-leader, we should include any query parameters in the response.
- The follow redirects code in the integration tests would add those parameters (including duplicating them)

## Why are we making these changes?
This is correct behavior.



