### PR TITLE
Add virtualenv to .gitignore in cli directory.

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 venv
 Pipfile
+virtualenv*


### PR DESCRIPTION
## Changes proposed in this PR

- Add virtualenv to .gitignore in cli directory.

## Why are we making these changes?

- Avoid clutter in dirty files if there are any virtualenvs here.
