### PR TITLE
Adds production? to settings

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -550,7 +550,10 @@
                 (fn [pattern-transformation]
                   (update pattern-transformation :match re-pattern))
                 pattern-transformations)))
-         constraint-attribute->transformation))}))
+         constraint-attribute->transformation))
+     :production?
+     (fnk [[:config {production? nil}]]
+       production?)}))
 
 (defn read-config
   "Given a config file path, reads the config and returns the map"


### PR DESCRIPTION
## Changes proposed in this PR

Adding `production?` field to Cook's config settings.

## Why are we making these changes?

So that we can ask a Cook if it is production or not, in order to only do certain operations (like killing running and waiting jobs) in non-production Cooks.
