### PR TITLE
Logs info, not error, when a deleted cluster's watch fails

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -395,7 +395,7 @@
         ; Initialize the node watch path.
         (api/initialize-node-watch this)
 
-        (api/initialize-event-watch api-client name all-pods-atom)
+        (api/initialize-event-watch this)
         (catch Throwable e
           (log/error e "Failed to bring up compute cluster" name)
           (throw e))))


### PR DESCRIPTION
## Changes proposed in this PR

- 
- 
- 

## Why are we making these changes?


