### PR TITLE
Adds annotation for using all gids

### DIFF
--- a/scheduler/src/cook/config_incremental.clj
+++ b/scheduler/src/cook/config_incremental.clj
@@ -123,7 +123,7 @@
      (select-config-from-values uuid incremental-config)
      (keyword? incremental-config)
      (select-config-from-key uuid incremental-config)))
-  ([^UUID uuid incremental-config fallback-config]
+  ([uuid incremental-config fallback-config]
    (let [resolved-incremental-config (resolve-incremental-config uuid incremental-config)]
      (if resolved-incremental-config
        [resolved-incremental-config :resolved-incremental-config]


### PR DESCRIPTION
## Changes proposed in this PR

- allowing a "use all gids" pod annotation to be incrementally added to pods

## Why are we making these changes?

In order to avoid contradictions between which group Cook thinks a user belongs to and which group Kubernetes thinks the user belongs to.
