### PR TITLE
allow incremental configurations for default job constraints

### DIFF
--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -30,6 +30,7 @@
 
 (def checkpoint-volume-mounts-key-selected :checkpoint-volume-mounts-key-selected)
 (def default-image-selected :default-image-selected)
+(def default-job-constraint-pattern-selected :default-job-constraint-pattern-selected)
 (def init-container-image-selected :init-container-image-selected)
 (def job-created :job-created)
 (def job-submitted :job-submitted)

--- a/scheduler/src/cook/passport.clj
+++ b/scheduler/src/cook/passport.clj
@@ -30,7 +30,6 @@
 
 (def checkpoint-volume-mounts-key-selected :checkpoint-volume-mounts-key-selected)
 (def default-image-selected :default-image-selected)
-(def default-job-constraint-pattern-selected :default-job-constraint-pattern-selected)
 (def init-container-image-selected :init-container-image-selected)
 (def job-created :job-created)
 (def job-submitted :job-submitted)

--- a/scheduler/src/cook/scheduler/constraints.clj
+++ b/scheduler/src/cook/scheduler/constraints.clj
@@ -22,7 +22,9 @@
             [cook.cached-queries :as cached-queries]
             [cook.compute-cluster :as cc]
             [cook.config :as config]
+            [cook.config-incremental :as config-incremental]
             [cook.group :as group]
+            [cook.passport :as passport]
             [cook.regexp-tools :as regexp-tools]
             [cook.tools :as util]
             [swiss.arrows :refer :all])
@@ -250,13 +252,37 @@
     [this _ vm-attributes _]
     (job-constraint-evaluate this _ vm-attributes)))
 
+(defn- resolve-incremental-default-job-constraints
+  "Resolve any incremental configurations used for default job constraint patterns"
+  [default-job-constraints {:keys [job/uuid job/name job/user]} pool-name]
+  (let [passport-event-base {:job-name name
+                             :job-uuid (str uuid)
+                             :pool pool-name
+                             :user user}]
+    (->> default-job-constraints
+         (map (fn [{:keys [constraint/attribute constraint/pattern constraint/pattern-fallback] :as constraint}]
+                (if (string? pattern)
+                  constraint
+                  (let [[resolved-pattern reason] (config-incremental/resolve-incremental-config uuid pattern pattern-fallback)]
+                    (passport/log-event (merge passport-event-base
+                                               {:event-type passport/default-job-constraint-pattern-selected
+                                                :constraint-attribute attribute
+                                                :constraint-pattern pattern
+                                                :reason reason
+                                                :resolved-pattern resolved-pattern}))
+                    (-> constraint
+                      (dissoc :constraint/pattern-fallback)
+                      (assoc :constraint/pattern resolved-pattern)))))))))
+
 (defn job->default-constraints
   "Returns the list of default constraints configured for the job's pool"
   [job]
-  (regexp-tools/match-based-on-pool-name
-    (config/default-job-constraints)
-    (cached-queries/job->pool-name job)
-    :default-constraints))
+  (let [pool-name (cached-queries/job->pool-name job)
+        default-job-constraints (regexp-tools/match-based-on-pool-name
+                                  (config/default-job-constraints)
+                                  pool-name
+                                  :default-constraints)]
+    (resolve-incremental-default-job-constraints default-job-constraints job pool-name)))
 
 (def machine-type-constraint-attributes
   #{"cpu-architecture" "node-family" "node-type"})


### PR DESCRIPTION
## Changes proposed in this PR

- allow incremental configurations for default job constraints

## Why are we making these changes?

We want different default job constraints for different jobs for example to transition to different GPU driver versions