### PR TITLE
Only adds workload fields to application when non-nil

### DIFF
--- a/jobclient/python/cookclient/jobs.py
+++ b/jobclient/python/cookclient/jobs.py
@@ -123,13 +123,14 @@ class Application:
                f'{self.workload_id}, {self.workload_details}) '
 
     def to_dict(self) -> dict:
-        return {
-            'name': self.name,
-            'version': self.version,
-            'workload-class': self.workload_class,
-            'workload-id': self.workload_id,
-            'workload-details': self.workload_details
-        }
+        d = {'name': self.name, 'version': self.version}
+        if self.workload_class:
+            d['workload-class'] = self.workload_class
+        if self.workload_id:
+            d['workload-id'] = self.workload_id
+        if self.workload_details:
+            d['workload-details'] = self.workload_details
+        return d
 
     @classmethod
     def from_dict(cls, d: dict) -> 'Application':


### PR DESCRIPTION
This is a follow-up to #1970.

## Changes proposed in this PR

Only add the `workload-*` fields to the dictionary when they are non-nil.

## Why are we making these changes?

Otherwise, Cook's API will reject job submissions because they have nil values in these fields.
