### PR TITLE
Fix vagrant scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ To test a simple job submission:
 
 To run automated tests:
 
+1. Run `cd ../jobclient/java && mvn install -DskipTests && cd -` to build jobclient dependency
 1. Run `lein test :all-but-benchmark` to run unit tests
 1. Run `cd ../integration && pytest -m 'not cli'` to run integration tests
 1. Run `cd ../integration && pytest -k test_basic_submit -n 0 -s` to run a particular integration test

--- a/scheduler/bin/start-datomic.sh
+++ b/scheduler/bin/start-datomic.sh
@@ -16,6 +16,9 @@ COOK_VERSION=$(lein print :version | tr -d '"')
 if [ ! -f "${DATOMIC_DIR}/lib/cook-${COOK_VERSION}.jar" ];
 then
     lein uberjar
+    # `lein print :version` would not have worked if nothing was built, so need to
+    # get version again after building
+    COOK_VERSION=$(lein print :version | tr -d '"')
     cp "${PROJECT_DIR}/target/cook-${COOK_VERSION}.jar" "${DATOMIC_DIR}/lib/"
 fi
 

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -229,7 +229,7 @@
    {:dependencies [[criterium "0.4.4"]
                    [org.clojure/test.check "0.6.1"]
                    [org.mockito/mockito-core "3.12.4"]
-                   [twosigma/cook-jobclient "0.8.6-SNAPSHOT"]]}
+                   [twosigma/cook-jobclient "0.8.7-SNAPSHOT"]]}
 
    :test-console
    [:test {:jvm-opts ["-Dcook.test.logging.console"]}]


### PR DESCRIPTION
## Changes proposed in this PR

- fix version of datomic.zip
- fix COOK_VERSION in start datomic script
- update jobclient dependency version
- add instructions to build jobclient dependency

## Why are we making these changes?

We should be able to follow the steps to set up Cook using Vagrant and have it work: https://github.com/twosigma/Cook#readme
