### PR TITLE
Cook logging diet

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -178,7 +178,6 @@
     (log/info "In" name "compute cluster, doing taskid scan. Visiting" (count taskids) "taskids")
     (doseq [^String taskid taskids]
       (try
-        (log/info "In" name "compute cluster, doing scan of" taskid)
         (controller/scan-process kcc taskid)
         (catch Exception e
           (log/error e "In" name

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -442,9 +442,11 @@
   (timers/time! (metrics/timer "controller-process" name)
     (loop [{:keys [cook-expected-state waiting-metric-timer] :as cook-expected-state-dict} (get @cook-expected-state-map pod-name)
            {:keys [synthesized-state pod] :as k8s-actual-state-dict} (get @k8s-actual-state-map pod-name)]
-      (log/info "In" name "compute cluster, processing pod" pod-name ";"
-                "cook-expected:" (prepare-cook-expected-state-dict-for-logging cook-expected-state-dict) ","
-                "k8s-actual:" (prepare-k8s-actual-state-dict-for-logging k8s-actual-state-dict))
+      ; Skip logging when both Cook and Kubernetes think the pod is running
+      (when-not (and (= cook-expected-state :cook-expected-state/running) (= synthesized-state :pod/running))
+        (log/info "In" name "compute cluster, processing pod" pod-name ";"
+                  "cook-expected:" (prepare-cook-expected-state-dict-for-logging cook-expected-state-dict) ","
+                  "k8s-actual:" (prepare-k8s-actual-state-dict-for-logging k8s-actual-state-dict)))
       ; We should have the cross product of
       ;      :cook-expected-state/starting :cook-expected-state/running :cook-expected-state/completed :cook-expected-state/killed :missing
       ; and

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -633,7 +633,6 @@
             assignments (-> result .getResultMap .values)]
         (doall (map (fn [^VirtualMachineLease lease]
                       (when (-> lease :offer :reject-after-match-attempt)
-                        (log/info "In" pool-name "pool, retracting lease" (-> lease :offer :id))
                         (locking fenzo
                           (.expireLease fenzo (.getId lease)))))
                     leases))

--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -73,7 +73,7 @@
                                          :k8s-actual-state-map (atom {name {:synthesized-state (or custom-test-state {:state k8s-actual-state})
                                                                             :pod (if force-nil-pod? nil pod)}})
                                          :cook-starting-pods (atom {})}
-                                        name)
+                                        name false)
                                       (get @cook-expected-state-map name {}))))
           do-process (fn [cook-expected-state k8s-actual-state & {:keys [create-namespaced-pod-fn
                                                                          ^V1PodCondition pod-condition
@@ -238,7 +238,7 @@
       (swap! k8s-actual-state-map assoc pod-name {:pod :a-watch-pod
                                                   :synthesized-state {:state :pod/waiting}})
       ; We're in :missing, :pod/starting. Should kill the pod and move to missing,missing.
-      (controller/process mock-cc pod-name)
+      (controller/process mock-cc pod-name false)
       (is (nil? (extract-cook-expected-state)))
 
       (is (= 2 @count-kill-pod)))))
@@ -253,7 +253,7 @@
                           :cook-expected-state-map cook-expected-state-map
                           :k8s-actual-state-map (atom {name {:synthesized-state {:state k8s-actual-state} :pod nil}})
                           :cook-starting-pods (atom {})}
-                         name)
+                         name false)
                        (:cook-expected-state (get @cook-expected-state-map name {}))))
         count-delete-pod (atom 0)]
     (with-redefs [controller/delete-pod  (fn [_ _ cook-expected-state-dict _] (swap! count-delete-pod inc) cook-expected-state-dict)


### PR DESCRIPTION
## Changes proposed in this PR
- remove per-uuid Fenzo "retracting lease" log
- remove per-taskid Kubernetes compute cluster scan log
- remove Cook-Kubernetes state map log when both agree the pod is running

## Why are we making these changes?
We prepose a few simple logging changes to remove low-value logs and slim down log volume (both number of lines and bytes).

