### PR TITLE
Fix metrics no longer beling logged with jdk11 update

### DIFF
--- a/scheduler/docs/configuration.adoc
+++ b/scheduler/docs/configuration.adoc
@@ -515,22 +515,6 @@ Internally, Cook uses Dropwizard Metrics 3, so we can easily add support for any
 JMX Metrics::
   To enable JMX metrics, set the `:metrics` key to `{:jmx true}`.
 
-Riemann Metrics::
-  To enable Riemann metrics, you'll need to populate the `:riemann` map.
-  Riemann allows you to customize the "local host" reported to the Riemann server, the prefix attached to all events, and the tags added to all events.
-  Cook automatically sends metrics every 30 seconds with a TTL of 60 seconds, to simplify failure detection with Riemann.
-  Here's a example of enabling Riemann metrics:
-+
-[source,edn]
-----
-:metrics {:riemann {:host "my-riemann-server.example.com"
-                    :port 5555 ; optional, default 5555
-                    :tags ["cook", "infrastructure"] ; defaults to no tags
-                    :local-host "alt-host-name.example.com" ; optional, defaults to local host's name
-                    :prefix "cook " ; optional, default nothing
-                   }}
-----
-
 Graphite Metrics::
   To enable Graphite metrics, you'll need to populate the `:graphite` map.
   We support setting a prefix on all metrics, choosing which graphite server to connect to, and whether to use the plain-text or pickled transport format.

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -92,10 +92,6 @@
                                                             org.clojure/clojure io.netty/netty]]
                  [metrics-clojure-jvm "2.6.1"]
                  [io.dropwizard.metrics/metrics-graphite "3.1.2"]
-                 [com.aphyr/metrics3-riemann-reporter "0.4.0"
-                  :exclusions [io.netty/netty
-                               com.google.protobuf/protobuf-java
-                               com.amazonaws/aws-java-sdk]] ; Brings in a lot of dependencies
 
                  ;;External system integrations
                  [org.clojure/tools.nrepl "0.2.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -85,14 +85,27 @@
                  ;[io.netty/netty-transport-native-unix-common "4.1.63.Final" :classifier "linux-x86_64"]
                  [io.netty/netty "3.10.1.Final"]
 
+
                  ;;Metrics
-                 [metrics-clojure "2.6.1"
+
+                 ; Metrics-clojure-jvm 2.10.0 depends on io.dropwizard.metrics 3.x, but
+                 ; io.dropwizard.metrics/metrics-jvm 3.x is broken on JDK > 8 because it makes an illegal access.
+                 ; metrics-clojure-jvm has had a fix for this -- updated dependencies -- since 2019 (in the unreleased 3.x)
+                 ; So we bring in 2.10.0 but force a later version of io.dropwizard.
+
+                 [io.dropwizard.metrics/metrics-graphite "4.1.21"]
+                 [io.dropwizard.metrics/metrics-core "4.1.21"]
+                 [io.dropwizard.metrics/metrics-jvm "4.1.21"]
+                 [io.dropwizard.metrics/metrics-jmx "4.1.21"]
+                 [metrics-clojure "2.10.0"
                   :exclusions [io.netty/netty org.clojure/clojure]]
+                 ; We want to include jvm metrics, but can't. Between dropwizard 3.x and 4.x, JvmAttributeGaugeSet moved
+                 ; packages metrics-clojure-jvm 3.x has the new location, but isn't released. So keep this disabled for now.
+                 ;[metrics-clojure-jvm "2.10.0"]; :exclusions [io.dropwizard.metrics/metrics-jvm]]
+                 [metrics-clojure-graphite "2.10.0"]
+
                  [metrics-clojure-ring "2.3.0" :exclusions [com.codahale.metrics/metrics-core
                                                             org.clojure/clojure io.netty/netty]]
-                 [metrics-clojure-jvm "2.6.1"]
-                 [io.dropwizard.metrics/metrics-graphite "3.1.2"]
-
                  ;;External system integrations
                  [org.clojure/tools.nrepl "0.2.3"]
 

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -48,6 +48,7 @@
             [cook.rest.impersonation :refer [impersonation-authorized-wrapper]]
             [cook.util :as util]
             [datomic.api :as d]
+            [fork.metrics-clojure.metrics.jvm.core :as metrics-jvm]
             [metrics.ring.instrument :refer [instrument]]
             [mount.core :as mount]
             [plumbing.core :refer [fnk]]
@@ -346,6 +347,7 @@
     ; dependency tree of anything using mount. See also issue #1370
     (mount/start-with-args (cook.config/read-config config-file-path))
     (pool/guard-invalid-default-pool (d/db datomic/conn))
+    (metrics-jvm/instrument-jvm)
     (let [server (scheduler-server config)]
       (intern 'user 'main-graph server)
       (log/info "Started Cook, stored variable in user/main-graph"))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -48,7 +48,6 @@
             [cook.rest.impersonation :refer [impersonation-authorized-wrapper]]
             [cook.util :as util]
             [datomic.api :as d]
-            [metrics.jvm.core :as metrics-jvm]
             [metrics.ring.instrument :refer [instrument]]
             [mount.core :as mount]
             [plumbing.core :refer [fnk]]
@@ -347,7 +346,6 @@
     ; dependency tree of anything using mount. See also issue #1370
     (mount/start-with-args (cook.config/read-config config-file-path))
     (pool/guard-invalid-default-pool (d/db datomic/conn))
-    (metrics-jvm/instrument-jvm)
     (let [server (scheduler-server config)]
       (intern 'user 'main-graph server)
       (log/info "Started Cook, stored variable in user/main-graph"))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -409,19 +409,6 @@
                          :publish-interval-ms 2500
                          :sequence-cache-threshold 1000}
                         progress))
