### PR TITLE
Update to clojure 1.10

### DIFF
--- a/scheduler/bin/start-datomic.sh
+++ b/scheduler/bin/start-datomic.sh
@@ -3,7 +3,7 @@
 set -euf -o pipefail
 
 PROJECT_DIR="$(dirname $0)/.."
-DATOMIC_VERSION="0.9.5394"
+DATOMIC_VERSION="0.9.5561.56"
 DATOMIC_DIR="${PROJECT_DIR}/datomic/datomic-free-${DATOMIC_VERSION}"
 
 if [ ! -d "${DATOMIC_DIR}" ];

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -16,7 +16,7 @@
 (defproject cook "1.55.3-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
 
                  ;;Data marshalling
                  [org.clojure/data.codec "0.1.0"]
@@ -119,6 +119,7 @@
                   :exclusions [org.slf4j/slf4j-log4j12
                                org.slf4j/log4j
                                log4j]]
+                 ; Used when doing local testing in open source to setup mock curator.
                  [org.apache.curator/curator-test "2.7.1"
                  :exclusions [io.netty/netty
                               io.netty/netty-transport-native-epoll]]
@@ -130,9 +131,11 @@
                  [io.kubernetes/client-java "11.0.0"]
                  [com.google.auth/google-auth-library-oauth2-http "0.16.2"]
 
+
                  ;Version forcing by JDK11 upgrade.
                  [org.flatland/ordered "1.5.9"] ; Upgraded from 1.5.3, brought in by clj-yaml.
                  [jakarta.xml.ws/jakarta.xml.ws-api "2.3.3"] ; Needed via liberator, No longer in JDK11.
+                 [com.taoensso/encore "3.19.0"] ; Used by ring-congestion. 
                  ]
 
   :repositories {"maven2" {:url "https://files.couchbase.com/maven2/"}
@@ -165,7 +168,7 @@
                    ; library instead of the datomic-free library, by
                    ; using a profiles.clj file that defines a profile
                    ; which pulls in datomic-pro
-                   [com.datomic/datomic-free "0.9.5206"
+                   [com.datomic/datomic-free "0.9.5206" ; Note that updating this causes activeMQ errors. Suspect related to OpenSSL.
                     :exclusions [io.netty/netty
                                  com.fasterxml.jackson.core/jackson-core
                                  joda-time
@@ -181,7 +184,7 @@
 
    :uberjar
    {:aot [cook.components]
-    :dependencies [[com.datomic/datomic-free "0.9.5206"
+    :dependencies [[com.datomic/datomic-free "0.9.5206" ; Note that updating this causes activeMQ errors. Suspect related to OpenSSL.
                     :exclusions [com.fasterxml.jackson.core/jackson-core
                                  joda-time
                                  org.slf4j/jcl-over-slf4j

--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -721,8 +721,8 @@
                   :state-locked? true
                   :template "template1"
                   :location "us-east1"
-                  :features [{:key "foo" :value "bar"}
-                             {:key "baz" :value "qux"}]}
+                  :features (list {:key "baz" :value "qux"}
+                                  {:key "foo" :value "bar"})}
                  (-> (get-db-config-ents (d/db conn))
                      (get "name")
                      compute-cluster-config-ent->compute-cluster-config)))


### PR DESCRIPTION
## Changes proposed in this PR

- Update Cook to Clojure 1.10
- Ensure that unit and integration tests pass.

## Why are we making these changes?
This enables us to use next.jdbc JDBC library.

