### PR TITLE
Add support for postgres-based unit tests.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,8 @@ jobs:
       GDRIVE_LOG_POST_URL: https://script.google.com/macros/s/AKfycbxOB55OzrQSbpZO_0gzsxZaJ8LaUWWo3PDLNc-gCiMN1iObxu7x/exec
     steps:
       - uses: actions/checkout@v2
+      - name: Showcase docker state.
+        run: docker ps
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -48,10 +50,38 @@ jobs:
           ./cli/travis/setup.sh
           cd scheduler && ./travis/setup.sh
       - name: JobClient Java unit tests
-        run: cd ./jobclient/java && mvn test -X 
+        run: cd ./jobclient/java && mvn test -X
       - name: JobClient Python unit tests
         run: cd ./jobclient/python && python -m pytest
       - name: CLI unit tests
         run: cd ./cli && python -m pytest
+      - name: Setup the database
+        run: cd ./scheduler/postgresql && bin/setup-database.sh
+        env:
+          PGPASSWORD: postgres
+          COOK_SCHEMA: cook_local
       - name: Scheduler Unit tests
         run: cd ./scheduler && lein with-profile +test test :all-but-benchmark
+        env:
+          PGPASSWORD: postgres
+          COOK_DB_TEST_PG_USER: cook_scheduler
+          COOK_DB_TEST_PG_SERVER: 127.0.0.1
+          COOK_DB_TEST_PG_SCHEMA: cook_local
+
+    services:
+      # Give it cook-postgres to match what our external build scripts use.
+      cook-postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432

--- a/scheduler/src/cook/postgres.clj
+++ b/scheduler/src/cook/postgres.clj
@@ -1,88 +1,10 @@
 (ns cook.postgres
   (:require [clojure.tools.logging :as log]
-            [clojure.java.jdbc :as sql]
-            [cook.config :as config])
-  (:import (java.lang Runtime)
-           (java.util Random)))
-
-(defn setup-database
-  "Setup a fresh cook schema from scratch. At present, calls out
-  to a bash script, passing it the target schema name and hopes it does the right thing."
-  [setup-script schema-name]
-  ; This environmental variable contains the path of a setup script that, given a schema name, creates a database.
-  (let [^Process p (-> (Runtime/getRuntime)
-                       (.exec (str setup-script " " schema-name)))
-        _ (log/info "Waiting for database schema production process" (.pid p) "to exit")
-        exit-code (.waitFor p)]
-    (assert (= exit-code 0) (str "Exit code for process creation is" exit-code "not zero"))))
-
-(defn make-database-connection-dictionary-for-unit-tests
-  "Given a target schema name and assuming a variety of environmental
-   variables are set, creates the metadata to connect to a database."
-  [currentSchema]
-  (merge {:dbtype "postgresql"
-          :dbname (or (System/getenv "COOK_DB_TEST_PG_DB") "cook_local")
-          ; Note that we need to save the currentSchema in the connection info to
-          :currentSchema currentSchema
-          :host (or (System/getenv "COOK_DB_TEST_PG_SERVER") "127.0.0.1")
-          :ssl false
-          :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
-         ; PGPASSWORD is the default enviornmental variable used by postgres psql.
-         (when-let [passwd (or  (System/getenv "COOK_DB_TEST_PG_PASSWORD")
-                                (System/getenv "PGPASSWORD"))]
-           {:password passwd})
-         (when-let [username (System/getenv "COOK_DB_TEST_PG_USER")]
-           {:user username})))
-
+            [cook.config :as config]))
 
 ; With unit tests, we need to create a new configuration dictionary in the test fixture.
 ; That gets stored here.
 (def saved-pg-config-dictionary (atom nil))
