### PR TITLE
Release Cook v1.59.1

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.59.1] - 2022-02-17
+### Added
+- Set USER env variable, in addition to COOK_JOB_USER, in Kubernetes by default, from @laurameng
+### Changed
+- Increase logging verbosity when submission fails with an exception, from @scrosby
+
 ## [1.58.12] - 2022-01-24
 ### Added
 - Initial Liquibase support for Cook for postgres configuration, from @scrosby

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.58.13-SNAPSHOT"
+(defproject cook "1.59.1"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.59.1"
+(defproject cook "1.59.2-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]


### PR DESCRIPTION
### Please Rebase and merge to preserve the two commits

## Changes proposed in this PR

- updating changelog
- bumping version 

## Why are we making these changes?

To release Cook Scheduler.