### PR TITLE
Add missing copyright notices.

### DIFF
--- a/scheduler/src/cook/plugins/adjustment.clj
+++ b/scheduler/src/cook/plugins/adjustment.clj
@@ -1,3 +1,18 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns cook.plugins.adjustment
   (:require [clojure.tools.logging :as log]
             [cook.config :as config]

--- a/scheduler/src/cook/plugins/completion.clj
+++ b/scheduler/src/cook/plugins/completion.clj
@@ -1,3 +1,18 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns cook.plugins.completion
   (:require [clojure.tools.logging :as log]
             [cook.config :as config]

--- a/scheduler/src/cook/plugins/file.clj
+++ b/scheduler/src/cook/plugins/file.clj
@@ -1,3 +1,18 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns cook.plugins.file
   (:require [clojure.tools.logging :as log]
             [cook.config :as config]


### PR DESCRIPTION
## Changes proposed in this PR

- When doing my clojure 1.10 and JDK8 upgrade, I noticed a few files with missing copyright declarations.

## Why are we making these changes?
AFAIK, all files are supposed to have copyright declarations.

