### PR TITLE
Makes test_preemption_basic respect the default submit pool

### DIFF
--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -443,23 +443,16 @@ class MultiUserCookTest(util.CookTest):
     @unittest.skipUnless(util.is_preemption_enabled(), 'Preemption is not enabled on the cluster')
     @unittest.skipUnless(util.default_submit_pool() is not None, 'Test requires a default test pool')
     @pytest.mark.serial
-    # @pytest.mark.xfail
     # The test timeout needs to be a little more than 2 times the
     # rebalancer interval to allow at least two runs of the rebalancer
-    @pytest.mark.timeout(((util.rebalancer_interval_seconds() * 2.5) + 60)*5)
+    @pytest.mark.timeout((util.rebalancer_interval_seconds() * 2.5) + 60)
     def test_preemption_basic(self):
         pool = util.default_submit_pool()
         rebalancer_pool_regex = util.rebalancer_settings().get('pool-regex', None)
         if rebalancer_pool_regex and re.match(rebalancer_pool_regex, pool):
             user = self.user_factory.new_user()
-            for i in range(5):
-                self.logger.info('=====')
-                self.logger.info(f'Starting {i}')
-                self.logger.info('=====')
-                self.trigger_preemption(pool, user)
-                self.logger.info('=====')
-                self.logger.info(f'Finished {i}')
-                self.logger.info('=====')
+            self.logger.info(f'Using pool {pool} and user {user.name} for preemption test')
+            self.trigger_preemption(pool, user)
         else:
             self.skipTest(f'The rebalancer pool regex ({rebalancer_pool_regex}) '
                           f'does not match the default submit pool ({pool})')

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -446,13 +446,13 @@ class MultiUserCookTest(util.CookTest):
     # @pytest.mark.xfail
     # The test timeout needs to be a little more than 2 times the
     # rebalancer interval to allow at least two runs of the rebalancer
-    @pytest.mark.timeout(((util.rebalancer_interval_seconds() * 2.5) + 60)*15)
+    @pytest.mark.timeout(((util.rebalancer_interval_seconds() * 2.5) + 60)*5)
     def test_preemption_basic(self):
         pool = util.default_submit_pool()
         rebalancer_pool_regex = util.rebalancer_settings().get('pool-regex', None)
         if rebalancer_pool_regex and re.match(rebalancer_pool_regex, pool):
             user = self.user_factory.new_user()
-            for i in range(15):
+            for i in range(5):
                 self.logger.info('=====')
                 self.logger.info(f'Starting {i}')
                 self.logger.info('=====')

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -446,13 +446,13 @@ class MultiUserCookTest(util.CookTest):
     # @pytest.mark.xfail
     # The test timeout needs to be a little more than 2 times the
     # rebalancer interval to allow at least two runs of the rebalancer
-    @pytest.mark.timeout(((util.rebalancer_interval_seconds() * 2.5) + 60)*25)
+    @pytest.mark.timeout(((util.rebalancer_interval_seconds() * 2.5) + 60)*15)
     def test_preemption_basic(self):
         pool = util.default_submit_pool()
         rebalancer_pool_regex = util.rebalancer_settings().get('pool-regex', None)
         if rebalancer_pool_regex and re.match(rebalancer_pool_regex, pool):
             user = self.user_factory.new_user()
-            for i in range(25):
+            for i in range(15):
                 self.logger.info('=====')
                 self.logger.info(f'Starting {i}')
                 self.logger.info('=====')

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -442,24 +442,20 @@ class MultiUserCookTest(util.CookTest):
                 util.reset_limit(self.cook_url, 'quota', user.name, reason=self.current_name(), pool=pool)
 
     @unittest.skipUnless(util.is_preemption_enabled(), 'Preemption is not enabled on the cluster')
+    @unittest.skipUnless(util.default_submit_pool() is not None, 'Test requires a default test pool')
     @pytest.mark.serial
-    @pytest.mark.xfail
+    # @pytest.mark.xfail
     # The test timeout needs to be a little more than 2 times the
     # rebalancer interval to allow at least two runs of the rebalancer
     @pytest.mark.timeout((util.rebalancer_interval_seconds() * 2.5) + 60)
     def test_preemption_basic(self):
