### PR TITLE
add waiting under quota user metrics

### DIFF
--- a/scheduler/src/cook/monitor.clj
+++ b/scheduler/src/cook/monitor.clj
@@ -161,7 +161,7 @@
   (let [running-stats (get-job-stats running-job-ents pool-name)
         waiting-stats (get-job-stats pending-job-ents pool-name)
         starved-stats (get-starved-job-stats db running-stats waiting-stats pool-name)
-        waiting-under-quota-stats (get-waiting-under-quota-job-stats  db running-stats waiting-stats pool-name)
+        waiting-under-quota-stats (get-waiting-under-quota-job-stats db running-stats waiting-stats pool-name)
         running-users (set (keys running-stats))
         waiting-users (set (keys waiting-stats))
         satisfied-users (difference running-users waiting-users)


### PR DESCRIPTION
## Changes proposed in this PR

- add waiting under quota user metrics

## Why are we making these changes?

If Cook and the public cloud were perfectly elastic then a user would not have any waiting jobs if they are under quota. This metric will show the real world tracking error at any moment from the theoretical ideal.
