### PR TITLE
Fix docker environment to work with clojure 1.10.

### DIFF
--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -37,7 +37,7 @@ RUN lein deps
 
 # Datomic setup
 COPY datomic /opt/cook/datomic
-RUN unzip -uo /opt/cook/datomic/datomic-free-0.9.5394.zip
+RUN unzip -uo /opt/cook/datomic/datomic-free-0.9.5561.56.zip
 
 # Copy the whole scheduler into the container
 COPY docker /opt/cook/docker
@@ -46,7 +46,7 @@ COPY java /opt/cook/java
 COPY src /opt/cook/src
 
 RUN lein uberjar
-RUN cp "target/cook-$(lein print :version | tr -d '"').jar" datomic-free-0.9.5394/lib/cook-$(lein print :version | tr -d '"').jar
+RUN cp "target/cook-$(lein print :version | tr -d '"').jar" datomic-free-0.9.5561.56/lib/cook-$(lein print :version | tr -d '"').jar
 COPY config* /opt/cook/
 
 # Run cook

--- a/scheduler/docker/run-cook.sh
+++ b/scheduler/docker/run-cook.sh
@@ -3,7 +3,7 @@
 DATOMIC_PROPERTIES_FILE=/opt/cook/datomic/datomic_transactor.properties
 
 echo "alt-host=$(hostname -i | cut -d' ' -f2)" >> ${DATOMIC_PROPERTIES_FILE}
-/opt/cook/datomic-free-0.9.5394/bin/transactor ${DATOMIC_PROPERTIES_FILE} &
+/opt/cook/datomic-free-0.9.5561.56/bin/transactor ${DATOMIC_PROPERTIES_FILE} &
 echo "Seeding test data..."
 lein exec -p /opt/cook/datomic/data/seed_pools.clj ${COOK_DATOMIC_URI}
 lein exec -p /opt/cook/datomic/data/seed_running_jobs.clj ${COOK_DATOMIC_URI}


### PR DESCRIPTION
## Changes proposed in this PR

- Upgrade datomic download to 0.9.5561.56 that works with clojure 1.10.

## Why are we making these changes?
Make our opensource Docker workflow work again.

