### PR TITLE
Upgrade everything to python 3.9 dependencies.

### DIFF
--- a/cli/cook/http.py
+++ b/cli/cook/http.py
@@ -68,7 +68,10 @@ def __delete(url, params=None):
 
 def __make_url(cluster, endpoint):
     """Given a cluster and an endpoint, returns the corresponding full URL"""
-    return urljoin(cluster['url'], endpoint)
+    url = cluster['url']
+    if not url.startswith("http"):
+        url = "http://" + url
+    return urljoin(url, endpoint)
 
 
 def post(cluster, endpoint, json_body):

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.9
 
 WORKDIR /opt/cook/integration
 COPY requirements.txt /opt/cook/integration

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,9 +1,9 @@
-beakerx==0.16.1
-tornado==5.1.1
-jupyter_client==5.2.3
-nbconvert==5.6.0
-nbformat==4.4.0
-numpy==1.15.3
+beakerx==1.3.0
+tornado==6.1.0
+jupyter_client==7.1.0
+nbconvert==6.3.0
+nbformat==5.1.3
+numpy==1.21.0
 pip==9.0.1; python_version >= '3.6'
 pytest==5.2.0
 pytest-timeout==1.3.3
@@ -12,4 +12,4 @@ python-dateutil==2.8.1
 requests==2.20.0
 retrying==1.3.3
 file:../cli#egg=cook_client
-pygit2==0.28.2
+pygit2==1.7.2

--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2081,7 +2081,7 @@ class CookTest(util.CookTest):
                                          command='python -m http.server 8080',
                                          ports=2,
                                          container={'type': 'DOCKER',
-                                                    'docker': {'image': 'python:3.6',
+                                                    'docker': {'image': 'python:3.9',
                                                                'network': 'BRIDGE',
                                                                'port-mapping': [{'host-port': 0,  # first assigned port
                                                                                  'container-port': 8080},

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -2346,10 +2346,11 @@ if __name__ == '__main__':
                 self.assertEqual(1, len(notebook['cells']))
                 self.assertEqual('code', cell['cell_type'])
                 self.assertEqual(1, cell['execution_count'])
-                self.assertLessEqual(1, len(cell['outputs']))
+                self.assertLessEqual(2, len(cell['outputs']))
                 self.assertEqual('stdout', output['name'], ''.join(output['text']))
                 self.assertEqual('\n', output['text'][0])
-                self.assertIn('=== Job: ', output['text'][1])
+                self.logger.info("Log output: "+repr(notebook))
+                self.assertIn('=== Job: ', cell['outputs'][1]['text'][0])
             finally:
                 os.remove(executed_notebook_filename)
         finally:

--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -118,7 +118,7 @@
                                    :pool-regex "^k8s-.+"}
          :default-containers
          [{:pool-regex "k8s-.*" :container {:type "docker"
-                                            :docker {:image "python:3.6",
+                                            :docker {:image "python:3.9",
                                                      :network "HOST"
                                                      :force-pull-image false
                                                      :parameters []}}}]


### PR DESCRIPTION
## Changes proposed in this PR

- Upgrade everything to python 3.9 dependencies.

## Why are we making these changes?
- Everything was previously wired to python 3.5.9 or python 3.6, but those are old and no longer maintained.

