### PR TITLE
Updates github actions to ubuntu-18.04

### DIFF
--- a/.github/workflows/executor-tests.yml
+++ b/.github/workflows/executor-tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
       PYTEST_ADDOPTS: --color=yes
       MESOS_NATIVE_JAVA_LIBRARY: /usr/lib/libmesos.so

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
       PYTEST_ADDOPTS: --color=yes
       MESOS_NATIVE_JAVA_LIBRARY: /usr/lib/libmesos.so


### PR DESCRIPTION
## Changes proposed in this PR

`ubuntu-16.04` -> `ubuntu-18.04` in the GitHub actions yaml.

## Why are we making these changes?

16.04 is no longer listed as an available environment here:

https://github.com/actions/virtual-environments#available-environments