### PR TITLE
Adding utility function for emitting structured logs and updating structured logging for match cycle metrics

### DIFF
--- a/scheduler/src/cook/log_structured.clj
+++ b/scheduler/src/cook/log_structured.clj
@@ -1,0 +1,71 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+;; This file implements structured logging.
+
+;; A structured log line consists of a human-readable string "Committing Blah to Blah", followed by a metadata dictionary.
+;; (structured-log/info "Launching task " {:pool ... ... ...}"
+
+;; This utility's usage is twofold:
+;; - adding simple metadata tags (e.g., pool name, compute cluster name) to regular log messages
+;; - emitting log metrics with a more complicated dictionary structure (e.g., the match cycle metrics)
+
+;; Within the metadata dictionary, we are standardizing the following key names to be used, where relevant:
+; :pool
+; :compute-cluster-name
+; :user
+; :instance-id
+; :job-id
+
+;; Warning: this utility provides the ability to override the default logger namespace of messages.
+;; This should be used very sparingly, for specific use cases that require it.
+
+(ns cook.log-structured
+  (:require
+    [clojure.data.json :as json]
+    [clojure.tools.logging :as log]))
+
+(defmacro logs
+  "Logs a structured message at the specified level.
+  Supports specifying a custom logger namespace as an optional parameter."
+  ([level data metadata]
+   `log/log ~level (json/write-str (assoc ~metadata :data ~data)))
+  ([level data metadata logger-ns]
+   `(log/log ~logger-ns ~level nil (json/write-str (assoc ~metadata :data ~data)))))
+
+(defmacro debug
+  "Logs a structured message at the debug level"
+  {:arglists '([data metadata] [data metadata logger-ns])}
+  [& args]
+  `(logs :debug ~@args))
+
+(defmacro info
+  "Logs a structured message at the info level"
+  {:arglists '([data metadata] [data metadata logger-ns])}
+  [& args]
+  `(logs :info ~@args))
+
+(defmacro warn
+  "Logs a structured message at the warn level"
+  {:arglists '([data metadata] [data metadata logger-ns])}
+  [& args]
+  `(logs :warn ~@args))
+
+(defmacro error
+  "Logs a structured message at the error level"
+  {:arglists '([data metadata] [data metadata logger-ns])}
+  [& args]
+  `(logs :error ~@args))

--- a/scheduler/src/cook/util.clj
+++ b/scheduler/src/cook/util.clj
@@ -16,6 +16,7 @@
 (ns cook.util
   (:refer-clojure :exclude [cast merge empty split replace])
   (:require [clojure.data :as data]
+            [clojure.data.json :as json]
             [clojure.java.io :as io :refer [file reader]]
             [clojure.java.shell :refer :all]
             [clojure.pprint :refer :all]
@@ -230,3 +231,11 @@
     (let [old-val @atom
           swap-happened (compare-and-set! atom old-val newval)]
       (if swap-happened old-val (recur)))))
+
+(defn log-structured
+  "Log a structured message at the info level.
+  Takes as input a metadata dictionary and a data string.
+  Can specify a custom logger namespace if desired.
+  "
+  ([data metadata] (log/info (json/write-str (assoc metadata :data data))))
+  ([logger-ns data metadata] (log/log logger-ns :info nil (json/write-str (assoc metadata :data data)))))

--- a/scheduler/src/cook/util.clj
+++ b/scheduler/src/cook/util.clj
@@ -16,7 +16,6 @@
 (ns cook.util
   (:refer-clojure :exclude [cast merge empty split replace])
   (:require [clojure.data :as data]
-            [clojure.data.json :as json]
             [clojure.java.io :as io :refer [file reader]]
             [clojure.java.shell :refer :all]
             [clojure.pprint :refer :all]
@@ -231,11 +230,3 @@
     (let [old-val @atom
           swap-happened (compare-and-set! atom old-val newval)]
       (if swap-happened old-val (recur)))))
-
-(defn log-structured
-  "Log a structured message at the info level.
-  Takes as input a metadata dictionary and a data string.
-  Can specify a custom logger namespace if desired.
-  "
-  ([data metadata] (log/info (json/write-str (assoc metadata :data data))))
-  ([logger-ns data metadata] (log/log logger-ns :info nil (json/write-str (assoc metadata :data data)))))


### PR DESCRIPTION
## Changes proposed in this PR
- Splitting per-user match cycle metrics to individual log lines. 
- Adding a utility function to emit structured logging, with support for specifying a custom logger namespace.

## Why are we making these changes?
- Splitting the per-user metrics to individual log lines reduces the cardinality of the structured logs field; instead of having custom field names with the user name, we will have a consistent log format with the user as the value.
- We intend to convert more log messages to use structured logging for fields like the pool name and kubernetes cluster.
- Having the ability to use a custom logger namespace allows us to send certain logs to a separate index for faster querying.

