### PR TITLE
Calls listPodForAllNamespaces with chunking

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -524,7 +524,7 @@
                              :clobber-synthetic-pods false
                              :controller-lock-num-shards controller-lock-num-shards
                              :default-workdir "/mnt/sandbox"
-                             :list-pods-limit 500
+                             :list-pods-limit 2000
                              :max-jobs-for-autoscaling 1000
                              :pod-condition-containers-not-initialized-seconds 120
                              :pod-condition-containers-not-ready-seconds 120

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -930,7 +930,7 @@
   (testing "basics"
     (with-redefs [config/kubernetes (constantly {:list-pods-limit 500})
                   api/list-pods-for-all-namespaces
-                  (constantly {:continue "" :pods []})
+                  (constantly {:continue "" :pods [] :resource-version "test-version"})
                   api/create-pod-watch (constantly nil)]
       (is (true? (fn? (api/initialize-pod-watch-helper {:all-pods-atom (atom [])} nil))))))
 
@@ -1186,8 +1186,8 @@
                     (fn [_ continue limit]
                       (is (= 1 limit))
                       (case continue
-                        nil {:continue "foo" :pods [pod-1]}
-                        "foo" {:continue "bar" :pods [pod-2]}
+                        nil {:continue "foo" :pods [pod-1] :resource-version "something"}
+                        "foo" {:continue "bar" :pods [pod-2] :resource-version "something"}
                         "bar" {:continue "" :pods [pod-3] :resource-version "something"}))]
         (is (= {:pods pods :resource-version "something"}
                (api/list-pods nil "test-compute-cluster" 1)))))))


### PR DESCRIPTION
## Changes proposed in this PR

Calling `listPodForAllNamespaces` with chunking.

## Why are we making these changes?

> On large clusters, retrieving the collection of some resource types may result in very large responses that can impact the server and client. For instance, a cluster may have tens of thousands of pods, each of which is 1-2kb of encoded JSON. Retrieving all pods across all namespaces may result in a very large response (10-20MB) and consume a large amount of server resources.

(https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks)