### PR TITLE
Adds field for command length

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -791,6 +791,7 @@
         job-submit-time (Date.)
         txn (cond-> {:db/id db-id
                      :job/command command
+                     :job/command-length (count command)
                      :job/commit-latch commit-latch-id
                      :job/custom-executor false
                      :job/disable-mea-culpa-retries disable-mea-culpa-retries

--- a/scheduler/src/cook/schema.clj
+++ b/scheduler/src/cook/schema.clj
@@ -205,6 +205,12 @@ for a job. E.g. {:resources {:cpus 4 :mem 3} :constraints {\"unique_host_constra
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one
     :db.install/_attribute :db.part/db}
+   {:db/id (d/tempid :db.part/db)
+    :db/doc "The length of the job command"
+    :db/ident :job/command-length
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
    ;; Group attributes
    {:db/id (d/tempid :db.part/db)
     :db/ident :group/uuid


### PR DESCRIPTION
## Changes proposed in this PR

Adding a field for the length of the job command.

## Why are we making these changes?

For easier data analysis on command line lengths in the wild.
