### PR TITLE
Adds application to integration test jobs

### DIFF
--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -526,7 +526,7 @@ def minimal_job(**kwargs):
         'application': {'name': 'cook-integration-tests',
                         'version': os.getenv('TEST_METRICS_COMMIT_HASH_UNDER_TEST', 'none'),
                         'workload-class': 'cook-integration-tests',
-                        'workload-id': get_caller(),
+                        'workload-id': os.getenv('PYTEST_CURRENT_TEST', 'none'),
                         'workload-details': 'cook-integration-test-job'},
         'command': 'echo Default Test Command',
         'cpus': get_default_cpus(),

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -522,18 +522,17 @@ def add_container_to_job_if_needed(job):
 
 
 def minimal_job(**kwargs):
-    caller = get_caller()
     job = {
         'application': {'name': 'cook-integration-tests',
                         'version': os.getenv('TEST_METRICS_COMMIT_HASH_UNDER_TEST', 'none'),
                         'workload-class': 'cook-integration-tests',
-                        'workload-id': caller,
+                        'workload-id': get_caller(),
                         'workload-details': 'cook-integration-test-job'},
         'command': 'echo Default Test Command',
         'cpus': get_default_cpus(),
         'max_retries': 1,
         'mem': int(os.getenv('COOK_DEFAULT_JOB_MEM_MB', 32)),
-        'name': (DEFAULT_JOB_NAME_PREFIX + caller),
+        'name': (DEFAULT_JOB_NAME_PREFIX + get_caller()),
         'priority': 1,
         'uuid': str(make_temporal_uuid())
     }

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -520,13 +520,20 @@ def add_container_to_job_if_needed(job):
             }
         }
 
+
 def minimal_job(**kwargs):
+    caller = get_caller()
     job = {
+        'application': {'name': 'cook-integration-tests',
+                        'version': os.getenv('TEST_METRICS_COMMIT_HASH_UNDER_TEST', 'none'),
+                        'workload-class': 'cook-integration-tests',
+                        'workload-id': caller,
+                        'workload-details': 'cook-integration-test-job'},
         'command': 'echo Default Test Command',
         'cpus': get_default_cpus(),
         'max_retries': 1,
         'mem': int(os.getenv('COOK_DEFAULT_JOB_MEM_MB', 32)),
-        'name': (DEFAULT_JOB_NAME_PREFIX + get_caller()),
+        'name': (DEFAULT_JOB_NAME_PREFIX + caller),
         'priority': 1,
         'uuid': str(make_temporal_uuid())
     }

--- a/integration/tests/cook/util.py
+++ b/integration/tests/cook/util.py
@@ -522,11 +522,18 @@ def add_container_to_job_if_needed(job):
 
 
 def minimal_job(**kwargs):
+    workload_id = 'none'
+    current_test = os.getenv('PYTEST_CURRENT_TEST', None)
+    if current_test:
+        last_part = current_test.split('::')[-1]
+        test_name = last_part.split(' ')[0]
+        workload_id = test_name
+
     job = {
         'application': {'name': 'cook-integration-tests',
                         'version': os.getenv('TEST_METRICS_COMMIT_HASH_UNDER_TEST', 'none'),
                         'workload-class': 'cook-integration-tests',
-                        'workload-id': os.getenv('PYTEST_CURRENT_TEST', 'none'),
+                        'workload-id': workload_id,
                         'workload-details': 'cook-integration-test-job'},
         'command': 'echo Default Test Command',
         'cpus': get_default_cpus(),


### PR DESCRIPTION
## Changes proposed in this PR

Adding `application` to the default job spec for integration test jobs.

## Why are we making these changes?

To have better analytics for integration test jobs.
