### PR TITLE
Make flag for enabling shm support on k8s.

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -648,6 +648,7 @@
   []
   (let [^V1EmptyDirVolumeSource volume-source (V1EmptyDirVolumeSource.)
         _ (.medium volume-source "Memory")
+        ; Randomize the name to reduce the changes of name collision with any other volume name.
         ^String name (str "shmvolume-" (+ (rand-int 899999) 100000))
         ^V1VolumeBuilder builder (-> ^V1VolumeBuilder (V1VolumeBuilder.)
                                      (.withName name)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -677,7 +677,7 @@
   "Conj the item onto the accum only if not nil"
   [accum item]
   (cond-> accum
-    (not (nil? item)) (conj item)))
+    (some? item) (conj item)))
 
 
 (defn make-volumes

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -643,6 +643,24 @@
                                      (.withEmptyDir (V1EmptyDirVolumeSource.)))]
     (.build builder)))
 
+(defn make-shm-volume
+  "Make a volume for /dev/shm and add it to the volume mount for the given image"
+  []
+  (let [^V1EmptyDirVolumeSource volume-source (V1EmptyDirVolumeSource.)
+        _ (.medium volume-source "Memory")
+        ^String name (str "shmvolume-" (+ (rand-int 899999) 100000))
+        ^V1VolumeBuilder builder (-> ^V1VolumeBuilder (V1VolumeBuilder.)
+                                     (.withName name)
+                                     (.withEmptyDir volume-source))]
+    (.build builder)))
+
+(defn- make-shm-volume-mount
+  "Make a volume mount for a shm volume mount."
+  ([^V1Volume volume]
+     (doto (V1VolumeMount.)
+       (.setName (.getName volume))
+       (.setMountPath "/dev/shm"))))
+
 (defn- make-volume-mount
   "Make a kubernetes volume mount"
   ([^V1Volume volume path read-only]
@@ -655,9 +673,16 @@
        (.setReadOnly read-only)
        (cond-> sub-path (.setSubPath sub-path))))))
 
