### PR TITLE
Trims pod event logs

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -485,6 +485,7 @@
   useful for debugging purposes (e.g. resourceVersion):
 
   - annotations
+  - creationTimestamp
   - deletionTimestamp
   - finalizers
   - labels
@@ -495,7 +496,6 @@
   We do not log the following fields:
 
   - clusterName
-  - creationTimestamp
   - deletionGracePeriodSeconds
   - generateName
   - generation
@@ -505,6 +505,7 @@
   - uid"
   [^V1ObjectMeta metadata]
   (let [annotations (.getAnnotations metadata)
+        creation-timestamp (.getCreationTimestamp metadata)
         deletion-timestamp (.getDeletionTimestamp metadata)
         finalizers (.getFinalizers metadata)
         labels (.getLabels metadata)]
@@ -513,6 +514,7 @@
        :namespace (.getNamespace metadata)
        :resource-version (.getResourceVersion metadata)}
       (seq annotations) (assoc :annotations (.toString annotations))
+      creation-timestamp (assoc :creation-timestamp (.toString creation-timestamp))
       deletion-timestamp (assoc :deletion-timestamp (.toString deletion-timestamp))
       (seq finalizers) (assoc :finalizers (.toString finalizers))
       (seq labels) (assoc :labels (.toString labels)))))
@@ -552,7 +554,6 @@
                                          :last-timestamp (some-> event .getLastTimestamp .toString)
                                          :message (.getMessage event)
                                          :metadata (some-> event .getMetadata prepare-object-metadata-for-logging)
-                                         :reason (.getReason event)
                                          :source
                                          (cond->
                                            {:component (some-> event .getSource .getComponent)}

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -101,47 +101,10 @@
       stripped-cook-expected-state-dict)))
 
 (defn prepare-pod-metadata-for-logging
-  "Generates a pruned version of pod metadata that is suitable for logging.
-
-  Logging the full metadata object is too much, in particular the
-  managedFields. This function generates a pruned version of metadata
-  that's not as verbose. This cuts logging output by about 2x compared to a
-  simple toString on V1ObjectMeta. As of version 11.0.0 of the Kubernetes
-  client library, the following fields are present in V1ObjectMeta,
-  separated by whether or not we're choosing to log them.
-
-  We do log the following fields because we either use them to determine
-  state in the state machine (e.g. labels) or because we know they are
-  useful for debugging purposes (e.g. resourceVersion):
-
-  - annotations
-  - deletionTimestamp
-  - finalizers
-  - labels
-  - name
-  - namespace
-  - resourceVersion
-
-  We do not log the following fields:
-
-  - clusterName
-  - creationTimestamp
-  - deletionGracePeriodSeconds
-  - generateName
-  - generation
-  - managedFields
-  - ownerReferences
-  - selfLink
-  - uid"
+  "Generates a pruned version of pod metadata that is suitable for logging"
   [pod]
   (when-let [^V1ObjectMeta metadata (some-> ^V1Pod pod .getMetadata)]
-    {:annotations (some-> metadata .getAnnotations .toString)
-     :deletion-timestamp (some-> metadata .getDeletionTimestamp .toString)
-     :finalizers (some-> metadata .getFinalizers .toString)
-     :labels (some-> metadata .getLabels .toString)
-     :name (.getName metadata)
-     :namespace (.getNamespace metadata)
-     :resource-version (.getResourceVersion metadata)}))
+    (api/prepare-object-metadata-for-logging metadata)))
 
 (defn prepare-k8s-actual-state-dict-for-logging
   [{:keys [pod] :as k8s-actual-state-dict}]


### PR DESCRIPTION
This is a follow-up to PR #1948.

## Changes proposed in this PR

Trimming down the pod event log lines.

## Why are we making these changes?

To avoid excessive and unnecessary logging.
