### PR TITLE
Transforms job constraints via configuration

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -541,7 +541,16 @@
                        queue-limits))
      :constraint-attribute->transformation
      (fnk [[:config {constraint-attribute->transformation {}}]]
-       (pc/map-vals #(update % :pattern-regex re-pattern) constraint-attribute->transformation))}))
+       (pc/map-vals
+         #(update
+            %
+            :pattern-transformations
+            (fn [pattern-transformations]
+              (map
+                (fn [pattern-transformation]
+                  (update pattern-transformation :match re-pattern))
+                pattern-transformations)))
+         constraint-attribute->transformation))}))
 
 (defn read-config
   "Given a config file path, reads the config and returns the map"

--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -479,7 +479,8 @@
 
     (testing "constraint transformations"
       (with-redefs [config/constraint-attribute->transformation
-                    (constantly {"a" {:new-attribute "z" :pattern-regex #"^bcd-(.*)$"}})]
+                    (constantly {"a" {:new-attribute "z"
+                                      :pattern-transformations [{:match #"^bcd-" :replacement ""}]}})]
         (let [user-constraints [{:constraint/attribute "a"
                                  :constraint/operator :constraint.operator/equals
                                  :constraint/pattern "bcd-efg"}]]
@@ -496,7 +497,18 @@
         [{:constraint/attribute "z" :constraint/pattern "efg"}]
         (cook.scheduler.constraints/transform-constraints
           [{:constraint/attribute "a" :constraint/pattern "bcd-efg"}]
-          {"a" {:new-attribute "z" :pattern-regex #"^bcd-(.*)$"}}))))
+          {"a" {:new-attribute "z" :pattern-transformations [{:match #"^bcd-" :replacement ""}]}}))))
+
+  (testing "multiple transformations"
+    (is
+      (=
+        [{:constraint/attribute "z" :constraint/pattern "something else"}]
+        (cook.scheduler.constraints/transform-constraints
+          [{:constraint/attribute "a" :constraint/pattern "bcd-efg"}]
+          {"a" {:new-attribute "z"
+                :pattern-transformations
+                [{:match #"^bcd-" :replacement ""}
+                 {:match #"^efg$" :replacement "something else"}]}}))))
 
   (testing "no transformations"
     (is
@@ -512,7 +524,7 @@
         [{:constraint/attribute "h" :constraint/pattern "bcd-efg"}]
         (cook.scheduler.constraints/transform-constraints
           [{:constraint/attribute "h" :constraint/pattern "bcd-efg"}]
-          {"a" {:new-attribute "oops" :pattern-regex "oops"}}))))
+          {"a" {}}))))
 
   (testing "no constraints"
     (is
@@ -520,4 +532,4 @@
         []
         (cook.scheduler.constraints/transform-constraints
           nil
-          {"a" {:new-attribute "oops" :pattern-regex "oops"}})))))
+          {"a" {}})))))


### PR DESCRIPTION
## Changes proposed in this PR

Introducing a new (optional) configuration field which allows for specifying job constraint "transformations", which allow the end-user constraint API to differ from the API with Kubernetes / Fenzo.

## Why are we making these changes?

We want to support constraining jobs by, for example, [`topology.kubernetes.io/region`](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesioregion), while using a different end-user-API attribute name and pattern (value) dictionary.
