### PR TITLE
Updating format-map-for-structured-logging to not flatten nested maps

### DIFF
--- a/scheduler/src/cook/util.clj
+++ b/scheduler/src/cook/util.clj
@@ -242,10 +242,15 @@
                resource-map))
 
 (defn format-map-for-structured-logging
-  "Given a map with different types of values,
-   formats the amount values as number and everything else as string for structured logging"
+  "Given a map with different types of values, formats the amount values as a number,
+   and everything else as string for structured logging.
+   Traverses nested maps to format appropriately."
   [resource-map]
-  (pc/map-vals #(if (number? %)
-                  % ; don't stringify #s
-                  (str %))
+  (pc/map-vals #(cond
+                  ; keep numbers as numbers
+                  (number? %) %
+                  ; for nested maps, traverse the map and format its values
+                  (map? %) (format-map-for-structured-logging %)
+                  ; everything else is a string
+                  :else (str %))
                resource-map))

--- a/scheduler/test/cook/test/util.clj
+++ b/scheduler/test/cook/test/util.clj
@@ -15,7 +15,9 @@
 ;;
 (ns cook.test.util
   (:require [clojure.test :refer :all]
-            [cook.util :refer :all]))
+            [cook.util :refer :all])
+  (:import (java.util UUID)))
+
 
 (deftest test-diff-map-keys
   (is (= [#{:b} #{:c} #{:a :d}]
@@ -60,11 +62,7 @@
 
 (deftest test-format-map-for-structured-logging
   "Tests that the format-map-for-structured logging preserves nested maps."
-  (let [map {:integer 2 :float 1.2 :string "foo" :nested-map {:nested-string "bar" :nested-int 3}}
+  (let [uuid (UUID/randomUUID)
+        map {:integer 2 :float 1.2 :string "foo" :uuid uuid :nested-map {:nested-string "bar" :nested-int 3}}
         formatted-map (format-map-for-structured-logging map)]
-    (is (number? (:integer formatted-map)))
-    (is (number? (:float formatted-map)))
-    (is (string? (:string formatted-map)))
-    (is (map? (:nested-map formatted-map)))
-    (is (number? (:nested-int (:nested-map formatted-map))))
-    (is (string? (:nested-string (:nested-map formatted-map))))))
+    (is (= {:integer 2 :float 1.2 :string "foo" :uuid (str uuid) :nested-map {:nested-string "bar" :nested-int 3}} formatted-map))))

--- a/scheduler/test/cook/test/util.clj
+++ b/scheduler/test/cook/test/util.clj
@@ -57,3 +57,14 @@
     (is (= (set-atom! state "a") {}))
     (is (= (set-atom! state {:a :b}) "a"))
     (is (= @state {:a :b}))))
+
+(deftest test-format-map-for-structured-logging
+  "Tests that the format-map-for-structured logging preserves nested maps."
+  (let [map {:integer 2 :float 1.2 :string "foo" :nested-map {:nested-string "bar" :nested-int 3}}
+        formatted-map (format-map-for-structured-logging map)]
+    (is (number? (:integer formatted-map)))
+    (is (number? (:float formatted-map)))
+    (is (string? (:string formatted-map)))
+    (is (map? (:nested-map formatted-map)))
+    (is (number? (:nested-int (:nested-map formatted-map))))
+    (is (string? (:nested-string (:nested-map formatted-map))))))


### PR DESCRIPTION
## Changes proposed in this PR
- Updates the `format-map-for-structured-logging` function to not flatten nested maps, but instead traverse them and format their values appropriately.

## Why are we making these changes?
This allows us to safely call the function on nested maps without flatting its values unintentionally.

