### PR TITLE
Add capability for default K8s pod labels per pool

### DIFF
--- a/scheduler/config-k8s.edn
+++ b/scheduler/config-k8s.edn
@@ -143,7 +143,11 @@
          :default-env
          [{:pool-regex "unused" :env {"foo" "bar"}}
                        {:pool-regex ".*" :env
-                        {"SAMPLE_DEFAULT_ENV_KEY" "SAMPLE_DEFAULT_ENV_VAL"}}]}
+                        {"SAMPLE_DEFAULT_ENV_KEY" "SAMPLE_DEFAULT_ENV_VAL"}}]
+         :default-pod-labels
+         [{:pool-regex "unused" :pod-labels {"org.foo/application" "label-val"}}
+          {:pool-regex ".*" :pod-labels
+           {"SAMPLE_DEFAULT_POD_LABEL_KEY" "SAMPLE_DEFAULT_POD_LABEL_VAL"}}]}
 
  :port #config/env-int "COOK_PORT"
  :ssl {:port #config/env-int "COOK_SSL_PORT"

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1328,7 +1328,7 @@
         pod (V1Pod.)
         pod-spec (V1PodSpec.)
         metadata (V1ObjectMeta.)
-        pod-labels (merge (job->pod-labels job) (get-default-pod-labels-for-pool pool-name) pod-labels)
+        pod-labels (merge (get-default-pod-labels-for-pool pool-name) (job->pod-labels job) pod-labels)
         labels (assoc pod-labels cook-pod-label compute-cluster-name)
         security-context (make-security-context parameters (:user command))
         sandbox-dir (:default-workdir (config/kubernetes))


### PR DESCRIPTION
## Changes proposed in this PR
- Capability for default Kubernetes pod labels per pool

## Why are we making these changes?
We want to give operators the ability to mark pool membership by labelling individual Kubernetes pods. This change supports the same regex pool name matching as the default-env configuration.

