### PR TITLE
Switch the implementation from using java.jdbc to next.jdbc

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -133,7 +133,7 @@
                  :exclusions [io.netty/netty
                               io.netty/netty-transport-native-epoll]]
                  [com.mchange/c3p0 "0.9.5.5"] ; Connection pooling.
-                 [org.clojure/java.jdbc "0.7.12"]
+                 [com.github.seancorfield/next.jdbc "1.2.761"]
 
                  ;; Dependency management
                  [mount "0.1.12"]

--- a/scheduler/src/cook/postgres.clj
+++ b/scheduler/src/cook/postgres.clj
@@ -1,6 +1,7 @@
 (ns cook.postgres
   (:require [clojure.tools.logging :as log]
-            [cook.config :as config])
+            [cook.config :as config]
+            [next.jdbc :as sql])
   (:import (com.mchange.v2.c3p0 ComboPooledDataSource)))
 
 ; With unit tests, we need to create a new configuration dictionary in the test fixture.
@@ -50,7 +51,7 @@
       (.setPassword cpds password))
     (when user
       (.setUser cpds user))
-    {:datasource cpds}))
+    (sql/get-datasource cpds)))
 
 (defn get-pg-config
   "Return access information for a postgresql database suitable for database access.

--- a/scheduler/src/cook/test/postgres.clj
+++ b/scheduler/src/cook/test/postgres.clj
@@ -1,8 +1,8 @@
 (ns cook.test.postgres
-  (:require [clojure.java.jdbc :as sql]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [clojure.tools.logging :as log]
-            [cook.postgres :as pg])
+            [cook.postgres :as pg]
+            [next.jdbc :as sql])
   (:import (java.lang Runtime)
            (java.util Random)))
 

--- a/scheduler/src/cook/test/postgres.clj
+++ b/scheduler/src/cook/test/postgres.clj
@@ -11,7 +11,7 @@
   db for each test."
   []
   (when-let [pg-dict @pg/c3p0-connection-pool]
-    (.close (:datasource pg-dict))
+    (.close pg-dict)
     (reset! pg/c3p0-connection-pool nil)))
 
 


### PR DESCRIPTION
## Changes proposed in this PR

- Switch the implementation from using java.jdbc to next.jdbc

## Why are we making these changes?

This is a more modern more performant library.
