### PR TITLE
Switch Cook to using c3p0 for database pooling.

### DIFF
--- a/scheduler/datomic/data/seed_k8s_pools.clj
+++ b/scheduler/datomic/data/seed_k8s_pools.clj
@@ -1,5 +1,6 @@
 (ns data.seed-k8s-pools
   (:require [cook.datomic :as datomic]
+            [cook.postgres :as pg]
             [cook.quota :as quota]
             [datomic.api :as d]))
 
@@ -27,6 +28,9 @@
 
 (try
   (let [conn (datomic/create-connection {:settings {:mesos-datomic-uri uri}})]
+    (->> (System/getenv "COOK_DB_TEST_PG_SCHEMA")
+         (pg/make-database-connection-dictionary-from-env-vars)
+         (reset! pg/saved-pg-config-dictionary))
     (println "Connected to Datomic:" conn)
     (create-pool conn "k8s-alpha" :pool.state/active)
     (create-pool conn "k8s-beta" :pool.state/inactive)

--- a/scheduler/docker/run-cook.sh
+++ b/scheduler/docker/run-cook.sh
@@ -9,6 +9,7 @@ echo "Seeding test data..."
 export COOK_DB_TEST_PG_DB="cook_local"
 export COOK_DB_TEST_PG_USER="cook_scheduler"
 export COOK_DB_TEST_PG_SERVER="cook-postgres"
+export COOK_DB_TEST_PG_SCHEMA="cook_local"
 lein exec -p /opt/cook/datomic/data/seed_k8s_pools.clj ${COOK_DATOMIC_URI}
 lein exec -p /opt/cook/datomic/data/seed_running_jobs.clj ${COOK_DATOMIC_URI}
 lein with-profiles +docker run $1

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -132,6 +132,7 @@
                  [org.apache.curator/curator-test "2.7.1"
                  :exclusions [io.netty/netty
                               io.netty/netty-transport-native-epoll]]
+                 [com.mchange/c3p0 "0.9.5.2"] ; Connection pooling.
                  [org.clojure/java.jdbc "0.7.12"]
 
                  ;; Dependency management
@@ -200,8 +201,7 @@
                    [twosigma/mesomatic "1.5.0-r4"]
                    ; Opensource JDBC
                    [org.postgresql/postgresql "42.2.18"] ; Use PG 13.2 features.
-                   [com.mchange/c3p0 "0.9.5.2"] ; Connection pooling.
-]}
+                   ]}
 
    :uberjar
    {:aot [cook.components]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -132,7 +132,7 @@
                  [org.apache.curator/curator-test "2.7.1"
                  :exclusions [io.netty/netty
                               io.netty/netty-transport-native-epoll]]
-                 [com.mchange/c3p0 "0.9.5.2"] ; Connection pooling.
+                 [com.mchange/c3p0 "0.9.5.5"] ; Connection pooling.
                  [org.clojure/java.jdbc "0.7.12"]
 
                  ;; Dependency management

--- a/scheduler/src/cook/postgres.clj
+++ b/scheduler/src/cook/postgres.clj
@@ -1,21 +1,93 @@
 (ns cook.postgres
   (:require [clojure.tools.logging :as log]
-            [cook.config :as config]))
+            [cook.config :as config])
+  (:import (com.mchange.v2.c3p0 ComboPooledDataSource)))
 
 ; With unit tests, we need to create a new configuration dictionary in the test fixture.
 ; That gets stored here.
 (def saved-pg-config-dictionary (atom nil))
 
