### PR TITLE
Support rotating logs each hour to reduce uncompressed log size.

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -100,6 +100,7 @@
                                                 :memory-limit 128.0}}
               :set-memory-limit? true}
  :log {:file #config/env "COOK_LOG_FILE"
+       :rotate-hourly true
        :levels {"datomic.db" :warn
                 "datomic.kv-cluster" :warn
                 "datomic.peer" :warn

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -63,7 +63,7 @@
                              "com.netflix.fenzo.AssignableVMs" :warn
                              "com.netflix.fenzo.TaskScheduler" :warn
                              "com.netflix.fenzo.AssignableVirtualMachine" :warn}}))
-  ([{:keys [file] :or {file "log/cook.log"} {:keys [default] :or {default :info} :as overrides} :levels}]
+  ([{:keys [file rotate-hourly] :or {file "log/cook.log" rotate-hourly false} {:keys [default] :or {default :info} :as overrides} :levels}]
    (try
      (-> (Logger/getRootLogger) .getLoggerRepository .resetConfiguration)
      (let [overrides (->> overrides
@@ -76,7 +76,9 @@
                       (PatternLayout.
                         "%d{ISO8601} %-5p %c [%t] - %m%n")
                       file
-                      "'.'yyyy-MM-dd")
+                      (if rotate-hourly
+                        "'.'yyyy-MM-dd-HH"
+                        "'.'yyyy-MM-dd"))
                :level default}
               overrides)
        (log4j-conf/set-loggers!


### PR DESCRIPTION
## Changes proposed in this PR

- Support rotating logs each hour

## Why are we making these changes?
This reduces uncompressed log size.

