### PR TITLE
Make offer handling unit test not depend on database at compile time.

### DIFF
--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -51,6 +51,7 @@
     (is (= config (compute-cluster-config-ent->compute-cluster-config config-ent)))))
 
 (deftest test-db-config-ents
+  (setup)
   (let [uri "datomic:mem://test-compute-cluster-config"
         conn (restore-fresh-database! uri)
         temp-db-id (d/tempid :db.part/user)
@@ -192,6 +193,7 @@
            {:a {}}))))
 
 (deftest test-get-job-instance-ids-for-cluster-name
+  (setup)
   (let [uri "datomic:mem://test-compute-cluster-config"
         conn (restore-fresh-database! uri)
         name "cluster1"


### PR DESCRIPTION
## Changes proposed in this PR

- Make offer handling unit test not depend on database at compile time.

## Why are we making these changes?
Helps with the postgres migration.