-     :riemann (fnk [[:config [:metrics {riemann nil}]]]
-                riemann)
-     :riemann-metrics (fnk [[:config [:metrics {riemann nil}]]]
-                        (when riemann
-                          (when-not (:host riemann)
-                            (throw (ex-info "You must specific the :host to send the riemann metrics to!" {:riemann riemann})))
-                          (when-not (every? string? (:tags riemann))
-                            (throw (ex-info "Riemann tags must be a [\"list\", \"of\", \"strings\"]" riemann)))
-                          (let [config (merge {:port 5555
-                                               :local-host (.getHostName
-                                                             (InetAddress/getLocalHost))}
-                                              riemann)]
-                            ((util/lazy-load-var 'cook.reporter/riemann-reporter) config))))
      :console-metrics (fnk [[:config [:metrics {console false}]]]
                         (when console
                           ((util/lazy-load-var 'cook.reporter/console-reporter))))

--- a/scheduler/src/cook/reporter.clj
+++ b/scheduler/src/cook/reporter.clj
@@ -18,10 +18,8 @@
             [datomic.api :refer [q]]
             [metatransaction.core :refer [db]]
             [metrics.core :as metrics])
-  (:import (com.aphyr.riemann.client RiemannClient)
-           (com.codahale.metrics ConsoleReporter MetricFilter)
+  (:import (com.codahale.metrics ConsoleReporter MetricFilter)
            (com.codahale.metrics.graphite Graphite GraphiteReporter PickledGraphite)
-           (com.codahale.metrics.riemann Riemann RiemannReporter)
            (java.net InetSocketAddress)
            (java.util.concurrent TimeUnit)))
 
@@ -46,30 +44,6 @@
               (convertRatesTo TimeUnit/SECONDS)
               (convertDurationsTo TimeUnit/MILLISECONDS)
               (build graphite))
-      (.start 30 TimeUnit/SECONDS))))
-
-(defn riemann-reporter
-  [{:keys [host port tags prefix mode local-host] :or {tags [] mode :tcp} :as cfg}]
-  (when (= mode :udp)
-    (throw (ex-info "You shouldn't use UDP mode Riemann! Almost every user finds it annoying when, without TCP backpressure, they start losing critical metrics during failure events." {})))
-  (let [addr (InetSocketAddress. host port)
-        riemann-client (case mode
-                         :tcp (RiemannClient/tcp host port)
-                         :udp (RiemannClient/udp addr)
-                         (throw (ex-info "Mode must be :tcp or :udp" cfg)))]
-    (try
-      (.connect riemann-client)
-      (catch Exception e
-        (log/warn e "Couldn't immediately connect to riemann. It will try to reconnect but for now no metrics are being sent.")))
-    (doto (.. (RiemannReporter/forRegistry metrics/default-registry)
-              (localHost local-host)
-              (prefixedWith prefix)
-              (filter MetricFilter/ALL)
-              (convertRatesTo TimeUnit/SECONDS)
-              (convertDurationsTo TimeUnit/MILLISECONDS)
-              (withTtl (float 60))
-              (tags tags)
-              (build (Riemann. riemann-client)))
       (.start 30 TimeUnit/SECONDS))))
 
 (defn console-reporter

--- a/scheduler/src/cook/reporter.clj
+++ b/scheduler/src/cook/reporter.clj
@@ -28,7 +28,7 @@
 
 (defn jmx-reporter
   []
-  (.. (com.codahale.metrics.JmxReporter/forRegistry metrics/default-registry)
+  (.. (com.codahale.metrics.jmx.JmxReporter/forRegistry metrics/default-registry)
       (build)
       (start)))
 

--- a/scheduler/src/fork/metrics_clojure/LICENSE.markdown
+++ b/scheduler/src/fork/metrics_clojure/LICENSE.markdown
@@ -1,0 +1,22 @@
+MIT/X11 License
+===============
+
+Copyright (c) 2011-2017 Steve Losh and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/scheduler/src/fork/metrics_clojure/README.txt
+++ b/scheduler/src/fork/metrics_clojure/README.txt
@@ -1,0 +1,4 @@
+This code is copied from https://github.com/metrics-clojure/metrics-clojure
+and git hash a1dbacc748a1f8165f0094e2229c84f228efe29b
+
+We need the unreleased 3.0.0x branch for support for >JDK8. We modified the file's package name.

--- a/scheduler/src/fork/metrics_clojure/metrics/jvm/core.clj
+++ b/scheduler/src/fork/metrics_clojure/metrics/jvm/core.clj
@@ -1,0 +1,46 @@
+(ns fork.metrics-clojure.metrics.jvm.core
+  (:import (com.codahale.metrics MetricRegistry)
+           (com.codahale.metrics.jvm ThreadStatesGaugeSet GarbageCollectorMetricSet FileDescriptorRatioGauge
+                                     MemoryUsageGaugeSet  JvmAttributeGaugeSet))
+  (:require [metrics.core :refer [add-metric default-registry]]))
+
+(defn register-jvm-attribute-gauge-set
+  ([^MetricRegistry reg]
+   (register-jvm-attribute-gauge-set reg ["jvm" "attribute"]))
+  ([^MetricRegistry reg title]
+   (add-metric reg title (new JvmAttributeGaugeSet))))
+
+(defn register-memory-usage-gauge-set
+  ([^MetricRegistry reg]
+   (register-memory-usage-gauge-set reg ["jvm" "memory"]))
+  ([^MetricRegistry reg title]
+   (add-metric reg title (new MemoryUsageGaugeSet))))
+
+(defn register-file-descriptor-ratio-gauge-set
+  ([^MetricRegistry reg]
+   (register-file-descriptor-ratio-gauge-set reg ["jvm" "file"]))
+  ([^MetricRegistry reg title]
+   (add-metric reg title (new FileDescriptorRatioGauge))))
+
+(defn register-garbage-collector-metric-set
+  ([^MetricRegistry reg]
+   (register-garbage-collector-metric-set reg ["jvm" "gc"]))
+  ([^MetricRegistry reg title]
+   (add-metric reg title (new GarbageCollectorMetricSet))))
+
+(defn register-thread-state-gauge-set
+  ([^MetricRegistry reg]
+   (register-thread-state-gauge-set reg ["jvm" "thread"]))
+  ([^MetricRegistry reg title]
+   (add-metric reg title (new ThreadStatesGaugeSet))))
+
+(defn instrument-jvm
+  ([]
+   (instrument-jvm default-registry))
+  ([^MetricRegistry reg]
+   (doseq [register-metric-set [register-jvm-attribute-gauge-set
+                                register-memory-usage-gauge-set
+                                register-file-descriptor-ratio-gauge-set
+                                register-garbage-collector-metric-set
+                                register-thread-state-gauge-set]]
+     (register-metric-set reg))))


### PR DESCRIPTION
## Changes proposed in this PR

- Remove support for Riemann metrics
- Update to newer version of dropwizard metrics that support >JDK8
- Import unreleased metrics-clojure that has changes needed to support later version of dropwizard.

## Why are we making these changes?
This makes metrics work with JDK11. Previously, they were failing because of JVM modularity rules. We needed to update dropwizard metrics, but have to deal with the non-updated metrics-clojure. (There is a class rename in io.dropwizard that causes them to fail.)

