### PR TITLE
Release Cook v1.59.4

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.59.4] - 2022-04-14
+### Changed
+- Splitting 'updating dynamic clusters' log into separate entries, from @samincheva
+- Convert match cycle log line to structured logging, from @laurameng
+
 ## [1.59.3] - 2022-03-31
 ### Added
 - Add second init sidecar for checkpointing, from @scrosby

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.59.4"
+(defproject cook "1.59.5-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.59.4-SNAPSHOT"
+(defproject cook "1.59.4"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]


### PR DESCRIPTION
### Please Rebase and merge to preserve the two commits

## Changes proposed in this PR

- updating changelog
- bumping version 

## Why are we making these changes?

To release Cook Scheduler.