### PR TITLE
Updates CLI version to 3.10.0

### DIFF
--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.9.1'
+VERSION = '3.10.0'


### PR DESCRIPTION
## Changes proposed in this PR
bumping CLI version to 3.1.0

## Why are we making these changes?
To publish the new version to pypi.

