### PR TITLE
Add gclog to .gitignore.

### DIFF
--- a/scheduler/.gitignore
+++ b/scheduler/.gitignore
@@ -1,1 +1,2 @@
 .pytest_cache
+gclog*


### PR DESCRIPTION
## Changes proposed in this PR

- With JDK11 logging changes. we clutter the directory with gclog files. Hide them with gitignore.

