### PR TITLE
Makes test_submit_constraint more robust

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -2399,18 +2399,26 @@ if __name__ == '__main__':
         else:
             self.logger.info(f'Using job shape validation: {json.dumps(node_type_lookups, indent=2)}')
 
-        node_family = 'n2'
-        cpu_architecture = 'intel-cascade-lake'
-        const = {
-            'node-family': {'value': node_family, 'found': False},
-            'cpu-architecture': {'value': cpu_architecture, 'found': False},
-        }
+        def choose_constraints():
+            for type_key, node_type_dict in node_type_lookups[0].items():
+                for family, node_family_dict in node_type_dict.items():
+                    for architecture, cpu_architecture_dict in node_family_dict.items():
+                        if type_key and family and architecture:
+                            return type_key, family, architecture
 
-        submit_flags = f'--constraint node-family={node_family} --constraint cpu-architecture={cpu_architecture}'
-        cp, uuids = cli.submit('ls', self.cook_url, submit_flags=submit_flags)
-        if not node_type_lookups[0].get('', {}).get(node_family, {}).get(cpu_architecture, None):
-            self.assertEqual(1, cp.returncode, cp.stdout)
-        else:
+            return None, None, None
+
+        node_type, node_family, cpu_architecture = choose_constraints()
+        if node_type and node_family and cpu_architecture:
+            const = {
+                'node-type': {'value': node_type, 'found': False},
+                'node-family': {'value': node_family, 'found': False},
+                'cpu-architecture': {'value': cpu_architecture, 'found': False},
+            }
+            submit_flags = f'--constraint node-type={node_type} ' \
+                           f'--constraint node-family={node_family} ' \
+                           f'--constraint cpu-architecture={cpu_architecture}'
+            cp, uuids = cli.submit('ls', self.cook_url, submit_flags=submit_flags)
             self.assertEqual(0, cp.returncode, cp.stderr)
             try:
                 job = util.load_job(self.cook_url, uuids[0])
@@ -2425,6 +2433,8 @@ if __name__ == '__main__':
                     self.assertTrue(v['found'])
             finally:
                 util.kill_jobs(self.cook_url, uuids, assert_response=False)
+        else:
+            self.skipTest(f'There is no usable job shape validation configured for the {default_pool} pool')
 
     def test_bad_cluster_argument(self):
         cluster_name = 'foo'


### PR DESCRIPTION
## Changes proposed in this PR

Consulting the configured job shape validation and acting accordingly in `test_submit_constraint`, e.g. don't expect the job submission to succeed if the validation won't allow it.

## Why are we making these changes?

So that we can subsequently enable further job shape validation and keep this test 🟢.