### PR TITLE
Increase logging verbosity when submission fails with an exception.

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2266,6 +2266,7 @@
      :put! (partial create-jobs! conn)
      :post! (partial create-jobs! conn)
      :handle-exception (fn [{:keys [exception]}]
+                         (log/warn exception "Exception occurred while creating jobs" (.getMessage exception))
                          (if (datomic/transaction-timeout? exception)
                            {:error (str "Transaction timed out."
                                         " Your jobs may not have been created successfully."


### PR DESCRIPTION
## Changes proposed in this PR

- Increase logging verbosity when submission fails with an exception.

## Why are we making these changes?
Improve the visibility. Make these errors show up in the log, not just returned to the user.
