### PR TITLE
make progress file compatible with checkpointing

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1311,7 +1311,7 @@
                      ;; Add a default progress file path to the environment when missing,
                      ;; preserving compatibility with Meosos + Cook Executor.
                      (not progress-file-path)
-                     (assoc progress-file-var (str workdir "/" task-id ".progress"))
+                     (assoc progress-file-var (str workdir "/" (str (:job/uuid job)) ".progress"))
 
                      mem
                      (assoc "COOK_USER_MEMORY_REQUEST_BYTES" (* memory-multiplier mem))

--- a/sidecar/cook/sidecar/config.py
+++ b/sidecar/cook/sidecar/config.py
@@ -67,6 +67,9 @@ def initialize_config(environment):
     instance_id = environment.get('COOK_INSTANCE_UUID')
     if instance_id is None:
         raise Exception('Task unknown! COOK_INSTANCE_UUID not set in environment.')
+    job_uuid = environment.get('COOK_JOB_UUID')
+    if job_uuid is None:
+        raise Exception('Job unknown! job_uuid not set in environment.')
 
     cook_scheduler_rest_url = environment.get('COOK_SCHEDULER_REST_URL')
     if cook_scheduler_rest_url is None:
@@ -83,7 +86,7 @@ def initialize_config(environment):
     if progress_output_env_variable not in environment:
         logging.info(f'No entry found for {progress_output_env_variable} in the environment')
 
-    default_progress_output_name = environment.get(progress_output_env_variable, f'{instance_id}.progress')
+    default_progress_output_name = environment.get(progress_output_env_variable, f'{job_uuid}.progress')
     if sandbox_directory:
         default_progress_output_file = os.path.join(sandbox_directory, default_progress_output_name)
     else:


### PR DESCRIPTION
## Changes proposed in this PR

- don't use instance uuid in progress file name

## Why are we making these changes?

When we use instance uuid in progress file name we make it fail when a job is checkpointed and restored because the instance uuid changes.