### PR TITLE
Update Cook to run on JDK-11

### DIFF
--- a/.github/workflows/executor-tests.yml
+++ b/.github/workflows/executor-tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       PYTEST_ADDOPTS: --color=yes
       MESOS_NATIVE_JAVA_LIBRARY: /usr/lib/libmesos.so
@@ -22,10 +22,10 @@ jobs:
       GDRIVE_LOG_POST_URL: https://script.google.com/macros/s/AKfycbxOB55OzrQSbpZO_0gzsxZaJ8LaUWWo3PDLNc-gCiMN1iObxu7x/exec
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK ``
         uses: actions/setup-java@v1
         with:
-          java-version: '8'
+          java-version: '11'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/executor-tests.yml
+++ b/.github/workflows/executor-tests.yml
@@ -22,7 +22,7 @@ jobs:
       GDRIVE_LOG_POST_URL: https://script.google.com/macros/s/AKfycbxOB55OzrQSbpZO_0gzsxZaJ8LaUWWo3PDLNc-gCiMN1iObxu7x/exec
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK ``
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: '11'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       PYTEST_ADDOPTS: --color=yes
       MESOS_NATIVE_JAVA_LIBRARY: /usr/lib/libmesos.so
@@ -22,10 +22,10 @@ jobs:
       GDRIVE_LOG_POST_URL: https://script.google.com/macros/s/AKfycbxOB55OzrQSbpZO_0gzsxZaJ8LaUWWo3PDLNc-gCiMN1iObxu7x/exec
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: '8'
+          java-version: '11'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,7 +48,7 @@ jobs:
           ./cli/travis/setup.sh
           cd scheduler && ./travis/setup.sh
       - name: JobClient Java unit tests
-        run: cd ./jobclient/java && mvn test 
+        run: cd ./jobclient/java && mvn test -X 
       - name: JobClient Python unit tests
         run: cd ./jobclient/python && python -m pytest
       - name: CLI unit tests

--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -21,7 +21,7 @@
           <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>build-helper-maven-plugin</artifactId>
-              <version>1.7</version>
+              <version>1.11</version>
               <executions>
                   <execution>
                       <id>add-source</id>
@@ -42,14 +42,14 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <version>3.1</version>
               <configuration>
-                  <source>1.7</source>
-                  <target>1.7</target>
+                  <source>1.11</source>
+                  <target>1.11</target>
               </configuration>
           </plugin>
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.20.1</version>
+              <version>2.22.1</version>
               <configuration>
                   <argLine>-javaagent:${env.HOME}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
               </configuration>

--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -51,7 +51,7 @@
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.22.1</version>
               <configuration>
-                  <argLine>-javaagent:${env.HOME}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
+                  <argLine>-javaagent:${env.HOME}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar  --illegal-access=permit</argLine>
               </configuration>
           </plugin>
       </plugins>

--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -21,7 +21,7 @@
           <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>build-helper-maven-plugin</artifactId>
-              <version>1.11</version>
+              <version>1.7</version>
               <executions>
                   <execution>
                       <id>add-source</id>
@@ -42,8 +42,8 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <version>3.1</version>
               <configuration>
-                  <source>1.11</source>
-                  <target>1.11</target>
+                  <source>1.7</source>
+                  <target>1.7</target>
               </configuration>
           </plugin>
           <plugin>

--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -52,7 +52,7 @@
               <version>2.22.1</version>
               <configuration>
 		  <forkCount>0</forkCount> <!-- changed this to 0 -->
-                  <argLine>-javaagent:${env.HOME}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar  --illegal-access=permit</argLine>
+                  <argLine>-javaagent:${env.HOME}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar  --illegal-access=permit -Djdk.attach.allowAttachSelf=true</argLine>
               </configuration>
           </plugin>
       </plugins>

--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -12,7 +12,7 @@
     </license>
   </licenses>
   <properties>
-      <jmockit.version>1.18</jmockit.version>
+      <jmockit.version>1.41</jmockit.version>  <!-- 1.42 is broken and fails to run. -->
   </properties>
   <build>
       <directory>target</directory>
