### PR TITLE
Fix permission bug in setting up databases in opensource.

### DIFF
--- a/scheduler/postgresql/sql/docker_init_new_database.sql
+++ b/scheduler/postgresql/sql/docker_init_new_database.sql
@@ -5,3 +5,7 @@
 DROP ROLE IF EXISTS cook_scheduler;
 CREATE ROLE cook_scheduler with password :'cook_user_password' LOGIN;
 CREATE DATABASE cook_local WITH owner cook_scheduler;
+
+-- Ensure that all schemas on this database are writeable by cook_scheduler user.
+ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO cook_scheduler;
+ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO cook_scheduler;


### PR DESCRIPTION
## Changes proposed in this PR

- Make sure all schemas created as any user are readable by Cook.

## Why are we making these changes?
Postgres schemas are, by default, permissioned only for the creating user. Make them available as cook_scheduler user for convenience.

