### PR TITLE
Fix expired certificates in docker so we can get JDK8 or JDK11

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -5,6 +5,7 @@ FROM mesosphere/mesos:1.3.0
 # https://www.docker.com/blog/changes-dockerproject-org-apt-yum-repositories/
 RUN rm /etc/apt/sources.list.d/docker.list && \
     apt-get -y update && apt-get -y install software-properties-common && \
+    sudo apt-get install --reinstall ca-certificates && \
     add-apt-repository ppa:openjdk-r/ppa && apt-get -y update && \
     apt-get --no-install-recommends -y install \
     curl \


### PR DESCRIPTION
## Changes proposed in this PR

- Change the docker build to update the certificate store.

## Why are we making these changes?
Without this, you cannot download openjdk ppa and download JDK 8 or JDK 11 on trusty (the base image for mesos:1.3.0)
