### PR TITLE
fix support for incremental default image configuration

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2068,25 +2068,7 @@ class CookTest(util.CookTest):
             max_retries=5)
         self.assertEqual(resp.status_code, 201)
         job = util.wait_for_job(self.cook_url, job_uuid, 'completed')
-        default_image_config = expected_container["docker"]["image"]
-        job_image = job["container"]["docker"]["image"]
-        if default_image_config != job_image:
-            resp = util.session.get(f'{self.cook_url}/incremental-config')
-            self.assertEqual(200, resp.status_code)
-            resp_json = resp.json()
-            config_values = resp_json.get(default_image_config, None)
-            test_failed = False
-            if not config_values or not isinstance(config_values, list):
-                test_failed = True
-            else:
-                image_matched = False
-                for config_value in config_values:
-                    if config_value.get('value', None) == job_image:
-                        image_matched = True
-                test_failed = not image_matched
-            if test_failed:
-                self.fail(f'job_image ({job_image}) does not match default_image_config ({default_image_config})'
-                          f' and does not match any incremental default image configurations ({config_values})')
+        self.assertIsNotNone(job["container"]["docker"]["image"])
         self.assertIn('success', [i['status'] for i in job['instances']])
 
     @unittest.skipUnless(util.docker_tests_enabled() and util.has_docker_service() and not util.using_kubernetes(),

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -586,6 +586,7 @@
         docker-id (d/tempid :db.part/user)
         volumes (or (:volumes container) [])
         docker (:docker container)
+        default-docker (:docker default-container)
         params (->> (or (:parameters docker) [])
                     (ensure-user-parameter user id))
         port-mappings (or (:port-mapping docker) [])
@@ -594,11 +595,15 @@
         ; user to set other container properties such as ports but not have to provide the actual image themselves.
         ; To do this, a user can omit the image field. The default container image is then used.
         image-config (if-not user-image
-                       (-> default-container :docker :image)
+                       (:image default-docker)
                        user-image)
         image (if (string? image-config)
                 image-config
-                (let [[resolved-config reason] (config-incremental/resolve-incremental-config uuid image-config (:image-fallback docker))]
+                (let [[resolved-config reason]
+                      (config-incremental/resolve-incremental-config
+                        uuid
+                        image-config
+                        (or (:image-fallback docker) (:image-fallback default-docker)))]
                   (passport/log-event {:event-type passport/default-image-selected
                                        :image-config image-config
                                        :job-name name

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -589,24 +589,25 @@
         params (->> (or (:parameters docker) [])
                     (ensure-user-parameter user id))
         port-mappings (or (:port-mapping docker) [])
-        image-config (:image docker)
+        user-image (:image docker)
         ; A user can specify their own container but use the image of the default container. This allows the
         ; user to set other container properties such as ports but not have to provide the actual image themselves.
         ; To do this, a user can omit the image field. The default container image is then used.
-        image (if-not image-config
-                (-> default-container :docker :image)
-                (if (string? image-config)
-                  image-config
-                  (let [[resolved-config reason] (config-incremental/resolve-incremental-config uuid image-config (:image-fallback docker))]
-                    (passport/log-event {:event-type passport/default-image-selected
-                                         :image-config image-config
-                                         :job-name name
-                                         :job-uuid (str uuid)
-                                         :pool pool-name
-                                         :reason reason
-                                         :resolved-config resolved-config
-                                         :user user})
-                    resolved-config)))]
+        image-config (if-not user-image
+                       (-> default-container :docker :image)
+                       user-image)
+        image (if (string? image-config)
+                image-config
+                (let [[resolved-config reason] (config-incremental/resolve-incremental-config uuid image-config (:image-fallback docker))]
+                  (passport/log-event {:event-type passport/default-image-selected
+                                       :image-config image-config
+                                       :job-name name
+                                       :job-uuid (str uuid)
+                                       :pool pool-name
+                                       :reason reason
+                                       :resolved-config resolved-config
+                                       :user user})
+                  resolved-config))]
     [[:db/add id :job/container container-id]
      (merge {:db/id container-id
              :container/type "DOCKER"}


### PR DESCRIPTION
## Changes proposed in this PR

- properly resolve incremental default image configuration
- fix bad test assertion

## Why are we making these changes?

We need to fix support incremental default image configuration. If a user omits the image from their container we must still resolve the image configuration from the default container, not try to use it directly.  The image configuration from the default container might be an incremental configuration, in which case it needs to be resolved. That is what this PR fixes.
