### PR TITLE
Partial fix for integration tests running in docker in opensource.

### DIFF
--- a/integration/bin/run-integration.sh
+++ b/integration/bin/run-integration.sh
@@ -50,13 +50,10 @@ then
     docker rm ${NAME}
 fi
 
-COOK_NAME=cook-scheduler-${COOK_PORT}
+COOK_NAME="cook-scheduler-${COOK_PORT}.localhost"
 
 COOK_IP=$(docker inspect ${COOK_NAME} | jq -r '.[].NetworkSettings.IPAddress')
 COOK_URL="http://${COOK_IP}:${COOK_PORT}"
-
-MESOS_MASTER_NAME=$(docker ps -q -f name=minimesos-master)
-MESOS_MASTER_IP=$(docker inspect $MESOS_MASTER_NAME | jq -r '.[].NetworkSettings.IPAddress')
 
 COOK_MULTICLUSTER_ENV=""
 if [ -n "${COOK_MULTI_CLUSTER+1}" ];
@@ -80,8 +77,7 @@ docker create \
        --name=cook-integration \
        -e "COOK_SCHEDULER_URL=${COOK_URL}" \
        -e "USER=root" \
-       -e "COOK_MESOS_LEADER_URL=http://${MESOS_MASTER_IP}:5050" \
-       -e "COOK_TEST_DOCKER_IMAGE=python:3.5.9-stretch" \
+       -e "COOK_TEST_DOCKER_IMAGE=python:3.9" \
        -v "/tmp/cook-integration-mount:/tmp/cook-integration-mount" \
        ${COOK_MULTICLUSTER_ENV} \
        ${DOCKER_VOLUME_ARGS} \


### PR DESCRIPTION
## Changes proposed in this PR

- Partial fix for integration tests running in docker in opensource.
- Remove some minimesos dependencies in opensource tests harnesses.

## Why are we making these changes?
These tests have bitrotten and not all succeed in integration/bin/run-integraion.sh. But at least this improves things a bit; you can run them. A lot still fail, but ate least we can run.

