### PR TITLE
Add missing fields to compute cluster API validation

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -3253,7 +3253,9 @@
    ; The state can't be modified when it's locked
    (s/optional-key :state-locked?) s/Bool
    ; Key used to look up the configuration template
-   :template NonEmptyString})
+   :template NonEmptyString}
+   (s/optional-key :location) s/Str
+   (s/optional-key :features) [{:key s/Str :value s/Str}])
 
 (defn compute-cluster-exists?
   [conn name]

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -3254,7 +3254,7 @@
    (s/optional-key :state-locked?) s/Bool
    ; Key used to look up the configuration template
    :template NonEmptyString
-   (s/optional-key :location) s/Str
+   (s/optional-key :location) (s/maybe s/Str)
    (s/optional-key :features) [{:key s/Str :value s/Str}]})
 
 (defn compute-cluster-exists?

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -3253,9 +3253,9 @@
    ; The state can't be modified when it's locked
    (s/optional-key :state-locked?) s/Bool
    ; Key used to look up the configuration template
-   :template NonEmptyString}
+   :template NonEmptyString
    (s/optional-key :location) s/Str
-   (s/optional-key :features) [{:key s/Str :value s/Str}])
+   (s/optional-key :features) [{:key s/Str :value s/Str}]})
 
 (defn compute-cluster-exists?
   [conn name]

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2708,7 +2708,9 @@
                                    "ca-cert" "test-ca-cert"
                                    "name" name
                                    "state" "running"
-                                   "template" "test-template"}
+                                   "template" "test-template"
+                                   "location" nil
+                                   "features" []}
                      :request-method :post
                      :scheme :http
                      :uri endpoint}]
@@ -2758,12 +2760,16 @@
                                          :ca-cert "ca-cert-1"
                                          :name "name-1"
                                          :state "running"
-                                         :template "template-1"}
+                                         :template "template-1"
+                                         :location nil
+                                         :features []}
                                :pending {:base-path "base-path-1"
                                          :ca-cert "ca-cert-1"
                                          :name "name-1"
                                          :state "running"
-                                         :template "template-1"}}]]
+                                         :template "template-1"
+                                         :location nil
+                                         :features []}}]]
         (with-redefs [api/read-compute-clusters (constantly compute-clusters)]
           (testing "successful query"
             (let [{:keys [status] :as response} (handler request)


### PR DESCRIPTION
## Changes proposed in this PR

- add missing fields to compute cluster API validation

## Why are we making these changes?

This was missed when adding the `location` and `features` fields to dynamic compute clusters
