### PR TITLE
Adds watch gap metrics

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.58.4"
+(defproject cook "1.58.5-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -20,7 +20,7 @@
             [cook.util :as util]
             [datomic.api :as d]
             [metrics.counters :as counters]
-            ;[metrics.histograms :as histograms]
+            [metrics.histograms :as histograms]
             [metrics.meters :as meters]
             [metrics.timers :as timers]
             [plumbing.core :as pc])
@@ -203,13 +203,7 @@
                  [compute-cluster-name watch-object-type])]
       (let [millis (- (System/currentTimeMillis) last-watch-response-or-connect-millis)
             metric-name (str (name watch-object-type) "-" metric-name)]
-        (set-metric-counter metric-name millis compute-cluster-name)
-        ;(histograms/update!
-        ;  (metrics/histogram
-        ;    (str (name watch-object-type) "-" metric-name)
-        ;    compute-cluster-name)
-        ;  millis)
-        )))
+        (histograms/update! (metrics/histogram metric-name compute-cluster-name) millis))))
 
   (defn update-disconnected-watch-gap-metric!
     "TODO(DPO)"
@@ -220,12 +214,7 @@
                  [compute-cluster-name watch-object-type])]
       (let [millis (- (System/currentTimeMillis) last-watch-response-or-connect-millis)
             metric-name (str (name watch-object-type) "-" metric-name)]
-        (set-metric-counter metric-name millis compute-cluster-name)
-        ;(histograms/update!
-        ;  (metrics/histogram
-        ;    (str (name watch-object-type) "-" metric-name)
-        ;    compute-cluster-name)
-        ;  millis)
+        (histograms/update! (metrics/histogram metric-name compute-cluster-name) millis)
         (log/info
           "In" compute-cluster-name "compute cluster, marking disconnected"
           (name watch-object-type) "watch gap"

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -186,10 +186,13 @@
 
 (let [last-watch-response-or-connect-millis-atom (atom {})]
   (defn update-watch-gap-metric!
-    "Given a compute cluster name and a watch object type
-    (either :pod or :node), updates a metric with the gap
-    in milliseconds between the last watch response or
-    connection and the current watch response or connection."
+    "Given a compute cluster name and a watch object type (either :pod or :node), updates a
+    metric with the gap in milliseconds between the last watch response or connection and the
+    current watch response or connection. The goal here is to measure 1) the gap between events
+    when we process watches, and 2) the gap when we're not processing anything because we're
+    reconnecting the watch. This function is called at the start of watch processing (with one
+    metric name) and between watch events (with a different metric name). In both cases, we
+    update the last-watch-response-or-connect timestamp."
     [compute-cluster-name watch-object-type metric-name log?]
     (when-let [last-watch-response-or-connect-millis
                (get-in

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -204,41 +204,22 @@
             "In" compute-cluster-name "compute cluster, marked watch gap"
             {:metric-name metric-name
              :watch-gap-millis millis
-             :watch-last-event (-> last-watch-response-or-connect-millis tc/from-long str)})))))
-
-  (defn mark-last-watch-response-or-connect-millis!
-    "Stores the current time as the last watch response or
-    connection for the given compute cluster and type."
-    [compute-cluster-name watch-object-type]
+             :watch-last-event (-> last-watch-response-or-connect-millis tc/from-long str)}))))
     (swap!
       last-watch-response-or-connect-millis-atom
       assoc-in
       [compute-cluster-name watch-object-type]
-      (System/currentTimeMillis)))
+      (System/currentTimeMillis))))
 
-  (defn mark-watch-gap!
-    "Updates the watch-gap-millis metric."
-    [compute-cluster-name watch-object-type]
-    (update-watch-gap-metric!
-      compute-cluster-name
-      watch-object-type
-      "watch-gap-millis"
-      false)
-    (mark-last-watch-response-or-connect-millis!
-      compute-cluster-name
-      watch-object-type))
+(defn mark-watch-gap!
+  "Updates the watch-gap-millis metric."
+  [compute-cluster-name watch-object-type]
+  (update-watch-gap-metric! compute-cluster-name watch-object-type "watch-gap-millis" false))
 
-  (defn mark-disconnected-watch-gap!
-    "Updates the disconnected-watch-gap-millis metric."
-    [compute-cluster-name watch-object-type]
-    (update-watch-gap-metric!
-      compute-cluster-name
-      watch-object-type
-      "disconnected-watch-gap-millis"
-      true)
-    (mark-last-watch-response-or-connect-millis!
-      compute-cluster-name
-      watch-object-type)))
+(defn mark-disconnected-watch-gap!
+  "Updates the disconnected-watch-gap-millis metric."
+  [compute-cluster-name watch-object-type]
+  (update-watch-gap-metric! compute-cluster-name watch-object-type "disconnected-watch-gap-millis" true))
 
 (defn handle-watch-updates
   "When a watch update occurs (for pods or nodes) update both the state atom as well as

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -201,7 +201,8 @@
                (get-in
                  @last-watch-response-or-connect-millis-atom
                  [compute-cluster-name watch-object-type])]
