### PR TITLE
use date in passport log file name

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -60,6 +60,7 @@
                   :exclusions [commons-codec]]
                  [prismatic/plumbing "0.5.3"]
                  [log4j "1.2.17"]
+                 [log4j/apache-log4j-extras "1.2.17"]
                  [instaparse "1.4.0"]
                  [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
                  [clj-pid "0.1.1"]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -33,7 +33,8 @@
            (java.io File)
            (java.net InetAddress)
            (org.apache.curator.test TestingServer)
-           (org.apache.log4j DailyRollingFileAppender Logger PatternLayout)))
+           (org.apache.log4j DailyRollingFileAppender Logger PatternLayout)
+           (org.apache.log4j.rolling RollingFileAppender TimeBasedRollingPolicy)))
 
 (defn env
   ^String
@@ -80,11 +81,13 @@
               overrides)
        (log4j-conf/set-loggers!
          (Logger/getLogger ^String passport-logger-ns)
-         {:out (DailyRollingFileAppender.
-                 (PatternLayout.
-                   "%d{ISO8601} %-5p %c [%t] - %m%n")
-                 "log/cook-passport.log"
-                 "'.'yyyy-MM-dd")
+         {:out (doto (RollingFileAppender.)
+                 (.setLayout (PatternLayout.
+                               "%d{ISO8601} %-5p %c [%t] - %m%n"))
+                 (.setRollingPolicy (doto (TimeBasedRollingPolicy.)
+                                      (.setFileNamePattern "log/cook-passport.log.%d")
+                                      (.activateOptions)))
+                 (.activateOptions))
           :level default}))
      (catch Throwable t
        (.println System/err (str "Failed to initialize logging! Error: " (.toString t)))


### PR DESCRIPTION
## Changes proposed in this PR

- use date in passport log file name

## Why are we making these changes?

Instead of using a fixed file name for the passport log file and renaming daily we want to use a file name that includes the date. When a new day starts a new file is created and no file is renamed. This reduces the chances for watchers of the passport log files to miss events when the file is renamed.