-        self.trigger_preemption(pool=None)
-
-    @unittest.skipUnless(util.is_preemption_enabled(), 'Preemption is not enabled on the cluster')
-    @unittest.skipUnless(util.are_pools_enabled(), 'Pools are not enabled on the cluster')
-    @pytest.mark.serial
-    @pytest.mark.xfail
-    def test_preemption_for_pools(self):
-        pools, _ = util.active_pools(self.cook_url)
-        self.assertLess(0, len(pools))
-        for pool in pools:
-            self.logger.info(f'Triggering preemption for {pool}')
-            self.trigger_preemption(pool=pool['name'])
+        pool = util.default_submit_pool()
+        rebalancer_pool_regex = util.rebalancer_settings().get('pool-regex', None)
+        if rebalancer_pool_regex and re.match(rebalancer_pool_regex, pool):
+            self.trigger_preemption(pool=pool)
+        else:
+            self.skipTest(f'The rebalancer pool regex ({rebalancer_pool_regex}) '
+                          f'does not match the default submit pool ({pool})')
 
     @unittest.skipUnless(util.are_pools_enabled(), "Requires pools")
     @unittest.skipIf(util.using_kubernetes(), 'This test is not yet supported on kubernetes')

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -361,7 +361,7 @@ class MultiUserCookTest(util.CookTest):
 
             trigger_submission_rate_limit()
 
-    def trigger_preemption(self, pool):
+    def trigger_preemption(self, pool, user):
         """
         Triggers preemption on the provided pool (which can be None) by doing the following:
 
@@ -372,7 +372,6 @@ class MultiUserCookTest(util.CookTest):
         5. Submit a job, J2, from X with 0.1 cpu and priority 100
         6. Wait until J1 is preempted (to make room for J2)
         """
-        user = self.user_factory.new_user()
         all_job_uuids = []
         try:
             large_cpus = util.get_default_cpus()
@@ -452,11 +451,12 @@ class MultiUserCookTest(util.CookTest):
         pool = util.default_submit_pool()
         rebalancer_pool_regex = util.rebalancer_settings().get('pool-regex', None)
         if rebalancer_pool_regex and re.match(rebalancer_pool_regex, pool):
+            user = self.user_factory.new_user()
             for i in range(25):
                 self.logger.info('=====')
                 self.logger.info(f'Starting {i}')
                 self.logger.info('=====')
-                self.trigger_preemption(pool=pool)
+                self.trigger_preemption(pool, user)
                 self.logger.info('=====')
                 self.logger.info(f'Finished {i}')
                 self.logger.info('=====')

--- a/integration/tests/cook/test_multi_user.py
+++ b/integration/tests/cook/test_multi_user.py
@@ -447,12 +447,19 @@ class MultiUserCookTest(util.CookTest):
     # @pytest.mark.xfail
     # The test timeout needs to be a little more than 2 times the
     # rebalancer interval to allow at least two runs of the rebalancer
-    @pytest.mark.timeout((util.rebalancer_interval_seconds() * 2.5) + 60)
+    @pytest.mark.timeout(((util.rebalancer_interval_seconds() * 2.5) + 60)*25)
     def test_preemption_basic(self):
         pool = util.default_submit_pool()
         rebalancer_pool_regex = util.rebalancer_settings().get('pool-regex', None)
         if rebalancer_pool_regex and re.match(rebalancer_pool_regex, pool):
-            self.trigger_preemption(pool=pool)
+            for i in range(25):
+                self.logger.info('=====')
+                self.logger.info(f'Starting {i}')
+                self.logger.info('=====')
+                self.trigger_preemption(pool=pool)
+                self.logger.info('=====')
+                self.logger.info(f'Finished {i}')
+                self.logger.info('=====')
         else:
             self.skipTest(f'The rebalancer pool regex ({rebalancer_pool_regex}) '
                           f'does not match the default submit pool ({pool})')


### PR DESCRIPTION
## Changes proposed in this PR

- making `test_preemption_basic` use the default submit pool for testing, if it's set and the rebalancer is enabled on it
- deleting `test_preemption_for_pools`

## Why are we making these changes?

`test_preemption_for_pools` was attempting to test preemption on every active pool, which was overkill and broken. `test_preemption_basic` was not respecting the default submit pool for testing, and instead using the default pool of the cluster under test, which was broken in cases where that pool didn't have the rebalancer enabled but some other pool in the cluster did.