### PR TITLE
Add tag for user-specified cluster to cli 'command.runs' metric

### DIFF
--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -85,7 +85,8 @@ def run(args, plugins):
         _, config_map = configuration.load_config_with_defaults(config_path)
         try:
             metrics.initialize(config_map)
-            metrics.inc('command.%s.runs' % action)
+            # measure the number of times users specify each cluster, including when none is specified
+            metrics.inc('command.%s.runs' % action, {'cluster': (cluster or 'default')})
             clusters = load_target_clusters(config_map, url, cluster)
             http.configure(config_map, plugins)
             cook.plugins.configure(plugins)

--- a/cli/cook/metrics.py
+++ b/cli/cook/metrics.py
@@ -71,7 +71,7 @@ def __send(metric):
         logging.exception('exception when sending metric %s' % metric)
 
 
-def inc(metric_name, count=1):
+def inc(metric_name, count=1, additional_tags={}):
     """Increments a counter with the given metric_name by count"""
     if __disabled:
         return
@@ -81,4 +81,6 @@ def inc(metric_name, count=1):
               'host': __host,
               'user': __user,
               'type': 'count'}
+    if additional_tags:
+        metric.update(additional_tags)
     __send(metric)


### PR DESCRIPTION
## Changes proposed in this PR

- Adds cluster as a tag to the existing command.<subcommand>.runs metric

## Why are we making these changes?
Allows us to track how users are submitting jobs (are they cluster dependent?)

