### PR TITLE
Cleans up 'no acceptable compute cluster' log

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -991,7 +991,7 @@
     (when-let [jobs (:no-acceptable-compute-cluster compute-cluster->jobs)]
       (log/info "In" pool-name
                 "pool, there are jobs with no acceptable compute cluster for autoscaling"
-                {:first-10-jobs (take 10 jobs)}))
+                {:first-10-jobs (->> jobs (take 10) (map :job/uuid) (map str))}))
     (dissoc compute-cluster->jobs :no-acceptable-compute-cluster)))
 
 (defn trigger-autoscaling!


### PR DESCRIPTION
## Changes proposed in this PR

Instead of logging the entire job, logging just the UUID.

## Why are we making these changes?

To make the log shorter and cleaner; you can always easily get job info from the UUID.