-      (let [millis (- (System/currentTimeMillis) last-watch-response-or-connect-millis)]
+      (let [millis (- (System/currentTimeMillis) last-watch-response-or-connect-millis)
+            metric-name (str (name watch-object-type) "-" metric-name)]
         (set-metric-counter metric-name millis compute-cluster-name)
         ;(histograms/update!
         ;  (metrics/histogram
@@ -217,7 +218,8 @@
                (get-in
                  @last-watch-response-or-connect-millis-atom
                  [compute-cluster-name watch-object-type])]
-      (let [millis (- (System/currentTimeMillis) last-watch-response-or-connect-millis)]
+      (let [millis (- (System/currentTimeMillis) last-watch-response-or-connect-millis)
+            metric-name (str (name watch-object-type) "-" metric-name)]
         (set-metric-counter metric-name millis compute-cluster-name)
         ;(histograms/update!
         ;  (metrics/histogram

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -9,6 +9,7 @@
             [cook.mesos.sandbox :as sandbox]
             [cook.passport :as passport]
             [cook.scheduler.scheduler :as scheduler]
+            [metrics.meters :as meters]
             [metrics.timers :as timers])
   (:import (clojure.lang IAtom)
            (com.twosigma.cook.kubernetes FinalizerHelper)
@@ -684,6 +685,8 @@
          (record-sandbox-url pod-name new-state)))
      (when (or force-process?
                (not (k8s-actual-state-equivalent? old-state new-state)))
+       (when-not force-process?
+         (meters/mark! (metrics/meter "pods-processed-unforced" name)))
        (try
          (process compute-cluster pod-name)
          (catch Exception e

--- a/scheduler/src/cook/kubernetes/metrics.clj
+++ b/scheduler/src/cook/kubernetes/metrics.clj
@@ -1,6 +1,6 @@
 (ns cook.kubernetes.metrics
   (:require [metrics.counters :as counters]
-            [metrics.histograms :as histograms]
+            ;[metrics.histograms :as histograms]
             [metrics.meters :as meters]
             [metrics.timers :as timers]))
 
@@ -26,7 +26,7 @@
   [metric-name compute-cluster-name]
   (timers/timer (calculate-name metric-name compute-cluster-name)))
 
-(defn histogram
-  "Given a metric name and a compute cluster name, returns a histogram metric."
-  [metric-name compute-cluster-name]
-  (histograms/histogram (calculate-name metric-name compute-cluster-name)))
+;(defn histogram
+;  "Given a metric name and a compute cluster name, returns a histogram metric."
+;  [metric-name compute-cluster-name]
+;  (histograms/histogram (calculate-name metric-name compute-cluster-name)))

--- a/scheduler/src/cook/kubernetes/metrics.clj
+++ b/scheduler/src/cook/kubernetes/metrics.clj
@@ -1,7 +1,6 @@
 (ns cook.kubernetes.metrics
   (:require [metrics.core :as core]
             [metrics.counters :as counters]
-            ;[metrics.histograms :as histograms]
             [metrics.meters :as meters]
             [metrics.timers :as timers])
   (:import (com.codahale.metrics Histogram MetricRegistry MetricRegistry$MetricSupplier SlidingTimeWindowArrayReservoir)
@@ -33,14 +32,23 @@
   (reify
     MetricRegistry$MetricSupplier
     (newMetric [_]
-      (Histogram. (SlidingTimeWindowArrayReservoir. 1 TimeUnit/MINUTES)))))
+      (Histogram.
+        ; The default implementation of `Reservoir` in dropwizard metrics is
+        ; `ExponentiallyDecayingReservoir`, which stores data samples for some
+        ; time. When new samples stop arriving, it uses the historical data and
+        ; returns the same characteristics for the data distribution again and
+        ; again, simply because the data distribution doesn’t change. Here we
+        ; switch from the default `ExponentiallyDecayingReservoir` to a sliding
+        ; time window reservoir, which gives zeros when there is no data. See
+        ; https://engineering.salesforce.com/be-careful-with-reservoirs-708884018daf
+        ; for more information.
+        (SlidingTimeWindowArrayReservoir. 60 TimeUnit/SECONDS)))))
 
 (defn histogram
   "Given a metric name and a compute cluster name, returns a histogram metric."
   [metric-name compute-cluster-name]
-  ;(histograms/histogram (calculate-name metric-name compute-cluster-name))
   (.histogram
-    ^MetricRegistry metrics.core/default-registry
+    ^MetricRegistry core/default-registry
     (core/metric-name
       (calculate-name metric-name compute-cluster-name))
     histogram-supplier))

--- a/scheduler/src/cook/kubernetes/metrics.clj
+++ b/scheduler/src/cook/kubernetes/metrics.clj
@@ -42,7 +42,7 @@
         ; time window reservoir, which gives zeros when there is no data. See
         ; https://engineering.salesforce.com/be-careful-with-reservoirs-708884018daf
         ; for more information.
-        (SlidingTimeWindowArrayReservoir. 30 TimeUnit/SECONDS)))))
+        (SlidingTimeWindowArrayReservoir. 300 TimeUnit/SECONDS)))))
 
 (defn histogram
   "Given a metric name and a compute cluster name, returns a histogram metric."

--- a/scheduler/src/cook/kubernetes/metrics.clj
+++ b/scheduler/src/cook/kubernetes/metrics.clj
@@ -42,7 +42,7 @@
         ; time window reservoir, which gives zeros when there is no data. See
         ; https://engineering.salesforce.com/be-careful-with-reservoirs-708884018daf
         ; for more information.
-        (SlidingTimeWindowArrayReservoir. 60 TimeUnit/SECONDS)))))
+        (SlidingTimeWindowArrayReservoir. 30 TimeUnit/SECONDS)))))
 
 (defn histogram
   "Given a metric name and a compute cluster name, returns a histogram metric."

--- a/scheduler/src/cook/kubernetes/metrics.clj
+++ b/scheduler/src/cook/kubernetes/metrics.clj
@@ -1,5 +1,6 @@
 (ns cook.kubernetes.metrics
   (:require [metrics.counters :as counters]
+            [metrics.histograms :as histograms]
             [metrics.meters :as meters]
             [metrics.timers :as timers]))
 
@@ -24,3 +25,8 @@
   "Given a metric name and a compute cluster name, returns a timer metric."
   [metric-name compute-cluster-name]
   (timers/timer (calculate-name metric-name compute-cluster-name)))
