### PR TITLE
Add pool-name, job-name, and user to Passport Logs

### DIFF
--- a/scheduler/src/cook/cached_queries.clj
+++ b/scheduler/src/cook/cached_queries.clj
@@ -33,6 +33,14 @@
       (fn [instance-uuid]
         (str (instance-uuid->job-uuid-datomic-query (d/db datomic/conn) instance-uuid)))]
   (defn instance-uuid->job-uuid-cache-lookup
-    "Get value from cache if it is present, else search datomic for it"
+    "Get job-uuid from cache if it is present, else search datomic for it"
     [instance-uuid]
     (ccache/lookup-cache! caches/instance-uuid->job-uuid identity miss-fn instance-uuid)))
+
+(let [miss-fn
+      (fn [job-uuid]
+        (d/entity (d/db datomic/conn) [:job/uuid job-uuid]))]
+  (defn job-uuid->job-map-cache-lookup
+    "Get job-map from cache if it is present, else search datomic for it"
+    [job-uuid]
+    (ccache/lookup-cache! caches/job-uuid->job-map identity miss-fn job-uuid)))

--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -45,3 +45,8 @@
     (.maximumSize (get-in config/config [:settings :passport :job-uuid-cache-set-size]))
     (.expireAfterAccess (get-in config/config [:settings :passport :job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
     (.build)))
+(mount/defstate ^Cache job-uuid->job-map :start
+                (-> (CacheBuilder/newBuilder)
+                  (.maximumSize (get-in config/config [:settings :passport :job-uuid-cache-set-size]))
+                  (.expireAfterAccess (get-in config/config [:settings :passport :job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
+                  (.build)))

--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -19,8 +19,8 @@
 (defn passport-cache [config]
   "Build a new passport-related cache"
   (-> (CacheBuilder/newBuilder)
-    (.maximumSize (get-in config [:settings :passport :job-uuid-cache-set-size]))
-    (.expireAfterAccess (get-in config [:settings :passport :job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
+    (.maximumSize (get-in config [:settings :passport :job-cache-set-size]))
+    (.expireAfterAccess (get-in config [:settings :passport :job-cache-expiry-time-hours]) TimeUnit/HOURS)
     (.build)))
 
 (defn lookup-cache-datomic-entity!

--- a/scheduler/src/cook/caches.clj
+++ b/scheduler/src/cook/caches.clj
@@ -16,6 +16,12 @@
       (.expireAfterAccess 2 TimeUnit/HOURS)
       (.build)))
 
+(defn passport-cache [config]
+  "Build a new passport-related cache"
+  (-> (CacheBuilder/newBuilder)
+    (.maximumSize (get-in config [:settings :passport :job-uuid-cache-set-size]))
+    (.expireAfterAccess (get-in config [:settings :passport :job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
+    (.build)))
 
 (defn lookup-cache-datomic-entity!
   "Specialized function for caching where datomic entities are the key.
@@ -40,13 +46,5 @@
 (mount/defstate ^Cache pool-name->accepts-submissions?-cache :start (new-cache config/config))
 (mount/defstate ^Cache pool-name->db-id-cache :start (new-cache config/config))
 (mount/defstate ^Cache user-and-pool-name->quota :start (new-cache config/config))
-(mount/defstate ^Cache instance-uuid->job-uuid :start
-  (-> (CacheBuilder/newBuilder)
-    (.maximumSize (get-in config/config [:settings :passport :job-uuid-cache-set-size]))
-    (.expireAfterAccess (get-in config/config [:settings :passport :job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
-    (.build)))
-(mount/defstate ^Cache job-uuid->job-map :start
-                (-> (CacheBuilder/newBuilder)
-                  (.maximumSize (get-in config/config [:settings :passport :job-uuid-cache-set-size]))
-                  (.expireAfterAccess (get-in config/config [:settings :passport :job-uuid-cache-expiry-time-hours]) TimeUnit/HOURS)
-                  (.build)))
+(mount/defstate ^Cache instance-uuid->job-uuid :start (passport-cache config/config))
+(mount/defstate ^Cache job-uuid->job-map :start (passport-cache config/config))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -512,8 +512,8 @@
                                   :default-pool "no-pool"}
                                  pool-selection)})))
      :passport (fnk [[:config {passport {}}]]
-                 (merge {:job-uuid-cache-expiry-time-hours 24
-                         :job-uuid-cache-set-size 1000000}
+                 (merge {:job-cache-expiry-time-hours 24
+                         :job-cache-set-size 1000000}
                         passport))
      :kubernetes (fnk [[:config {kubernetes {}}]]
                    (let [{:keys [controller-lock-num-shards

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1140,11 +1140,13 @@
         {:keys [docker volumes]} container
         {:keys [parameters]} docker
         {:keys [environment]} command
-        pool-name (cached-queries/job->pool-name job)
-        pod (V1Pod.)
-        pod-spec (V1PodSpec.)
-        metadata (V1ObjectMeta.)
-        pod-labels (merge (job->pod-labels job) pod-labels)
+        job-name (:job/name job)
+          user (:job/user job)
+          pool-name (cached-queries/job->pool-name job)
+          pod (V1Pod.)
+          pod-spec (V1PodSpec.)
+          metadata (V1ObjectMeta.)
+          pod-labels (merge (job->pod-labels job) pod-labels)
           labels (assoc pod-labels cook-pod-label compute-cluster-name)
           security-context (make-security-context parameters (:user command))
           sandbox-dir (:default-workdir (config/kubernetes))
@@ -1184,6 +1186,8 @@
           progress-env (task/build-executor-environment job)
           checkpoint-env (checkpoint->env checkpoint)
           metadata-env {"COOK_COMPUTE_CLUSTER_NAME" compute-cluster-name
+                        "COOK_JOB_NAME" job-name
+                        "COOK_JOB_USER" user
                         "COOK_POOL" pool-name
                         "COOK_SCHEDULER_REST_URL" (config/scheduler-rest-url)}
           main-env-base (merge environment params-env progress-env sandbox-env checkpoint-env metadata-env)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -89,12 +89,13 @@
         job-uuid (or (pod-name->job-uuid pod-name)
                      (cached-queries/instance-uuid->job-uuid-cache-lookup instance-uuid))
         {job-name :job/name user :job/user {pool-name :pool/name} :job/pool} (cached-queries/job-uuid->job-map-cache-lookup job-uuid)]
-    {:instance-uuid instance-uuid
-     :job-name job-name
-     :job-uuid job-uuid
-     :pod-name pod-name
-     :pool pool-name
-     :user user}))
+    (cond->
+          {:job-name job-name
+           :job-uuid job-uuid
+           :pod-name pod-name
+           :pool pool-name
+           :user user}
+          instance-uuid (assoc :instance-uuid instance-uuid))))
 
 ; DeletionCandidateTaint is a soft taint that k8s uses to mark unneeded
 ; nodes as preferably unschedulable. This taint is added as soon as the

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -88,16 +88,13 @@
   (let [instance-uuid (pod-name->instance-uuid pod-name)
         job-uuid (or (pod-name->job-uuid pod-name)
                      (cached-queries/instance-uuid->job-uuid-cache-lookup instance-uuid))
-        job-map (cached-queries/job-uuid->job-map-cache-lookup job-uuid)
-        job-name (:job/name job-map)
-        pool (:pool/name (:job/pool job-map))
-        user (:job/user job-map)]
+        {job-name :job/name user :job/user {pool-name :pool/name} :job/pool} (cached-queries/job-uuid->job-map-cache-lookup job-uuid)]
     (cond->
       event-map
       instance-uuid (assoc :instance-uuid instance-uuid)
       job-uuid (assoc :job-uuid job-uuid)
       job-name (assoc :job-name job-name)
-      pool (assoc :pool pool)
+      pool-name (assoc :pool pool-name)
       user (assoc :user user))))
 
 ; DeletionCandidateTaint is a soft taint that k8s uses to mark unneeded

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1137,12 +1137,12 @@
         {:keys [parameters]} docker
         {:keys [environment]} command
         job-name (:job/name job)
-          user (:job/user job)
-          pool-name (cached-queries/job->pool-name job)
-          pod (V1Pod.)
-          pod-spec (V1PodSpec.)
-          metadata (V1ObjectMeta.)
-          pod-labels (merge (job->pod-labels job) pod-labels)
+        user (:job/user job)
+        pool-name (cached-queries/job->pool-name job)
+        pod (V1Pod.)
+        pod-spec (V1PodSpec.)
+        metadata (V1ObjectMeta.)
+        pod-labels (merge (job->pod-labels job) pod-labels)
           labels (assoc pod-labels cook-pod-label compute-cluster-name)
           security-context (make-security-context parameters (:user command))
           sandbox-dir (:default-workdir (config/kubernetes))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -293,8 +293,8 @@
         ^V1Pod pod (api/task-metadata->pod pod-namespace compute-cluster task-metadata)
         new-cook-expected-state-dict {:cook-expected-state :cook-expected-state/starting
                                       :launch-pod {:pod pod}}
-        job-map (get-in task-metadata [:task-request :job])
-        job-uuid (str (:job/uuid job-map))]
+        {:keys [job/uuid] :as job-map} (get-in task-metadata [:task-request :job])
+        job-uuid (str uuid)]
     ; If a pod is not synthetic, cache a mapping of its instance-uuid to job-uuid in order to give all state machine passport events access to job-uuid
     (when-not (api/synthetic-pod? pod-name)
       (cache/put-cache! caches/instance-uuid->job-uuid identity pod-name job-uuid))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -292,10 +292,14 @@
         pod-name (:task-id task-metadata)
         ^V1Pod pod (api/task-metadata->pod pod-namespace compute-cluster task-metadata)
         new-cook-expected-state-dict {:cook-expected-state :cook-expected-state/starting
-                                      :launch-pod {:pod pod}}]
+                                      :launch-pod {:pod pod}}
+        job-map (get-in task-metadata [:task-request :job])
+        job-uuid (str (:job/uuid job-map))]
     ; If a pod is not synthetic, cache a mapping of its instance-uuid to job-uuid in order to give all state machine passport events access to job-uuid
     (when-not (api/synthetic-pod? pod-name)
-      (cache/put-cache! caches/instance-uuid->job-uuid identity pod-name (str (get-in task-metadata [:task-request :job :job/uuid]))))
+      (cache/put-cache! caches/instance-uuid->job-uuid identity pod-name job-uuid))
+    ; Cache job-uuid->job-map for use when doing passport logging
+    (cache/put-cache! caches/job-uuid->job-map identity job-uuid job-map)
     (try
       (controller/update-cook-expected-state compute-cluster pod-name new-cook-expected-state-dict)
       (.stop timer-context)
@@ -492,7 +496,7 @@
                     task-metadata-seq
                     (->> new-jobs
                          (take max-launchable)
-                         (map (fn [{:keys [job/user job/uuid job/environment] :as job}]
+                         (map (fn [{:keys [job/name job/user job/uuid job/environment] :as job}]
                                 (let [pool-specific-resources
                                       ((adjust-job-resources-for-pool-fn pool-name) job (tools/job-ent->resources job))]
                                   (.put cook.caches/recent-synthetic-pod-job-uuids uuid uuid)
@@ -535,7 +539,10 @@
                                    :task-id (str api/cook-synthetic-pod-name-prefix "-" pool-name "-" uuid)
                                    :task-request {:scalar-requests (walk/stringify-keys pool-specific-resources)
                                                   :job {:job/pool {:pool/name synthetic-task-pool-name}
-                                                        :job/environment environment}
+                                                        :job/environment environment
+                                                        :job/name name
+                                                        :job/user user
+                                                        :job/uuid uuid}
                                                   ; Need to pass in resources to task-metadata->pod for gpu count
                                                   :resources pool-specific-resources}}))))
                     num-synthetic-pods-to-launch (count task-metadata-seq)]

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -158,7 +158,7 @@
   [{:keys [name]}
    {:keys [task-id state reason]}]
   (let [pod-name (task-id :value)
-        event-map (api/assoc-uuids
+        event-map (api/assoc-fields
                     {:compute-cluster name
                      :event-type passport/pod-completed
                      :pod-name pod-name

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -157,15 +157,12 @@
   "Helper function for logging completed job status to cook passport"
   [{:keys [name]}
    {:keys [task-id state reason]}]
-  (let [pod-name (task-id :value)
-        event-map (api/assoc-fields
-                    {:compute-cluster name
-                     :event-type passport/pod-completed
-                     :pod-name pod-name
-                     :reason reason
-                     :state state}
-                    pod-name)]
-    (passport/log-event event-map)))
+  (passport/log-event (merge
+                        (api/pod-name->job-map (task-id :value))
+                        {:compute-cluster name
+                         :event-type passport/pod-completed
+                         :reason reason
+                         :state state})))
 
 (defn handle-pod-submission-failed
   "Marks the corresponding job instance as failed in the database and

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -1975,9 +1975,11 @@
               (map (fn [job-pool-name-map]
                      (update job-pool-name-map :job #(dissoc % :command)))
                    job-pool-name-maps))
-    (doseq [{{:keys [uuid, user]} :job} job-pool-name-maps]
+    (doseq [{{:keys [uuid, user, name]} :job pool :pool-name} job-pool-name-maps]
       (passport/log-event {:event-type passport/job-created
+                           :job-name name
                            :job-uuid (str uuid)
+                           :pool pool
                            :user user}))
     (let [jobs (map :job job-pool-name-maps)
           group-uuids (set (map :uuid groups))
@@ -2182,9 +2184,10 @@
                          time-until-out-of-debt (rate-limit/time-until-out-of-debt-millis! rate-limit/job-submission-rate-limiter user)
                          in-debt? (not (zero? time-until-out-of-debt))]
                      (try
-                       (doseq [{:keys [uuid]} jobs]
+                       (doseq [{:keys [uuid name]} jobs]
                          (passport/log-event
                            {:event-type passport/job-submitted
+                            :job-name name
                             :job-uuid (str uuid)
                             :pool pool-name
                             :pool-header pool-header

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -141,7 +141,8 @@
                            #'caches/pool-name->accepts-submissions?-cache
                            #'caches/pool-name->db-id-cache
                            #'caches/user-and-pool-name->quota
-                           #'caches/instance-uuid->job-uuid)))
+                           #'caches/instance-uuid->job-uuid
+                           #'caches/job-uuid->job-map)))
 
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."
@@ -204,7 +205,8 @@
   (.invalidateAll caches/pool-name->accepts-submissions?-cache)
   (.invalidateAll caches/pool-name->db-id-cache)
   (.invalidateAll caches/user-and-pool-name->quota)
-  (.invalidateAll caches/instance-uuid->job-uuid))
+  (.invalidateAll caches/instance-uuid->job-uuid)
+  (.invalidateAll caches/job-uuid->job-map))
 
 (defn restore-fresh-database!
   "Completely delete all data, start a fresh database and apply transactions if

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -195,6 +195,8 @@
             (is (= "alpine:latest" (.getImage container)))
             (is (not (nil? container)))
             (is (= ["COOK_COMPUTE_CLUSTER_NAME"
+                    "COOK_JOB_NAME"
+                    "COOK_JOB_USER"
                     "COOK_MEMORY_REQUEST_BYTES"
                     "COOK_POOL"
                     "COOK_SANDBOX"

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -31,7 +31,11 @@
                                                           pod-status container-status))))))
 (deftest test-process
   (with-redefs [cached-queries/instance-uuid->job-uuid-datomic-query (constantly (java.util.UUID/randomUUID))
-    d/db (constantly nil)]
+                d/db (constantly nil)
+                cached-queries/job-uuid->job-map-cache-lookup (constantly {:job/name "sample-name"
+                                                                           :job/user "sample-user"
+                                                                           :job/uuid "sample-uuid"
+                                                                           :job/pool {:pool/name "sample-pool"}})]
     (let [name "TestPodName"
           reason (atom nil)
           do-process-full-state (fn [cook-expected-state k8s-actual-state & {:keys [create-namespaced-pod-fn
@@ -264,7 +268,11 @@
 
 (deftest test-handle-pod-completed
   (with-redefs [cached-queries/instance-uuid->job-uuid-datomic-query (constantly (java.util.UUID/randomUUID))
-                d/db (constantly nil)]
+                d/db (constantly nil)
+                cached-queries/job-uuid->job-map-cache-lookup (constantly {:job/name "sample-name"
+                                                                           :job/user "sample-user"
+                                                                           :job/uuid "sample-uuid"
+                                                                           :job/pool {:pool/name "sample-pool"}})]
     (testing "graceful handling of lack of exit code"
       (let [pod (tu/pod-helper "podA" "hostA" {})
             pod-status (V1PodStatus.)]


### PR DESCRIPTION
## Changes proposed in this PR

- Create a cache mapping `job-uuid` to `job-map`
- Log `pool`, `job-name`, and `user` fields in passport events
- Add `COOK_JOB_NAME` AND `COOK_JOB_USER` as pod environment variables

## Why are we making these changes?

- These changes allow us to use those 3 fields when looking at cook metrics and to filter on them when looking at passport events.

