### PR TITLE
add metrics related to node and pod usage

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -414,18 +414,18 @@
   (let [api (CoreV1Api. api-client)
         ^V1NodeList current-nodes-raw
         (timers/time! (metrics/timer "get-all-nodes" compute-cluster-name)
-          (.listNode api
-                     nil ; pretty
-                     nil ; allowWatchBookmarks
-                     nil ; continue
-                     nil ; fieldSelector
-                     nil ; labelSelector
-                     nil ; limit
-                     nil ; resourceVersion
-                     nil ; resourceVersionMatch
-                     nil ; timeoutSeconds
-                     nil ; watch
-                     ))
+                      (.listNode api
+                                 nil ; pretty
+                                 nil ; allowWatchBookmarks
+                                 nil ; continue
+                                 nil ; fieldSelector
+                                 nil ; labelSelector
+                                 nil ; limit
+                                 nil ; resourceVersion
+                                 nil ; resourceVersionMatch
+                                 nil ; timeoutSeconds
+                                 nil ; watch
+                                 ))
         current-nodes (pc/map-from-vals node->node-name (.getItems current-nodes-raw))
         callbacks
         [(tools/make-atom-updater current-nodes-atom) ; Update the set of all pods.
@@ -455,7 +455,7 @@
         (try
           (log/info "In" compute-cluster-name "compute cluster, handling node watch updates")
           (handle-watch-updates current-nodes-atom watch node->node-name
-                                callbacks              ; Update the set of all nodes.
+                                callbacks ; Update the set of all nodes.
                                 (fn []
                                   (set-metric-counter "total-nodes" (-> @current-nodes-atom keys count) compute-cluster-name)
                                   (when max-total-nodes (set-metric-counter "max-total-nodes" max-total-nodes compute-cluster-name))))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -307,7 +307,6 @@
 
 (defn- set-metric-counter
   [counter-name counter-value compute-cluster-name]
-  (log/info "zzz" ["cook-k8s" counter-name (str "compute-cluster-" compute-cluster-name)] counter-value)
   (monitor/set-counter!
     (counters/counter ["cook-k8s" counter-name (str "compute-cluster-" compute-cluster-name)])
     counter-value))
@@ -359,9 +358,8 @@
           (handle-watch-updates all-pods-atom watch get-pod-namespaced-key
                                 callbacks
                                 (fn []
-                                  (log/info "zzz In" compute-cluster-name "compute cluster, handled pod watch updates")
                                   (set-metric-counter "total-pods" (-> @all-pods-atom keys count) compute-cluster-name)
-                                  (set-metric-counter "max-total-pods" max-total-pods compute-cluster-name)))
+                                  (when max-total-pods (set-metric-counter "max-total-pods" max-total-pods compute-cluster-name))))
           (catch Exception e
             (let [cause (.getCause e)]
               (if (and cause (instance? SocketTimeoutException cause))
@@ -459,9 +457,8 @@
           (handle-watch-updates current-nodes-atom watch node->node-name
                                 callbacks              ; Update the set of all nodes.
                                 (fn []
-                                  (log/info "zzz In" compute-cluster-name "compute cluster, handled node watch updates")
                                   (set-metric-counter "total-nodes" (-> @current-nodes-atom keys count) compute-cluster-name)
-                                  (set-metric-counter "max-total-nodes" max-total-nodes compute-cluster-name)))
+                                  (when max-total-nodes (set-metric-counter "max-total-nodes" max-total-nodes compute-cluster-name))))
           (catch Exception e
             (let [cause (-> e Throwable->map :cause)]
               (if (= cause "Socket closed")

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -305,6 +305,7 @@
 
 (defn- set-metric-counter
   [counter-name counter-value compute-cluster-name]
+  (log/info "zzz" ["cook-k8s" counter-name (str "compute-cluster-" compute-cluster-name)] counter-value)
   (monitor/set-counter!
     (counters/counter ["cook-k8s" counter-name (str "compute-cluster-" compute-cluster-name)])
     counter-value))
@@ -355,6 +356,7 @@
           (log/info "In" compute-cluster-name "compute cluster, handling pod watch updates")
           (handle-watch-updates all-pods-atom watch get-pod-namespaced-key
                                 callbacks)
+          (log/info "zzz In" compute-cluster-name "compute cluster, handled pod watch updates")
           (set-metric-counter "total-pods" (-> @all-pods-atom keys count) compute-cluster-name)
           (set-metric-counter "max-total-pods" max-total-pods compute-cluster-name)
           (catch Exception e
@@ -453,6 +455,7 @@
           (log/info "In" compute-cluster-name "compute cluster, handling node watch updates")
           (handle-watch-updates current-nodes-atom watch node->node-name
                                 callbacks) ; Update the set of all nodes.
+          (log/info "zzz In" compute-cluster-name "compute cluster, handled node watch updates")
           (set-metric-counter "total-nodes" (-> @current-nodes-atom keys count) compute-cluster-name)
           (set-metric-counter "max-total-nodes" max-total-nodes compute-cluster-name)
           (catch Exception e

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -482,8 +482,8 @@
           (set-counter-fn "max-total-pods" max-total-pods)
           (set-counter-fn "total-nodes" total-nodes)
           (set-counter-fn "max-total-nodes" max-total-nodes)
-          (set-counter-fn "num-synthetic-pods" num-synthetic-pods)
-          (set-counter-fn "max-pods-outstanding" max-pods-outstanding)
+          (set-counter-fn "total-synthetic-pods" num-synthetic-pods)
+          (set-counter-fn "max-total-synthetic-pods" max-pods-outstanding)
 
           (let [max-launchable (min (- max-pods-outstanding num-synthetic-pods)
                                     (- max-total-nodes total-nodes)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -462,7 +462,7 @@
                :or {command "exit 0" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config
               set-counter-fn (fn [counter-name counter-value]
                                (monitor/set-counter!
-                                 (counters/counter ["cook-k8s" counter-name (str "compute-cluster-" name "pool-" pool-name)])
+                                 (counters/counter ["cook-k8s" counter-name (str "compute-cluster-" name) (str "pool-" pool-name)])
                                  counter-value))]
 
           (when (>= total-pods max-total-pods)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -462,7 +462,7 @@
                :or {command "exit 0" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config
               set-counter-fn (fn [counter-name counter-value]
                                (monitor/set-counter!
-                                 (counters/counter ["cook-k8s" counter-name (str "pool-" pool-name)])
+                                 (counters/counter ["cook-k8s" counter-name (str "compute-cluster-" name "pool-" pool-name)])
                                  counter-value))]
 
           (when (>= total-pods max-total-pods)
@@ -478,10 +478,6 @@
                       {:max-synthetic-pods max-pods-outstanding
                        :synthetic-pods num-synthetic-pods}))
 
-          (set-counter-fn "total-pods" total-pods)
-          (set-counter-fn "max-total-pods" max-total-pods)
-          (set-counter-fn "total-nodes" total-nodes)
-          (set-counter-fn "max-total-nodes" max-total-nodes)
           (set-counter-fn "total-synthetic-pods" num-synthetic-pods)
           (set-counter-fn "max-total-synthetic-pods" max-pods-outstanding)
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -461,6 +461,7 @@
               {:keys [image user command max-pods-outstanding max-total-pods max-total-nodes]
                :or {command "exit 0" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config
               set-counter-fn (fn [counter-name counter-value]
+                               (log/info "zzz" ["cook-k8s" counter-name (str "compute-cluster-" name "pool-" pool-name)] counter-value)
                                (monitor/set-counter!
                                  (counters/counter ["cook-k8s" counter-name (str "compute-cluster-" name "pool-" pool-name)])
                                  counter-value))]

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -20,6 +20,7 @@
             [cook.tools :as tools]
             [cook.util :as util]
             [datomic.api :as d]
+            [metrics.counters :as counters]
             [metrics.meters :as meters]
             [metrics.timers :as timers])
   (:import (com.google.auth.oauth2 GoogleCredentials)
@@ -458,7 +459,11 @@
               total-pods (-> @all-pods-atom keys count)
               total-nodes (-> @current-nodes-atom keys count)
               {:keys [image user command max-pods-outstanding max-total-pods max-total-nodes]
-               :or {command "exit 0" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config]
+               :or {command "exit 0" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config
+              set-counter-fn (fn [counter-name counter-value]
+                               (monitor/set-counter!
+                                 (counters/counter ["cook-k8s" counter-name (str "pool-" pool-name)])
+                                 counter-value))]
 
           (when (>= total-pods max-total-pods)
             (log/warn "In" name "compute cluster, total pods are maxed out"
@@ -472,6 +477,13 @@
             (log/warn "In" name "compute cluster, synthetic pods are maxed out"
                       {:max-synthetic-pods max-pods-outstanding
                        :synthetic-pods num-synthetic-pods}))
+
+          (set-counter-fn "total-pods" total-pods)
+          (set-counter-fn "max-total-pods" max-total-pods)
+          (set-counter-fn "total-nodes" total-nodes)
+          (set-counter-fn "max-total-nodes" max-total-nodes)
+          (set-counter-fn "num-synthetic-pods" num-synthetic-pods)
+          (set-counter-fn "max-pods-outstanding" max-pods-outstanding)
 
           (let [max-launchable (min (- max-pods-outstanding num-synthetic-pods)
                                     (- max-total-nodes total-nodes)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -461,7 +461,6 @@
               {:keys [image user command max-pods-outstanding max-total-pods max-total-nodes]
                :or {command "exit 0" max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config
               set-counter-fn (fn [counter-name counter-value]
-                               (log/info "zzz" ["cook-k8s" counter-name (str "compute-cluster-" name "pool-" pool-name)] counter-value)
                                (monitor/set-counter!
                                  (counters/counter ["cook-k8s" counter-name (str "compute-cluster-" name "pool-" pool-name)])
                                  counter-value))]


### PR DESCRIPTION
## Changes proposed in this PR

- add metrics related to node and pod usage

## Why are we making these changes?

We have limits to the total number of nodes and pods we can have and we alert when we hit those limits. But we don't have metrics of those limits.
