### PR TITLE
Extra logging with graphite.

### DIFF
--- a/scheduler/src/cook/reporter.clj
+++ b/scheduler/src/cook/reporter.clj
@@ -34,6 +34,7 @@
 
 (defn graphite-reporter
   [{:keys [prefix host port pickled?]}]
+  (log/info "Starting graphite reporter")
   (let [addr (InetSocketAddress. host port)
         graphite (if pickled?
                    (PickledGraphite. addr)


### PR DESCRIPTION
## Changes proposed in this PR

- Log when we start the graphite reporter

## Why are we making these changes?
Makes it easier to diagnose whether metrics reporting has started or not.

