### PR TITLE
Makes test_submit_constraint work with no default submit pool configured

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -2390,7 +2390,7 @@ if __name__ == '__main__':
         settings_dict = util.settings(self.cook_url)
         job_shape_validation_config_map = \
             settings_dict.get('plugins', {}).get('job-shape-validation', {}).get('non-gpu-jobs', [])
-        default_pool = util.default_submit_pool()
+        default_pool = util.default_submit_pool() or util.default_pool(self.cook_url)
         node_type_lookups = [entry['node-type-lookup'] for entry in job_shape_validation_config_map if
                              re.match(entry['pool-regex'], default_pool)]
         if len(node_type_lookups) == 0:


### PR DESCRIPTION
## Changes proposed in this PR

When there is no default submit pool configured, using the default pool from the cluster under test.

## Why are we making these changes?

Not all test runs configure the default submit pool.
