### PR TITLE
Avoid reflection by annotating Java calls with java object types.

### DIFF
--- a/scheduler/src/cook/cache.clj
+++ b/scheduler/src/cook/cache.clj
@@ -53,7 +53,7 @@
 
 (defn- expire-key-helper
   "Helper function for expiring a key explicitly."
-  [cache key]
+  [^Cache cache key]
   (when-let [result (.getIfPresent cache key)]
     (let [{:keys [cache-expires-at]} result]
       (when (and cache-expires-at (t/after? (t/now) cache-expires-at))  (.invalidate cache key)))))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -68,7 +68,7 @@
            (org.apache.curator.retry BoundedExponentialBackoffRetry)
            (org.eclipse.jetty.security DefaultUserIdentity UserAuthentication)
            (org.eclipse.jetty.server.handler HandlerCollection RequestLogHandler)
-           (org.eclipse.jetty.server NCSARequestLog)))
+           (org.eclipse.jetty.server NCSARequestLog Request)))
 
 (defn wrap-no-cache
   [handler]
@@ -180,7 +180,7 @@
   does so to make sure it's available for Jetty to log"
   (fn [req]
     (do
-      (.setAuthentication (:servlet-request req)
+      (.setAuthentication ^Request (:servlet-request req)
                           (UserAuthentication.
                             "kerberos"
                             (DefaultUserIdentity.

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -106,7 +106,7 @@
   RateLimit
 
   (get-key [self {:keys [authorization/user]}]
-    (str (.getName (type self)) id "-" user))
+    (str (.getName ^Class (type self)) id "-" user))
 
   (get-quota [_ {:keys [authorization/user]}]
     (if user

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -593,7 +593,7 @@
 (defn get-bearer-token
   "Takes a GoogleCredentials object and refreshes the credentials, and returns a bearer token suitable for use
    in an Authorization header."
-  [scoped-credentials]
+  [^GoogleCredentials scoped-credentials]
   (.refresh scoped-credentials)
   (str "Bearer " (.getTokenValue (.getAccessToken scoped-credentials))))
 

--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -140,11 +140,10 @@
                                (conj (:uri (config/executor-config))))
                  :user (or mesos-run-as-user (:job/user job-ent))
                  :value (if cook-executor? (:command (config/executor-config)) (:job/command job-ent))}
-        data (.getBytes
-               (if cook-executor?
-                 (json/write-str {"command" (:job/command job-ent)})
-                 (pr-str {:instance instance-num}))
-               "UTF-8")]
+        ^String data-as-string (if cook-executor?
+                                 (json/write-str {"command" (:job/command job-ent)})
+                                 (pr-str {:instance instance-num}))
+        data (.getBytes data-as-string "UTF-8")]
     (when (and (= :executor/cook (:job/executor job-ent))
                (not= executor-key :cook-executor))
       (log/warn "Task" task-id "requested to use cook executor, but will be executed using" (name executor-key)))

--- a/scheduler/src/cook/rate_limit/generic.clj
+++ b/scheduler/src/cook/rate_limit/generic.clj
@@ -81,7 +81,7 @@
   (let [key (get-key key)]
     (locking cache
       (let [tbf (tbf/earn-tokens (get-token-bucket-filter this key) (current-time-in-millis))]
-        (.put cache key tbf)))))
+        (.put ^LoadingCache cache key tbf)))))
 
 (defrecord TokenBucketFilterRateLimiter
   [config ^LoadingCache cache ^Boolean enforce?]

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1125,7 +1125,7 @@
                       {:constraints task-constraints
                        :job job})))
     (when (and (:command-length-limit task-constraints)
-               (> (.length command) (:command-length-limit task-constraints)))
+               (> (.length ^String command) (:command-length-limit task-constraints)))
       (throw (ex-info (str "Job command length of " (.length command) " is greater than the maximum command length ("
                            (:command-length-limit task-constraints) ")")
                       {:command-length-limit (:command-length-limit task-constraints)

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -28,8 +28,9 @@
             [cook.scheduler.data-locality :as dl]
             [cook.tools :as util]
             [swiss.arrows :refer :all])
-  (:import (com.netflix.fenzo ConstraintEvaluator ConstraintEvaluator$Result TaskRequest TaskTrackerState VirtualMachineCurrentState VirtualMachineLease)
-           (java.util Date)))
+  (:import (com.netflix.fenzo ConstraintEvaluator ConstraintEvaluator$Result TaskRequest TaskTrackerState VirtualMachineCurrentState VirtualMachineLease TaskTracker$ActiveTask)
+           (java.util Date)
+           (org.joda.time DateTime)))
 
 ;; Wisdom:
 ;; * This code expects that attributes COOK_GPU? and HOSTNAME are set for all
@@ -62,7 +63,8 @@
 (defn get-class-name
   "Returns the name of a class without package information."
   [object]
-  (.getSimpleName (type object)))
+  (let [^Class obj-type (type object)]
+    (.getSimpleName obj-type)))
 
 (defrecord novel-host-constraint [job previous-hosts]
   JobConstraint
@@ -403,7 +405,7 @@
                                            (- agent-start-grace-period-mins)
                                            (* 1000 60))
             capped-expected-runtime (min max-expected-runtime longest-reasonable-runtime)
-            expected-end-time (+ (.getMillis (t/now)) capped-expected-runtime)]
+            expected-end-time (+ (.getMillis ^DateTime (t/now)) capped-expected-runtime)]
         (when (< 0 max-expected-runtime)
           (->estimated-completion-constraint expected-end-time host-lifetime-mins))))))
 

--- a/scheduler/src/cook/scheduler/fenzo_utils.clj
+++ b/scheduler/src/cook/scheduler/fenzo_utils.clj
@@ -15,7 +15,8 @@
 ;;
 (ns cook.scheduler.fenzo-utils
   (:require [clojure.tools.logging :as log]
-            [datomic.api :as d]))
+            [datomic.api :as d])
+  (:import (com.netflix.fenzo TaskAssignmentResult)))
 
 (defn extract-message
   "For some reason, Fenzo's AssignmentFailure doesn't have a getter for the
@@ -59,7 +60,7 @@
   all the messages].  Along the way, logs each result message if debug-level
   logging is enabled."
   [failures]
-  (let [job (:job  (.. (first failures) (getRequest)))
+  (let [job (:job (.getRequest ^TaskAssignmentResult (first failures)))
         under-investigation? (:job/under-investigation job)
         summary (when (or under-investigation? (log/enabled? :debug))
                   (reduce summarize-placement-failure {} failures))]

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -1036,4 +1036,4 @@
 (defn job->submit-time
   "Get submit-time for a job. due to a bug, submit time may not exist for some jobs"
   [job]
-  (when (:job/submit-time job) (.getTime (:job/submit-time job))))
+  (when (:job/submit-time job) (.getTime ^Date (:job/submit-time job))))


### PR DESCRIPTION
## Changes proposed in this PR

- Annotate a number of types within Cook to avoid reflective calls

## Why are we making these changes?
We found that a lot of heap space is spent/wasted on reflection. A reflection call is roughly O(n) time and garbage with N being the number of methods in the called java class. Even small test clusters are seeing 100k calls/sec. 

