### PR TITLE
Stop string formatting stats in match logging

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -533,7 +533,7 @@
                      (->> resource-maps
                           (sort-by #(get % resource))
                           last
-                          tools/format-resource-map))
+                          tools/format-resource-map-for-structured-logging))
                    resources-of-interest)
      :percentiles (pc/map-from-keys
                     (fn percentiles
@@ -543,11 +543,11 @@
                                                  (remove nil?))]
                         (-> resource-values
                             (task-stats/percentiles 50 95 100)
-                            tools/format-resource-map)))
+                            tools/format-resource-map-for-structured-logging)))
                     resources-of-interest)
      :totals (->> resource-maps
                   (reduce (partial merge-with +))
-                  tools/format-resource-map)}))
+                  tools/format-resource-map-for-structured-logging)}))
 
 (defn offers->stats
   "Given a collection of offers, returns stats about the offers"

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -1030,6 +1030,15 @@
                   (str %))
                resource-map))
 
+(defn format-resource-map-for-structured-logging
+  "Given a map with resource amount values,
+   formats the amount values for structured logging"
+  [resource-map]
+  (pc/map-vals #(if (number? %)
+                  % ; don't stringify #s
+                  (str %))
+               resource-map))
+
 (defn job->submit-time
   "Get submit-time for a job. due to a bug, submit time may not exist for some jobs"
   [job]


### PR DESCRIPTION
## Changes proposed in this PR

- Remove string formatting from structured logging output

## Why are we making these changes?
We want to allow downstream systems to intelligently pick type-mappings for the match cycle structured logs.