### PR TITLE
Revert "Update Cook to run on JDK-11 (#1937)"

### DIFF
--- a/.github/workflows/executor-tests.yml
+++ b/.github/workflows/executor-tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-16.04
     env:
       PYTEST_ADDOPTS: --color=yes
       MESOS_NATIVE_JAVA_LIBRARY: /usr/lib/libmesos.so
@@ -22,10 +22,10 @@ jobs:
       GDRIVE_LOG_POST_URL: https://script.google.com/macros/s/AKfycbxOB55OzrQSbpZO_0gzsxZaJ8LaUWWo3PDLNc-gCiMN1iObxu7x/exec
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-16.04
     env:
       PYTEST_ADDOPTS: --color=yes
       MESOS_NATIVE_JAVA_LIBRARY: /usr/lib/libmesos.so
@@ -22,10 +22,10 @@ jobs:
       GDRIVE_LOG_POST_URL: https://script.google.com/macros/s/AKfycbxOB55OzrQSbpZO_0gzsxZaJ8LaUWWo3PDLNc-gCiMN1iObxu7x/exec
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '8'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
@@ -48,7 +48,7 @@ jobs:
           ./cli/travis/setup.sh
           cd scheduler && ./travis/setup.sh
       - name: JobClient Java unit tests
-        run: cd ./jobclient/java && mvn test -X 
+        run: cd ./jobclient/java && mvn test 
       - name: JobClient Python unit tests
         run: cd ./jobclient/python && python -m pytest
       - name: CLI unit tests

--- a/jobclient/java/pom.xml
+++ b/jobclient/java/pom.xml
@@ -12,7 +12,7 @@
     </license>
   </licenses>
   <properties>
-      <jmockit.version>1.41</jmockit.version>  <!-- 1.42 is broken and fails to run. -->
+      <jmockit.version>1.18</jmockit.version>
   </properties>
   <build>
       <directory>target</directory>
@@ -49,7 +49,7 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.22.1</version>
+              <version>2.20.1</version>
               <configuration>
                   <argLine>-javaagent:${env.HOME}/.m2/repository/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
               </configuration>

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -8,14 +8,14 @@ RUN rm /etc/apt/sources.list.d/docker.list && \
     add-apt-repository ppa:openjdk-r/ppa && apt-get -y update && \
     apt-get --no-install-recommends -y install \
     curl \