@@ -51,8 +51,7 @@
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.22.1</version>
               <configuration>
-		  <forkCount>0</forkCount> <!-- changed this to 0 -->
-                  <argLine>-javaagent:${env.HOME}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar  --illegal-access=permit -Djdk.attach.allowAttachSelf=true</argLine>
+                  <argLine>-javaagent:${env.HOME}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
               </configuration>
           </plugin>
       </plugins>

--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -51,6 +51,7 @@
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.22.1</version>
               <configuration>
+		  <forkCount>0</forkCount> <!-- changed this to 0 -->
                   <argLine>-javaagent:${env.HOME}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar  --illegal-access=permit</argLine>
               </configuration>
           </plugin>

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -8,7 +8,7 @@ RUN rm /etc/apt/sources.list.d/docker.list && \
     add-apt-repository ppa:openjdk-r/ppa && apt-get -y update && \
     apt-get --no-install-recommends -y install \
     curl \
-    openjdk-8-jdk \
+    openjdk-11-jdk \
     unzip && apt-get clean && rm -Rf /var/lib/apt/lists/*
 
 # Env setup

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -15,7 +15,7 @@ RUN rm /etc/apt/sources.list.d/docker.list && \
 ENV HOME "/root/"
 ENV LEIN_ROOT true
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
-ENV JAVA_CMD=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
+ENV JAVA_CMD=/usr/lib/jvm/java-11-openjdk-amd64/bin/java
 
 # Generate SSL certificate
 RUN mkdir /opt/ssl

--- a/scheduler/bin/bootstrap
+++ b/scheduler/bin/bootstrap
@@ -26,7 +26,7 @@ apt-get clean
 rm -Rf /var/lib/apt/lists/*
 
 # Java setup
-export JAVA_CMD=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
+export JAVA_CMD=/usr/lib/jvm/java-11-openjdk-amd64/bin/java
 echo 'export JAVA_CMD='$JAVA_CMD | tee -a $bashrc
 
 # Lein setup (https://leiningen.org/#install)

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -77,12 +77,12 @@
 
                  ; Bring in netty. Note that this is brought in in a lot of other places, Exclude it whenever finding another one.
                  ; Need to make sure all imports are importing the same version.
-                 [io.netty/netty-handler "4.1.63.Final"]
+                 ;[io.netty/netty-handler "4.1.63.Final"]
                  ; Netty now uses epoll with a native library. We need to tell lein our architecture so it can bring in the
                  ; right library architecture. Make sure this version smatches.
-                 [io.netty/netty-transport-native-epoll "4.1.63.Final" :classifier "linux-x86_64"]
-                 [io.netty/netty-transport-native-unix-common "4.1.63.Final" :classifier "linux-x86_64"]
-
+                 ;[io.netty/netty-transport-native-epoll "4.1.63.Final" :classifier "linux-x86_64"]
+                 ;[io.netty/netty-transport-native-unix-common "4.1.63.Final" :classifier "linux-x86_64"]
+                 [io.netty/netty "3.10.1.Final"]
 
                  ;;Metrics
                  [metrics-clojure "2.6.1"
@@ -111,13 +111,13 @@
                  [liberator "0.15.0"]
 
                  ;;Databases
-                 [org.apache.curator/curator-framework "5.2.0"
+                 [org.apache.curator/curator-framework "2.7.1"
                   :exclusions [io.netty/netty]]
-                 [org.apache.curator/curator-recipes "5.2.0"
+                 [org.apache.curator/curator-recipes "2.7.1"
                   :exclusions [org.slf4j/slf4j-log4j12
                                org.slf4j/log4j
                                log4j]]
-                 [org.apache.curator/curator-test "5.2.0"
+                 [org.apache.curator/curator-test "2.7.1"
                  :exclusions [io.netty/netty
                               io.netty/netty-transport-native-epoll]]
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -67,7 +67,6 @@
 
                  ;;Networking
                  [twosigma/clj-http "2.0.0-ts1"]
-                 [io.netty/netty "3.10.1.Final"]
                  [cc.qbits/jet "0.6.4" :exclusions [org.eclipse.jetty/jetty-io
                                                     org.eclipse.jetty/jetty-security
                                                     org.eclipse.jetty/jetty-server

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -118,9 +118,8 @@
                                org.slf4j/log4j
                                log4j]]
                  [org.apache.curator/curator-test "2.7.1"
-                 ;:exclusions [io.netty/netty
-                 ;             io.netty/netty-transport-native-epoll]
-                              ]
+                 :exclusions [io.netty/netty
+                              io.netty/netty-transport-native-epoll]]
 
                  ;; Dependency management
                  [mount "0.1.12"]
@@ -165,8 +164,9 @@
                    ; using a profiles.clj file that defines a profile
                    ; which pulls in datomic-pro
                    [com.datomic/datomic-free "0.9.5206"
-                    :exclusions [;io.netty/netty
+                    :exclusions [io.netty/netty
                                  com.fasterxml.jackson.core/jackson-core
+                                 io.netty/netty
                                  joda-time
                                  org.slf4j/jcl-over-slf4j
                                  org.slf4j/jul-to-slf4j

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -37,7 +37,7 @@
                  [clj-time "0.12.0"]
                  [org.clojure/core.async "0.3.442" :exclusions [org.clojure/tools.reader]]
                  [org.clojure/tools.cli "0.3.5"]
-                 [prismatic/schema "1.1.3"]
+                 [prismatic/schema "1.1.3"]7
                  [clojure-miniprofiler "0.4.0"]
                  [jarohen/chime "0.1.6"]
                  [org.clojure/data.priority-map "0.0.5"]
@@ -223,7 +223,8 @@
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"
-             "-Xlog:gc*,compaction*,stringdedup*=debug,stringtable*,ergo*,safepoint,age=trace:file=gclog-%t:time,level,tags"
+;             "-Xlog:gc*,compaction*,stringdedup*=debug,stringtable*,ergo*,safepoint,age=trace:file=gclog-%t:time,level,tags"
+; TODO: Disable logging until whole stack migrated to JDK-11
              "-XX:+UseG1GC"
              "-XX:+UseStringDeduplication"
              "-XX:+HeapDumpOnOutOfMemoryError"

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -236,7 +236,7 @@
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"
-             "-Xlog:gc*,compaction*,stringdedup*=debug,stringtable*,ergo*,safepoint,age=trace:file=gclog-%t:time,level,tags"
+             "-Xlog:gc*,compaction*,stringdedup*=debug,stringtable*,ergo*,safepoint,gc+age=trace:file=gclog-%t:time,level,tags"
              "-XX:+UseG1GC"
              "-XX:+UseStringDeduplication"
              "-XX:+HeapDumpOnOutOfMemoryError"

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -228,4 +228,3 @@
              "-XX:+UseStringDeduplication"
              "-XX:+HeapDumpOnOutOfMemoryError"
              "--illegal-access=warn"])
-; TODO: Re-add back needed GC options suitable for JDK11.

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -23,7 +23,6 @@
                  ^:displace [cheshire "5.3.1"]
                  [byte-streams "0.1.4"]
                  [org.clojure/data.json "0.2.2"]
-                 [circleci/clj-yaml "0.5.5"]
                  [camel-snake-kebab "0.4.0"]
                  [com.rpl/specter "1.0.1"]
 
@@ -117,7 +116,16 @@
 
                  ;; Kubernetes
                  [io.kubernetes/client-java "11.0.0"]
-                 [com.google.auth/google-auth-library-oauth2-http "0.16.2"]]
+                 [com.google.auth/google-auth-library-oauth2-http "0.16.2"]
+
+                 ;Version forcing by JDK11 upgrade.
+                 [org.flatland/ordered "1.5.9"] ; Upgraded from 1.5.3, brought in by clj-yaml.
+                 ;IMPL: NOT NEEDED (I think) [com.sun.xml.ws/jaxws-rt "2.3.3"] ; Needed via liberator, No longer in JDK11.
+                 [jakarta.xml.ws/jakarta.xml.ws-api "2.3.3"] ; Needed via liberator, No longer in JDK11.
+                 ; TODO: javassist upgrade. Used by curator-test, Illegal reflective access.
+
+
+                 ]
 
   :repositories {"maven2" {:url "https://files.couchbase.com/maven2/"}
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
@@ -219,5 +227,6 @@
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"
-             "-XX:+HeapDumpOnOutOfMemoryError"])
+             "-XX:+HeapDumpOnOutOfMemoryError"
+             "--illegal-access=warn"])
 ; TODO: Re-add back needed GC options suitable for JDK11.

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -112,7 +112,7 @@
                  [liberator "0.15.0"]
 
                  ;;Databases
-                 ;; TODO: Should upgrade curator to avoid illegal reflective access warnings.
+                 ;; TODO: Should upgrade curator to avoid illegal reflective access warnings. (5.2.0 is latest)
                  [org.apache.curator/curator-framework "2.7.1"
                   :exclusions [io.netty/netty]]
                  [org.apache.curator/curator-recipes "2.7.1"

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -118,8 +118,9 @@
                                org.slf4j/log4j
                                log4j]]
                  [org.apache.curator/curator-test "2.7.1"
-                 :exclusions [io.netty/netty
-                              io.netty/netty-transport-native-epoll]]
+                 ;:exclusions [io.netty/netty
+                 ;             io.netty/netty-transport-native-epoll]
+                              ]
 
                  ;; Dependency management
                  [mount "0.1.12"]
@@ -164,9 +165,8 @@
                    ; using a profiles.clj file that defines a profile
                    ; which pulls in datomic-pro
                    [com.datomic/datomic-free "0.9.5206"
-                    :exclusions [io.netty/netty
+                    :exclusions [;io.netty/netty
                                  com.fasterxml.jackson.core/jackson-core
-                                 io.netty/netty
                                  joda-time
                                  org.slf4j/jcl-over-slf4j
                                  org.slf4j/jul-to-slf4j

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -223,9 +223,10 @@
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"
-;             "-Xlog:gc*,compaction*,stringdedup*=debug,stringtable*,ergo*,safepoint,age=trace:file=gclog-%t:time,level,tags"
-; TODO: Disable logging until whole stack migrated to JDK-11
+             "-Xlog:gc*,compaction*,stringdedup*=debug,stringtable*,ergo*,safepoint,age=trace:file=gclog-%t:time,level,tags"
+ TODO: Disable logging until whole stack migrated to JDK-11
              "-XX:+UseG1GC"
              "-XX:+UseStringDeduplication"
              "-XX:+HeapDumpOnOutOfMemoryError"
-             "--illegal-access=warn"])
+             "--illegal-access=warn"
+	     ])

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -122,6 +122,9 @@
                  [org.flatland/ordered "1.5.9"] ; Upgraded from 1.5.3, brought in by clj-yaml.
                  ;IMPL: NOT NEEDED (I think) [com.sun.xml.ws/jaxws-rt "2.3.3"] ; Needed via liberator, No longer in JDK11.
                  [jakarta.xml.ws/jakarta.xml.ws-api "2.3.3"] ; Needed via liberator, No longer in JDK11.
+                 ; Note: This doesn't silence the warning.
+                 [org.javassist/javassist "3.28.0-GA"] ; Needed bu cyrator-test. Upgraded from 3.18.1-GA
+
                  ; TODO: javassist upgrade. Used by curator-test, Illegal reflective access.
                  ; TODO: mockito-core upgrade Currently 1.10.19. Imported directly into :test profile.
 
@@ -200,7 +203,7 @@
    :test
    {:dependencies [[criterium "0.4.4"]
                    [org.clojure/test.check "0.6.1"]
-                   [org.mockito/mockito-core "1.10.19"]
+                   [org.mockito/mockito-core "3.12.4"]
                    [twosigma/cook-jobclient "0.8.6-SNAPSHOT"]]}
 
    :test-console

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -75,10 +75,13 @@
                  [org.eclipse.jetty/jetty-server "9.2.6.v20141205"]
                  [org.eclipse.jetty/jetty-security "9.2.6.v20141205"]
 
-                 ; Bring in netty. Note the black magic needed to import the native netty library for lein
-                 ; These versions must match. Make sure to add exclusions for both of these to suppress mismatched imports.
+                 ; Bring in netty. Note that this is brought in in a lot of other places, Exclude it whenever finding another one.
+                 ; Need to make sure all imports are importing the same version.
                  [io.netty/netty-handler "4.1.63.Final"]
+                 ; Netty now uses epoll with a native library. We need to tell lein our architecture so it can bring in the
+                 ; right library architecture. Make sure this version smatches.
                  [io.netty/netty-transport-native-epoll "4.1.63.Final" :classifier "linux-x86_64"]
+                 [io.netty/netty-transport-native-unix-common "4.1.63.Final" :classifier "linux-x86_64"]
 
 
                  ;;Metrics

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -75,11 +75,12 @@
                  [org.eclipse.jetty/jetty-server "9.2.6.v20141205"]
                  [org.eclipse.jetty/jetty-security "9.2.6.v20141205"]
 
+                 ; TODO: Upgrade netty.
                  ; Bring in netty. Note that this is brought in in a lot of other places, Exclude it whenever finding another one.
                  ; Need to make sure all imports are importing the same version.
                  ;[io.netty/netty-handler "4.1.63.Final"]
                  ; Netty now uses epoll with a native library. We need to tell lein our architecture so it can bring in the
-                 ; right library architecture. Make sure this version smatches.
+                 ; right library architecture. Make sure this version matches.
                  ;[io.netty/netty-transport-native-epoll "4.1.63.Final" :classifier "linux-x86_64"]
                  ;[io.netty/netty-transport-native-unix-common "4.1.63.Final" :classifier "linux-x86_64"]
                  [io.netty/netty "3.10.1.Final"]
@@ -111,6 +112,7 @@
                  [liberator "0.15.0"]
 
                  ;;Databases
+                 ;; TODO: Should upgrade curator to avoid illegal reflective access warnings.
                  [org.apache.curator/curator-framework "2.7.1"
                   :exclusions [io.netty/netty]]
                  [org.apache.curator/curator-recipes "2.7.1"
@@ -166,7 +168,6 @@
                    [com.datomic/datomic-free "0.9.5206"
                     :exclusions [io.netty/netty
                                  com.fasterxml.jackson.core/jackson-core
-                                 io.netty/netty
                                  joda-time
                                  org.slf4j/jcl-over-slf4j
                                  org.slf4j/jul-to-slf4j

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -37,7 +37,7 @@
                  [clj-time "0.12.0"]
                  [org.clojure/core.async "0.3.442" :exclusions [org.clojure/tools.reader]]
                  [org.clojure/tools.cli "0.3.5"]
-                 [prismatic/schema "1.1.3"]7
+                 [prismatic/schema "1.1.3"]
                  [clojure-miniprofiler "0.4.0"]
                  [jarohen/chime "0.1.6"]
                  [org.clojure/data.priority-map "0.0.5"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -221,9 +221,5 @@
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"
              "-verbose:gc"
              "-XX:+PrintGCDetails"
-             "-Xloggc:gclog"
-             "-XX:+UseGCLogFileRotation"
-             "-XX:NumberOfGCLogFiles=20"
-             "-XX:GCLogFileSize=128M"
-             "-XX:+PrintGCDateStamps"
              "-XX:+HeapDumpOnOutOfMemoryError"])
+; TODO: Re-add back needed GC options suitable for JDK11.

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -123,7 +123,7 @@
                  ;IMPL: NOT NEEDED (I think) [com.sun.xml.ws/jaxws-rt "2.3.3"] ; Needed via liberator, No longer in JDK11.
                  [jakarta.xml.ws/jakarta.xml.ws-api "2.3.3"] ; Needed via liberator, No longer in JDK11.
                  ; TODO: javassist upgrade. Used by curator-test, Illegal reflective access.
-
+                 ; TODO: mockito-core upgrade Currently 1.10.19. Imported directly into :test profile.
 
                  ]
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -84,7 +84,8 @@
                  [metrics-clojure-jvm "2.6.1"]
                  [io.dropwizard.metrics/metrics-graphite "3.1.2"]
                  [com.aphyr/metrics3-riemann-reporter "0.4.0"
-                  :exclusions [com.google.protobuf/protobuf-java
+                  :exclusions [io.netty/netty
+                               com.google.protobuf/protobuf-java
                                com.amazonaws/aws-java-sdk]] ; Brings in a lot of dependencies
 
                  ;;External system integrations

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -223,6 +223,9 @@
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"
+             "-Xlog:gc*,compaction*,stringdedup*=debug,stringtable*,ergo*,safepoint,age=trace:file=gclog-%t:time,level,tags"
+             "-XX:+UseG1GC"
+             "-XX:+UseStringDeduplication"
              "-XX:+HeapDumpOnOutOfMemoryError"
              "--illegal-access=warn"])
 ; TODO: Re-add back needed GC options suitable for JDK11.

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -75,6 +75,11 @@
                  [org.eclipse.jetty/jetty-server "9.2.6.v20141205"]
                  [org.eclipse.jetty/jetty-security "9.2.6.v20141205"]
 
+                 ; Bring in netty. Note the black magic needed to import the native netty library for lein
+                 ; These versions must match. Make sure to add exclusions for both of these to suppress mismatched imports.
+                 [io.netty/netty-handler "4.1.63.Final"]
+                 [io.netty/netty-transport-native-epoll "4.1.63.Final" :classifier "linux-x86_64"]
+
 
                  ;;Metrics
                  [metrics-clojure "2.6.1"
@@ -109,7 +114,9 @@
                   :exclusions [org.slf4j/slf4j-log4j12
                                org.slf4j/log4j
                                log4j]]
-                 [org.apache.curator/curator-test "5.2.0"]
+                 [org.apache.curator/curator-test "5.2.0"
+                 :exclusions [io.netty/netty
+                              io.netty/netty-transport-native-epoll]]
 
                  ;; Dependency management
                  [mount "0.1.12"]
@@ -154,7 +161,9 @@
                    ; using a profiles.clj file that defines a profile
                    ; which pulls in datomic-pro
                    [com.datomic/datomic-free "0.9.5206"
-                    :exclusions [com.fasterxml.jackson.core/jackson-core
+                    :exclusions [io.netty/netty
+                                 com.fasterxml.jackson.core/jackson-core
+                                 io.netty/netty
                                  joda-time
                                  org.slf4j/jcl-over-slf4j
                                  org.slf4j/jul-to-slf4j

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -219,7 +219,5 @@
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"
-             "-verbose:gc"
-             "-XX:+PrintGCDetails"
              "-XX:+HeapDumpOnOutOfMemoryError"])
 ; TODO: Re-add back needed GC options suitable for JDK11.

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -224,7 +224,6 @@
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"
              "-Xlog:gc*,compaction*,stringdedup*=debug,stringtable*,ergo*,safepoint,age=trace:file=gclog-%t:time,level,tags"
- TODO: Disable logging until whole stack migrated to JDK-11
              "-XX:+UseG1GC"
              "-XX:+UseStringDeduplication"
              "-XX:+HeapDumpOnOutOfMemoryError"

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -103,13 +103,13 @@
                  [liberator "0.15.0"]
 
                  ;;Databases
-                 [org.apache.curator/curator-framework "2.7.1"
+                 [org.apache.curator/curator-framework "5.2.0"
                   :exclusions [io.netty/netty]]
-                 [org.apache.curator/curator-recipes "2.7.1"
+                 [org.apache.curator/curator-recipes "5.2.0"
                   :exclusions [org.slf4j/slf4j-log4j12
                                org.slf4j/log4j
                                log4j]]
-                 [org.apache.curator/curator-test "2.7.1"]
+                 [org.apache.curator/curator-test "5.2.0"]
 
                  ;; Dependency management
                  [mount "0.1.12"]
@@ -120,14 +120,7 @@
 
                  ;Version forcing by JDK11 upgrade.
                  [org.flatland/ordered "1.5.9"] ; Upgraded from 1.5.3, brought in by clj-yaml.
-                 ;IMPL: NOT NEEDED (I think) [com.sun.xml.ws/jaxws-rt "2.3.3"] ; Needed via liberator, No longer in JDK11.
                  [jakarta.xml.ws/jakarta.xml.ws-api "2.3.3"] ; Needed via liberator, No longer in JDK11.
-                 ; Note: This doesn't silence the warning.
-                 [org.javassist/javassist "3.28.0-GA"] ; Needed bu cyrator-test. Upgraded from 3.18.1-GA
-
-                 ; TODO: javassist upgrade. Used by curator-test, Illegal reflective access.
-                 ; TODO: mockito-core upgrade Currently 1.10.19. Imported directly into :test profile.
-
                  ]
 
   :repositories {"maven2" {:url "https://files.couchbase.com/maven2/"}

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -97,51 +97,53 @@
       (fake-test-compute-cluster-with-driver conn cluster-name nil))
     (or compute-cluster (cc/compute-cluster-name->ComputeCluster cluster-name))))
 
-(let [minimal-config {:authorization {:one-user ""}
-                      :cache-working-set-size 1000
-                      :compute-clusters [{:factory-fn cook.mesos.mesos-compute-cluster/factory-fn
-                                          :config {:compute-cluster-name fake-test-compute-cluster-name}}]
-                      :database {:datomic-uri ""}
-                      :log (cond-> {}
-                             ; Allow tests that go through the real logging
-                             ; initialization code to log to the console when
-                             ; requested via the property
-                             (System/getProperty "cook.test.logging.console")
-                             (assoc :file "/dev/stdout"))
-                      :mesos {:leader-path "", :master ""}
-                      :metrics {}
-                      :nrepl {}
-                      :port 80
-                      :scheduler {}
-                      :kubernetes {:synthetic-pod-recency-seconds 1 :max-jobs-for-autoscaling 1000 :autoscaling-scale-factor 1000.0}
-                      :unhandled-exceptions {}
-                      :zookeeper {:local? true}}]
-  (defn setup
-    "Given an optional config map, initializes the config state"
-    [& {:keys [config], :or nil}]
-    (mount/stop)
-    (mount/start-with-args (merge minimal-config config)
-                           #'cook.config/config
-                           #'cook.plugins.adjustment/plugin
-                           #'cook.plugins.file/plugin
-                           #'cook.plugins.launch/job-launch-cache
-                           #'cook.plugins.launch/plugin-object
-                           #'cook.plugins.pool/plugin
-                           #'cook.plugins.submission/plugin-object
-                           #'caches/job-ent->resources-cache
-                           #'caches/job-ent->pool-cache
-                           #'caches/task-ent->user-cache
-                           #'caches/task->feature-vector-cache
-                           #'caches/job-ent->user-cache
-                           #'cook.quota/per-user-per-pool-launch-rate-limiter
-                           #'caches/user->group-ids-cache
-                           #'caches/recent-synthetic-pod-job-uuids
-                           #'caches/pool-name->exists?-cache
-                           #'caches/pool-name->accepts-submissions?-cache
-                           #'caches/pool-name->db-id-cache
-                           #'caches/user-and-pool-name->quota
-                           #'caches/instance-uuid->job-uuid
-                           #'caches/job-uuid->job-map)))
+(defn minimal-config
+  []
+  {:authorization {:one-user ""}
+   :cache-working-set-size 1000
+   :compute-clusters [{:factory-fn cook.mesos.mesos-compute-cluster/factory-fn
+                       :config {:compute-cluster-name fake-test-compute-cluster-name}}]
+   :database {:datomic-uri ""}
+   :log (cond-> {}
+          ; Allow tests that go through the real logging
+          ; initialization code to log to the console when
+          ; requested via the property
+          (System/getProperty "cook.test.logging.console")
+          (assoc :file "/dev/stdout"))
+   :mesos {:leader-path "", :master ""}
+   :metrics {}
+   :nrepl {}
+   :port 80
+   :scheduler {}
+   :kubernetes {:synthetic-pod-recency-seconds 1 :max-jobs-for-autoscaling 1000 :autoscaling-scale-factor 1000.0}
+   :unhandled-exceptions {}
+   :zookeeper {:local? true}})
+(defn setup
+  "Given an optional config map, initializes the config state"
+  [& {:keys [config] :or {config nil}}]
+  (mount/stop)
+  (mount/start-with-args (merge (minimal-config) config)
+                         #'cook.config/config
+                         #'cook.plugins.adjustment/plugin
+                         #'cook.plugins.file/plugin
+                         #'cook.plugins.launch/job-launch-cache
+                         #'cook.plugins.launch/plugin-object
+                         #'cook.plugins.pool/plugin
+                         #'cook.plugins.submission/plugin-object
+                         #'caches/job-ent->resources-cache
+                         #'caches/job-ent->pool-cache
+                         #'caches/task-ent->user-cache
+                         #'caches/task->feature-vector-cache
+                         #'caches/job-ent->user-cache
+                         #'cook.quota/per-user-per-pool-launch-rate-limiter
+                         #'caches/user->group-ids-cache
+                         #'caches/recent-synthetic-pod-job-uuids
+                         #'caches/pool-name->exists?-cache
+                         #'caches/pool-name->accepts-submissions?-cache
+                         #'caches/pool-name->db-id-cache
+                         #'caches/user-and-pool-name->quota
+                         #'caches/instance-uuid->job-uuid
+                         #'caches/job-uuid->job-map))
 
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -118,6 +118,7 @@
    :kubernetes {:synthetic-pod-recency-seconds 1 :max-jobs-for-autoscaling 1000 :autoscaling-scale-factor 1000.0}
    :unhandled-exceptions {}
    :zookeeper {:local? true}})
+   
 (defn setup
   "Given an optional config map, initializes the config state"
   [& {:keys [config] :or {config nil}}]

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -52,7 +52,7 @@
             [metrics.timers :as timers]
             [plumbing.core :as pc])
   (:import (clojure.lang ExceptionInfo)
-           (com.netflix.fenzo SimpleAssignmentResult TaskAssignmentResult TaskRequest TaskScheduler)
+           (com.netflix.fenzo SimpleAssignmentResult TaskAssignmentResult TaskRequest TaskScheduler SchedulingResult)
            (com.netflix.fenzo.plugins BinPackingFitnessCalculators)
            (cook.compute_cluster ComputeCluster)
            (java.util UUID)
@@ -181,7 +181,7 @@
                     :cpus cpus :mem mem :gpus gpus :disk disk :attrs attrs) 0))
 
 (defn schedule-and-run-jobs
-  [conn scheduler offers job-ids]
+  [conn ^TaskScheduler scheduler offers job-ids]
   (let [db (d/db conn)
         jobs (->> job-ids
                   (map #(d/entity db %))
@@ -192,8 +192,8 @@
         tasks (map #(sched/make-task-request db %1 nil :task-id %2 :guuid->considerable-cotask-ids guuid->considerable-cotask-ids
                                              :running-cotask-cache cache)
                    jobs task-ids)
-        result (-> scheduler
-                   (.scheduleOnce tasks offers))
+        ^SchedulingResult result (-> scheduler
+                                     (.scheduleOnce tasks offers))
         tasks-assigned (some->> result
                                 .getResultMap
                                 vals


### PR DESCRIPTION
## Changes proposed in this PR

- Update Cook to support JDK-11

## Why are we making these changes?
- JDK8 is EOL

