### PR TITLE
Sets pytest maxfail to 3

### DIFF
--- a/integration/setup.cfg
+++ b/integration/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -n10 -v --timeout-method=thread --maxfail=5 --log-level=DEBUG --durations=25
+addopts = -n10 -v --timeout-method=thread --maxfail=3 --log-level=DEBUG --durations=25
 timeout = 1200
 usefixtures = record_test_metric
 markers =


### PR DESCRIPTION
## Changes proposed in this PR

Setting maxfail to 3 instead of 5.

## Why are we making these changes?

Three failing tests is enough to abort a run, and it will save time when tests are taking a long time to fail, e.g. due to timeouts.
