### PR TITLE
Fix default image selection logging

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -582,7 +582,7 @@
     (throw (ex-info "The uid is unavailable for the user" {:job-id id :user user}))))
 
 (defn- build-docker-container
-  [user id container {:keys [uuid]} pool-name]
+  [user id container {:keys [uuid name]} pool-name]
   (let [container-id (d/tempid :db.part/user)
         docker-id (d/tempid :db.part/user)
         volumes (or (:volumes container) [])


### PR DESCRIPTION
## Changes proposed in this PR

- log job's name instead of the name clojure function
- edit test_default_container_for_pool test to allow for incrementally configured default image

## Why are we making these changes?

The default image selection logging payload is not the job name, it is the clojure function "name" and it crashes if we attempt to log
