### PR TITLE
Release Cook v1.59.2

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.59.2] - 2022-03-09
+### Added
+- Add capability for configuring default Kubernetes pod labels on a per pool basis, from @laurameng
+### Changed
+- Reduced Cook logging to condense log volume, from @laurameng
+  - Remove low-value Fenzo log as part of log diet efforts
+  - Remove Kubernetes controller pod process logs on scans when Cook & Kubernetes agree on "running" state
+  - Remove taskid scan log
+
 ## [1.59.1] - 2022-02-17
 ### Added
 - Set USER env variable, in addition to COOK_JOB_USER, in Kubernetes by default, from @laurameng

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.59.2"
+(defproject cook "1.59.3-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.59.2-SNAPSHOT"
+(defproject cook "1.59.2"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]


### PR DESCRIPTION
### Please Rebase and merge to preserve the two commits

## Changes proposed in this PR

- updating changelog
- bumping version 

## Why are we making these changes?

To release Cook Scheduler.