### PR TITLE
Make cook add a finalizer to its k8s pods to prevent GC.

### DIFF
--- a/scheduler/java/com/twosigma/cook/kubernetes/FinalizerHelper.java
+++ b/scheduler/java/com/twosigma/cook/kubernetes/FinalizerHelper.java
@@ -10,10 +10,10 @@ import org.joda.time.DateTime;
 
 import java.util.List;
 
-public class RemoveFinalizerHelper {
+public class FinalizerHelper {
     /** A finalizer that is attached to a pod to ensure that it is not GC'ed by K8s before cook
      * has had a chance to collect the completion result (success or failed) */
-    static public final String collectResultsFinalizer = "ts.cook/prevent-pod-gc";
+    static public final String collectResultsFinalizer = "cook/prevent-pod-gc";
 
     /** Remove the collectResultsFinalizer from a pod if it exists on a pod and the pod is morked for
      * deletion. */
@@ -43,7 +43,7 @@ public class RemoveFinalizerHelper {
                                                 null),
                                 V1Patch.PATCH_FORMAT_JSON_PATCH,
                                 apiClient);
-                        return; // Early abort of we've found the finalizer.
+                        return; // Early abort if we've found the finalizer.
                     }
                 }
             }

--- a/scheduler/java/com/twosigma/cook/kubernetes/RemoveFinalizerHelper.java
+++ b/scheduler/java/com/twosigma/cook/kubernetes/RemoveFinalizerHelper.java
@@ -1,0 +1,53 @@
+package com.twosigma.cook.kubernetes;
+
+import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.util.PatchUtils;
+import org.joda.time.DateTime;
+
+import java.util.List;
+
+public class RemoveFinalizerHelper {
+    /** A finalizer that is attached to a pod to ensure that it is not GC'ed by K8s before cook
+     * has had a chance to collect the completion result (success or failed) */
+    static public final String collectResultsFinalizer = "ts.cook/prevent-pod-gc";
+
+    /** Remove the collectResultsFinalizer from a pod if it exists on a pod and the pod is morked for
+     * deletion. */
+    static public void removeFinalizer(ApiClient apiClient, V1Pod pod) throws ApiException {
+        CoreV1Api api = new CoreV1Api(apiClient);
+
+        DateTime deletionTimestamp = pod.getMetadata().getDeletionTimestamp();
+        if (deletionTimestamp != null) {
+            List<String> finalizers = pod.getMetadata().getFinalizers();
+            if (finalizers != null) {
+                for (int ii = 0; ii < finalizers.size(); ii++) {
+                    if (collectResultsFinalizer.equals(finalizers.get(ii))) {
+                        String jsonPatchStr = "[{\"op\": \"remove\", \"path\": \"/metadata/finalizers/" + ii + "\"}]";
+                        String podName = pod.getMetadata().getName();
+                        String namespaceName = pod.getMetadata().getNamespace();
+                        PatchUtils.patch(
+                                V1Pod.class,
+                                () ->
+                                        api.patchNamespacedPodCall(
+                                                podName,
+                                                namespaceName,
+                                                new V1Patch(jsonPatchStr),
+                                                null,
+                                                null,
+                                                null, // field-manager is optional
+                                                null,
+                                                null),
+                                V1Patch.PATCH_FORMAT_JSON_PATCH,
+                                apiClient);
+                        return; // Early abort of we've found the finalizer.
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/scheduler/src/cook/config_incremental.clj
+++ b/scheduler/src/cook/config_incremental.clj
@@ -85,7 +85,7 @@
 
 (defn select-config-from-values
   "Select one value for a uuid given incremental values."
-  [^UUID uuid incremental-values]
+  [uuid incremental-values]
   (try
     (when (not-empty incremental-values)
       (let [pct (-> uuid .hashCode Math/abs (/ Integer/MAX_VALUE) double)]
@@ -101,7 +101,7 @@
 
 (defn select-config-from-key
   "Select one value for a uuid given a key to look up incremental values."
-  [^UUID uuid config-key]
+  [uuid config-key]
   (select-config-from-values uuid (read-config config-key)))
 
 (defn resolve-incremental-config
@@ -114,7 +114,7 @@
   If it is a keyword, then it is used as a key to look up a collection of incremental values in the database.
   An collection of incremental values is resolved by picking one of the values using the job uuid hash. Each incremental
   value has an associated portion and the portions must add up to 1.0"
-  ([^UUID uuid incremental-config]
+  ([uuid incremental-config]
    (cond
      (coll? incremental-config)
      (select-config-from-values uuid incremental-config)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -21,7 +21,7 @@
             [metrics.timers :as timers]
             [plumbing.core :as pc])
   (:import (com.google.gson JsonSyntaxException)
-           (com.twosigma.cook.kubernetes WatchHelper)
+           (com.twosigma.cook.kubernetes WatchHelper RemoveFinalizerHelper)
            (io.kubernetes.client.custom IntOrString Quantity Quantity$Format)
            (io.kubernetes.client.openapi ApiClient ApiException JSON)
            (io.kubernetes.client.openapi.apis CoreV1Api)
@@ -1453,6 +1453,9 @@
       (.setName metadata pod-name)
       (.setNamespace metadata namespace)
       (.setLabels metadata labels)
+      ; Only include finalizers with real pods.
+      (when-not (synthetic-pod? pod-name)
+        (.setFinalizers metadata (list RemoveFinalizerHelper/collectResultsFinalizer)))
       (when pod-annotations
         (.setAnnotations metadata pod-annotations))
 
@@ -1696,7 +1699,7 @@
           ^V1ContainerStatus job-status (first (filter (fn [^V1ContainerStatus c] (= cook-container-name-for-job (.getName c)))
                                     container-statuses))
           {:keys [node-preempted-label]} (config/kubernetes)
-          pod-metadata (some-> pod .getMetadata)
+          ^V1ObjectMeta pod-metadata (some-> pod .getMetadata)
           pod-preempted-timestamp
           (some-> pod-metadata
                   .getLabels

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -21,7 +21,7 @@
             [metrics.timers :as timers]
             [plumbing.core :as pc])
   (:import (com.google.gson JsonSyntaxException)
-           (com.twosigma.cook.kubernetes WatchHelper RemoveFinalizerHelper)
+           (com.twosigma.cook.kubernetes FinalizerHelper WatchHelper)
            (io.kubernetes.client.custom IntOrString Quantity Quantity$Format)
            (io.kubernetes.client.openapi ApiClient ApiException JSON)
            (io.kubernetes.client.openapi.apis CoreV1Api)
@@ -1455,7 +1455,7 @@
       (.setLabels metadata labels)
       ; Only include finalizers with real pods.
       (when-not (synthetic-pod? pod-name)
-        (.setFinalizers metadata (list RemoveFinalizerHelper/collectResultsFinalizer)))
+        (.setFinalizers metadata (list FinalizerHelper/collectResultsFinalizer)))
       (when pod-annotations
         (.setAnnotations metadata pod-annotations))
 

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1455,7 +1455,9 @@
       (.setLabels metadata labels)
       ; Only include finalizers with real pods.
       (when-not (synthetic-pod? pod-name)
-        (.setFinalizers metadata (list FinalizerHelper/collectResultsFinalizer)))
+        (let [[resolved-config reason] (config-incremental/resolve-incremental-config task-id :add-finalizer "false")]
+          (if (= "true" resolved-config)
+            (.setFinalizers metadata (list FinalizerHelper/collectResultsFinalizer)))))
       (when pod-annotations
         (.setAnnotations metadata pod-annotations))
 

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -11,7 +11,7 @@
             [cook.scheduler.scheduler :as scheduler]
             [metrics.timers :as timers])
   (:import (clojure.lang IAtom)
-           (com.twosigma.cook.kubernetes RemoveFinalizerHelper)
+           (com.twosigma.cook.kubernetes FinalizerHelper)
            (io.kubernetes.client.openapi.models V1ContainerStatus V1ObjectMeta V1Pod V1PodStatus)
            (java.net URLEncoder)
            (java.util.concurrent.locks Lock)))
@@ -668,10 +668,10 @@
 
    (let [^V1ObjectMeta pod-metadata (some-> pod .getMetadata)
          pod-deletion-timestamp (some-> pod .getMetadata .getDeletionTimestamp)]
-     (when (and pod-deletion-timestamp (some #(= RemoveFinalizerHelper/collectResultsFinalizer %) (.getFinalizers pod-metadata)))
+     (when (and pod-deletion-timestamp (some #(= FinalizerHelper/collectResultsFinalizer %) (.getFinalizers pod-metadata)))
        (log/info "In compute-cluster" name ", deleting finalizer for pod" pod-name)
        (try
-         (RemoveFinalizerHelper/removeFinalizer api-client pod)
+         (FinalizerHelper/removeFinalizer api-client pod)
          (catch Exception e
            (log/error e "In compute-cluster" name ", error deleting finalizer for pod" pod-name)))))
 

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -11,6 +11,7 @@
             [cook.scheduler.scheduler :as scheduler]
             [metrics.timers :as timers])
   (:import (clojure.lang IAtom)
+           (com.twosigma.cook.kubernetes RemoveFinalizerHelper)
            (io.kubernetes.client.openapi.models V1ContainerStatus V1ObjectMeta V1Pod V1PodStatus)
            (java.net URLEncoder)
            (java.util.concurrent.locks Lock)))
@@ -663,7 +664,17 @@
   if force-process? is true."
   ([compute-cluster pod-name ^V1Pod pod]
    (synthesize-state-and-process-pod-if-changed compute-cluster pod-name pod false))
-  ([{:keys [k8s-actual-state-map name] :as compute-cluster} pod-name ^V1Pod pod force-process?]
+  ([{:keys [k8s-actual-state-map api-client name] :as compute-cluster} pod-name ^V1Pod pod force-process?]
+
+   (let [^V1ObjectMeta pod-metadata (some-> pod .getMetadata)
+         pod-deletion-timestamp (some-> pod .getMetadata .getDeletionTimestamp)]
+     (when (and pod-deletion-timestamp (some #(= RemoveFinalizerHelper/collectResultsFinalizer %) (.getFinalizers pod-metadata)))
+       (log/info "In compute-cluster" name ", deleting finalizer for pod" pod-name)
+       (try
+         (RemoveFinalizerHelper/removeFinalizer api-client pod)
+         (catch Exception e
+           (log/error e "In compute-cluster" name ", error deleting finalizer for pod" pod-name)))))
+
    (let [new-state {:pod pod
                     :synthesized-state (api/pod->synthesized-pod-state pod-name pod)
                     :sandbox-file-server-container-state (api/pod->sandbox-file-server-container-state pod)}

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -119,463 +119,465 @@
   (tu/setup :config {:pools {:default-env [{:pool-regex "unused" :env {"foo" "bar"}}
                                            {:pool-regex ".*" :env
                                             {"SAMPLE_DEFAULT_ENV_KEY" "SAMPLE_DEFAULT_ENV_VAL"}}]}})
-  (let [fake-cc-config {:name "test-compute-cluster" :cook-pool-taint-name "test-taint" :cook-pool-taint-prefix ""}]
-    (testing "supplemental group ids"
-      (with-redefs [sh/sh (constantly {:exit 0 :out "12 34 56 78"})]
-        ; Invocation with user alice, successful
-        (let [task-metadata {:command {:user "alice"}
-                             :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
-              ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                                 fake-cc-config
-                                                 task-metadata)]
-          (is (= [12 34 56 78] (-> pod .getSpec .getSecurityContext .getSupplementalGroups)))))
+  (let [fake-cc-config {:name "test-compute-cluster" :cook-pool-taint-name "test-taint" :cook-pool-taint-prefix ""}
+        conn (tu/restore-fresh-database! "datomic:mem://test-task-metadata-pod")]
+    (with-redefs [cook.config-incremental/get-conn (fn [] conn)]
+      (testing "supplemental group ids"
+        (with-redefs [sh/sh (constantly {:exit 0 :out "12 34 56 78"})]
+          ; Invocation with user alice, successful
+          (let [task-metadata {:command {:user "alice"}
+                               :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
+                ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                   fake-cc-config
+                                                   task-metadata)]
+            (is (= [12 34 56 78] (-> pod .getSpec .getSecurityContext .getSupplementalGroups)))))
 
-      (with-redefs [sh/sh (constantly {:exit 1})]
-        ; Invocation with user alice, cached
-        (let [task-metadata {:command {:user "alice"}
-                             :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
-              ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                                 fake-cc-config
-                                                 task-metadata)]
-          (is (= [12 34 56 78] (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))
+        (with-redefs [sh/sh (constantly {:exit 1})]
+          ; Invocation with user alice, cached
+          (let [task-metadata {:command {:user "alice"}
+                               :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
+                ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                   fake-cc-config
+                                                   task-metadata)]
+            (is (= [12 34 56 78] (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))
 
-        ; Invocation with user bob, unsucessful
-        (let [task-metadata {:command {:user "bob"}
-                             :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
-              ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                                 fake-cc-config
-                                                 task-metadata)]
-          (is (= [] (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))))
+          ; Invocation with user bob, unsucessful
+          (let [task-metadata {:command {:user "bob"}
+                               :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
+                ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                   fake-cc-config
+                                                   task-metadata)]
+            (is (= [] (-> pod .getSpec .getSecurityContext .getSupplementalGroups))))))
 
-    (testing "creates pod from metadata"
-      (with-redefs [config/kubernetes (constantly {:default-workdir "/mnt/sandbox"
-                                                   :memory-limit-job-label-name "platform/memory.allow-usage-above-request"
-                                                   :add-job-label-to-pod-prefix "platform/"})]
+      (testing "creates pod from metadata"
+        (with-redefs [config/kubernetes (constantly {:default-workdir "/mnt/sandbox"
+                                                     :memory-limit-job-label-name "platform/memory.allow-usage-above-request"
+                                                     :add-job-label-to-pod-prefix "platform/"})]
+          (let [task-metadata {:task-id "my-task"
+                               :command {:value "foo && bar"
+                                         :environment {"FOO" "BAR"}
+                                         :user (System/getProperty "user.name")}
+                               :container {:type :docker
+                                           :docker {:image "alpine:latest"}}
+                               ;; assume this task requested {cpu:1.0,mem:512} for the job's container
+                               ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
+                               :task-request {:resources {:mem 576
+                                                          :cpus 1.1}
+                                              :scalar-requests {"mem" 512
+                                                                "cpus" 1.0}
+                                              :job {:job/pool {:pool/name "fake-pool-12"}
+                                                    :job/label [{:label/key "platform/memory.allow-usage-above-request"
+                                                                 :label/value "True"}]}}
+                               :hostname "kubehost"}
+                pod (api/task-metadata->pod "cook" {:name "testing-cluster" :cook-pool-taint-name "test-taint" :cook-pool-taint-prefix "taint-prefix-"} task-metadata)]
+            (is (= "my-task" (-> pod .getMetadata .getName)))
+            (is (= "cook" (-> pod .getMetadata .getNamespace)))
+            (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
+            (is (= "kubehost" (-> pod .getSpec .getNodeSelector (get api/k8s-hostname-label))))
+            (is (= 1 (count (-> pod .getSpec .getContainers))))
+            (is (= "testing-cluster" (-> pod .getMetadata .getLabels (get api/cook-pod-label))))
+            (is (= "True" (-> pod .getMetadata .getLabels (get (:memory-limit-job-label-name (config/kubernetes))))))
+            (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))
+            (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
+
+            (let [tolerations-on-pod (or (some-> pod .getSpec .getTolerations) [])
+                  found-cook-pool-toleration (filter #(= "test-taint" (.getKey %)) tolerations-on-pod)]
+              (is (= 1 (count found-cook-pool-toleration)))
+              (is (= "taint-prefix-fake-pool-12" (-> found-cook-pool-toleration first .getValue))))
+
+            (let [cook-sandbox-volume (->> pod
+                                           .getSpec
+                                           .getVolumes
+                                           (filter (fn [^V1Volume v] (= "cook-sandbox-volume" (.getName v))))
+                                           first)]
+              (is (not (nil? cook-sandbox-volume)))
+              (is (not (nil? (.getEmptyDir cook-sandbox-volume)))))
+
+            (let [^V1Container container (-> pod .getSpec .getContainers first)
+                  container-env (.getEnv container)]
+              (is (= "required-cook-job-container" (.getName container)))
+              (is (= (conj api/default-shell "foo && bar") (.getCommand container)))
+              (is (= "alpine:latest" (.getImage container)))
+              (is (not (nil? container)))
+              (is (= ["COOK_COMPUTE_CLUSTER_NAME"
+                      "COOK_JOB_NAME"
+                      "COOK_JOB_USER"
+                      "COOK_MEMORY_REQUEST_BYTES"
+                      "COOK_POOL"
+                      "COOK_SANDBOX"
+                      "COOK_SCHEDULER_REST_URL"
+                      "COOK_USER_MEMORY_REQUEST_BYTES"
+                      "EXECUTOR_PROGRESS_OUTPUT_FILE"
+                      "FOO"
+                      "HOME"
+                      "HOST_IP"
+                      "MESOS_DIRECTORY"
+                      "MESOS_SANDBOX"
+                      "SAMPLE_DEFAULT_ENV_KEY"
+                      "SIDECAR_WORKDIR"]
+                     (->> container-env (map #(.getName %)) sort)))
+              (is (= "/mnt/sandbox" (.getWorkingDir container)))
+              (let [cook-sandbox-mount (->> container
+                                            .getVolumeMounts
+                                            (filter (fn [^V1VolumeMount m] (= "cook-sandbox-volume" (.getName m))))
+                                            first)]
+                (is (= "/mnt/sandbox" (.getMountPath cook-sandbox-mount))))
+
+              (assert-env-var-value container "FOO" "BAR")
+              (assert-env-var-value container "SAMPLE_DEFAULT_ENV_KEY" "SAMPLE_DEFAULT_ENV_VAL")
+              (assert-env-var-value container "HOME" (.getWorkingDir container))
+              (assert-env-var-value container "MESOS_SANDBOX" (.getWorkingDir container))
+
+              (let [resources (-> container .getResources)]
+                (is (= 1.0 (-> resources .getRequests (get "cpu") .getNumber .doubleValue)))
+                (is (= (* 512.0 api/memory-multiplier) (-> resources .getRequests (get "memory") .getNumber .doubleValue)))
+                (is (nil? (-> resources .getLimits (get "memory")))))))))
+
+      (testing "user parameter"
+        (let [task-metadata {:task-id "my-task"
+                             :command {:value "foo && bar"
+                                       :environment {"FOO" "BAR"}
+                                       :user (System/getProperty "user.name")}
+                             :container {:type :docker
+                                         :docker {:image "alpine:latest"
+                                                  :parameters [{:key "user"
+                                                                :value "100:10"}]}}
+                             ;; assume this task requested {cpu:1.0,mem:512} for the job's container
+                             ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
+                             :task-request {:resources {:mem 576
+                                                        :cpus 1.1}
+                                            :scalar-requests {"mem" 512
+                                                              "cpus" 1.0}}
+                             :hostname "kubehost"}
+              pod (api/task-metadata->pod "cook" "test-cluster" task-metadata)]
+          (is (= 100 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
+          (is (= 10 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))))
+
+      (testing "node selector for pool"
+        (let [pool-name "test-pool"
+              task-metadata {:command {:user "user"}
+                             :container {:docker {:parameters [{:key "user"
+                                                                :value "100:10"}]}}
+                             :task-request {:job {:job/pool {:pool/name pool-name}}
+                                            :scalar-requests {"mem" 512
+                                                              "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod nil {:cook-pool-label-name "pool-label-1"} task-metadata)
+              ^V1PodSpec pod-spec (.getSpec pod)
+              node-selector (.getNodeSelector pod-spec)]
+          (is (contains? node-selector "pool-label-1"))
+          (is (= pool-name (get node-selector "pool-label-1")))))
+
+      (testing "node selector for hostname"
+        (let [hostname "test-host"
+              task-metadata {:command {:user "user"}
+                             :container {:docker {:parameters [{:key "user"
+                                                                :value "100:10"}]}}
+                             :hostname hostname
+                             :task-request {:scalar-requests {"mem" 512
+                                                              "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
+              ^V1PodSpec pod-spec (.getSpec pod)
+              node-selector (.getNodeSelector pod-spec)]
+          (is (contains? node-selector api/k8s-hostname-label))
+          (is (= hostname (get node-selector api/k8s-hostname-label)))))
+
+      (testing "cpu limit configurability"
+        (let [task-metadata {:command {:user "user"}
+                             :container {:docker {:parameters [{:key "user"
+                                                                :value "100:10"}]}}
+                             :task-request {:scalar-requests {"mem" 512
+                                                              "cpus" 1.0}}}
+              pod->cpu-limit-fn (fn [^V1Pod pod]
+                                  (let [^V1Container container (-> pod .getSpec .getContainers first)
+                                        ^V1ResourceRequirements resources (-> container .getResources)]
+                                    (-> resources .getLimits (get "cpu"))))]
+
+          (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? true})]
+            (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
+              (is (= 1.0 (-> pod pod->cpu-limit-fn .getNumber .doubleValue)))))
+
+          (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? false})]
+            (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
+              (is (nil? (pod->cpu-limit-fn pod)))))
+
+          (with-redefs [config/kubernetes (constantly {})]
+            (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
+              (is (nil? (pod->cpu-limit-fn pod)))))))
+
+      (testing "checkpointing volumes"
+        (with-redefs [config/kubernetes (constantly {:default-checkpoint-config {:volume-name "cook-checkpointing-tools-volume"
+                                                                                 :init-container-volume-mounts [{:path "/abc/xyz"}]
+                                                                                 :main-container-volume-mounts [{:path "/abc/xyz"}
+                                                                                                                {:path "/qed/bbq"
+                                                                                                                 :sub-path "efg/hij"}]}
+                                                     :init-container {:command ["init container command"]
+                                                                      :image "init container image"}})]
+          (let [task-metadata {:command {:user "user"}
+                               :container {:docker {:parameters [{:key "user"
+                                                                  :value "100:10"}]}}
+                               :task-request {:scalar-requests {"mem" 512
+                                                                "cpus" 1.0}
+                                              :job {:job/checkpoint {:checkpoint/mode "auto"}}}}
+                ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
+                ^V1Container init-container (-> pod .getSpec .getInitContainers first)
+                ^V1Container main-container (-> pod .getSpec .getContainers (->> (filter #(= (.getName %) api/cook-container-name-for-job))) first)
+                init-container-paths (into #{} (-> init-container .getVolumeMounts
+                                                   (->> (filter #(= (.getName %) "cook-checkpointing-tools-volume")))
+                                                   (->> (map #(str (.getMountPath %) (.getSubPath %))))))
+                main-container-paths (into #{} (-> main-container .getVolumeMounts
+                                                   (->> (filter #(= (.getName %) "cook-checkpointing-tools-volume")))
+                                                   (->> (map #(str (.getMountPath %) (.getSubPath %))))))]
+            (is (= #{"/abc/xyz"} init-container-paths))
+            (is (= #{"/abc/xyz" "/qed/bbqefg/hij"} main-container-paths)))))
+
+      (testing "gpu task-metadata"
         (let [task-metadata {:task-id "my-task"
                              :command {:value "foo && bar"
                                        :environment {"FOO" "BAR"}
                                        :user (System/getProperty "user.name")}
                              :container {:type :docker
                                          :docker {:image "alpine:latest"}}
-                             ;; assume this task requested {cpu:1.0,mem:512} for the job's container
-                             ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
                              :task-request {:resources {:mem 576
-                                                        :cpus 1.1}
+                                                        :cpus 1.1
+                                                        :gpus 2}
                                             :scalar-requests {"mem" 512
                                                               "cpus" 1.0}
-                                            :job {:job/pool {:pool/name "fake-pool-12"}
-                                                  :job/label [{:label/key "platform/memory.allow-usage-above-request"
-                                                               :label/value "True"}]}}
+                                            :job {:job/environment #{{:environment/name "COOK_GPU_MODEL"
+                                                                      :environment/value "nvidia-tesla-p100"}}}}
                              :hostname "kubehost"}
-              pod (api/task-metadata->pod "cook" {:name "testing-cluster" :cook-pool-taint-name "test-taint" :cook-pool-taint-prefix "taint-prefix-"} task-metadata)]
-          (is (= "my-task" (-> pod .getMetadata .getName)))
-          (is (= "cook" (-> pod .getMetadata .getNamespace)))
-          (is (= "Never" (-> pod .getSpec .getRestartPolicy)))
-          (is (= "kubehost" (-> pod .getSpec .getNodeSelector (get api/k8s-hostname-label))))
-          (is (= 1 (count (-> pod .getSpec .getContainers))))
-          (is (= "testing-cluster" (-> pod .getMetadata .getLabels (get api/cook-pod-label))))
-          (is (= "True" (-> pod .getMetadata .getLabels (get (:memory-limit-job-label-name (config/kubernetes))))))
-          (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))
-          (is (< 0 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
+              ^V1Pod pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)
+              ^V1PodSpec pod-spec (.getSpec pod)
+              ^V1Container container (-> pod-spec .getContainers first)]
+          (is (= (-> pod-spec .getNodeSelector (get "cloud.google.com/gke-accelerator")) "nvidia-tesla-p100"))
+          (is (= (-> pod-spec .getNodeSelector (get "gpu-count")) "2"))
+          (is (= 2 (-> container .getResources .getRequests (get "nvidia.com/gpu") api/to-int)))
+          (is (= 2 (-> container .getResources .getLimits (get "nvidia.com/gpu") api/to-int)))))
 
-          (let [tolerations-on-pod (or (some-> pod .getSpec .getTolerations) [])
-                found-cook-pool-toleration (filter #(= "test-taint" (.getKey %)) tolerations-on-pod)]
-            (is (= 1 (count found-cook-pool-toleration)))
-            (is (= "taint-prefix-fake-pool-12" (-> found-cook-pool-toleration first .getValue))))
+      (testing "disk task-metadata"
+        (with-redefs [config/disk (constantly [{:pool-regex "test-pool"
+                                                :max-size 256000.0
+                                                :valid-types #{"standard", "pd-ssd"}
+                                                :default-type "standard"
+                                                :default-request 10000.0
+                                                :type-map {"standard", "pd-standard"}
+                                                :enable-constraint? true
+                                                :disk-node-label "cloud.google.com/gke-boot-disk"}])]
+          (let [pool-name "test-pool"
+                task-metadata {:task-id "my-task"
+                               :command {:value "foo && bar"
+                                         :environment {"FOO" "BAR"}
+                                         :user (System/getProperty "user.name")}
+                               :container {:type :docker
+                                           :docker {:image "alpine:latest"}}
+                               :task-request {:resources {:mem  576
+                                                          :cpus 1.1
+                                                          :disk {:request 250000.0, :limit 255000.0, :type "standard"}}
+                                              :scalar-requests {"mem"  512
+                                                                "cpus" 1.0}
+                                              :job {:job/pool {:pool/name pool-name}}}
+                               :hostname "kubehost"}
+                ^V1Pod pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)
+                ^V1PodSpec pod-spec (.getSpec pod)
+                ^V1Container container (-> pod-spec .getContainers first)]
+            (is (= (-> pod-spec .getNodeSelector (get "cloud.google.com/gke-boot-disk")) "pd-standard"))
+            (is (= (* constraints/disk-multiplier 250000.0) (some-> container .getResources .getRequests (get "ephemeral-storage") api/to-double)))
+            (is (= (* constraints/disk-multiplier 255000.0) (some-> container .getResources .getLimits (get "ephemeral-storage") api/to-double))))
 
-          (let [cook-sandbox-volume (->> pod
-                                         .getSpec
-                                         .getVolumes
-                                         (filter (fn [^V1Volume v] (= "cook-sandbox-volume" (.getName v))))
-                                         first)]
-            (is (not (nil? cook-sandbox-volume)))
-            (is (not (nil? (.getEmptyDir cook-sandbox-volume)))))
+          (let [pool-name "test-pool"
+                task-metadata {:task-id "my-task"
+                               :command {:value "foo && bar"
+                                         :environment {"FOO" "BAR"}
+                                         :user (System/getProperty "user.name")}
+                               :container {:type :docker
+                                           :docker {:image "alpine:latest"}}
+                               :task-request {:resources {:mem  576
+                                                          :cpus 1.1}
+                                              :scalar-requests {"mem"  512
+                                                                "cpus" 1.0}
+                                              :job {:job/pool {:pool/name pool-name}}}
+                               :hostname "kubehost"}
+                ^V1Pod pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)
+                ^V1PodSpec pod-spec (.getSpec pod)
+                ^V1Container container (-> pod-spec .getContainers first)]
+            ; check that pod has default values for disk request, type, and limit
+            (is (= (-> pod-spec .getNodeSelector (get "cloud.google.com/gke-boot-disk")) "pd-standard"))
+            (is (= (* constraints/disk-multiplier 10000.0) (-> container .getResources .getRequests (get "ephemeral-storage") api/to-double)))
+            (is (nil? (-> container .getResources .getLimits (get "ephemeral-storage")))))))
 
-          (let [^V1Container container (-> pod .getSpec .getContainers first)
+      (testing "job labels -> pod labels"
+        (let [task-metadata {:command {:user "test-user"}
+                             :task-request {:job {:job/label [{:label/key "not-platform/foo"
+                                                               :label/value "bar"}
+                                                              {:label/key "platform/baz"
+                                                               :label/value "qux"}
+                                                              {:label/key "platform/another"
+                                                               :label/value "included"}]}
+                                            :scalar-requests {"mem" 512 "cpus" 1.0}}}]
+
+          ; With a prefix configured
+          (with-redefs [config/kubernetes
+                        (constantly {:add-job-label-to-pod-prefix "platform/"})]
+            (let [^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                     fake-cc-config
+                                                     task-metadata)
+                  pod-labels (-> pod .getMetadata .getLabels)]
+              (is (= "qux" (get pod-labels "platform/baz")))
+              (is (= "included" (get pod-labels "platform/another")))
+              (is (not (contains? pod-labels "not-platform/foo")))))
+
+          ; With no prefix configured
+          (with-redefs [config/kubernetes (constantly {})]
+            (let [^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                     fake-cc-config
+                                                     task-metadata)
+                  pod-labels (-> pod .getMetadata .getLabels)]
+              (is (not (contains? pod-labels "platform/baz")))
+              (is (not (contains? pod-labels "platform/another")))
+              (is (not (contains? pod-labels "not-platform/foo")))))))
+
+      (testing "job application -> pod labels"
+        ; All workload- fields specified
+        (let [task-metadata {:command {:user "test-user"}
+                             :task-request {:job {:job/application {:application/workload-class "foo"
+                                                                    :application/workload-id "bar"
+                                                                    :application/workload-details "baz"}}
+                                            :scalar-requests {"mem" 512 "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                 fake-cc-config
+                                                 task-metadata)
+              pod-labels (-> pod .getMetadata .getLabels)]
+          (is (= "foo" (get pod-labels "application.workload-class")))
+          (is (= "bar" (get pod-labels "application.workload-id")))
+          (is (= "baz" (get pod-labels "application.workload-details"))))
+
+        ; No workload-class specified
+        (let [task-metadata {:command {:user "test-user"}
+                             :task-request {:job {:job/application {:application/workload-id "bar"
+                                                                    :application/workload-details "baz"}}
+                                            :scalar-requests {"mem" 512 "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                 fake-cc-config
+                                                 task-metadata)
+              pod-labels (-> pod .getMetadata .getLabels)]
+          (is (= "undefined" (get pod-labels "application.workload-class")))
+          (is (= "bar" (get pod-labels "application.workload-id")))
+          (is (= "baz" (get pod-labels "application.workload-details"))))
+
+        ; No workload-id specified
+        (let [task-metadata {:command {:user "test-user"}
+                             :task-request {:job {:job/application {:application/workload-class "foo"
+                                                                    :application/workload-details "baz"}}
+                                            :scalar-requests {"mem" 512 "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                 fake-cc-config
+                                                 task-metadata)
+              pod-labels (-> pod .getMetadata .getLabels)]
+          (is (= "foo" (get pod-labels "application.workload-class")))
+          (is (= "undefined" (get pod-labels "application.workload-id")))
+          (is (= "baz" (get pod-labels "application.workload-details"))))
+
+        ; No workload-details specified
+        (let [task-metadata {:command {:user "test-user"}
+                             :task-request {:job {:job/application {:application/workload-class "foo"
+                                                                    :application/workload-id "bar"}}
+                                            :scalar-requests {"mem" 512 "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                 fake-cc-config
+                                                 task-metadata)
+              pod-labels (-> pod .getMetadata .getLabels)]
+          (is (= "foo" (get pod-labels "application.workload-class")))
+          (is (= "bar" (get pod-labels "application.workload-id")))
+          (is (= "undefined" (get pod-labels "application.workload-details"))))
+
+        ; No workload- fields specified
+        (let [task-metadata {:command {:user "test-user"}
+                             :task-request {:job {:job/application {}}
+                                            :scalar-requests {"mem" 512 "cpus" 1.0}}}
+              ^V1Pod pod (api/task-metadata->pod "test-namespace"
+                                                 fake-cc-config
+                                                 task-metadata)
+              pod-labels (-> pod .getMetadata .getLabels)]
+          (is (= "undefined" (get pod-labels "application.workload-class")))
+          (is (= "undefined" (get pod-labels "application.workload-id")))
+          (is (= "undefined" (get pod-labels "application.workload-details")))))
+
+      (testing "synthetic pod anti-affinity"
+        (with-redefs [config/kubernetes (constantly {:synthetic-pod-anti-affinity-namespace "test-namespace"
+                                                     :synthetic-pod-anti-affinity-pod-label-key "test-key"
+                                                     :synthetic-pod-anti-affinity-pod-label-value "test-value"})]
+          (let [task-metadata {:command {:user "test-user"}
+                               :task-id "synthetic"
+                               :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
+                pod (api/task-metadata->pod "test-namespace" fake-cc-config task-metadata)
+                ^V1PodAffinityTerm pod-affinity-term (-> pod
+                                                         .getSpec
+                                                         .getAffinity
+                                                         .getPodAntiAffinity
+                                                         .getRequiredDuringSchedulingIgnoredDuringExecution
+                                                         first)
+                namespaces (-> pod-affinity-term .getNamespaces)]
+            (is pod-affinity-term)
+            (is (= api/k8s-hostname-label (.getTopologyKey pod-affinity-term)))
+            (is (= {"test-key" "test-value"} (-> pod-affinity-term .getLabelSelector .getMatchLabels)))
+            (is (= 1 (count namespaces)))
+            (is (= "test-namespace" (first namespaces))))))
+
+      (testing "telemetry environment"
+        (with-redefs [config/kubernetes (constantly {:add-job-label-to-pod-prefix "test-prefix/"
+                                                     :telemetry-agent-host-var-name "TEST_AGENT"
+                                                     :telemetry-env-var-name "TEST_ENV"
+                                                     :telemetry-env-value "test-env"
+                                                     :telemetry-pool-regex "^telemetry-pool$"
+                                                     :telemetry-service-var-name "TEST_SERVICE"
+                                                     :telemetry-tags-entry-separator " "
+                                                     :telemetry-tags-key-invalid-char-pattern (re-pattern "[^a-zA-Z0-9-]")
+                                                     :telemetry-tags-key-invalid-char-replacement "."
+                                                     :telemetry-tags-key-value-separator ":"
+                                                     :telemetry-tags-var-name "TEST_TAGS"
+                                                     :telemetry-version-var-name "TEST_VERSION"})]
+          (let [task-metadata {:command {:user "test-user"}
+                               :task-request {:job {:job/pool {:pool/name "telemetry-pool"}
+                                                    :job/application {:application/name "test-name"
+                                                                      :application/version "test-version"
+                                                                      :application/workload-class "foo"
+                                                                      :application/workload-id "bar"
+                                                                      :application/workload-details "baz"}}
+                                              :scalar-requests {"mem" 512 "cpus" 1.0}}}
+                pod (api/task-metadata->pod "test-namespace" fake-cc-config task-metadata)
+                ^V1Container container (-> pod .getSpec .getContainers first)
                 container-env (.getEnv container)]
             (is (= "required-cook-job-container" (.getName container)))
-            (is (= (conj api/default-shell "foo && bar") (.getCommand container)))
-            (is (= "alpine:latest" (.getImage container)))
-            (is (not (nil? container)))
-            (is (= ["COOK_COMPUTE_CLUSTER_NAME"
-                    "COOK_JOB_NAME"
-                    "COOK_JOB_USER"
-                    "COOK_MEMORY_REQUEST_BYTES"
-                    "COOK_POOL"
-                    "COOK_SANDBOX"
-                    "COOK_SCHEDULER_REST_URL"
-                    "COOK_USER_MEMORY_REQUEST_BYTES"
-                    "EXECUTOR_PROGRESS_OUTPUT_FILE"
-                    "FOO"
-                    "HOME"
-                    "HOST_IP"
-                    "MESOS_DIRECTORY"
-                    "MESOS_SANDBOX"
-                    "SAMPLE_DEFAULT_ENV_KEY"
-                    "SIDECAR_WORKDIR"]
-                   (->> container-env (map #(.getName %)) sort)))
-            (is (= "/mnt/sandbox" (.getWorkingDir container)))
-            (let [cook-sandbox-mount (->> container
-                                          .getVolumeMounts
-                                          (filter (fn [^V1VolumeMount m] (= "cook-sandbox-volume" (.getName m))))
-                                          first)]
-              (is (= "/mnt/sandbox" (.getMountPath cook-sandbox-mount))))
-
-            (assert-env-var-value container "FOO" "BAR")
-            (assert-env-var-value container "SAMPLE_DEFAULT_ENV_KEY" "SAMPLE_DEFAULT_ENV_VAL")
-            (assert-env-var-value container "HOME" (.getWorkingDir container))
-            (assert-env-var-value container "MESOS_SANDBOX" (.getWorkingDir container))
-
-            (let [resources (-> container .getResources)]
-              (is (= 1.0 (-> resources .getRequests (get "cpu") .getNumber .doubleValue)))
-              (is (= (* 512.0 api/memory-multiplier) (-> resources .getRequests (get "memory") .getNumber .doubleValue)))
-              (is (nil? (-> resources .getLimits (get "memory")))))))))
-
-    (testing "user parameter"
-      (let [task-metadata {:task-id "my-task"
-                           :command {:value "foo && bar"
-                                     :environment {"FOO" "BAR"}
-                                     :user (System/getProperty "user.name")}
-                           :container {:type :docker
-                                       :docker {:image "alpine:latest"
-                                                :parameters [{:key "user"
-                                                              :value "100:10"}]}}
-                           ;; assume this task requested {cpu:1.0,mem:512} for the job's container
-                           ;; plus an additional {cpu:0.1,mem:64} for a sidecar container
-                           :task-request {:resources {:mem 576
-                                                      :cpus 1.1}
-                                          :scalar-requests {"mem" 512
-                                                            "cpus" 1.0}}
-                           :hostname "kubehost"}
-            pod (api/task-metadata->pod "cook" "test-cluster" task-metadata)]
-        (is (= 100 (-> pod .getSpec .getSecurityContext .getRunAsUser)))
-        (is (= 10 (-> pod .getSpec .getSecurityContext .getRunAsGroup)))))
-
-    (testing "node selector for pool"
-      (let [pool-name "test-pool"
-            task-metadata {:command {:user "user"}
-                           :container {:docker {:parameters [{:key "user"
-                                                              :value "100:10"}]}}
-                           :task-request {:job {:job/pool {:pool/name pool-name}}
-                                          :scalar-requests {"mem" 512
-                                                            "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod nil {:cook-pool-label-name "pool-label-1"} task-metadata)
-            ^V1PodSpec pod-spec (.getSpec pod)
-            node-selector (.getNodeSelector pod-spec)]
-        (is (contains? node-selector "pool-label-1"))
-        (is (= pool-name (get node-selector "pool-label-1")))))
-
-    (testing "node selector for hostname"
-      (let [hostname "test-host"
-            task-metadata {:command {:user "user"}
-                           :container {:docker {:parameters [{:key "user"
-                                                              :value "100:10"}]}}
-                           :hostname hostname
-                           :task-request {:scalar-requests {"mem" 512
-                                                            "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
-            ^V1PodSpec pod-spec (.getSpec pod)
-            node-selector (.getNodeSelector pod-spec)]
-        (is (contains? node-selector api/k8s-hostname-label))
-        (is (= hostname (get node-selector api/k8s-hostname-label)))))
-
-    (testing "cpu limit configurability"
-      (let [task-metadata {:command {:user "user"}
-                           :container {:docker {:parameters [{:key "user"
-                                                              :value "100:10"}]}}
-                           :task-request {:scalar-requests {"mem" 512
-                                                            "cpus" 1.0}}}
-            pod->cpu-limit-fn (fn [^V1Pod pod]
-                                (let [^V1Container container (-> pod .getSpec .getContainers first)
-                                      ^V1ResourceRequirements resources (-> container .getResources)]
-                                  (-> resources .getLimits (get "cpu"))))]
-
-        (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? true})]
-          (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
-            (is (= 1.0 (-> pod pod->cpu-limit-fn .getNumber .doubleValue)))))
-
-        (with-redefs [config/kubernetes (constantly {:set-container-cpu-limit? false})]
-          (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
-            (is (nil? (pod->cpu-limit-fn pod)))))
-
-        (with-redefs [config/kubernetes (constantly {})]
-          (let [^V1Pod pod (api/task-metadata->pod nil nil task-metadata)]
-            (is (nil? (pod->cpu-limit-fn pod)))))))
-
-    (testing "checkpointing volumes"
-      (with-redefs [config/kubernetes (constantly {:default-checkpoint-config {:volume-name "cook-checkpointing-tools-volume"
-                                                                               :init-container-volume-mounts [{:path "/abc/xyz"}]
-                                                                               :main-container-volume-mounts [{:path "/abc/xyz"}
-                                                                                                              {:path "/qed/bbq"
-                                                                                                               :sub-path "efg/hij"}]}
-                                                   :init-container {:command ["init container command"]
-                                                                    :image "init container image"}})]
-        (let [task-metadata {:command {:user "user"}
-                             :container {:docker {:parameters [{:key "user"
-                                                                :value "100:10"}]}}
-                             :task-request {:scalar-requests {"mem" 512
-                                                              "cpus" 1.0}
-                                            :job {:job/checkpoint {:checkpoint/mode "auto"}}}}
-              ^V1Pod pod (api/task-metadata->pod nil nil task-metadata)
-              ^V1Container init-container (-> pod .getSpec .getInitContainers first)
-              ^V1Container main-container (-> pod .getSpec .getContainers (->> (filter #(= (.getName %) api/cook-container-name-for-job))) first)
-              init-container-paths (into #{} (-> init-container .getVolumeMounts
-                                                 (->> (filter #(= (.getName %) "cook-checkpointing-tools-volume")))
-                                                 (->> (map #(str (.getMountPath %) (.getSubPath %))))))
-              main-container-paths (into #{} (-> main-container .getVolumeMounts
-                                                 (->> (filter #(= (.getName %) "cook-checkpointing-tools-volume")))
-                                                 (->> (map #(str (.getMountPath %) (.getSubPath %))))))]
-          (is (= #{"/abc/xyz"} init-container-paths))
-          (is (= #{"/abc/xyz" "/qed/bbqefg/hij"} main-container-paths)))))
-
-    (testing "gpu task-metadata"
-      (let [task-metadata {:task-id "my-task"
-                           :command {:value "foo && bar"
-                                     :environment {"FOO" "BAR"}
-                                     :user (System/getProperty "user.name")}
-                           :container {:type :docker
-                                       :docker {:image "alpine:latest"}}
-                           :task-request {:resources {:mem 576
-                                                      :cpus 1.1
-                                                      :gpus 2}
-                                          :scalar-requests {"mem" 512
-                                                            "cpus" 1.0}
-                                          :job {:job/environment #{{:environment/name "COOK_GPU_MODEL"
-                                                                    :environment/value "nvidia-tesla-p100"}}}}
-                           :hostname "kubehost"}
-            ^V1Pod pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)
-            ^V1PodSpec pod-spec (.getSpec pod)
-            ^V1Container container (-> pod-spec .getContainers first)]
-        (is (= (-> pod-spec .getNodeSelector (get "cloud.google.com/gke-accelerator")) "nvidia-tesla-p100"))
-        (is (= (-> pod-spec .getNodeSelector (get "gpu-count")) "2"))
-        (is (= 2 (-> container .getResources .getRequests (get "nvidia.com/gpu") api/to-int)))
-        (is (= 2 (-> container .getResources .getLimits (get "nvidia.com/gpu") api/to-int)))))
-
-    (testing "disk task-metadata"
-      (with-redefs [config/disk (constantly [{:pool-regex "test-pool"
-                                              :max-size 256000.0
-                                              :valid-types #{"standard", "pd-ssd"}
-                                              :default-type "standard"
-                                              :default-request 10000.0
-                                              :type-map {"standard", "pd-standard"}
-                                              :enable-constraint? true
-                                              :disk-node-label "cloud.google.com/gke-boot-disk"}])]
-        (let [pool-name "test-pool"
-              task-metadata {:task-id "my-task"
-                             :command {:value "foo && bar"
-                                       :environment {"FOO" "BAR"}
-                                       :user (System/getProperty "user.name")}
-                             :container {:type :docker
-                                         :docker {:image "alpine:latest"}}
-                             :task-request {:resources {:mem  576
-                                                        :cpus 1.1
-                                                        :disk {:request 250000.0, :limit 255000.0, :type "standard"}}
-                                            :scalar-requests {"mem"  512
-                                                              "cpus" 1.0}
-                                            :job {:job/pool {:pool/name pool-name}}}
-                             :hostname "kubehost"}
-              ^V1Pod pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)
-              ^V1PodSpec pod-spec (.getSpec pod)
-              ^V1Container container (-> pod-spec .getContainers first)]
-          (is (= (-> pod-spec .getNodeSelector (get "cloud.google.com/gke-boot-disk")) "pd-standard"))
-          (is (= (* constraints/disk-multiplier 250000.0) (some-> container .getResources .getRequests (get "ephemeral-storage") api/to-double)))
-          (is (= (* constraints/disk-multiplier 255000.0) (some-> container .getResources .getLimits (get "ephemeral-storage") api/to-double))))
-
-        (let [pool-name "test-pool"
-              task-metadata {:task-id "my-task"
-                             :command {:value "foo && bar"
-                                       :environment {"FOO" "BAR"}
-                                       :user (System/getProperty "user.name")}
-                             :container {:type :docker
-                                         :docker {:image "alpine:latest"}}
-                             :task-request {:resources {:mem  576
-                                                        :cpus 1.1}
-                                            :scalar-requests {"mem"  512
-                                                              "cpus" 1.0}
-                                            :job {:job/pool {:pool/name pool-name}}}
-                             :hostname "kubehost"}
-              ^V1Pod pod (api/task-metadata->pod "cook" "testing-cluster" task-metadata)
-              ^V1PodSpec pod-spec (.getSpec pod)
-              ^V1Container container (-> pod-spec .getContainers first)]
-          ; check that pod has default values for disk request, type, and limit
-          (is (= (-> pod-spec .getNodeSelector (get "cloud.google.com/gke-boot-disk")) "pd-standard"))
-          (is (= (* constraints/disk-multiplier 10000.0) (-> container .getResources .getRequests (get "ephemeral-storage") api/to-double)))
-          (is (nil? (-> container .getResources .getLimits (get "ephemeral-storage")))))))
-
-    (testing "job labels -> pod labels"
-      (let [task-metadata {:command {:user "test-user"}
-                           :task-request {:job {:job/label [{:label/key "not-platform/foo"
-                                                             :label/value "bar"}
-                                                            {:label/key "platform/baz"
-                                                             :label/value "qux"}
-                                                            {:label/key "platform/another"
-                                                             :label/value "included"}]}
-                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}]
-
-        ; With a prefix configured
-        (with-redefs [config/kubernetes
-                      (constantly {:add-job-label-to-pod-prefix "platform/"})]
-          (let [^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                                   fake-cc-config
-                                                   task-metadata)
-                pod-labels (-> pod .getMetadata .getLabels)]
-            (is (= "qux" (get pod-labels "platform/baz")))
-            (is (= "included" (get pod-labels "platform/another")))
-            (is (not (contains? pod-labels "not-platform/foo")))))
-
-        ; With no prefix configured
-        (with-redefs [config/kubernetes (constantly {})]
-          (let [^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                                   fake-cc-config
-                                                   task-metadata)
-                pod-labels (-> pod .getMetadata .getLabels)]
-            (is (not (contains? pod-labels "platform/baz")))
-            (is (not (contains? pod-labels "platform/another")))
-            (is (not (contains? pod-labels "not-platform/foo")))))))
-
-    (testing "job application -> pod labels"
-      ; All workload- fields specified
-      (let [task-metadata {:command {:user "test-user"}
-                           :task-request {:job {:job/application {:application/workload-class "foo"
-                                                                  :application/workload-id "bar"
-                                                                  :application/workload-details "baz"}}
-                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                               fake-cc-config
-                                               task-metadata)
-            pod-labels (-> pod .getMetadata .getLabels)]
-        (is (= "foo" (get pod-labels "application.workload-class")))
-        (is (= "bar" (get pod-labels "application.workload-id")))
-        (is (= "baz" (get pod-labels "application.workload-details"))))
-
-      ; No workload-class specified
-      (let [task-metadata {:command {:user "test-user"}
-                           :task-request {:job {:job/application {:application/workload-id "bar"
-                                                                  :application/workload-details "baz"}}
-                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                               fake-cc-config
-                                               task-metadata)
-            pod-labels (-> pod .getMetadata .getLabels)]
-        (is (= "undefined" (get pod-labels "application.workload-class")))
-        (is (= "bar" (get pod-labels "application.workload-id")))
-        (is (= "baz" (get pod-labels "application.workload-details"))))
-
-      ; No workload-id specified
-      (let [task-metadata {:command {:user "test-user"}
-                           :task-request {:job {:job/application {:application/workload-class "foo"
-                                                                  :application/workload-details "baz"}}
-                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                               fake-cc-config
-                                               task-metadata)
-            pod-labels (-> pod .getMetadata .getLabels)]
-        (is (= "foo" (get pod-labels "application.workload-class")))
-        (is (= "undefined" (get pod-labels "application.workload-id")))
-        (is (= "baz" (get pod-labels "application.workload-details"))))
-
-      ; No workload-details specified
-      (let [task-metadata {:command {:user "test-user"}
-                           :task-request {:job {:job/application {:application/workload-class "foo"
-                                                                  :application/workload-id "bar"}}
-                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                               fake-cc-config
-                                               task-metadata)
-            pod-labels (-> pod .getMetadata .getLabels)]
-        (is (= "foo" (get pod-labels "application.workload-class")))
-        (is (= "bar" (get pod-labels "application.workload-id")))
-        (is (= "undefined" (get pod-labels "application.workload-details"))))
-
-      ; No workload- fields specified
-      (let [task-metadata {:command {:user "test-user"}
-                           :task-request {:job {:job/application {}}
-                                          :scalar-requests {"mem" 512 "cpus" 1.0}}}
-            ^V1Pod pod (api/task-metadata->pod "test-namespace"
-                                               fake-cc-config
-                                               task-metadata)
-            pod-labels (-> pod .getMetadata .getLabels)]
-        (is (= "undefined" (get pod-labels "application.workload-class")))
-        (is (= "undefined" (get pod-labels "application.workload-id")))
-        (is (= "undefined" (get pod-labels "application.workload-details")))))
-
-    (testing "synthetic pod anti-affinity"
-      (with-redefs [config/kubernetes (constantly {:synthetic-pod-anti-affinity-namespace "test-namespace"
-                                                   :synthetic-pod-anti-affinity-pod-label-key "test-key"
-                                                   :synthetic-pod-anti-affinity-pod-label-value "test-value"})]
-        (let [task-metadata {:command {:user "test-user"}
-                             :task-id "synthetic"
-                             :task-request {:scalar-requests {"mem" 512 "cpus" 1.0}}}
-              pod (api/task-metadata->pod "test-namespace" fake-cc-config task-metadata)
-              ^V1PodAffinityTerm pod-affinity-term (-> pod
-                                                       .getSpec
-                                                       .getAffinity
-                                                       .getPodAntiAffinity
-                                                       .getRequiredDuringSchedulingIgnoredDuringExecution
-                                                       first)
-              namespaces (-> pod-affinity-term .getNamespaces)]
-          (is pod-affinity-term)
-          (is (= api/k8s-hostname-label (.getTopologyKey pod-affinity-term)))
-          (is (= {"test-key" "test-value"} (-> pod-affinity-term .getLabelSelector .getMatchLabels)))
-          (is (= 1 (count namespaces)))
-          (is (= "test-namespace" (first namespaces))))))
-
-    (testing "telemetry environment"
-      (with-redefs [config/kubernetes (constantly {:add-job-label-to-pod-prefix "test-prefix/"
-                                                   :telemetry-agent-host-var-name "TEST_AGENT"
-                                                   :telemetry-env-var-name "TEST_ENV"
-                                                   :telemetry-env-value "test-env"
-                                                   :telemetry-pool-regex "^telemetry-pool$"
-                                                   :telemetry-service-var-name "TEST_SERVICE"
-                                                   :telemetry-tags-entry-separator " "
-                                                   :telemetry-tags-key-invalid-char-pattern (re-pattern "[^a-zA-Z0-9-]")
-                                                   :telemetry-tags-key-invalid-char-replacement "."
-                                                   :telemetry-tags-key-value-separator ":"
-                                                   :telemetry-tags-var-name "TEST_TAGS"
-                                                   :telemetry-version-var-name "TEST_VERSION"})]
-        (let [task-metadata {:command {:user "test-user"}
-                             :task-request {:job {:job/pool {:pool/name "telemetry-pool"}
-                                                  :job/application {:application/name "test-name"
-                                                                    :application/version "test-version"
-                                                                    :application/workload-class "foo"
-                                                                    :application/workload-id "bar"
-                                                                    :application/workload-details "baz"}}
-                                            :scalar-requests {"mem" 512 "cpus" 1.0}}}
-              pod (api/task-metadata->pod "test-namespace" fake-cc-config task-metadata)
-              ^V1Container container (-> pod .getSpec .getContainers first)
-              container-env (.getEnv container)]
-          (is (= "required-cook-job-container" (.getName container)))
-          (is (set/subset?
-                #{"TEST_AGENT"
-                  "TEST_ENV"
-                  "TEST_SERVICE"
-                  "TEST_TAGS"
-                  "TEST_VERSION"}
-                (->> container-env (map #(.getName %)) set)))
-          (assert-env-var-value container "TEST_ENV" "test-env")
-          (assert-env-var-value container "TEST_SERVICE" "test-name")
-          (assert-env-var-value container "TEST_TAGS"
-                                (str "test-prefix.application.name:test-name "
-                                     "test-prefix.application.version:test-version "
-                                     "test-prefix.application.workload-class:foo "
-                                     "test-prefix.application.workload-id:bar "
-                                     "test-prefix.application.workload-details:baz"))
-          (assert-env-var-value container "TEST_VERSION" "test-version"))
-        (let [task-metadata {:command {:user "test-user"}
-                             :task-request {:job {:job/pool {:pool/name "non-telemetry-pool"}
-                                                  :job/application {:application/name "test-name"
-                                                                    :application/version "test-version"
-                                                                    :application/workload-class "foo"
-                                                                    :application/workload-id "bar"
-                                                                    :application/workload-details "baz"}}
-                                            :scalar-requests {"mem" 512 "cpus" 1.0}}}
-              pod (api/task-metadata->pod "test-namespace" fake-cc-config task-metadata)
-              ^V1Container container (-> pod .getSpec .getContainers first)
-              container-env (.getEnv container)]
-          (is (= "required-cook-job-container" (.getName container)))
-          (is (not (set/subset?
-                     #{"TEST_AGENT"}
-                     (->> container-env (map #(.getName %)) set)))))))))
+            (is (set/subset?
+                  #{"TEST_AGENT"
+                    "TEST_ENV"
+                    "TEST_SERVICE"
+                    "TEST_TAGS"
+                    "TEST_VERSION"}
+                  (->> container-env (map #(.getName %)) set)))
+            (assert-env-var-value container "TEST_ENV" "test-env")
+            (assert-env-var-value container "TEST_SERVICE" "test-name")
+            (assert-env-var-value container "TEST_TAGS"
+                                  (str "test-prefix.application.name:test-name "
+                                       "test-prefix.application.version:test-version "
+                                       "test-prefix.application.workload-class:foo "
+                                       "test-prefix.application.workload-id:bar "
+                                       "test-prefix.application.workload-details:baz"))
+            (assert-env-var-value container "TEST_VERSION" "test-version"))
+          (let [task-metadata {:command {:user "test-user"}
+                               :task-request {:job {:job/pool {:pool/name "non-telemetry-pool"}
+                                                    :job/application {:application/name "test-name"
+                                                                      :application/version "test-version"
+                                                                      :application/workload-class "foo"
+                                                                      :application/workload-id "bar"
+                                                                      :application/workload-details "baz"}}
+                                              :scalar-requests {"mem" 512 "cpus" 1.0}}}
+                pod (api/task-metadata->pod "test-namespace" fake-cc-config task-metadata)
+                ^V1Container container (-> pod .getSpec .getContainers first)
+                container-env (.getEnv container)]
+            (is (= "required-cook-job-container" (.getName container)))
+            (is (not (set/subset?
+                       #{"TEST_AGENT"}
+                       (->> container-env (map #(.getName %)) set))))))))))
 
 (defn- k8s-volume->clj [^V1Volume volume]
   {:name (.getName volume)

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -66,7 +66,8 @@
         launched-pod-atom (atom nil)]
     (with-redefs [api/launch-pod (fn [_ _ {:keys [launch-pod]} _]
                                    (reset! launched-pod-atom launch-pod))
-                  api/make-security-context (constantly (V1PodSecurityContext.))]
+                  api/make-security-context (constantly (V1PodSecurityContext.))
+                  cook.config-incremental/get-conn (fn [] conn)]
       (testing "static namespace"
         (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil
                                                               (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
@@ -107,134 +108,135 @@
 
 (deftest test-generate-offers
   (tu/setup)
-  (with-redefs [api/launch-pod (constantly true)
-                config/disk (constantly [{:pool-regex "test-pool"
-                                          :max-size 256000.0
-                                          :valid-types #{"standard", "pd-ssd"}
-                                          :default-type "standard"
-                                          :default-request 10000.0
-                                          :type-map {"standard", "pd-standard"}
-                                          :enable-constraint? true
-                                          :disk-node-label "cloud.google.com/gke-boot-disk"}])]
-    (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")
-          compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil
-                                                          (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
-                                                          {:kind :static :namespace "cook"} nil 3 nil nil
-                                                          (Executors/newSingleThreadExecutor)
-                                                          {} (atom :running) (atom false) false
-                                                          cook.rate-limit/AllowAllRateLimiter "t-c" "p-c" "l-c" (repeatedly 16 #(ReentrantLock.)))
-          node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 10 "nvidia-tesla-p100" nil nil)
-                           "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 25 "nvidia-tesla-p100" nil nil)
-                           "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil nil nil nil)
-                           "nodeE" (tu/node-helper "nodeE" 2.0 1100.0 nil nil {:disk-amount 256000 :disk-type "pd-standard"} nil)
-                           "my.fake.host" (tu/node-helper "my.fake.host" 1.0 1000.0 nil nil nil nil)}
-          _ (tu/create-pool conn "no-pool")
-          j1 (tu/create-dummy-job conn :ncpus 0.1 :pool "no-pool")
-          j2 (tu/create-dummy-job conn :ncpus 0.2 :pool "no-pool")
-          db (d/db conn)
-          job-ent-1 (d/entity db j1)
-          job-ent-2 (d/entity db j2)
-          task-1 (tu/make-task-metadata job-ent-1 db compute-cluster)
-          task-2 (tu/make-task-metadata job-ent-2 db compute-cluster)
-          _ (cc/launch-tasks compute-cluster "no-pool" [{:task-metadata-seq [task-1 task-2]}] (fn [_]))
-          task-1-id (-> task-1 :task-request :task-id)
-          pods {{:namespace "cook" :name "podA"} (tu/pod-helper "podA" "nodeA"
-                                                                {:cpus 0.25 :mem 250.0 :gpus "9" :gpu-model "nvidia-tesla-p100"}
-                                                                {:cpus 0.1 :mem 100.0})
-                {:namespace "cook" :name "podB"} (tu/pod-helper "podB" "nodeA"
-                                                                {:cpus 0.25 :mem 250.0 :gpus "1" :gpu-model "nvidia-tesla-p100"})
-                {:namespace "cook" :name "podC"} (tu/pod-helper "podC" "nodeB"
-                                                                {:cpus 1.0 :mem 1100.0 :gpus "10" :gpu-model "nvidia-tesla-p100"})
-                {:namespace "cook" :name "podD"} (tu/pod-helper "podD" "nodeD"
-                                                                {:cpus 1.0 :mem 1100.0 :gpus "10" :gpu-model "nvidia-tesla-p100"})
-                {:namespace "cook" :name "podE"} (tu/pod-helper "podE" "nodeE"
-                                                                {:cpus 1.0 :mem 1100.0 :disk {:disk-request 50 :disk-limit 70 :disk-type "pd-standard"}})
-                {:namespace "cook" :name task-1-id} (tu/pod-helper task-1-id "my.fake.host"
-                                                                   {:cpus 0.1 :mem 10.0})}
-          node-name->pods (api/pods->node-name->pods (kcc/add-starting-pods compute-cluster pods))
-          offers (kcc/generate-offers compute-cluster node-name->node node-name->pods "test-pool")]
-      (is (= 5 (count offers)))
-      (let [offer (first (filter #(= "nodeA" (:hostname %))
-                                 offers))]
-        (is (not (nil? offer)))
-        (is (= "kubecompute" (:framework-id offer)))
-        (is (= {:value "nodeA"} (:slave-id offer)))
-        (is (= [{:name "mem" :type :value-scalar :scalar 400.0}
-                {:name "cpus" :type :value-scalar :scalar 0.4}
-                {:name "disk" :type :value-text->scalar :text->scalar {}}
-                {:name "gpus" :type :value-text->scalar :text->scalar {"nvidia-tesla-p100" 0}}]
-               (:resources offer)))
-        (is (:reject-after-match-attempt offer)))
+  (let [conn (tu/restore-fresh-database! "datomic:mem://test-generate-offers")]
+    (with-redefs [api/launch-pod (constantly true)
+                  config/disk (constantly [{:pool-regex "test-pool"
+                                            :max-size 256000.0
+                                            :valid-types #{"standard", "pd-ssd"}
+                                            :default-type "standard"
+                                            :default-request 10000.0
+                                            :type-map {"standard", "pd-standard"}
+                                            :enable-constraint? true
+                                            :disk-node-label "cloud.google.com/gke-boot-disk"}])
+                  cook.config-incremental/get-conn (fn [] conn)]
+      (let [compute-cluster (kcc/->KubernetesComputeCluster nil "kubecompute" nil nil
+                                                            (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom {}) (atom nil)
+                                                            {:kind :static :namespace "cook"} nil 3 nil nil
+                                                            (Executors/newSingleThreadExecutor)
+                                                            {} (atom :running) (atom false) false
+                                                            cook.rate-limit/AllowAllRateLimiter "t-c" "p-c" "l-c" (repeatedly 16 #(ReentrantLock.)))
+            node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 10 "nvidia-tesla-p100" nil nil)
+                             "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 25 "nvidia-tesla-p100" nil nil)
+                             "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil nil nil nil)
+                             "nodeE" (tu/node-helper "nodeE" 2.0 1100.0 nil nil {:disk-amount 256000 :disk-type "pd-standard"} nil)
+                             "my.fake.host" (tu/node-helper "my.fake.host" 1.0 1000.0 nil nil nil nil)}
+            _ (tu/create-pool conn "no-pool")
+            j1 (tu/create-dummy-job conn :ncpus 0.1 :pool "no-pool")
+            j2 (tu/create-dummy-job conn :ncpus 0.2 :pool "no-pool")
+            db (d/db conn)
+            job-ent-1 (d/entity db j1)
+            job-ent-2 (d/entity db j2)
+            task-1 (tu/make-task-metadata job-ent-1 db compute-cluster)
+            task-2 (tu/make-task-metadata job-ent-2 db compute-cluster)
+            _ (cc/launch-tasks compute-cluster "no-pool" [{:task-metadata-seq [task-1 task-2]}] (fn [_]))
+            task-1-id (-> task-1 :task-request :task-id)
+            pods {{:namespace "cook" :name "podA"} (tu/pod-helper "podA" "nodeA"
+                                                                  {:cpus 0.25 :mem 250.0 :gpus "9" :gpu-model "nvidia-tesla-p100"}
+                                                                  {:cpus 0.1 :mem 100.0})
+                  {:namespace "cook" :name "podB"} (tu/pod-helper "podB" "nodeA"
+                                                                  {:cpus 0.25 :mem 250.0 :gpus "1" :gpu-model "nvidia-tesla-p100"})
+                  {:namespace "cook" :name "podC"} (tu/pod-helper "podC" "nodeB"
+                                                                  {:cpus 1.0 :mem 1100.0 :gpus "10" :gpu-model "nvidia-tesla-p100"})
+                  {:namespace "cook" :name "podD"} (tu/pod-helper "podD" "nodeD"
+                                                                  {:cpus 1.0 :mem 1100.0 :gpus "10" :gpu-model "nvidia-tesla-p100"})
+                  {:namespace "cook" :name "podE"} (tu/pod-helper "podE" "nodeE"
+                                                                  {:cpus 1.0 :mem 1100.0 :disk {:disk-request 50 :disk-limit 70 :disk-type "pd-standard"}})
+                  {:namespace "cook" :name task-1-id} (tu/pod-helper task-1-id "my.fake.host"
+                                                                     {:cpus 0.1 :mem 10.0})}
+            node-name->pods (api/pods->node-name->pods (kcc/add-starting-pods compute-cluster pods))
+            offers (kcc/generate-offers compute-cluster node-name->node node-name->pods "test-pool")]
+        (is (= 5 (count offers)))
+        (let [offer (first (filter #(= "nodeA" (:hostname %))
+                                   offers))]
+          (is (not (nil? offer)))
+          (is (= "kubecompute" (:framework-id offer)))
+          (is (= {:value "nodeA"} (:slave-id offer)))
+          (is (= [{:name "mem" :type :value-scalar :scalar 400.0}
+                  {:name "cpus" :type :value-scalar :scalar 0.4}
+                  {:name "disk" :type :value-text->scalar :text->scalar {}}
+                  {:name "gpus" :type :value-text->scalar :text->scalar {"nvidia-tesla-p100" 0}}]
+                 (:resources offer)))
+          (is (:reject-after-match-attempt offer)))
 
-      (let [offer (first (filter #(= "nodeB" (:hostname %))
-                                 offers))]
-        (is (= {:value "nodeB"} (:slave-id offer)))
-        (is (= [{:name "mem" :type :value-scalar :scalar 0.0}
-                {:name "cpus" :type :value-scalar :scalar 0.0}
-                {:name "disk" :type :value-text->scalar :text->scalar {}}
-                {:name "gpus" :type :value-text->scalar :text->scalar {"nvidia-tesla-p100" 15}}]
-               (:resources offer))))
+        (let [offer (first (filter #(= "nodeB" (:hostname %))
+                                   offers))]
+          (is (= {:value "nodeB"} (:slave-id offer)))
+          (is (= [{:name "mem" :type :value-scalar :scalar 0.0}
+                  {:name "cpus" :type :value-scalar :scalar 0.0}
+                  {:name "disk" :type :value-text->scalar :text->scalar {}}
+                  {:name "gpus" :type :value-text->scalar :text->scalar {"nvidia-tesla-p100" 15}}]
+                 (:resources offer))))
 
-      (let [offer (first (filter #(= "my.fake.host" (:hostname %)) offers))]
-        (is (= [{:name "mem" :type :value-scalar :scalar 980.0}
-                {:name "cpus" :type :value-scalar :scalar 0.7}
-                {:name "disk" :type :value-text->scalar :text->scalar {}}
-                {:name "gpus" :type :value-text->scalar :text->scalar {}}]
-               (:resources offer))))
+        (let [offer (first (filter #(= "my.fake.host" (:hostname %)) offers))]
+          (is (= [{:name "mem" :type :value-scalar :scalar 980.0}
+                  {:name "cpus" :type :value-scalar :scalar 0.7}
+                  {:name "disk" :type :value-text->scalar :text->scalar {}}
+                  {:name "gpus" :type :value-text->scalar :text->scalar {}}]
+                 (:resources offer))))
 
-      (let [offer (first (filter #(= "nodeE" (:hostname %))
-                                 offers))]
-        (is (= {:value "nodeE"} (:slave-id offer)))
-        (is (= [{:name "mem" :type :value-scalar :scalar 0.0}
-                {:name "cpus" :type :value-scalar :scalar 1.0}
-                {:name "disk" :type :value-text->scalar :text->scalar {"pd-standard" 255950.0}}
-                {:name "gpus" :type :value-text->scalar :text->scalar {}}]
-               (:resources offer))))
+        (let [offer (first (filter #(= "nodeE" (:hostname %))
+                                   offers))]
+          (is (= {:value "nodeE"} (:slave-id offer)))
+          (is (= [{:name "mem" :type :value-scalar :scalar 0.0}
+                  {:name "cpus" :type :value-scalar :scalar 1.0}
+                  {:name "disk" :type :value-text->scalar :text->scalar {"pd-standard" 255950.0}}
+                  {:name "gpus" :type :value-text->scalar :text->scalar {}}]
+                 (:resources offer))))
 
-      (let [entire-node-a-capacity [{:name "mem"
-                                     :type :value-scalar
-                                     :scalar 1000.0}
-                                    {:name "cpus"
-                                     :type :value-scalar
-                                     :scalar 1.0}
-                                    {:name "disk"
-                                     :type :value-text->scalar
-                                     :text->scalar {}}
-                                    {:name "gpus"
-                                     :type :value-text->scalar
-                                     :text->scalar {"nvidia-tesla-p100" 10}}]]
-        (testing "graceful handling of node with empty pod list"
-          (let [offers
-                (kcc/generate-offers
-                  compute-cluster
-                  node-name->node
-                  (assoc node-name->pods "nodeA" [])
-                  "test-pool")
-                offer (first (filter #(= "nodeA" (:hostname %)) offers))]
-            (is offer)
-            (is (= entire-node-a-capacity (:resources offer)))))
+        (let [entire-node-a-capacity [{:name "mem"
+                                       :type :value-scalar
+                                       :scalar 1000.0}
+                                      {:name "cpus"
+                                       :type :value-scalar
+                                       :scalar 1.0}
+                                      {:name "disk"
+                                       :type :value-text->scalar
+                                       :text->scalar {}}
+                                      {:name "gpus"
+                                       :type :value-text->scalar
+                                       :text->scalar {"nvidia-tesla-p100" 10}}]]
+          (testing "graceful handling of node with empty pod list"
+            (let [offers
+                  (kcc/generate-offers
+                    compute-cluster
+                    node-name->node
+                    (assoc node-name->pods "nodeA" [])
+                    "test-pool")
+                  offer (first (filter #(= "nodeA" (:hostname %)) offers))]
+              (is offer)
+              (is (= entire-node-a-capacity (:resources offer)))))
 
-        (testing "graceful handling of node with nil pod list"
-          (let [offers
-                (kcc/generate-offers
-                  compute-cluster
-                  node-name->node
-                  (assoc node-name->pods "nodeA" nil)
-                  "test-pool")
-                offer (first (filter #(= "nodeA" (:hostname %)) offers))]
-            (is offer)
-            (is (= entire-node-a-capacity (:resources offer)))))
+          (testing "graceful handling of node with nil pod list"
+            (let [offers
+                  (kcc/generate-offers
+                    compute-cluster
+                    node-name->node
+                    (assoc node-name->pods "nodeA" nil)
+                    "test-pool")
+                  offer (first (filter #(= "nodeA" (:hostname %)) offers))]
+              (is offer)
+              (is (= entire-node-a-capacity (:resources offer)))))
 
-        (testing "graceful handling of node with pods with no resource requests"
-          (let [offers
-                (kcc/generate-offers
-                  compute-cluster
-                  node-name->node
-                  (assoc node-name->pods "nodeA" [(V1Pod.) (V1Pod.)])
-                  "test-pool")
-                offer (first (filter #(= "nodeA" (:hostname %)) offers))]
-            (is offer)
-            (is (= entire-node-a-capacity (:resources offer)))))))))
+          (testing "graceful handling of node with pods with no resource requests"
+            (let [offers
+                  (kcc/generate-offers
+                    compute-cluster
+                    node-name->node
+                    (assoc node-name->pods "nodeA" [(V1Pod.) (V1Pod.)])
+                    "test-pool")
+                  offer (first (filter #(= "nodeA" (:hostname %)) offers))]
+              (is offer)
+              (is (= entire-node-a-capacity (:resources offer))))))))))
 
 (deftest determine-cook-expected-state
   ; TODO


### PR DESCRIPTION
This gives Cook time to collect the pod completion status.

## Changes proposed in this PR

- Have Cook put finalizers on its pods

## Why are we making these changes?

This prevents pod-gc from deleting pods before cook can collect the completion status.
