### PR TITLE
add incremental image config support for aux containers

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2943,6 +2943,7 @@ class CookTest(util.CookTest):
     @unittest.skipUnless(util.using_kubernetes() and util.in_cloud(), 'Test requires kubernetes')
     def test_kubernetes_checkpointing(self):
         docker_image = util.docker_image()
+
         container = {'type': 'docker',
                      'docker': {'image': docker_image}}
         try:

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2941,7 +2941,6 @@ class CookTest(util.CookTest):
             util.kill_jobs(self.cook_url, [job_uuid1, job_uuid2])
 
     @unittest.skipUnless(util.using_kubernetes() and util.in_cloud(), 'Test requires kubernetes')
-    @pytest.mark.xfail  # Temporarily disable because of infrastructure issue. TODO: this should not exist past 20210312
     def test_kubernetes_checkpointing(self):
         docker_image = util.docker_image()
         container = {'type': 'docker',

--- a/scheduler/src/cook/config_incremental.clj
+++ b/scheduler/src/cook/config_incremental.clj
@@ -100,7 +100,14 @@
 
 (defn resolve-incremental-config
   "Resolve an incremental config to the appropriate value.
-  With an overload that takes a fallback config to use in case the incremental config cannot be resolved."
+  With an overload that takes a fallback config to use in case the incremental config cannot be resolved.
+  If the incremental config cannot be resolved and there is no fallback then nil is returned and it is up to the caller
+  to handle appropriately.
+
+  An incremental configuration can either be a collection of incremental values or a keyword.
+  If it is a keyword, then it is used as a key to look up a collection of incremental values in the database.
+  An collection of incremental values is resolved by picking one of the values using the job uuid hash. Each incremental
+  value has an associated portion and the portions must add up to 1.0"
   ([^UUID uuid incremental-config]
    (cond
      (coll? incremental-config)

--- a/scheduler/src/cook/config_incremental.clj
+++ b/scheduler/src/cook/config_incremental.clj
@@ -99,10 +99,18 @@
   (select-config-from-values uuid (read-config config-key)))
 
 (defn resolve-incremental-config
-  "Resolve an incremental config to the appropriate value."
-  [^UUID uuid incremental-config]
-  (cond
-    (coll? incremental-config)
-    (select-config-from-values uuid incremental-config)
-    (keyword? incremental-config)
-    (select-config-from-key uuid incremental-config)))
+  "Resolve an incremental config to the appropriate value.
+  With an overload that takes a fallback config to use in case the incremental config cannot be resolved."
+  ([^UUID uuid incremental-config]
+   (cond
+     (coll? incremental-config)
+     (select-config-from-values uuid incremental-config)
+     (keyword? incremental-config)
+     (select-config-from-key uuid incremental-config)))
+  ([^UUID uuid incremental-config fallback-config]
+   (let [resolved-incremental-config (resolve-incremental-config uuid incremental-config)]
+     (if resolved-incremental-config
+       [resolved-incremental-config :resolved-incremental-config]
+       ; use a fallback config in case there is a problem resolving an incremental config
+       [fallback-config :used-fallback-config]))))
+

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1156,7 +1156,7 @@
 (defn resolve-image-from-incremental-config
   "Helper method to resolve a container's image from an incremental configuration"
   [job passport-event-base passport-event-type image-config image-fallback]
-  (let [job-uuid (:uuid job)]
+  (let [job-uuid (:job/uuid job)]
     (if (string? image-config)
       image-config
       (let [[resolved-config reason] (config-incremental/resolve-incremental-config job-uuid image-config image-fallback)]
@@ -1367,7 +1367,7 @@
                                 :main-container-checkpoint-volume-mounts main-container-checkpoint-volume-mounts
                                 :main-env-vars main-env-vars
                                 :passport-event-base {:job-name job-name
-                                                      :job-uuid (str (:uuid job))
+                                                      :job-uuid (str (:job/uuid job))
                                                       :pool pool-name
                                                       :user user}
                                 :pod-name pod-name

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -7,6 +7,7 @@
             [clojure.walk :as walk]
             [cook.cached-queries :as cached-queries]
             [cook.config :as config]
+            [cook.config-incremental :as config-incremental]
             [cook.kubernetes.metrics :as metrics]
             [cook.passport :as passport]
             [cook.regexp-tools :as regexp-tools]
@@ -1152,11 +1153,26 @@
 
     (.addContainersItem pod-spec container)))
 
+(defn resolve-image-from-incremental-config
+  "Helper method to resolve a container's image from an incremental configuration"
+  [job passport-event-base passport-event-type image-config image-fallback]
+  (let [job-uuid (:uuid job)]
+    (if (string? image-config)
+      image-config
+      (let [[resolved-config reason] (config-incremental/resolve-incremental-config job-uuid image-config image-fallback)]
+        (passport/log-event (merge passport-event-base
+                                   {:event-type passport-event-type
+                                    :image-config image-config
+                                    :reason reason
+                                    :resolved-config resolved-config}))
+        resolved-config))))
+
 (defn add-cook-init-to-pod
   "Create Cook init container and add it to the pod"
   [{:keys [computed-mem cpus init-container init-container-checkpoint-volume-mounts init-container-workdir
-           init-container-workdir-volume-mount-fn main-env-vars ^V1PodSpec pod-spec scratch-space-volume-mount-fn sidecar use-cook-sidecar?]}]
-  (when-let [{:keys [command image]} init-container]
+           init-container-workdir-volume-mount-fn main-env-vars ^V1PodSpec pod-spec scratch-space-volume-mount-fn
+           sidecar use-cook-sidecar? job passport-event-base]}]
+  (when-let [{:keys [command image image-fallback]} init-container]
     (let [container (V1Container.)
           get-resource-requirements-fn (fn [fieldname] (if use-cook-sidecar?
                                                          (get-in sidecar [:resource-requirements fieldname])
@@ -1168,7 +1184,9 @@
           resources (V1ResourceRequirements.)]
       ; container
       (.setName container cook-init-container-name)
-      (.setImage container image)
+      (.setImage container (resolve-image-from-incremental-config
+                             job passport-event-base passport/init-container-image-selected
+                             image image-fallback))
       (.setCommand container command)
       (.setWorkingDir container init-container-workdir)
       (.setEnv container main-env-vars)
@@ -1181,14 +1199,17 @@
 
 (defn add-cook-sidecar-to-pod
   "Create Cook Sidecar container and add it to the pod"
-  [{:keys [main-env-vars ^V1PodSpec pod-spec sidecar sandbox-dir sandbox-volume-mount-fn scratch-space-volume-mount-fn sidecar-workdir sidecar-workdir-volume-mount-fn]}]
-  (when-let [{:keys [command health-check-endpoint image port resource-requirements]} sidecar]
+  [{:keys [main-env-vars ^V1PodSpec pod-spec sidecar sandbox-dir sandbox-volume-mount-fn scratch-space-volume-mount-fn
+           sidecar-workdir sidecar-workdir-volume-mount-fn job passport-event-base]}]
+  (when-let [{:keys [command health-check-endpoint image image-fallback port resource-requirements]} sidecar]
     (let [{:keys [cpu-request cpu-limit memory-request memory-limit]} resource-requirements
           container (V1Container.)
           resources (V1ResourceRequirements.)]
       ; container
       (.setName container cook-container-name-for-file-server)
-      (.setImage container image)
+      (.setImage container (resolve-image-from-incremental-config
+                             job passport-event-base passport/sidecar-image-selected
+                             image image-fallback))
       (.setCommand container (conj command (str port)))
       (.setWorkingDir container sidecar-workdir)
       (.setPorts container [(.containerPort (V1ContainerPort.) (int port))])
@@ -1342,8 +1363,13 @@
                                 :init-container-checkpoint-volume-mounts init-container-checkpoint-volume-mounts
                                 :init-container-workdir init-container-workdir
                                 :init-container-workdir-volume-mount-fn init-container-workdir-volume-mount-fn
+                                :job job
                                 :main-container-checkpoint-volume-mounts main-container-checkpoint-volume-mounts
                                 :main-env-vars main-env-vars
+                                :passport-event-base {:job-name job-name
+                                                      :job-uuid (str (:uuid job))
+                                                      :pool pool-name
+                                                      :user user}
                                 :pod-name pod-name
                                 :pod-spec pod-spec
                                 :pool-name pool-name

--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -29,10 +29,12 @@
                                                      :event-type (str "cook-scheduler/" (name event-type)))))))
 
 (def default-image-selected :default-image-selected)
+(def init-container-image-selected :init-container-image-selected)
 (def job-created :job-created)
 (def job-submitted :job-submitted)
 (def pod-completed :pod-completed)
 (def pod-submission-succeeded :pod-submission-succeeded)
+(def sidecar-image-selected :sidecar-image-selected)
 (def synthetic-pod-submission-succeeded :synthetic-pod-submission-succeeded)
 (def pod-submission-failed :pod-submission-failed)
 (def synthetic-pod-submission-failed :synthetic-pod-submission-failed)

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -593,11 +593,7 @@
         image-config (:image docker)
         image (if (string? image-config)
                 image-config
-                (let [incremental-image-config (config-incremental/resolve-incremental-config uuid image-config)
-                      [resolved-config reason] (if incremental-image-config
-                                                 [incremental-image-config :resolved-incremental-config]
-                                                 ; use a fallback image in case there is a problem resolving an incremental config
-                                                 [(:image-fallback docker) :used-image-fallback])]
+                (let [[resolved-config reason] (config-incremental/resolve-incremental-config uuid image-config (:image-fallback docker))]
                   (passport/log-event {:event-type passport/default-image-selected
                                        :image-config image-config
                                        :job-name name

--- a/scheduler/test/cook/test/config_incremental.clj
+++ b/scheduler/test/cook/test/config_incremental.clj
@@ -46,7 +46,10 @@
       (testing "static or dynamic config"
         (is (= "value a" (resolve-incremental-config uuid-a key)))
         (is (= "value a" (resolve-incremental-config uuid-a values)))
-        (is (= nil (resolve-incremental-config uuid-a "other value"))))
+        (is (= nil (resolve-incremental-config uuid-a "other value")))
+        (is (= ["value a" :resolved-incremental-config] (resolve-incremental-config uuid-a key "fallback")))
+        (is (= ["value a" :resolved-incremental-config] (resolve-incremental-config uuid-a values "fallback")))
+        (is (= ["fallback" :used-fallback-config] (resolve-incremental-config uuid-a "other value" "fallback"))))
       (testing "statistical distribution"
         (let [get-distribution (fn get-distribution
                                  [rand bytes key]

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -1193,7 +1193,7 @@
                (api/list-pods nil "test-compute-cluster" 1)))))))
 
 (deftest test-resolve-image-from-incremental-config
-  (let [job {:uuid (java.util.UUID/fromString "41062821-b248-4375-82f8-a8256643c94e")}
+  (let [job {:job/uuid (java.util.UUID/fromString "41062821-b248-4375-82f8-a8256643c94e")}
         image-config [{:value "my-image" :portion 1.0}]
         image-fallback "fallback-image"]
     (is (= "my-image" (api/resolve-image-from-incremental-config job nil nil image-config image-fallback)))

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -1191,3 +1191,10 @@
                         "bar" {:continue "" :pods [pod-3] :resource-version "something"}))]
         (is (= {:pods pods :resource-version "something"}
                (api/list-pods nil "test-compute-cluster" 1)))))))
+
+(deftest test-resolve-image-from-incremental-config
+  (let [job {:uuid (java.util.UUID/fromString "41062821-b248-4375-82f8-a8256643c94e")}
+        image-config [{:value "my-image" :portion 1.0}]
+        image-fallback "fallback-image"]
+    (is (= "my-image" (api/resolve-image-from-incremental-config job nil nil image-config image-fallback)))
+    (is (= "fallback-image" (api/resolve-image-from-incremental-config job nil nil nil image-fallback)))))


### PR DESCRIPTION
## Changes proposed in this PR

- add incremental image config support for aux containers

## Why are we making these changes?

We want the auxiliary containers for the job pod to support incremental image configurations. This will allow us to incrementally test new functionality.
