### PR TITLE
support upserting > 1 incremental config in one transaction

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -3417,23 +3417,23 @@
 ;;
 
 (def IncrementalConfigRequest
-  {; key
-   :key s/Keyword
-   ; values
-   :values [{; actual config value
-             :value s/Str
-             ; number between 0 and 1. portion of jobs that should have the associated value. portions must add up to 1
-             :portion s/Num
-             ; optional comment to describe how this incremental value is different from the others
-             (s/optional-key :comment) s/Str}]})
+  {; configs
+   :configs [{; key
+              :key s/Keyword
+              ; values
+              :values [{; actual config value
+                        :value s/Str
+                        ; number between 0 and 1. portion of jobs that should have the associated value. portions must add up to 1
+                        :portion s/Num
+                        ; optional comment to describe how this incremental value is different from the others
+                        (s/optional-key :comment) s/Str}]}]})
 
-(defn upsert-incremental-config!
+(defn upsert-incremental-configs!
   [conn leadership-atom ctx]
-  (let [{:keys [key values]} (-> ctx :request :body-params)
-        result (:tempids (config-incremental/write-config key values))]
+  (let [{:keys [configs]} (-> ctx :request :body-params)
+        result (:tempids (config-incremental/write-configs configs))]
     (log/info "Result of upsert-incremental-config! REST API call"
-              {:key key
-               :values values
+              {:configs configs
                :result result})
     [true {:response result}]))
 
@@ -3464,7 +3464,7 @@
     leader-selector
     {:allowed-methods [:post]
      :handle-created (fn [{:keys [response]}] response)
-     :processable? (partial upsert-incremental-config! conn leadership-atom)}))
+     :processable? (partial upsert-incremental-configs! conn leadership-atom)}))
 
 (defn read-incremental-config
   [conn ctx]

--- a/scheduler/test/cook/test/task.clj
+++ b/scheduler/test/cook/test/task.clj
@@ -112,5 +112,5 @@
                  values [{:value "bar" :portion 1.0}]]
              (with-redefs [cook.config/executor-config (constantly executor-config)
                            cook.config-incremental/get-conn (fn [] conn)]
-               (cook.config-incremental/write-config key values)
+               (cook.config-incremental/write-configs [{:key key :values values}])
                (task/build-executor-environment job-ent)))))))


### PR DESCRIPTION

## Changes proposed in this PR

- add support for upserting more than one incremental configuration in one transaction

## Why are we making these changes?

We want the ability to atomically adjust multiple incremental configurations at once. Portions for incremental configurations are calculated atomically so different configurations with the same portions will affect the same jobs.
