### PR TITLE
Logs pod events with type Warning

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -550,7 +550,7 @@
                               (= event-type "Warning")
                               ; The fieldPath is something like:
                               ; "spec.containers{aux-cook-sidecar-container}"
-                              (-> field-path str/lower-case (str/includes? "cook"))))
+                              (some-> field-path str/lower-case (str/includes? "cook"))))
                       (log/info "In" compute-cluster-name
                                 "compute cluster, received pod event"
                                 {:event-reason (.getReason event)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -543,7 +543,14 @@
                         (some-> @all-pods-atom
                           (get namespaced-pod-name)
                           (is-cook-scheduler-pod compute-cluster-name))]
-                    (when (or tracked-pod? (= event-type "Warning"))
+                    (when (or
+                            tracked-pod?
+                            (and
+                              ; The event type is either "Normal" or "Warning"
+                              (= event-type "Warning")
+                              ; The fieldPath is something like:
+                              ; "spec.containers{aux-cook-sidecar-container}"
+                              (-> field-path str/lower-case (str/includes? "cook"))))
                       (log/info "In" compute-cluster-name
                                 "compute cluster, received pod event"
                                 {:event-reason (.getReason event)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -546,7 +546,8 @@
                     (when (or
                             tracked-pod?
                             (and
-                              ; The event type is either "Normal" or "Warning"
+                              ; The event type can be either "Normal" or "Warning", and we're
+                              ; only interested in "Warning" events for non-tracked pods
                               (= event-type "Warning")
                               ; The fieldPath is something like:
                               ; "spec.containers{aux-cook-sidecar-container}"


### PR DESCRIPTION
## Changes proposed in this PR

Logging pod events that do not correspond to currently tracked pods, if they both have event type `Warning` and reference `cook` in the `fieldPath`.

## Why are we making these changes?

Pod events tied to Cook pods can arrive after Cook has deleted the pod, and we want these events to show up in the log as well.