+
+(defn histogram
+  "Given a metric name and a compute cluster name, returns a histogram metric."
+  [metric-name compute-cluster-name]
+  (histograms/histogram (calculate-name metric-name compute-cluster-name)))

--- a/scheduler/src/cook/kubernetes/metrics.clj
+++ b/scheduler/src/cook/kubernetes/metrics.clj
@@ -1,8 +1,11 @@
 (ns cook.kubernetes.metrics
-  (:require [metrics.counters :as counters]
+  (:require [metrics.core :as core]
+            [metrics.counters :as counters]
             ;[metrics.histograms :as histograms]
             [metrics.meters :as meters]
-            [metrics.timers :as timers]))
+            [metrics.timers :as timers])
+  (:import (com.codahale.metrics Histogram MetricRegistry MetricRegistry$MetricSupplier SlidingTimeWindowArrayReservoir)
+           (java.util.concurrent TimeUnit)))
 
 (defn calculate-name
   "Given a metric name and compute cluster name, come up with the metric path to use."
@@ -26,7 +29,18 @@
   [metric-name compute-cluster-name]
   (timers/timer (calculate-name metric-name compute-cluster-name)))
 
-;(defn histogram
-;  "Given a metric name and a compute cluster name, returns a histogram metric."
-;  [metric-name compute-cluster-name]
-;  (histograms/histogram (calculate-name metric-name compute-cluster-name)))
+(def histogram-supplier
+  (reify
+    MetricRegistry$MetricSupplier
+    (newMetric [_]
+      (Histogram. (SlidingTimeWindowArrayReservoir. 1 TimeUnit/MINUTES)))))
+
+(defn histogram
+  "Given a metric name and a compute cluster name, returns a histogram metric."
+  [metric-name compute-cluster-name]
+  ;(histograms/histogram (calculate-name metric-name compute-cluster-name))
+  (.histogram
+    ^MetricRegistry metrics.core/default-registry
+    (core/metric-name
+      (calculate-name metric-name compute-cluster-name))
+    histogram-supplier))


### PR DESCRIPTION
## Changes proposed in this PR

Adding metrics for:

- time during a disconnected pod/node watch
- time between pod/node watch responses
- pods processed from the pod watch

## Why are we making these changes?

To better understand the effects of watches disconnecting.
