### PR TITLE
support using default image with a user-specified container

### DIFF
--- a/jobclient/python/cookclient/__init__.py
+++ b/jobclient/python/cookclient/__init__.py
@@ -28,7 +28,7 @@ from . import util
 from .containers import AbstractContainer
 from .jobs import Application, Disk, Job
 
-CLIENT_VERSION = '0.3.4'
+CLIENT_VERSION = '0.3.5'
 
 _LOG = logging.getLogger(__name__)
 _LOG.addHandler(logging.StreamHandler())

--- a/jobclient/python/cookclient/containers.py
+++ b/jobclient/python/cookclient/containers.py
@@ -194,7 +194,7 @@ class DockerContainer(AbstractContainer):
 
                  volumes: Optional[List[Volume]] = None):
         # backwards-compatible change to allow user to keep supplying image as the first positional argument
-        self.image = image or args[0]
+        self.image = image or (args[0] if args else None)
         self.network = network
         self.force_pull_image = force_pull_image
         self.parameters = parameters

--- a/jobclient/python/cookclient/containers.py
+++ b/jobclient/python/cookclient/containers.py
@@ -184,7 +184,7 @@ class DockerContainer(AbstractContainer):
     parameters: Optional[List[Dict[str, str]]]
     port_mapping: Optional[List[DockerPortMapping]]
 
-    def __init__(self, *,
+    def __init__(self, *args,
 
                  image: Optional[str] = None,
                  network: Optional[str] = None,
@@ -193,7 +193,8 @@ class DockerContainer(AbstractContainer):
                  port_mapping: Optional[List[DockerPortMapping]] = None,
 
                  volumes: Optional[List[Volume]] = None):
-        self.image = image
+        # backwards-compatible change to allow user to keep supplying image as the first positional argument
+        self.image = image or args[0]
         self.network = network
         self.force_pull_image = force_pull_image
         self.parameters = parameters

--- a/jobclient/python/cookclient/containers.py
+++ b/jobclient/python/cookclient/containers.py
@@ -164,8 +164,8 @@ class DockerPortMapping:
 class DockerContainer(AbstractContainer):
     """A Docker container description.
 
-    :param image: Name of the image to use.
-    :type image: str
+    :param image: Name of the image to use. Defaults to None.
+    :type image: str, optional
     :param network: Network the container should be in. Defaults to None.
     :type network: str, optional
     :param force_pull_image: If true, then the image will always be pulled.
@@ -177,15 +177,16 @@ class DockerContainer(AbstractContainer):
         Defaults to None.
     :type port_mapping: List[DockerPortMapping], optional
     """
-    image: str
+    image: Optional[str]
 
     network: Optional[str]
     force_pull_image: Optional[bool]
     parameters: Optional[List[Dict[str, str]]]
     port_mapping: Optional[List[DockerPortMapping]]
 
-    def __init__(self, image: str, *,
+    def __init__(self, *,
 
+                 image: Optional[str] = None,
                  network: Optional[str] = None,
                  force_pull_image: Optional[bool] = None,
                  parameters: Optional[List[Dict[str, str]]] = None,

--- a/jobclient/python/cookclient/containers.py
+++ b/jobclient/python/cookclient/containers.py
@@ -217,7 +217,9 @@ class DockerContainer(AbstractContainer):
         """Get the ``dict`` representation of this container."""
         d = super().to_dict()
 
-        docker = {'image': self.image}
+        docker = {}
+        if self.image is not None:
+            docker['image'] = self.image
         if self.network is not None:
             docker['network'] = self.network
         if self.force_pull_image is not None:

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -735,7 +735,3 @@
 (defn constraint-attribute->transformation
   []
   (-> config :settings :constraint-attribute->transformation))
-
-(defn default-image-symbolic-name
-  []
-  (-> config :settings :default-image-symbolic-name))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -538,7 +538,9 @@
                               offer-matching))
      :queue-limits (fnk [[:config {queue-limits {}}]]
                      (merge {:update-interval-seconds 180}
-                       queue-limits))
+                            queue-limits))
+     :default-image-symbolic-name (fnk [[:config {default-image-symbolic-name nil}]]
+                                    default-image-symbolic-name)
      :constraint-attribute->transformation
      (fnk [[:config {constraint-attribute->transformation {}}]]
        (pc/map-vals
@@ -733,3 +735,7 @@
 (defn constraint-attribute->transformation
   []
   (-> config :settings :constraint-attribute->transformation))
+
+(defn default-image-symbolic-name
+  []
+  (-> config :settings :default-image-symbolic-name))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -539,8 +539,6 @@
      :queue-limits (fnk [[:config {queue-limits {}}]]
                      (merge {:update-interval-seconds 180}
                             queue-limits))
-     :default-image-symbolic-name (fnk [[:config {default-image-symbolic-name nil}]]
-                                    default-image-symbolic-name)
      :constraint-attribute->transformation
      (fnk [[:config {constraint-attribute->transformation {}}]]
        (pc/map-vals

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -593,9 +593,9 @@
         ; A user can specify their own container but use the image of the default container. This allows the
         ; user to set other container properties such as ports but not have to provide the actual image themselves.
         ; To do this, a user must specify a special symbolic name for the image. This image name must match the
-        ; :default-image-symbolic-name field of the default container. The default container image is then used.
+        ; default-image-symbolic-name config. The default container image is then used.
         image (if (string? image-config)
-                (if (= (-> default-container :docker :default-image-symbolic-name) image-config)
+                (if (= (config/default-image-symbolic-name) image-config)
                   (-> default-container :docker :image)
                   image-config)
                 (let [[resolved-config reason] (config-incremental/resolve-incremental-config uuid image-config (:image-fallback docker))]


### PR DESCRIPTION
## Changes proposed in this PR

- support using default image with a user-specified container


## Why are we making these changes?

Currently the user can only use the default image if they do not specify any container. A user is not able to specify properties of a container such as open ports and at the same time use the default image. They must specify all or nothing.
This PR lets the user set a special symbolic image in their container spec name that will be translated into the default image.

