### PR TITLE
Convert match cycle log line to structured logging and add simple counters

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1038,27 +1038,27 @@
                                                   frequencies)]
     (if (= number-considerable-jobs 0)
       ; keep the log slim in the 0 considerables case
-      (log/info (json/write-str {:jobs-considerable {:total 0}
+      (log/info (json/write-str {:inputs {:jobs-considerable 0}
                                  :pool-name pool-name}))
       ; nonzero considerables case
-      (log/info (json/write-str {:jobs-considerable {:matched number-matched-jobs
-                                                     :total number-considerable-jobs
-                                                     :unmatched number-unmatched-jobs
-                                                     :stats (jobs->stats considerable-jobs)}
-                                 :head-considerable {:was-matched head-job-matched?
-                                                     :resources head-job-resources}
-                                 :offers {:matched (count offers-scheduled)
-                                          :total (count offers)
-                                          :unmatched (- (count offers) (count offers-scheduled))
-                                          :stats (offers->stats offers)}
+      (log/info (json/write-str {:inputs {:jobs-considerable number-considerable-jobs
+                                          :offers (count offers)
+                                          :users user->number-total-considerable-jobs}
+                                 :matched {:jobs-considerable number-matched-jobs
+                                           :offers (count offers-scheduled)
+                                           :users user->number-matched-considerable-jobs
+                                           :match-percent (/ number-matched-jobs number-considerable-jobs)
+                                           :head-matched head-job-matched?}
                                  :pool-name pool-name
-                                 :users-considerable user->number-total-considerable-jobs
-                                 :users-matched user->number-matched-considerable-jobs
-                                 :users-unmatched (merge-with
-                                                    -
-                                                    user->number-total-considerable-jobs
-                                                    user->number-matched-considerable-jobs)
-                                 })))
+                                 :unmatched {:jobs-considerable number-unmatched-jobs
+                                             :offers (- (count offers) (count offers-scheduled))
+                                             :users (merge-with
+                                                      -
+                                                      user->number-total-considerable-jobs
+                                                      user->number-matched-considerable-jobs)}
+                                 :stats {:jobs-considerable (jobs->stats considerable-jobs)
+                                         :offers (offers->stats offers)
+                                         :head-resources head-job-resources}})))
     (counters/inc! cycle-considerable number-considerable-jobs)
     (counters/inc! cycle-matched number-matched-jobs)
     (counters/inc! cycle-unmatched number-unmatched-jobs)))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1027,7 +1027,7 @@
 (counters/defcounter [cook-scheduler match cycle-unmatched])
 
 (defn handle-match-cycle-metrics
-  [pool-name considerable-jobs matches offers offers-scheduled head-job-matched? head-job-resources
+  [pool-name max-considerable considerable-jobs matches offers offers-scheduled head-job-matched? head-job-resources
    number-considerable-jobs number-matched-jobs number-unmatched-jobs]
   (let [user->number-matched-considerable-jobs (->> matches
                                                     matches->jobs
@@ -1043,12 +1043,14 @@
       ; nonzero considerables case
       (log/info (json/write-str {:inputs {:jobs-considerable number-considerable-jobs
                                           :offers (count offers)
-                                          :users user->number-total-considerable-jobs}
+                                          :users user->number-total-considerable-jobs
+                                          :max-considerable max-considerable
+                                          :queue-was-full (= max-considerable number-considerable-jobs)}
                                  :matched {:jobs-considerable number-matched-jobs
                                            :offers (count offers-scheduled)
                                            :users user->number-matched-considerable-jobs
                                            :match-percent (/ number-matched-jobs number-considerable-jobs)
-                                           :head-matched head-job-matched?}
+                                           :head-was-matched head-job-matched?}
                                  :pool-name pool-name
                                  :unmatched {:jobs-considerable number-unmatched-jobs
                                              :offers (- (count offers) (count offers-scheduled))
@@ -1102,7 +1104,7 @@
               number-considerable-jobs (count considerable-jobs)
               number-unmatched-jobs (- number-considerable-jobs number-matched-jobs)]
 
-          (handle-match-cycle-metrics pool-name considerable-jobs matches offers offers-scheduled
+          (handle-match-cycle-metrics pool-name num-considerable considerable-jobs matches offers offers-scheduled
                                       matched-considerable-jobs-head? first-considerable-job-resources
                                       number-considerable-jobs number-matched-jobs number-unmatched-jobs)
 


### PR DESCRIPTION
## Changes proposed in this PR

- Convert existing log in handle-resource-offers! to structured logging
- Add basic number matched, unmatched, considered metrics

## Why are we making these changes?
We want to improve Cook's metrics surrounding the match cycle. This is a first step to aid in gathering data to determine future metrics.

