### PR TITLE
Adds exit-code to pod-completed passport event

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -155,12 +155,12 @@
 
 (defn write-status-to-passport
   "Helper function for logging completed job status to cook passport"
-  [{:keys [name]}
-   {:keys [task-id state reason]}]
+  [{:keys [name]} {:keys [task-id state reason]} exit-code]
   (passport/log-event (merge
                         (api/pod-name->job-map (task-id :value))
                         {:compute-cluster name
                          :event-type passport/pod-completed
+                         :exit-code exit-code
                          :reason reason
                          :state state})))
 
@@ -334,7 +334,7 @@
   (when-not (api/synthetic-pod? pod-name)
     (let [{:keys [status exit-code]} (calculate-pod-status compute-cluster pod-name k8s-actual-state :reason reason)]
       (write-status-to-datomic compute-cluster status)
-      (write-status-to-passport compute-cluster status)
+      (write-status-to-passport compute-cluster status exit-code)
       (when exit-code
         (sandbox/aggregate-exit-code (:exit-code-syncer-state compute-cluster) pod-name exit-code))))
   ; Must never return nil, we want it to return non-nil so that we will retry with writing the state to datomic in case we lose a race.

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -161,6 +161,7 @@
                         {:compute-cluster name
                          :event-type passport/pod-completed
                          :exit-code exit-code
+                         :instance-exited? (some? exit-code)
                          :reason reason
                          :state state})))
 


### PR DESCRIPTION
## Changes proposed in this PR

Adding exit-code (which can be `nil`) to the `pod-completed` passport event.

## Why are we making these changes?

It can be useful for analysis to have exit-code in addition to the instance reason.
