### PR TITLE
Updating more logs to use structured logging

### DIFF
--- a/scheduler/src/cook/log_structured.clj
+++ b/scheduler/src/cook/log_structured.clj
@@ -25,7 +25,7 @@
 
 ;; Within the metadata dictionary, we are standardizing the following key names to be used, where relevant:
 ; :pool
-; :compute-cluster-name
+; :compute-cluster
 ; :user
 ; :instance-id
 ; :job-id
@@ -42,30 +42,38 @@
   "Logs a structured message at the specified level.
   Supports specifying a custom logger namespace as an optional parameter."
   ([level data metadata]
-   `log/log ~level (json/write-str (assoc ~metadata :data ~data)))
-  ([level data metadata logger-ns]
-   `(log/log ~logger-ns ~level nil (json/write-str (assoc ~metadata :data ~data)))))
+   `(log/log ~level (json/write-str (assoc ~metadata :data ~data))))
+  ([level data metadata throwable]
+   `(log/log ~level (json/write-str (assoc ~metadata :data ~data
+                                                     :error (with-out-str (clojure.stacktrace/print-throwable ~throwable))
+                                                     :stacktrace (with-out-str (clojure.stacktrace/print-cause-trace ~throwable))))))
+  ([level data metadata throwable logger-ns]
+   (if (nil? throwable)
+     `(log/log ~logger-ns ~level nil (json/write-str (assoc ~metadata :data ~data)))
+     `(log/log ~logger-ns ~level nil (json/write-str (assoc ~metadata :data ~data
+                                                                      :error (with-out-str (clojure.stacktrace/print-throwable ~throwable))
+                                                                      :stacktrace (with-out-str (clojure.stacktrace/print-cause-trace ~throwable))))))))
 
 (defmacro debug
   "Logs a structured message at the debug level"
-  {:arglists '([data metadata] [data metadata logger-ns])}
+  {:arglists '([data metadata] [data metadata throwable] [data metadata throwable logger-ns])}
   [& args]
   `(logs :debug ~@args))
 
 (defmacro info
   "Logs a structured message at the info level"
-  {:arglists '([data metadata] [data metadata logger-ns])}
+  {:arglists '([data metadata] [data metadata throwable] [data metadata throwable logger-ns])}
   [& args]
   `(logs :info ~@args))
 
 (defmacro warn
   "Logs a structured message at the warn level"
-  {:arglists '([data metadata] [data metadata logger-ns])}
+  {:arglists '([data metadata] [data metadata throwable] [data metadata throwable logger-ns])}
   [& args]
   `(logs :warn ~@args))
 
 (defmacro error
   "Logs a structured message at the error level"
-  {:arglists '([data metadata] [data metadata logger-ns])}
+  {:arglists '([data metadata] [data metadata throwable] [data metadata throwable logger-ns])}
   [& args]
   `(logs :error ~@args))

--- a/scheduler/test/cook/test/log_structured.clj
+++ b/scheduler/test/cook/test/log_structured.clj
@@ -1,0 +1,32 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns cook.test.log_structured
+  (:require [clojure.test :refer :all]
+             [cook.log-structured :as log-structured]))
+
+(deftest test-level-disabled
+  "Tests that functions are not evaluated at a disabled log level."
+  (let [fn-was-called (atom false)
+        shouldnt-be-called (fn [] (reset! fn-was-called true))]
+      (log-structured/debug (str (shouldnt-be-called)) {:test (shouldnt-be-called)})
+      (is (= @fn-was-called false))))
+
+(deftest test-level-enabled
+  "Tests that functions are evaluated as expected at an enabled log level."
+  (let [fn-was-called (atom false)
+        should-be-called (fn [] (reset! fn-was-called true))]
+    (log-structured/info (str (should-be-called)) {:test (should-be-called)})
+    (is (= @fn-was-called true))))


### PR DESCRIPTION
## Changes proposed in this PR
- Update more messages to use structured logging with fields like pool name and compute cluster name.

## Why are we making these changes?
This will make it easier to filter out logs and visualize metrics.