-
-
-(let [custom-formatter (clj-time.format/formatter "yyyyMMdd")]
-  (defn make-new-schema-name
-    "Generate the schema name we want to use for unit tests"
-    []
-    (str "db_tests_" (System/getenv "USER") "_" (clj-time.format/unparse-local-date custom-formatter (clj-time.core/today)) "_" (+ 1000 (.nextInt (Random.) 9000)))))
-
-(defn configure-database-connection-for-unit-tests
-  "Configure the database connection."
-  []
-  (if-let [schema-name (System/getenv "COOK_DB_TEST_PG_SCHEMA")]
-    (do
-      (let [pg-connection-meta (make-database-connection-dictionary-for-unit-tests schema-name)]
-        (log/info "Using existing schema " schema-name " with connection " pg-connection-meta)
-        (reset! saved-pg-config-dictionary pg-connection-meta)
-        pg-connection-meta))
-    ; If I have an environment saying to autocreate schema:
-    (do
-      (let [setup-script (System/getenv "COOK_DB_TEST_AUTOCREATE_SCHEMA")
-            schema-name (make-new-schema-name)
-            pg-connection-meta (make-database-connection-dictionary-for-unit-tests schema-name)]
-        (log/info "Auto-creating schema " schema-name "with connection" pg-connection-meta)
-        (setup-database setup-script schema-name)
-        (reset! saved-pg-config-dictionary pg-connection-meta)
-        pg-connection-meta))))
-
-(defn deconfigure-database-connection-for-unit-tests
-  "Deconfigure the database connection. Used when completing a test fixture."
-  []
-  (when-not (System/getenv "COOK_DB_TEST_PG_SCHEMA")
-    (let [schema-name (:currentSchema @saved-pg-config-dictionary)]
-      (log/info "Auto-destroying schema " schema-name "with connection" @saved-pg-config-dictionary)
-      ; Can't use '?' here with parameter substitution.
-      (sql/execute! @saved-pg-config-dictionary [(str "DROP SCHEMA " schema-name " CASCADE;")]))
-    (reset! saved-pg-config-dictionary nil)))
-
-(defn with-pg-db [f]
-  "Test fixture that sets up a new postgres database (if needed), runs the unit tests, and demolishes it afterwards.
-  Setup a postgres database test fixture that creates a database and destroys it afterwards"
-  (configure-database-connection-for-unit-tests)
-  (try
-    (f)
-    (finally
-      (deconfigure-database-connection-for-unit-tests))))
 
 (defn pg-db
   "Return access information for a postgresql database suitable for database access.

--- a/scheduler/src/cook/postgres.clj
+++ b/scheduler/src/cook/postgres.clj
@@ -1,0 +1,98 @@
+(ns cook.postgres
+  (:require [clojure.tools.logging :as log]
+            [clojure.java.jdbc :as sql]
+            [cook.config :as config])
+  (:import (java.lang Runtime)
+           (java.util Random)))
+
+(defn setup-database
+  "Setup a fresh cook schema from scratch. At present, calls out
+  to a bash script, passing it the target schema name and hopes it does the right thing."
+  [setup-script schema-name]
+  ; This environmental variable contains the path of a setup script that, given a schema name, creates a database.
+  (let [^Process p (-> (Runtime/getRuntime)
+                       (.exec (str setup-script " " schema-name)))
+        _ (log/info "Waiting for database schema production process" (.pid p) "to exit")
+        exit-code (.waitFor p)]
+    (assert (= exit-code 0) (str "Exit code for process creation is" exit-code "not zero"))))
+
+(defn make-database-connection-dictionary-for-unit-tests
+  "Given a target schema name and assuming a variety of environmental
+   variables are set, creates the metadata to connect to a database."
+  [currentSchema]
+  (merge {:dbtype "postgresql"
+          :dbname (or (System/getenv "COOK_DB_TEST_PG_DB") "cook_local")
+          ; Note that we need to save the currentSchema in the connection info to
+          :currentSchema currentSchema
+          :host (or (System/getenv "COOK_DB_TEST_PG_SERVER") "127.0.0.1")
+          :ssl false
+          :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
+         ; PGPASSWORD is the default enviornmental variable used by postgres psql.
+         (when-let [passwd (or  (System/getenv "COOK_DB_TEST_PG_PASSWORD")
+                                (System/getenv "PGPASSWORD"))]
+           {:password passwd})
+         (when-let [username (System/getenv "COOK_DB_TEST_PG_USER")]
+           {:user username})))
+
+
+; With unit tests, we need to create a new configuration dictionary in the test fixture.
+; That gets stored here.
+(def saved-pg-config-dictionary (atom nil))
+
+
+(let [custom-formatter (clj-time.format/formatter "yyyyMMdd")]
+(defn make-new-schema-name
+  "Generate the schema name we want to use for unit tests"
+  []
+  (str "db_tests_" (System/getenv "USER") "_" (clj-time.format/unparse-local-date custom-formatter (clj-time.core/today)) "_" (+ 1000 (.nextInt (Random.) 9000)))))
+
+(defn configure-database-connection-for-unit-tests
+  "Configure the database connection."
+  []
+  (if-let [schema-name (System/getenv "COOK_DB_TEST_PG_SCHEMA")]
+    (do
+      (let [pg-connection-meta (make-database-connection-dictionary-for-unit-tests schema-name)]
+        (log/info "Using existing schema " schema-name " with connection " pg-connection-meta)
+        (reset! saved-pg-config-dictionary pg-connection-meta)
+        pg-connection-meta))
+    ; If I have an environment saying to autocreate schema:
+    (do
+      (let [setup-script (System/getenv "COOK_DB_TEST_AUTOCREATE_SCHEMA")
+            schema-name (make-new-schema-name)
+            pg-connection-meta (make-database-connection-dictionary-for-unit-tests schema-name)]
+        (log/info "Auto-creating schema " schema-name "with connection" pg-connection-meta)
+        (setup-database setup-script schema-name)
+        (reset! saved-pg-config-dictionary pg-connection-meta)
+        pg-connection-meta))))
+
+(defn deconfigure-database-connection-for-unit-tests
+  "Deconfigure the database connection. Used when completing a test fixture."
+  []
+  (when-not (System/getenv "COOK_DB_TEST_PG_SCHEMA")
+    (let [schema-name (:currentSchema @saved-pg-config-dictionary)]
+      (log/info "Auto-destroying schema " schema-name "with connection" @saved-pg-config-dictionary)
+      ; Can't use '?' here with parameter substitution.
+      (sql/execute! @saved-pg-config-dictionary [(str "DROP SCHEMA " schema-name " CASCADE;")]))
+    (reset! saved-pg-config-dictionary nil)))
+
+(defn with-pg-db [f]
+  "Test fixture that sets up a new postgres database (if needed), runs the unit tests, and demolishes it afterwards. Setup a postgres database test fixture that creates a database and destroys it afterwards"
+  (configure-database-connection-for-unit-tests)
+  (try
+    (f)
+    (finally
+      (deconfigure-database-connection-for-unit-tests))))
+
+(defn pg-db
+  "Return access information for a postgresql database suitable for database access.
+
+   There are 2 main codepaths we take here:
+
+   1. If there is a config/config with a pg-config in config.edn, (I.e., we're running
+      integration tests or production) run with that config.
+
+   2. If there's a saved configuration dictionary (used for unit tests), return that."
+  []
+  (or
+    (-> config/config :settings :pg-config)
+    @saved-pg-config-dictionary))

--- a/scheduler/src/cook/postgres.clj
+++ b/scheduler/src/cook/postgres.clj
@@ -41,10 +41,10 @@
 
 
 (let [custom-formatter (clj-time.format/formatter "yyyyMMdd")]
-(defn make-new-schema-name
-  "Generate the schema name we want to use for unit tests"
-  []
-  (str "db_tests_" (System/getenv "USER") "_" (clj-time.format/unparse-local-date custom-formatter (clj-time.core/today)) "_" (+ 1000 (.nextInt (Random.) 9000)))))
+  (defn make-new-schema-name
+    "Generate the schema name we want to use for unit tests"
+    []
+    (str "db_tests_" (System/getenv "USER") "_" (clj-time.format/unparse-local-date custom-formatter (clj-time.core/today)) "_" (+ 1000 (.nextInt (Random.) 9000)))))
 
 (defn configure-database-connection-for-unit-tests
   "Configure the database connection."
@@ -76,7 +76,8 @@
     (reset! saved-pg-config-dictionary nil)))
 
 (defn with-pg-db [f]
-  "Test fixture that sets up a new postgres database (if needed), runs the unit tests, and demolishes it afterwards. Setup a postgres database test fixture that creates a database and destroys it afterwards"
+  "Test fixture that sets up a new postgres database (if needed), runs the unit tests, and demolishes it afterwards.
+  Setup a postgres database test fixture that creates a database and destroys it afterwards"
   (configure-database-connection-for-unit-tests)
   (try
     (f)

--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -17,13 +17,16 @@
   (:require [clojure.test :refer :all]
             [cook.compute-cluster :refer :all]
             [cook.config :as config]
+            [cook.postgres]
             [cook.test.testutil :refer [create-dummy-job-with-instances
                                         restore-fresh-database!
                                         setup]]
-            [datomic.api :as d]
             [cook.tools]
+            [datomic.api :as d]
             [plumbing.core :refer [map-vals map-from-vals]])
   (:import (clojure.lang ExceptionInfo)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-datomic-entity-conversion
   (let [config {:name "name"

--- a/scheduler/test/cook/test/compute_cluster.clj
+++ b/scheduler/test/cook/test/compute_cluster.clj
@@ -17,7 +17,7 @@
   (:require [clojure.test :refer :all]
             [cook.compute-cluster :refer :all]
             [cook.config :as config]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :refer [create-dummy-job-with-instances
                                         restore-fresh-database!
                                         setup]]
@@ -26,7 +26,7 @@
             [plumbing.core :refer [map-vals map-from-vals]])
   (:import (clojure.lang ExceptionInfo)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-datomic-entity-conversion
   (let [config {:name "name"

--- a/scheduler/test/cook/test/config_incremental.clj
+++ b/scheduler/test/cook/test/config_incremental.clj
@@ -16,14 +16,14 @@
 (ns cook.test.config-incremental
   (:require [clojure.test :refer :all]
             [cook.config-incremental :refer :all]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :refer [restore-fresh-database!
                                         setup]]
             [plumbing.core :refer [map-from-keys]])
   (:import (java.util Random UUID)
            (java.math RoundingMode)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-incremental-config
   (setup)

--- a/scheduler/test/cook/test/config_incremental.clj
+++ b/scheduler/test/cook/test/config_incremental.clj
@@ -16,11 +16,14 @@
 (ns cook.test.config-incremental
   (:require [clojure.test :refer :all]
             [cook.config-incremental :refer :all]
+            [cook.postgres]
             [cook.test.testutil :refer [restore-fresh-database!
                                         setup]]
             [plumbing.core :refer [map-from-keys]])
   (:import (java.util Random UUID)
            (java.math RoundingMode)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-incremental-config
   (setup)

--- a/scheduler/test/cook/test/group.clj
+++ b/scheduler/test/cook/test/group.clj
@@ -3,11 +3,11 @@
             [clj-time.core :as t]
             [clojure.test :refer :all]
             [cook.group :as group]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :refer [create-dummy-group create-dummy-instance create-dummy-job restore-fresh-database!]]
             [datomic.api :as d :refer [db q]]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-find-stragglers
   (let [uri "datomic:mem://test-find-stragglers"

--- a/scheduler/test/cook/test/group.clj
+++ b/scheduler/test/cook/test/group.clj
@@ -3,8 +3,11 @@
             [clj-time.core :as t]
             [clojure.test :refer :all]
             [cook.group :as group]
+            [cook.postgres]
             [cook.test.testutil :refer [create-dummy-group create-dummy-instance create-dummy-job restore-fresh-database!]]
             [datomic.api :as d :refer [db q]]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-find-stragglers
   (let [uri "datomic:mem://test-find-stragglers"

--- a/scheduler/test/cook/test/jobclient/jobclient.clj
+++ b/scheduler/test/cook/test/jobclient/jobclient.clj
@@ -16,12 +16,15 @@
 (ns cook.test.jobclient.jobclient
   (:require [clojure.core.async :as async]
             [clojure.test :refer :all]
+            [cook.postgres]
             [cook.test.testutil :refer [create-dummy-instance restore-fresh-database! setup with-test-server]]
             [datomic.api :as d])
   (:import (com.twosigma.cook.jobclient FetchableURI FetchableURI$Builder Group Group$Builder Group$Status GroupListener HostPlacement
                                         HostPlacement$Builder HostPlacement$Type Job Job$Builder Job$Status JobClient JobClient$Builder
                                         JobListener StragglerHandling StragglerHandling$Builder StragglerHandling$Type)
            (java.util ArrayList UUID)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (def port 3001)
 

--- a/scheduler/test/cook/test/jobclient/jobclient.clj
+++ b/scheduler/test/cook/test/jobclient/jobclient.clj
@@ -16,7 +16,7 @@
 (ns cook.test.jobclient.jobclient
   (:require [clojure.core.async :as async]
             [clojure.test :refer :all]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :refer [create-dummy-instance restore-fresh-database! setup with-test-server]]
             [datomic.api :as d])
   (:import (com.twosigma.cook.jobclient FetchableURI FetchableURI$Builder Group Group$Builder Group$Status GroupListener HostPlacement
@@ -24,7 +24,7 @@
                                         JobListener StragglerHandling StragglerHandling$Builder StragglerHandling$Type)
            (java.util ArrayList UUID)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (def port 3001)
 

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -5,7 +5,7 @@
             [clojure.test :refer :all]
             [cook.config :as config]
             [cook.kubernetes.api :as api]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.scheduler.constraints :as constraints]
             [cook.test.testutil :as tu]
             [datomic.api :as d])
@@ -17,7 +17,7 @@
                                                 V1ResourceRequirements V1Taint V1Volume V1VolumeMount)
            (java.util.concurrent Executors)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-get-consumption
   (testing "correctly computes consumption for a single pod without gpus"

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -5,6 +5,7 @@
             [clojure.test :refer :all]
             [cook.config :as config]
             [cook.kubernetes.api :as api]
+            [cook.postgres]
             [cook.scheduler.constraints :as constraints]
             [cook.test.testutil :as tu]
             [datomic.api :as d])
@@ -15,6 +16,8 @@
                                                 V1PodAffinityTerm V1PodCondition V1PodList V1PodSpec V1PodStatus
                                                 V1ResourceRequirements V1Taint V1Volume V1VolumeMount)
            (java.util.concurrent Executors)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-get-consumption
   (testing "correctly computes consumption for a single pod without gpus"

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -6,7 +6,7 @@
             [cook.kubernetes.api :as api]
             [cook.kubernetes.compute-cluster :as kcc]
             [cook.mesos.task :as task]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.scheduler.scheduler :as sched]
             [cook.test.testutil :as tu]
             [datomic.api :as d])
@@ -16,7 +16,7 @@
            (java.util.concurrent.locks ReentrantLock)
            (java.util UUID)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-get-or-create-cluster-entity-id
   (let [conn (tu/restore-fresh-database! "datomic:mem://test-get-or-create-cluster-entity-id")]

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -6,6 +6,7 @@
             [cook.kubernetes.api :as api]
             [cook.kubernetes.compute-cluster :as kcc]
             [cook.mesos.task :as task]
+            [cook.postgres]
             [cook.scheduler.scheduler :as sched]
             [cook.test.testutil :as tu]
             [datomic.api :as d])
@@ -14,6 +15,8 @@
            (java.util.concurrent Executors)
            (java.util.concurrent.locks ReentrantLock)
            (java.util UUID)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-get-or-create-cluster-entity-id
   (let [conn (tu/restore-fresh-database! "datomic:mem://test-get-or-create-cluster-entity-id")]

--- a/scheduler/test/cook/test/mesos.clj
+++ b/scheduler/test/cook/test/mesos.clj
@@ -21,8 +21,11 @@
             [cook.compute-cluster :as cc]
             [cook.datomic]
             [cook.mesos :as mesos]
+            [cook.postgres]
             [cook.test.testutil :refer [create-dummy-job-with-instances restore-fresh-database!]]
             [datomic.api :as d :refer (q db)]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (defn make-jobs-in-db
   "Takes a list of pairs, where the pairs are the cpu/memory of the job, and returns

--- a/scheduler/test/cook/test/mesos.clj
+++ b/scheduler/test/cook/test/mesos.clj
@@ -21,11 +21,11 @@
             [cook.compute-cluster :as cc]
             [cook.datomic]
             [cook.mesos :as mesos]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :refer [create-dummy-job-with-instances restore-fresh-database!]]
             [datomic.api :as d :refer (q db)]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (defn make-jobs-in-db
   "Takes a list of pairs, where the pairs are the cpu/memory of the job, and returns

--- a/scheduler/test/cook/test/mesos/heartbeat.clj
+++ b/scheduler/test/cook/test/mesos/heartbeat.clj
@@ -18,8 +18,11 @@
   (:require [clojure.core.async :as async]
             [clojure.test :refer :all]
             [cook.mesos.heartbeat :as heartbeat]
+            [cook.postgres]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job restore-fresh-database!]]
             [datomic.api :as d :refer [q]]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-update-heartbeat
   (testing

--- a/scheduler/test/cook/test/mesos/heartbeat.clj
+++ b/scheduler/test/cook/test/mesos/heartbeat.clj
@@ -18,11 +18,11 @@
   (:require [clojure.core.async :as async]
             [clojure.test :refer :all]
             [cook.mesos.heartbeat :as heartbeat]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job restore-fresh-database!]]
             [datomic.api :as d :refer [q]]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-update-heartbeat
   (testing

--- a/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
+++ b/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
@@ -6,6 +6,7 @@
             [cook.mesos.heartbeat :as heartbeat]
             [cook.mesos.mesos-compute-cluster :as mcc]
             [cook.mesos.sandbox :as sandbox]
+            [cook.postgres]
             [cook.scheduler.scheduler :as sched]
             [cook.test.testutil :as testutil :refer [create-dummy-instance create-dummy-job]]
             [datomic.api :as d]
@@ -14,6 +15,8 @@
             [plumbing.core :as pc])
   (:import (java.util.concurrent CountDownLatch TimeUnit)
            (org.apache.mesos Protos$TaskStatus$Reason)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-in-order-status-update-processing
   (let [status-store (atom {})

--- a/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
+++ b/scheduler/test/cook/test/mesos/mesos_compute_cluster.clj
@@ -6,7 +6,7 @@
             [cook.mesos.heartbeat :as heartbeat]
             [cook.mesos.mesos-compute-cluster :as mcc]
             [cook.mesos.sandbox :as sandbox]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.scheduler.scheduler :as sched]
             [cook.test.testutil :as testutil :refer [create-dummy-instance create-dummy-job]]
             [datomic.api :as d]
@@ -16,7 +16,7 @@
   (:import (java.util.concurrent CountDownLatch TimeUnit)
            (org.apache.mesos Protos$TaskStatus$Reason)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-in-order-status-update-processing
   (let [status-store (atom {})

--- a/scheduler/test/cook/test/mesos/mesos_mock.clj
+++ b/scheduler/test/cook/test/mesos/mesos_mock.clj
@@ -6,6 +6,7 @@
             [clojure.tools.logging :as log]
             [cook.compute-cluster :as cc]
             [cook.mesos.mesos-mock :as mm]
+            [cook.postgres]
             [cook.scheduler.share :as share]
             [cook.test.testutil :refer [create-dummy-job poll-until restore-fresh-database! setup]]
             [cook.test.zz-simulator :refer [dump-jobs-to-csv pull-all-task-ents with-cook-scheduler]]
@@ -14,6 +15,8 @@
             [mesomatic.scheduler :as mesos]
             [mesomatic.types :as mesos-types])
   (:import (java.util UUID)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (defn string->uuid
   "Parses the uuid if `uuid-str` is a uuid, returns nil otherwise"

--- a/scheduler/test/cook/test/mesos/mesos_mock.clj
+++ b/scheduler/test/cook/test/mesos/mesos_mock.clj
@@ -6,7 +6,7 @@
             [clojure.tools.logging :as log]
             [cook.compute-cluster :as cc]
             [cook.mesos.mesos-mock :as mm]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.scheduler.share :as share]
             [cook.test.testutil :refer [create-dummy-job poll-until restore-fresh-database! setup]]
             [cook.test.zz-simulator :refer [dump-jobs-to-csv pull-all-task-ents with-cook-scheduler]]
@@ -16,7 +16,7 @@
             [mesomatic.types :as mesos-types])
   (:import (java.util UUID)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (defn string->uuid
   "Parses the uuid if `uuid-str` is a uuid, returns nil otherwise"

--- a/scheduler/test/cook/test/mesos/reason.clj
+++ b/scheduler/test/cook/test/mesos/reason.clj
@@ -16,8 +16,11 @@
 (ns cook.test.mesos.reason
   (:use clojure.test)
   (:require [cook.mesos.reason :as r]
+            [cook.postgres]
             [cook.test.testutil :refer (restore-fresh-database!)]
             [datomic.api :as d :refer (q db)]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest reasons-api
   (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")

--- a/scheduler/test/cook/test/mesos/reason.clj
+++ b/scheduler/test/cook/test/mesos/reason.clj
@@ -16,11 +16,11 @@
 (ns cook.test.mesos.reason
   (:use clojure.test)
   (:require [cook.mesos.reason :as r]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :refer (restore-fresh-database!)]
             [datomic.api :as d :refer (q db)]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest reasons-api
   (let [conn (restore-fresh-database! "datomic:mem://mesos-api-test")

--- a/scheduler/test/cook/test/mesos/sandbox.clj
+++ b/scheduler/test/cook/test/mesos/sandbox.clj
@@ -19,14 +19,14 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [cook.mesos.sandbox :as sandbox]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :as tu]
             [datomic.api :as d]
             [metrics.counters :as counters]
             [plumbing.core :as pc])
   (:import (java.util.concurrent CountDownLatch TimeUnit)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-agent->task-id->sandbox
   (let [agent->task-id->value (fn [an-agent task-id] (get @an-agent task-id))

--- a/scheduler/test/cook/test/mesos/sandbox.clj
+++ b/scheduler/test/cook/test/mesos/sandbox.clj
@@ -19,11 +19,14 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [cook.mesos.sandbox :as sandbox]
+            [cook.postgres]
             [cook.test.testutil :as tu]
             [datomic.api :as d]
             [metrics.counters :as counters]
             [plumbing.core :as pc])
   (:import (java.util.concurrent CountDownLatch TimeUnit)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-agent->task-id->sandbox
   (let [agent->task-id->value (fn [an-agent task-id] (get @an-agent task-id))

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -5,14 +5,14 @@
             [clojure.test :refer :all]
             [cook.compute-cluster :as cc]
             [cook.mesos.task :as task]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.scheduler.offer :as offer]
             [cook.test.testutil :as tu]
             [datomic.api :as d]
             [mesomatic.types :as mtypes])
   (:import (java.util UUID)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-resources-by-role
   (let [

--- a/scheduler/test/cook/test/mesos/task.clj
+++ b/scheduler/test/cook/test/mesos/task.clj
@@ -5,11 +5,14 @@
             [clojure.test :refer :all]
             [cook.compute-cluster :as cc]
             [cook.mesos.task :as task]
+            [cook.postgres]
             [cook.scheduler.offer :as offer]
             [cook.test.testutil :as tu]
             [datomic.api :as d]
             [mesomatic.types :as mtypes])
   (:import (java.util UUID)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-resources-by-role
   (let [

--- a/scheduler/test/cook/test/plugins.clj
+++ b/scheduler/test/cook/test/plugins.clj
@@ -20,12 +20,12 @@
             [cook.config :as config]
             [cook.plugins.definitions :as chd]
             [cook.plugins.launch :as launch-plugin]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :as testutil :refer [create-dummy-job restore-fresh-database!]]
             [cook.tools :as util]
             [datomic.api :as d]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-aged-out?
   (with-redefs

--- a/scheduler/test/cook/test/plugins.clj
+++ b/scheduler/test/cook/test/plugins.clj
@@ -20,9 +20,12 @@
             [cook.config :as config]
             [cook.plugins.definitions :as chd]
             [cook.plugins.launch :as launch-plugin]
+            [cook.postgres]
             [cook.test.testutil :as testutil :refer [create-dummy-job restore-fresh-database!]]
             [cook.tools :as util]
             [datomic.api :as d]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-aged-out?
   (with-redefs

--- a/scheduler/test/cook/test/pool.clj
+++ b/scheduler/test/cook/test/pool.clj
@@ -1,8 +1,11 @@
 (ns cook.test.pool
   (:require [clojure.test :refer :all]
             [cook.config :as config]
-            [cook.pool :as pool])
+            [cook.pool :as pool]
+            [cook.postgres])
   (:import (clojure.lang ExceptionInfo)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-guard-invalid-default-pool
   (with-redefs [pool/all-pools (constantly [{:pool/name "foo"}])

--- a/scheduler/test/cook/test/pool.clj
+++ b/scheduler/test/cook/test/pool.clj
@@ -2,10 +2,10 @@
   (:require [clojure.test :refer :all]
             [cook.config :as config]
             [cook.pool :as pool]
-            [cook.postgres])
+            [cook.test.postgres])
   (:import (clojure.lang ExceptionInfo)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-guard-invalid-default-pool
   (with-redefs [pool/all-pools (constantly [{:pool/name "foo"}])

--- a/scheduler/test/cook/test/postgres.clj
+++ b/scheduler/test/cook/test/postgres.clj
@@ -1,0 +1,80 @@
+(ns cook.test.postgres
+  (:require [clojure.java.jdbc :as sql]
+            [clojure.test :refer :all]
+            [clojure.tools.logging :as log]
+            [cook.postgres :as pg])
+  (:import (java.lang Runtime)
+           (java.util Random)))
+
+(defn setup-database
+  "Setup a fresh cook schema from scratch. At present, calls out
+  to a bash script, passing it the target schema name and hopes it does the right thing."
+  [setup-script schema-name]
+  ; This environmental variable contains the path of a setup script that, given a schema name, creates a database.
+  (let [^Process p (-> (Runtime/getRuntime)
+                       (.exec (str setup-script " " schema-name)))
+        _ (log/info "Waiting for database schema production process" (.pid p) "to exit")
+        exit-code (.waitFor p)]
+    (assert (= exit-code 0) (str "Exit code for process creation is" exit-code "not zero"))))
+
+(defn make-database-connection-dictionary-for-unit-tests
+  "Given a target schema name and assuming a variety of environmental
+   variables are set, creates the metadata to connect to a database."
+  [currentSchema]
+  (merge {:dbtype "postgresql"
+          :dbname (or (System/getenv "COOK_DB_TEST_PG_DB") "cook_local")
+          ; Note that we need to save the currentSchema in the connection info to
+          :currentSchema currentSchema
+          :host (or (System/getenv "COOK_DB_TEST_PG_SERVER") "127.0.0.1")
+          :ssl false
+          :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
+         ; PGPASSWORD is the default enviornmental variable used by postgres psql.
+         (when-let [passwd (or  (System/getenv "COOK_DB_TEST_PG_PASSWORD")
+                                (System/getenv "PGPASSWORD"))]
+           {:password passwd})
+         (when-let [username (System/getenv "COOK_DB_TEST_PG_USER")]
+           {:user username})))
+
+(let [custom-formatter (clj-time.format/formatter "yyyyMMdd")]
+  (defn make-new-schema-name
+    "Generate the schema name we want to use for unit tests"
+    []
+    (str "db_tests_" (System/getenv "USER") "_" (clj-time.format/unparse-local-date custom-formatter (clj-time.core/today)) "_" (+ 1000 (.nextInt (Random.) 9000)))))
+
+(defn configure-database-connection-for-unit-tests
+  "Configure the database connection."
+  []
+  (if-let [schema-name (System/getenv "COOK_DB_TEST_PG_SCHEMA")]
+    (do
+      (let [pg-connection-meta (make-database-connection-dictionary-for-unit-tests schema-name)]
+        (log/info "Using existing schema " schema-name " with connection " pg-connection-meta)
+        (reset! pg/saved-pg-config-dictionary pg-connection-meta)
+        pg-connection-meta))
+    ; If I have an environment saying to autocreate schema:
+    (do
+      (let [setup-script (System/getenv "COOK_DB_TEST_AUTOCREATE_SCHEMA")
+            schema-name (make-new-schema-name)
+            pg-connection-meta (make-database-connection-dictionary-for-unit-tests schema-name)]
+        (log/info "Auto-creating schema " schema-name "with connection" pg-connection-meta)
+        (setup-database setup-script schema-name)
+        (reset! pg/saved-pg-config-dictionary pg-connection-meta)
+        pg-connection-meta))))
+
+(defn deconfigure-database-connection-for-unit-tests
+  "Deconfigure the database connection. Used when completing a test fixture."
+  []
+  (when-not (System/getenv "COOK_DB_TEST_PG_SCHEMA")
+    (let [schema-name (:currentSchema @pg/saved-pg-config-dictionary)]
+      (log/info "Auto-destroying schema " schema-name "with connection" @pg/saved-pg-config-dictionary)
+      ; Can't use '?' here with parameter substitution.
+      (sql/execute! @pg/saved-pg-config-dictionary [(str "DROP SCHEMA " schema-name " CASCADE;")]))
+    (reset! pg/saved-pg-config-dictionary nil)))
+
+(defn with-pg-db [f]
+  "Test fixture that sets up a new postgres database (if needed), runs the unit tests, and demolishes it afterwards.
+  Setup a postgres database test fixture that creates a database and destroys it afterwards"
+  (configure-database-connection-for-unit-tests)
+  (try
+    (f)
+    (finally
+      (deconfigure-database-connection-for-unit-tests))))

--- a/scheduler/test/cook/test/progress.clj
+++ b/scheduler/test/cook/test/progress.clj
@@ -18,10 +18,13 @@
   (:require [clojure.core.async :as async]
             [clojure.core.cache :as cache]
             [clojure.test :refer :all]
+            [cook.postgres]
             [cook.progress :as progress]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job poll-until restore-fresh-database!]]
             [datomic.api :as d]
             [plumbing.core :as pc]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (defn- progress-entry
   [message percent sequence & {:keys [instance-id]}]

--- a/scheduler/test/cook/test/progress.clj
+++ b/scheduler/test/cook/test/progress.clj
@@ -18,13 +18,13 @@
   (:require [clojure.core.async :as async]
             [clojure.core.cache :as cache]
             [clojure.test :refer :all]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.progress :as progress]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job poll-until restore-fresh-database!]]
             [datomic.api :as d]
             [plumbing.core :as pc]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (defn- progress-entry
   [message percent sequence & {:keys [instance-id]}]

--- a/scheduler/test/cook/test/quota.clj
+++ b/scheduler/test/cook/test/quota.clj
@@ -17,9 +17,12 @@
   (:require [clojure.test :refer :all]
             [cook.config :as config]
             [cook.quota :as quota]
+            [cook.postgres]
             [cook.test.testutil :refer [create-pool restore-fresh-database!]]
             [datomic.api :as d]
             [metatransaction.core :as mt :refer [db]]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-quota
   (let [uri "datomic:mem://test"

--- a/scheduler/test/cook/test/quota.clj
+++ b/scheduler/test/cook/test/quota.clj
@@ -17,12 +17,12 @@
   (:require [clojure.test :refer :all]
             [cook.config :as config]
             [cook.quota :as quota]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :refer [create-pool restore-fresh-database!]]
             [datomic.api :as d]
             [metatransaction.core :as mt :refer [db]]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-quota
   (let [uri "datomic:mem://test"

--- a/scheduler/test/cook/test/rebalancer.clj
+++ b/scheduler/test/cook/test/rebalancer.clj
@@ -20,7 +20,7 @@
             [cook.cache :as ccache]
             [cook.queries :as queries]
             [cook.quota :as quota]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.rebalancer :as rebalancer :refer [->State]]
             [cook.scheduler.dru :as dru]
             [cook.scheduler.scheduler :as sched]
@@ -29,7 +29,7 @@
             [cook.tools :as util]
             [datomic.api :as d :refer [q]]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (defn create-running-job
   [conn host & args]

--- a/scheduler/test/cook/test/rebalancer.clj
+++ b/scheduler/test/cook/test/rebalancer.clj
@@ -20,6 +20,7 @@
             [cook.cache :as ccache]
             [cook.queries :as queries]
             [cook.quota :as quota]
+            [cook.postgres]
             [cook.rebalancer :as rebalancer :refer [->State]]
             [cook.scheduler.dru :as dru]
             [cook.scheduler.scheduler :as sched]
@@ -27,6 +28,8 @@
             [cook.test.testutil :refer [create-dummy-group create-dummy-instance create-dummy-job init-agent-attributes-cache restore-fresh-database! setup]]
             [cook.tools :as util]
             [datomic.api :as d :refer [q]]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (defn create-running-job
   [conn host & args]

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -30,6 +30,7 @@
             [cook.plugins.definitions :refer [FileUrlGenerator JobRouter]]
             [cook.plugins.file :as file-plugin]
             [cook.plugins.submission :as submission-plugin]
+            [cook.postgres]
             [cook.quota :as quota]
             [cook.rate-limit :as rate-limit]
             [cook.rest.api :as api]
@@ -52,6 +53,8 @@
            (java.util.concurrent ExecutionException)
            (javax.servlet ServletOutputStream ServletResponse)
            (org.apache.curator.test TestingServer)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (defn kw-keys
   [m]

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -30,7 +30,7 @@
             [cook.plugins.definitions :refer [FileUrlGenerator JobRouter]]
             [cook.plugins.file :as file-plugin]
             [cook.plugins.submission :as submission-plugin]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.quota :as quota]
             [cook.rate-limit :as rate-limit]
             [cook.rest.api :as api]
@@ -54,7 +54,7 @@
            (javax.servlet ServletOutputStream ServletResponse)
            (org.apache.curator.test TestingServer)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (defn kw-keys
   [m]

--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -18,6 +18,7 @@
   (:require [clj-time.core :as t]
             [clojure.test :refer :all]
             [cook.config :as config]
+            [cook.postgres]
             [cook.scheduler.constraints :as constraints]
             [cook.scheduler.offer :as offer]
             [cook.scheduler.scheduler :as sched]
@@ -28,6 +29,8 @@
             [datomic.api :as d :refer [db]])
   (:import (java.util Date)
            (org.joda.time DateTime)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-get-group-constraint-name
   (is (= "unique-host-placement-group-constraint"

--- a/scheduler/test/cook/test/scheduler/constraints.clj
+++ b/scheduler/test/cook/test/scheduler/constraints.clj
@@ -18,7 +18,7 @@
   (:require [clj-time.core :as t]
             [clojure.test :refer :all]
             [cook.config :as config]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.scheduler.constraints :as constraints]
             [cook.scheduler.offer :as offer]
             [cook.scheduler.scheduler :as sched]
@@ -30,7 +30,7 @@
   (:import (java.util Date)
            (org.joda.time DateTime)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-get-group-constraint-name
   (is (= "unique-host-placement-group-constraint"

--- a/scheduler/test/cook/test/scheduler/dru.clj
+++ b/scheduler/test/cook/test/scheduler/dru.clj
@@ -15,12 +15,15 @@
 ;;
 (ns cook.test.scheduler.dru
   (:require [clojure.test :refer :all]
+            [cook.postgres]
             [cook.scheduler.dru :as dru]
             [cook.scheduler.share :as share]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job restore-fresh-database!]]
             [cook.tools :as util]
             [datomic.api :as d :refer [db q]]
             [plumbing.core :refer [map-vals]]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-compute-task-scored-task-pairs
   (testing "return empty set on input empty set"

--- a/scheduler/test/cook/test/scheduler/dru.clj
+++ b/scheduler/test/cook/test/scheduler/dru.clj
@@ -15,7 +15,7 @@
 ;;
 (ns cook.test.scheduler.dru
   (:require [clojure.test :refer :all]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.scheduler.dru :as dru]
             [cook.scheduler.share :as share]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job restore-fresh-database!]]
@@ -23,7 +23,7 @@
             [datomic.api :as d :refer [db q]]
             [plumbing.core :refer [map-vals]]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-compute-task-scored-task-pairs
   (testing "return empty set on input empty set"

--- a/scheduler/test/cook/test/scheduler/fenzo_utils.clj
+++ b/scheduler/test/cook/test/scheduler/fenzo_utils.clj
@@ -15,12 +15,15 @@
 ;;
 (ns cook.test.scheduler.fenzo-utils
   (:require [clojure.test :refer :all]
+            [cook.postgres]
             [cook.scheduler.fenzo-utils :as fenzo]
             [cook.scheduler.scheduler :as scheduler]
             [cook.test.testutil :refer [create-dummy-job restore-fresh-database!]]
             [cook.tools :as util]
             [datomic.api :as d])
   (:import (com.netflix.fenzo AssignmentFailure ConstraintFailure SimpleAssignmentResult VMResource)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 ;; Fenzo is aware of other resources as well; just limiting it to ones
 ;; Cook will usually encounter

--- a/scheduler/test/cook/test/scheduler/fenzo_utils.clj
+++ b/scheduler/test/cook/test/scheduler/fenzo_utils.clj
@@ -15,7 +15,7 @@
 ;;
 (ns cook.test.scheduler.fenzo-utils
   (:require [clojure.test :refer :all]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.scheduler.fenzo-utils :as fenzo]
             [cook.scheduler.scheduler :as scheduler]
             [cook.test.testutil :refer [create-dummy-job restore-fresh-database!]]
@@ -23,7 +23,7 @@
             [datomic.api :as d])
   (:import (com.netflix.fenzo AssignmentFailure ConstraintFailure SimpleAssignmentResult VMResource)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 ;; Fenzo is aware of other resources as well; just limiting it to ones
 ;; Cook will usually encounter

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -34,7 +34,7 @@
             [cook.plugins.definitions :as pd]
             [cook.plugins.launch :as launch-plugin]
             [cook.pool :as pool]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.progress :as progress]
             [cook.quota :as quota]
             [cook.rate-limit :as rate-limit]
@@ -59,7 +59,7 @@
            (org.mockito Mockito)))
 
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (def datomic-uri "datomic:mem://test-mesos-jobs")
 

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -34,6 +34,7 @@
             [cook.plugins.definitions :as pd]
             [cook.plugins.launch :as launch-plugin]
             [cook.pool :as pool]
+            [cook.postgres]
             [cook.progress :as progress]
             [cook.quota :as quota]
             [cook.rate-limit :as rate-limit]
@@ -56,6 +57,9 @@
            (cook.compute_cluster ComputeCluster)
            (java.util UUID)
            (org.mockito Mockito)))
+
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (def datomic-uri "datomic:mem://test-mesos-jobs")
 

--- a/scheduler/test/cook/test/scheduler/share.clj
+++ b/scheduler/test/cook/test/scheduler/share.clj
@@ -16,12 +16,12 @@
 (ns cook.test.scheduler.share
   (:require [clojure.test :refer :all]
             [cook.config :as config]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.scheduler.share :as share]
             [cook.test.testutil :refer [create-pool restore-fresh-database!]]
             [metatransaction.core :as mt]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test'
   (let [uri "datomic:mem://test"

--- a/scheduler/test/cook/test/scheduler/share.clj
+++ b/scheduler/test/cook/test/scheduler/share.clj
@@ -16,9 +16,12 @@
 (ns cook.test.scheduler.share
   (:require [clojure.test :refer :all]
             [cook.config :as config]
+            [cook.postgres]
             [cook.scheduler.share :as share]
             [cook.test.testutil :refer [create-pool restore-fresh-database!]]
             [metatransaction.core :as mt]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test'
   (let [uri "datomic:mem://test"

--- a/scheduler/test/cook/test/schema.clj
+++ b/scheduler/test/cook/test/schema.clj
@@ -16,8 +16,11 @@
 
 (ns cook.test.schema
   (:require [clojure.test :refer :all]
+            [cook.postgres]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job restore-fresh-database!]]
             [datomic.api :as d :refer [db q]]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (def datomic-uri "datomic:mem://test")
 

--- a/scheduler/test/cook/test/schema.clj
+++ b/scheduler/test/cook/test/schema.clj
@@ -16,11 +16,11 @@
 
 (ns cook.test.schema
   (:require [clojure.test :refer :all]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job restore-fresh-database!]]
             [datomic.api :as d :refer [db q]]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (def datomic-uri "datomic:mem://test")
 

--- a/scheduler/test/cook/test/task.clj
+++ b/scheduler/test/cook/test/task.clj
@@ -1,11 +1,11 @@
 (ns cook.test.task
   (:require [clojure.test :refer :all]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.task :as task]
             [cook.test.testutil :refer [restore-fresh-database!
                                         setup]]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-build-executor-environment
   (testing "default values"

--- a/scheduler/test/cook/test/task.clj
+++ b/scheduler/test/cook/test/task.clj
@@ -1,8 +1,11 @@
 (ns cook.test.task
   (:require [clojure.test :refer :all]
+            [cook.postgres]
             [cook.task :as task]
             [cook.test.testutil :refer [restore-fresh-database!
                                         setup]]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-build-executor-environment
   (testing "default values"

--- a/scheduler/test/cook/test/tools.clj
+++ b/scheduler/test/cook/test/tools.clj
@@ -20,6 +20,7 @@
             [clojure.core.cache :as cache]
             [clojure.test :refer :all]
             [cook.config :as config]
+            [cook.postgres]
             [cook.queries :as queries]
             [cook.test.testutil :as testutil
              :refer [create-dummy-group create-dummy-instance create-dummy-job create-dummy-job-with-instances create-pool restore-fresh-database!]]
@@ -29,6 +30,8 @@
   (:import (java.util.concurrent ExecutionException)
            (java.util Date)
            (org.joda.time DateTime)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (deftest test-total-resources-of-jobs
   (let [uri "datomic:mem://test-total-resources-of-jobs"

--- a/scheduler/test/cook/test/tools.clj
+++ b/scheduler/test/cook/test/tools.clj
@@ -20,7 +20,7 @@
             [clojure.core.cache :as cache]
             [clojure.test :refer :all]
             [cook.config :as config]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.queries :as queries]
             [cook.test.testutil :as testutil
              :refer [create-dummy-group create-dummy-instance create-dummy-job create-dummy-job-with-instances create-pool restore-fresh-database!]]
@@ -31,7 +31,7 @@
            (java.util Date)
            (org.joda.time DateTime)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (deftest test-total-resources-of-jobs
   (let [uri "datomic:mem://test-total-resources-of-jobs"

--- a/scheduler/test/cook/test/unscheduled.clj
+++ b/scheduler/test/cook/test/unscheduled.clj
@@ -15,7 +15,7 @@
 ;;
 (ns cook.test.unscheduled
   (:require [clojure.test :refer :all]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.quota :as quota]
             [cook.rate-limit :as rate-limit]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job restore-fresh-database! setup]]
@@ -23,7 +23,7 @@
             [cook.unscheduled :as u]
             [datomic.api :as d]))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 (defn resource-map->list
   [m]

--- a/scheduler/test/cook/test/unscheduled.clj
+++ b/scheduler/test/cook/test/unscheduled.clj
@@ -15,12 +15,15 @@
 ;;
 (ns cook.test.unscheduled
   (:require [clojure.test :refer :all]
+            [cook.postgres]
             [cook.quota :as quota]
             [cook.rate-limit :as rate-limit]
             [cook.test.testutil :refer [create-dummy-instance create-dummy-job restore-fresh-database! setup]]
             [cook.tools :as tools]
             [cook.unscheduled :as u]
             [datomic.api :as d]))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 (defn resource-map->list
   [m]

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -23,6 +23,7 @@
             [cook.mesos.mesos-compute-cluster :as mcc]
             [cook.mesos.mesos-mock :as mm]
             [cook.plugins.completion :as completion]
+            [cook.postgres]
             [cook.progress :as progress]
             [cook.scheduler.scheduler :as sched]
             [cook.scheduler.share :as share]
@@ -35,6 +36,8 @@
            (org.apache.curator.framework.state ConnectionStateListener)
            (org.apache.curator.retry BoundedExponentialBackoffRetry)
            (org.joda.time DateTimeUtils)))
+
+(use-fixtures :once cook.postgres/with-pg-db)
 
 ;;; This namespace contains a simulator for cook scheduler that accepts a trace file
 ;;; (defined later on) of jobs to "run" through the simulation as well as how much

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -23,7 +23,7 @@
             [cook.mesos.mesos-compute-cluster :as mcc]
             [cook.mesos.mesos-mock :as mm]
             [cook.plugins.completion :as completion]
-            [cook.postgres]
+            [cook.test.postgres]
             [cook.progress :as progress]
             [cook.scheduler.scheduler :as sched]
             [cook.scheduler.share :as share]
@@ -37,7 +37,7 @@
            (org.apache.curator.retry BoundedExponentialBackoffRetry)
            (org.joda.time DateTimeUtils)))
 
-(use-fixtures :once cook.postgres/with-pg-db)
+(use-fixtures :once cook.test.postgres/with-pg-db)
 
 ;;; This namespace contains a simulator for cook scheduler that accepts a trace file
 ;;; (defined later on) of jobs to "run" through the simulation as well as how much


### PR DESCRIPTION
## Changes proposed in this PR

- Add in the infrastructure so that unit tests run with a live postgres database.
- This includes all opensource test environments.
- No actual use of postgresql in this code.

## Why are we making these changes?
To setup a development environment. This code has been tested with a Proof-of-Concept quota on postgres change. to validate correctness.

