### PR TITLE
Fix pod label regex

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -257,7 +257,7 @@
   (re-matches #"[\.a-zA-Z0-9_-]{1,128}" s))
 
 (def valid-k8s-pod-label-value-regex
-  #"[a-zA-Z0-9][\.a-zA-Z0-9_-]{0,61}[a-zA-Z0-9]")
+  #"([a-zA-Z0-9]{1,2}|[a-zA-Z0-9][\.a-zA-Z0-9_-]{0,61}[a-zA-Z0-9])?")
 
 (defn valid-k8s-pod-label-value?
   "Returns true if s contains only '.', '_', '-' or any word or

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -431,6 +431,20 @@
             (is (str/includes? (:cook.rest.api/error resp) "don't match the regex"))
             (is (str/includes? (:cook.rest.api/error resp) "1234567890123456789012345678901234567890123456789012345678901234"))
             (is (= 400 (:status resp))))))
+      (testing "invalid pod label bad non alpha"
+        (with-redefs [config/kubernetes (constantly {:add-job-label-to-pod-prefix "pod-label"})]
+          (let [job (assoc (basic-job) "labels" {"pod-label/test" "b/b"})
+                resp (h {:request-method :post
+                         :scheme :http
+                         :uri "/rawscheduler"
+                         :headers {"Content-Type" "application/json"}
+                         :authorization/user "test"
+                         :body-params {"jobs" [job]}})]
+            (is (str/includes? (:cook.rest.api/error resp) "Value does not match schema"))
+            (is (str/includes? (:cook.rest.api/error resp) "pod prefix `pod-label`"))
+            (is (str/includes? (:cook.rest.api/error resp) "don't match the regex"))
+            (is (str/includes? (:cook.rest.api/error resp) "b/b"))
+            (is (= 400 (:status resp))))))
       (testing "Valid pod label one character"
         (with-redefs [config/kubernetes (constantly {:add-job-label-to-pod-prefix "pod-label"})]
           (let [job (assoc (basic-job) "labels" {"pod-label/test" "a"})

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -461,6 +461,16 @@
                          :authorization/user "test"
                          :body-params {"jobs" [job]}})]
             (is (= 201 (:status resp))))))
+      (testing "Valid pod label shortest non alpha"
+        (with-redefs [config/kubernetes (constantly {:add-job-label-to-pod-prefix "pod-label"})]
+          (let [job (assoc (basic-job) "labels" {"pod-label/test" "b.b"})
+                resp (h {:request-method :post
+                         :scheme :http
+                         :uri "/rawscheduler"
+                         :headers {"Content-Type" "application/json"}
+                         :authorization/user "test"
+                         :body-params {"jobs" [job]}})]
+            (is (= 201 (:status resp))))))
       (testing "valid constraints"
         (let [job (assoc (basic-job) "constraints" [["aa" "EQUALS" "will-not-get-scheduled"]])
               resp (h {:request-method :post


### PR DESCRIPTION
## Changes proposed in this PR

- Fix valid pod label regex to match spec

## Why are we making these changes?

Our current pod label validation regex does not match the spec https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
