### PR TITLE
Splitting 'updating dynamic clusters' log into separate entries

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -530,11 +530,13 @@
         dissoc-ca-cert-vals
         (fn [configs]
           (map-vals dissoc-ca-cert configs))]
-    (log/info "Updating dynamic clusters."
-              {:current-configs (dissoc-ca-cert-vals current-configs)
-               :force? force?
-               :new-configs (dissoc-ca-cert-vals new-configs)
-               :updates (map #(update % :goal-config dissoc-ca-cert) updates)})
+    (log/info "Updating dynamic clusters.")
+    (doseq [current-config (dissoc-ca-cert-vals current-configs)]
+      (log/info "Updating dynamic cluster" (key current-config) "current config:" current-config))
+    (doseq [new-config (dissoc-ca-cert-vals new-configs)]
+      (log/info "Updating dynamic cluster" (key new-config) "new config:" new-config))
+    (doseq [updated-config (map #(update % :goal-config dissoc-ca-cert) updates)]
+      (log/info "Updating dynamic cluster" :force? force? "updated config:" updated-config))
     (let [updates-with-results (map
                                  #(assoc % :update-result
                                            (when (:valid? %) (execute-update! conn %)))


### PR DESCRIPTION
## Changes proposed in this PR
- Split the "Updating dynamic clusters" log line into multiple entries for each config.

## Why are we making these changes?
The current log is too long and hard to read.