-(defn pg-db
+; We keep the c3p0 pool for talking to the database here. Lazily initialized.
+(def c3p0-connection-pool (atom nil))
+
+(defn make-database-connection-dictionary-from-env-vars
+  "Given a target schema name and assuming a variety of environmental
+   variables are set, creates the metadata to connect to a database."
+  [currentSchema]
+  (merge {:dbtype "postgresql"
+          :dbname (or (System/getenv "COOK_DB_TEST_PG_DB") "cook_local")
+          ; Note that we need to save the currentSchema in the connection info so that we can delete the schema in
+          ; test fixture teardown.
+          :currentSchema currentSchema
+          :host (or (System/getenv "COOK_DB_TEST_PG_SERVER") "127.0.0.1")
+          :ssl false
+          :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
+         ; PGPASSWORD is the default environmental variable used by postgres psql.
+         (when-let [passwd (or  (System/getenv "COOK_DB_TEST_PG_PASSWORD")
+                                (System/getenv "PGPASSWORD"))]
+           {:password passwd})
+         (when-let [username (System/getenv "COOK_DB_TEST_PG_USER")]
+           {:user username})))
+
+(defn make-c3p0-datasource
+  "Given a database configuration dictionary, make a c3p0 connection pool for it."
+  [{:keys [dbtype dbname currentSchema host ssl sslfactory password user c3p0-min-pool-size c3p0-max-pool-size]
+    :or {c3p0-min-pool-size 2 c3p0-max-pool-size 20}
+    :as pg-config}]
+  (let [driverclass "org.postgresql.Driver"
+        subname ""
+        cpds (doto (ComboPooledDataSource.)
+               (.setDriverClass driverclass)
+               (.setForceUseNamedDriverClass true)
+               (.setJdbcUrl (str "jdbc:" dbtype ":" subname "//" host "/" dbname "?" "currentSchema=" currentSchema))
+               (.setMinPoolSize c3p0-min-pool-size)
+               (.setMaxPoolSize c3p0-max-pool-size);
+               ;; expire excess connections after 30 minutes of inactivity:
+               (.setMaxIdleTimeExcessConnections (* 30 60))
+               ;; expire connections after 3 hours of inactivity:
+               (.setMaxIdleTime (* 3 60 60)))]
+    (when password
+      (.setPassword cpds password))
+    (when user
+      (.setUser cpds user))
+    {:datasource cpds}))
+
+(defn get-pg-config
   "Return access information for a postgresql database suitable for database access.
 
-   There are 2 main codepaths we take here:
+   There are four situations where we can run with a postgres database:
 
-   1. If there is a config/config with a pg-config in config.edn, (I.e., we're running
-      integration tests or production) run with that config.
+   1. Cook is running for real or in integration tests. The db configuration is set in config.edn.
 
-   2. If there's a saved configuration dictionary (used for unit tests), return that."
+   2. seed_pools.clj is running. (This seeds pools into an empty database for integration tests). In this environment,
+      there is no config.edn, so we need to get a configuration out of environmental variables. This codepath is implicit.
+      seed_k8s_pools.clj and seed_pools.clj sets saved-pg-config-dictionary directly.
+      (TODO: We can use liquibase contexts to seed integration test data when the
+      postgres migration is complete and remove this case.)
+
+   3. We are running unit tests when the database is already configured. This is triggered by COOK_DB_TEST_PG_SCHEMA.
+      In this case, the configuration is parsed from the environment and stuffed into saved-pg-config-dictionary by the
+      unit test fixture.
+
+   4. We are running unit tests when the database is not configured. This is triggered by COOK_DB_TEST_PG_SCHEMA not existing
+      when we are running the test fixture. In that case, we make and load a new schema, then load it here. The test fixture
+      code then tears it down.
+
+   Note that cases 2 and 3 are essentially the same: Look for COOK_DB_TEST_PG_SCHEMA and stuff into a configuration dictionary.
+   If we didn't have the fixture code do it in case 3 we could simply default it with an '(or ..'.
+
+   In any case, once there's a configuration dictionary. The first time we try to get a connection, we make a
+   persistent connection pool and store it into c3p0-connection-pool."
   []
   (or
     (-> config/config :settings :pg-config)
     @saved-pg-config-dictionary))
+
+(defn pg-db
+  "Get a database connection for talking to postgresql. Something that can be used as part of the object argument to a
+  JDBC API function."
+  []
+  (locking c3p0-connection-pool
+    (when-not @c3p0-connection-pool
+      (reset! c3p0-connection-pool (make-c3p0-datasource (get-pg-config))))
+    @c3p0-connection-pool))

--- a/scheduler/src/cook/test/postgres.clj
+++ b/scheduler/src/cook/test/postgres.clj
@@ -6,6 +6,15 @@
   (:import (java.lang Runtime)
            (java.util Random)))
 
+(defn reset-c3p0-pool
+  "If there's a c3p0 pool, cleanly close it. Used as part of test fixture shutdown for unit tests when we're doing a new
+  db for each test."
+  []
+  (when-let [pg-dict @pg/c3p0-connection-pool]
+    (.close (:datasource pg-dict))
+    (reset! pg/c3p0-connection-pool nil)))
+
+
 (defn setup-database
   "Setup a fresh cook schema from scratch. At present, calls out
   to a bash script, passing it the target schema name and hopes it does the right thing."
@@ -17,24 +26,6 @@
         exit-code (.waitFor p)]
     (assert (= exit-code 0) (str "Exit code for process creation is" exit-code "not zero"))))
 
