### PR TITLE
Fix a missing import in setting up postgresql for unit tests.

### DIFF
--- a/scheduler/src/cook/test/postgres.clj
+++ b/scheduler/src/cook/test/postgres.clj
@@ -1,5 +1,6 @@
 (ns cook.test.postgres
-  (:require [clojure.test :refer :all]
+  (:require [clj-time.format]
+            [clojure.test :refer :all]
             [clojure.tools.logging :as log]
             [cook.postgres :as pg]
             [next.jdbc :as sql])


### PR DESCRIPTION
## Changes proposed in this PR

- Fix a missing import in setting up postgresql for unit tests.

## Why are we making these changes?
In some `lein test :only` paths, we can get an import error.