-    openjdk-11-jdk \
+    openjdk-8-jdk \
     unzip && apt-get clean && rm -Rf /var/lib/apt/lists/*
 
 # Env setup
 ENV HOME "/root/"
 ENV LEIN_ROOT true
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
-ENV JAVA_CMD=/usr/lib/jvm/java-11-openjdk-amd64/bin/java
+ENV JAVA_CMD=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
 
 # Generate SSL certificate
 RUN mkdir /opt/ssl

--- a/scheduler/bin/bootstrap
+++ b/scheduler/bin/bootstrap
@@ -26,7 +26,7 @@ apt-get clean
 rm -Rf /var/lib/apt/lists/*
 
 # Java setup
-export JAVA_CMD=/usr/lib/jvm/java-11-openjdk-amd64/bin/java
+export JAVA_CMD=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
 echo 'export JAVA_CMD='$JAVA_CMD | tee -a $bashrc
 
 # Lein setup (https://leiningen.org/#install)

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -99,12 +99,6 @@
 
                  [metrics-clojure-ring "2.3.0" :exclusions [com.codahale.metrics/metrics-core
                                                             org.clojure/clojure io.netty/netty]]
-                 [metrics-clojure-jvm "2.6.1"]
-                 [io.dropwizard.metrics/metrics-graphite "3.1.2"]
-                 [com.aphyr/metrics3-riemann-reporter "0.4.0"
-                  :exclusions [com.google.protobuf/protobuf-java
-                               com.amazonaws/aws-java-sdk]] ; Brings in a lot of dependencies
-
                  ;;External system integrations
                  [org.clojure/tools.nrepl "0.2.3"]
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -23,6 +23,7 @@
                  ^:displace [cheshire "5.3.1"]
                  [byte-streams "0.1.4"]
                  [org.clojure/data.json "0.2.2"]
+                 [circleci/clj-yaml "0.5.5"]
                  [camel-snake-kebab "0.4.0"]
                  [com.rpl/specter "1.0.1"]
 
@@ -67,6 +68,7 @@
 
                  ;;Networking
                  [twosigma/clj-http "2.0.0-ts1"]
+                 [io.netty/netty "3.10.1.Final"]
                  [cc.qbits/jet "0.6.4" :exclusions [org.eclipse.jetty/jetty-io
                                                     org.eclipse.jetty/jetty-security
                                                     org.eclipse.jetty/jetty-server
@@ -75,15 +77,6 @@
                  [org.eclipse.jetty/jetty-server "9.2.6.v20141205"]
                  [org.eclipse.jetty/jetty-security "9.2.6.v20141205"]
 
-                 ; TODO: Upgrade netty.
-                 ; Bring in netty. Note that this is brought in in a lot of other places, Exclude it whenever finding another one.
-                 ; Need to make sure all imports are importing the same version.
-                 ;[io.netty/netty-handler "4.1.63.Final"]
-                 ; Netty now uses epoll with a native library. We need to tell lein our architecture so it can bring in the
-                 ; right library architecture. Make sure this version matches.
-                 ;[io.netty/netty-transport-native-epoll "4.1.63.Final" :classifier "linux-x86_64"]
-                 ;[io.netty/netty-transport-native-unix-common "4.1.63.Final" :classifier "linux-x86_64"]
-                 [io.netty/netty "3.10.1.Final"]
 
 
                  ;;Metrics
@@ -106,6 +99,12 @@
 
                  [metrics-clojure-ring "2.3.0" :exclusions [com.codahale.metrics/metrics-core
                                                             org.clojure/clojure io.netty/netty]]
+                 [metrics-clojure-jvm "2.6.1"]
+                 [io.dropwizard.metrics/metrics-graphite "3.1.2"]
+                 [com.aphyr/metrics3-riemann-reporter "0.4.0"
+                  :exclusions [com.google.protobuf/protobuf-java
+                               com.amazonaws/aws-java-sdk]] ; Brings in a lot of dependencies
+
                  ;;External system integrations
                  [org.clojure/tools.nrepl "0.2.3"]
 
@@ -121,28 +120,20 @@
                  [liberator "0.15.0"]
 
                  ;;Databases
-                 ;; TODO: Should upgrade curator to avoid illegal reflective access warnings. (5.2.0 is latest)
                  [org.apache.curator/curator-framework "2.7.1"
                   :exclusions [io.netty/netty]]
                  [org.apache.curator/curator-recipes "2.7.1"
                   :exclusions [org.slf4j/slf4j-log4j12
                                org.slf4j/log4j
                                log4j]]
-                 [org.apache.curator/curator-test "2.7.1"
-                 :exclusions [io.netty/netty
-                              io.netty/netty-transport-native-epoll]]
+                 [org.apache.curator/curator-test "2.7.1"]
 
                  ;; Dependency management
                  [mount "0.1.12"]
 
                  ;; Kubernetes
                  [io.kubernetes/client-java "11.0.0"]
-                 [com.google.auth/google-auth-library-oauth2-http "0.16.2"]
-
-                 ;Version forcing by JDK11 upgrade.
-                 [org.flatland/ordered "1.5.9"] ; Upgraded from 1.5.3, brought in by clj-yaml.
-                 [jakarta.xml.ws/jakarta.xml.ws-api "2.3.3"] ; Needed via liberator, No longer in JDK11.
-                 ]
+                 [com.google.auth/google-auth-library-oauth2-http "0.16.2"]]
 
   :repositories {"maven2" {:url "https://files.couchbase.com/maven2/"}
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
@@ -175,8 +166,7 @@
                    ; using a profiles.clj file that defines a profile
                    ; which pulls in datomic-pro
                    [com.datomic/datomic-free "0.9.5206"
-                    :exclusions [io.netty/netty
-                                 com.fasterxml.jackson.core/jackson-core
+                    :exclusions [com.fasterxml.jackson.core/jackson-core
                                  joda-time
                                  org.slf4j/jcl-over-slf4j
                                  org.slf4j/jul-to-slf4j
@@ -218,7 +208,7 @@
    :test
    {:dependencies [[criterium "0.4.4"]
                    [org.clojure/test.check "0.6.1"]
-                   [org.mockito/mockito-core "3.12.4"]
+                   [org.mockito/mockito-core "1.10.19"]
                    [twosigma/cook-jobclient "0.8.6-SNAPSHOT"]]}
 
    :test-console
@@ -245,9 +235,11 @@
              ;"-Dsun.security.jgss.native=true"
              ;"-Dsun.security.jgss.lib=/opt/mitkrb5/lib/libgssapi_krb5.so"
              ;"-Djavax.security.auth.useSubjectCredsOnly=false"
-             "-Xlog:gc*,compaction*,stringdedup*=debug,stringtable*,ergo*,safepoint,gc+age=trace:file=gclog-%t:time,level,tags"
-             "-XX:+UseG1GC"
-             "-XX:+UseStringDeduplication"
-             "-XX:+HeapDumpOnOutOfMemoryError"
-             "--illegal-access=warn"
-	     ])
+             "-verbose:gc"
+             "-XX:+PrintGCDetails"
+             "-Xloggc:gclog"
+             "-XX:+UseGCLogFileRotation"
+             "-XX:NumberOfGCLogFiles=20"
+             "-XX:GCLogFileSize=128M"
+             "-XX:+PrintGCDateStamps"
+             "-XX:+HeapDumpOnOutOfMemoryError"])

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -97,54 +97,51 @@
       (fake-test-compute-cluster-with-driver conn cluster-name nil))
     (or compute-cluster (cc/compute-cluster-name->ComputeCluster cluster-name))))
 
-(defn minimal-config
-  []
-  {:authorization {:one-user ""}
-   :cache-working-set-size 1000
-   :compute-clusters [{:factory-fn cook.mesos.mesos-compute-cluster/factory-fn
-                       :config {:compute-cluster-name fake-test-compute-cluster-name}}]
-   :database {:datomic-uri ""}
-   :log (cond-> {}
-          ; Allow tests that go through the real logging
-          ; initialization code to log to the console when
-          ; requested via the property
-          (System/getProperty "cook.test.logging.console")
-          (assoc :file "/dev/stdout"))
-   :mesos {:leader-path "", :master ""}
-   :metrics {}
-   :nrepl {}
-   :port 80
-   :scheduler {}
-   :kubernetes {:synthetic-pod-recency-seconds 1 :max-jobs-for-autoscaling 1000 :autoscaling-scale-factor 1000.0}
-   :unhandled-exceptions {}
-   :zookeeper {:local? true}})
-   
-(defn setup
-  "Given an optional config map, initializes the config state"
-  [& {:keys [config] :or {config nil}}]
-  (mount/stop)
-  (mount/start-with-args (merge (minimal-config) config)
-                         #'cook.config/config
-                         #'cook.plugins.adjustment/plugin
-                         #'cook.plugins.file/plugin
-                         #'cook.plugins.launch/job-launch-cache
-                         #'cook.plugins.launch/plugin-object
-                         #'cook.plugins.pool/plugin
-                         #'cook.plugins.submission/plugin-object
-                         #'caches/job-ent->resources-cache
-                         #'caches/job-ent->pool-cache
-                         #'caches/task-ent->user-cache
-                         #'caches/task->feature-vector-cache
-                         #'caches/job-ent->user-cache
-                         #'cook.quota/per-user-per-pool-launch-rate-limiter
-                         #'caches/user->group-ids-cache
-                         #'caches/recent-synthetic-pod-job-uuids
-                         #'caches/pool-name->exists?-cache
-                         #'caches/pool-name->accepts-submissions?-cache
-                         #'caches/pool-name->db-id-cache
-                         #'caches/user-and-pool-name->quota
-                         #'caches/instance-uuid->job-uuid
-                         #'caches/job-uuid->job-map))
+(let [minimal-config {:authorization {:one-user ""}
+                      :cache-working-set-size 1000
+                      :compute-clusters [{:factory-fn cook.mesos.mesos-compute-cluster/factory-fn
+                                          :config {:compute-cluster-name fake-test-compute-cluster-name}}]
+                      :database {:datomic-uri ""}
+                      :log (cond-> {}
+                             ; Allow tests that go through the real logging
+                             ; initialization code to log to the console when
+                             ; requested via the property
+                             (System/getProperty "cook.test.logging.console")
+                             (assoc :file "/dev/stdout"))
+                      :mesos {:leader-path "", :master ""}
+                      :metrics {}
+                      :nrepl {}
+                      :port 80
+                      :scheduler {}
+                      :kubernetes {:synthetic-pod-recency-seconds 1 :max-jobs-for-autoscaling 1000 :autoscaling-scale-factor 1000.0}
+                      :unhandled-exceptions {}
+                      :zookeeper {:local? true}}]
+  (defn setup
+    "Given an optional config map, initializes the config state"
+    [& {:keys [config], :or nil}]
+    (mount/stop)
+    (mount/start-with-args (merge minimal-config config)
+                           #'cook.config/config
+                           #'cook.plugins.adjustment/plugin
+                           #'cook.plugins.file/plugin
+                           #'cook.plugins.launch/job-launch-cache
+                           #'cook.plugins.launch/plugin-object
+                           #'cook.plugins.pool/plugin
+                           #'cook.plugins.submission/plugin-object
+                           #'caches/job-ent->resources-cache
+                           #'caches/job-ent->pool-cache
+                           #'caches/task-ent->user-cache
+                           #'caches/task->feature-vector-cache
+                           #'caches/job-ent->user-cache
+                           #'cook.quota/per-user-per-pool-launch-rate-limiter
+                           #'caches/user->group-ids-cache
+                           #'caches/recent-synthetic-pod-job-uuids
+                           #'caches/pool-name->exists?-cache
+                           #'caches/pool-name->accepts-submissions?-cache
+                           #'caches/pool-name->db-id-cache
+                           #'caches/user-and-pool-name->quota
+                           #'caches/instance-uuid->job-uuid
+                           #'caches/job-uuid->job-map)))
 
 (defn run-test-server-in-thread
   "Runs a minimal cook scheduler server for testing inside a thread. Note that it is not properly kerberized."

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -52,7 +52,7 @@
             [metrics.timers :as timers]
             [plumbing.core :as pc])
   (:import (clojure.lang ExceptionInfo)
-           (com.netflix.fenzo SimpleAssignmentResult TaskAssignmentResult TaskRequest TaskScheduler SchedulingResult)
+           (com.netflix.fenzo SimpleAssignmentResult TaskAssignmentResult TaskRequest TaskScheduler)
            (com.netflix.fenzo.plugins BinPackingFitnessCalculators)
            (cook.compute_cluster ComputeCluster)
            (java.util UUID)
@@ -181,7 +181,7 @@
                     :cpus cpus :mem mem :gpus gpus :disk disk :attrs attrs) 0))
 
 (defn schedule-and-run-jobs
-  [conn ^TaskScheduler scheduler offers job-ids]
+  [conn scheduler offers job-ids]
   (let [db (d/db conn)
         jobs (->> job-ids
                   (map #(d/entity db %))
@@ -192,8 +192,8 @@
         tasks (map #(sched/make-task-request db %1 nil :task-id %2 :guuid->considerable-cotask-ids guuid->considerable-cotask-ids
                                              :running-cotask-cache cache)
                    jobs task-ids)
-        ^SchedulingResult result (-> scheduler
-                                     (.scheduleOnce tasks offers))
+        result (-> scheduler
+                   (.scheduleOnce tasks offers))
         tasks-assigned (some->> result
                                 .getResultMap
                                 vals


### PR DESCRIPTION
This reverts commit 957ecf968f03eae7a8d62bb701cb4bcf9dcd1347.

## Changes proposed in this PR

- Revert "Update Cook to run on JDK-11 (#1937)"

## Why are we making these changes?

We encountered issues upgrading from JDK-8 to JDK-11 and wish to revert for now