+(defn maybe-conj
+  "Conj the item onto the accum only if not nil"
+  [accum item]
+  (cond-> accum
+    (not (nil? item)) (conj item)))
+
+
 (defn make-volumes
   "Converts a list of cook volumes to kubernetes volumes and volume mounts."
-  [cook-volumes sandbox-dir]
+  [cook-volumes sandbox-dir job-labels]
   (let [{:keys [disallowed-container-paths]} (config/kubernetes)
         allowed-cook-volumes (remove (fn [{:keys [container-path host-path mode]}]
                                        (contains? disallowed-container-paths
@@ -682,10 +707,14 @@
         sandbox-volume-mount-fn #(make-volume-mount sandbox-volume sandbox-dir %)
         sandbox-volume-mount (sandbox-volume-mount-fn false)
         ; mesos-sandbox-volume-mount added for Mesos backward compatibility
-        mesos-sandbox-volume-mount (make-volume-mount sandbox-volume "/mnt/mesos/sandbox" false)]
+        mesos-sandbox-volume-mount (make-volume-mount sandbox-volume "/mnt/mesos/sandbox" false)
+        label-prefix (:add-job-label-to-pod-prefix (config/kubernetes))
+        make-shm-volume? (= "true" (get job-labels (str label-prefix "shared-memory")))
+        shm-volume (when make-shm-volume? (make-shm-volume))
+        shm-volume-mount (when make-shm-volume? (make-shm-volume-mount shm-volume))]
     {:sandbox-volume-mount-fn sandbox-volume-mount-fn
-     :volumes (conj volumes sandbox-volume)
-     :volume-mounts (conj volume-mounts sandbox-volume-mount mesos-sandbox-volume-mount)}))
+     :volumes (maybe-conj (conj volumes sandbox-volume) shm-volume)
+     :volume-mounts (maybe-conj (conj volume-mounts sandbox-volume-mount mesos-sandbox-volume-mount) shm-volume-mount)}))
 
 (defn toleration-for-pool
   "For a given cook pool name, create the right V1Toleration so that Cook will ignore that cook-pool taint."
@@ -1142,7 +1171,7 @@
           security-context (make-security-context parameters (:user command))
           sandbox-dir (:default-workdir (config/kubernetes))
           workdir (get-workdir parameters sandbox-dir)
-          {:keys [volumes volume-mounts sandbox-volume-mount-fn]} (make-volumes volumes sandbox-dir)
+          {:keys [volumes volume-mounts sandbox-volume-mount-fn]} (make-volumes volumes sandbox-dir pod-labels)
           {:keys [custom-shell init-container sidecar telemetry-agent-host-var-name telemetry-env-var-name
                   telemetry-env-value telemetry-service-var-name telemetry-tags-entry-separator
                   telemetry-tags-key-invalid-char-pattern telemetry-tags-key-invalid-char-replacement

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -636,7 +636,13 @@
         (is (= 2 (count volume-mounts))))
       (let [{:keys [volumes volume-mounts]} (api/make-volumes [{:container-path "/tmp/foo"}] "/tmp/unused" {})]
         (is (= 1 (count volumes)))
-        (is (= 2 (count volume-mounts)))))))
+        (is (= 2 (count volume-mounts))))))
+
+  (testing "shm volume correctly created"
+    (with-redefs [config/kubernetes (constantly {:add-job-label-to-pod-prefix "the.secret.prefix/"})]
+      (let [{:keys [volumes volume-mounts]} (api/make-volumes [] sandbox-path {"the.secret.prefix/shared-memory" "true"})]
+        (is (= 2 (count volumes)))
+        (is (= 3 (count volume-mounts)))))))
 
 
 (deftest test-pod->synthesized-pod-state

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -586,7 +586,7 @@
 
 (deftest test-make-volumes
   (testing "empty cook volumes"
-    (let [{:keys [volumes volume-mounts]} (api/make-volumes [] sandbox-path)
+    (let [{:keys [volumes volume-mounts]} (api/make-volumes [] sandbox-path {})
           volumes (map k8s-volume->clj volumes)
           volume-mounts (map k8s-mount->clj volume-mounts)]
       (is (= volumes [expected-sandbox-volume]))
@@ -594,7 +594,7 @@
 
   (testing "valid generated volume names"
     (let [host-path "/tmp/main/foo"
-          {:keys [volumes volume-mounts]} (api/make-volumes [{:host-path host-path}] sandbox-path)]
+          {:keys [volumes volume-mounts]} (api/make-volumes [{:host-path host-path}] sandbox-path {})]
       (let [volume (first volumes)
             volume-mount (first volume-mounts)]
         (is (= (.getName volume)
@@ -605,7 +605,7 @@
   (testing "validate minimal cook volume spec defaults"
     (with-redefs [d/squuid (dummy-uuid-generator)]
       (let [host-path "/tmp/main/foo"
-            {:keys [volumes volume-mounts]} (api/make-volumes [{:host-path host-path}] sandbox-path)
+            {:keys [volumes volume-mounts]} (api/make-volumes [{:host-path host-path}] sandbox-path {})
           volumes (map k8s-volume->clj volumes)
           volume-mounts (map k8s-mount->clj volume-mounts)]
         (is (= volumes
@@ -620,7 +620,7 @@
           container-path "/mnt/foo"
           {:keys [volumes volume-mounts]} (api/make-volumes [{:host-path host-path
                                                               :container-path container-path
-                                                              :mode "RW"}] container-path)
+                                                              :mode "RW"}] container-path {})
           [volume] volumes
           [volume-mount] volume-mounts]
       (is (= (.getName volume)
@@ -631,10 +631,10 @@
 
   (testing "disallows configured volumes"
     (with-redefs [config/kubernetes (constantly {:disallowed-container-paths #{"/tmp/foo"}})]
-      (let [{:keys [volumes volume-mounts]} (api/make-volumes [{:host-path "/tmp/foo"}] "/tmp/unused")]
+      (let [{:keys [volumes volume-mounts]} (api/make-volumes [{:host-path "/tmp/foo"}] "/tmp/unused" {})]
         (is (= 1 (count volumes)))
         (is (= 2 (count volume-mounts))))
-      (let [{:keys [volumes volume-mounts]} (api/make-volumes [{:container-path "/tmp/foo"}] "/tmp/unused")]
+      (let [{:keys [volumes volume-mounts]} (api/make-volumes [{:container-path "/tmp/foo"}] "/tmp/unused" {})]
         (is (= 1 (count volumes)))
         (is (= 2 (count volume-mounts)))))))
 


### PR DESCRIPTION
## Changes proposed in this PR

- Make flag for enabling shm support on k8s.

## Why are we making these changes?
- Some cases of python multiprocessing need SHM support to work.