-(defn make-database-connection-dictionary-for-unit-tests
-  "Given a target schema name and assuming a variety of environmental
-   variables are set, creates the metadata to connect to a database."
-  [currentSchema]
-  (merge {:dbtype "postgresql"
-          :dbname (or (System/getenv "COOK_DB_TEST_PG_DB") "cook_local")
-          ; Note that we need to save the currentSchema in the connection info to
-          :currentSchema currentSchema
-          :host (or (System/getenv "COOK_DB_TEST_PG_SERVER") "127.0.0.1")
-          :ssl false
-          :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
-         ; PGPASSWORD is the default enviornmental variable used by postgres psql.
-         (when-let [passwd (or  (System/getenv "COOK_DB_TEST_PG_PASSWORD")
-                                (System/getenv "PGPASSWORD"))]
-           {:password passwd})
-         (when-let [username (System/getenv "COOK_DB_TEST_PG_USER")]
-           {:user username})))
-
 (let [custom-formatter (clj-time.format/formatter "yyyyMMdd")]
   (defn make-new-schema-name
     "Generate the schema name we want to use for unit tests"
@@ -42,11 +33,11 @@
     (str "db_tests_" (System/getenv "USER") "_" (clj-time.format/unparse-local-date custom-formatter (clj-time.core/today)) "_" (+ 1000 (.nextInt (Random.) 9000)))))
 
 (defn configure-database-connection-for-unit-tests
-  "Configure the database connection."
+  "Configure the database connection for unit tests and install it into the atom's in cook.postgres"
   []
   (if-let [schema-name (System/getenv "COOK_DB_TEST_PG_SCHEMA")]
     (do
-      (let [pg-connection-meta (make-database-connection-dictionary-for-unit-tests schema-name)]
+      (let [pg-connection-meta (pg/make-database-connection-dictionary-from-env-vars schema-name)]
         (log/info "Using existing schema " schema-name " with connection " pg-connection-meta)
         (reset! pg/saved-pg-config-dictionary pg-connection-meta)
         pg-connection-meta))
@@ -54,9 +45,10 @@
     (do
       (let [setup-script (System/getenv "COOK_DB_TEST_AUTOCREATE_SCHEMA")
             schema-name (make-new-schema-name)
-            pg-connection-meta (make-database-connection-dictionary-for-unit-tests schema-name)]
+            pg-connection-meta (pg/make-database-connection-dictionary-from-env-vars schema-name)]
         (log/info "Auto-creating schema " schema-name "with connection" pg-connection-meta)
         (setup-database setup-script schema-name)
+        ; Saving it here is critical. We need currentSchema to tear it down later.
         (reset! pg/saved-pg-config-dictionary pg-connection-meta)
         pg-connection-meta))))
 
@@ -64,10 +56,12 @@
   "Deconfigure the database connection. Used when completing a test fixture."
   []
   (when-not (System/getenv "COOK_DB_TEST_PG_SCHEMA")
+    ; Only shutdown if we don't have a schema set (I.e., only if we're doing a schema per namespace.)
     (let [schema-name (:currentSchema @pg/saved-pg-config-dictionary)]
       (log/info "Auto-destroying schema " schema-name "with connection" @pg/saved-pg-config-dictionary)
       ; Can't use '?' here with parameter substitution.
-      (sql/execute! @pg/saved-pg-config-dictionary [(str "DROP SCHEMA " schema-name " CASCADE;")]))
+      (sql/execute! @pg/saved-pg-config-dictionary [(str "DROP SCHEMA " schema-name " CASCADE;")])
+      (reset-c3p0-pool))
     (reset! pg/saved-pg-config-dictionary nil)))
 
 (defn with-pg-db [f]


### PR DESCRIPTION
## Changes proposed in this PR

- Enable Cook to use c3p0 connection pooling for postgres.
- Fix a bug where we didn't set the connection metadata from the environment in seed_pools startup.

## Why are we making these changes?
Enable c3p0 and fix a bug in Postgres support
