### PR TITLE
Bump sidecar requests requirement to 2.27.0

### DIFF
--- a/sidecar/cook/sidecar/version.py
+++ b/sidecar/cook/sidecar/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.2.2'
+VERSION = '1.2.3'

--- a/sidecar/setup.py
+++ b/sidecar/setup.py
@@ -7,7 +7,7 @@ from cook.sidecar import version
 requirements = [
     'flask~=1.1.0',
     'gunicorn~=20.1.0',
-    'requests~=2.26.0',
+    'requests~=2.27.0',
 ]
 
 test_requirements = [


### PR DESCRIPTION
## Changes proposed in this PR

- Bump sidecar `requests` requirement to `~=2.27.0`

## Why are we making these changes?


