### PR TITLE
Make Cook decide the pool based on the node label instead of taint.

### DIFF
--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -55,7 +55,7 @@ class CookCliTest(util.CookTest):
     def test_config_defaults_are_respected(self):
         # Submit job with defaults in config file
         config = {'defaults': {'submit': {'mem': 256,
-                                          'cpus': 2,
+                                          'cpus': 0.2,
                                           'priority': 16,
                                           'max-retries': 2,
                                           'max-runtime': 300}}}
@@ -154,7 +154,7 @@ if __name__ == '__main__':
     def test_specifying_cluster_name_explicitly(self):
         cluster_name = 'foo'
         config = {'clusters': [{'name': cluster_name, 'url': self.cook_url}],
-                  'defaults': {'submit': {'mem': 256, 'cpus': 2, 'max-retries': 2}}}
+                  'defaults': {'submit': {'mem': 256, 'cpus': 0.2, 'max-retries': 2}}}
         with cli.temp_config_file(config) as path:
             flags = f'--config {path} --cluster {cluster_name}'
             cp, uuids = cli.submit('ls', flags=flags)
@@ -2442,7 +2442,7 @@ if __name__ == '__main__':
     def test_bad_cluster_argument(self):
         cluster_name = 'foo'
         config = {'clusters': [{'name': cluster_name, 'url': self.cook_url}],
-                  'defaults': {'submit': {'mem': 256, 'cpus': 2, 'max-retries': 2}}}
+                  'defaults': {'submit': {'mem': 256, 'cpus': 0.2, 'max-retries': 2}}}
         with cli.temp_config_file(config) as path:
             flags = f'--config {path} --cluster badcluster'
             cp = cli.cli('jobs', flags=flags)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1340,7 +1340,7 @@
 
 (defn ^V1Pod task-metadata->pod
   "Given a task-request and other data generate the kubernetes V1Pod to launch that task."
-  [namespace {:keys [cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name] compute-cluster-name :name}
+  [namespace {:keys [cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name cook-pool-label-prefix] compute-cluster-name :name}
    {:keys [task-id command container task-request hostname pod-annotations pod-constraints pod-hostnames-to-avoid
            pod-labels pod-priority-class pod-supports-cook-init? pod-supports-cook-sidecar?]
     :or {pod-priority-class cook-job-pod-priority-class
@@ -1705,7 +1705,7 @@
     (.addTolerationsItem pod-spec (toleration-for-pool cook-pool-taint-name cook-pool-taint-prefix pool-name))
     ; We need to make sure synthetic pods --- which don't have a hostname set --- have a node selector
     ; to run only in nodes labelled with the appropriate cook pool
-    (when-not hostname (add-node-selector pod-spec cook-pool-label-name pool-name))
+    (when-not hostname (add-node-selector pod-spec cook-pool-label-name (str cook-pool-label-prefix pool-name)))
 
     (when pod-constraints
       (doseq [{:keys [constraint/attribute

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -339,7 +339,7 @@
                                      synthetic-pods-config node-blocklist-labels
                                      ^ExecutorService controller-executor-service
                                      cluster-definition state-atom state-locked?-atom dynamic-cluster-config?
-                                     compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name
+                                     compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name cook-pool-label-prefix
                                      controller-lock-objects]
   cc/ComputeCluster
   (launch-tasks [this pool-name matches process-task-post-launch-fn]
@@ -752,6 +752,7 @@
            cook-pool-taint-name
            cook-pool-taint-prefix
            cook-pool-label-name
+           cook-pool-label-prefix
            ^String config-file
            dynamic-cluster-config?
            compute-cluster-launch-rate-limits
@@ -784,6 +785,7 @@
          cook-pool-taint-name "cook-pool"
          cook-pool-taint-prefix ""
          cook-pool-label-name "cook-pool"
+         cook-pool-label-prefix ""
          use-token-refreshing-authenticator? false}
     :as compute-cluster-config}
    {:keys [exit-code-syncer-state]}]
@@ -831,7 +833,7 @@
                                                     (atom state)
                                                     (atom state-locked?)
                                                     dynamic-cluster-config?
-                                                    compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name
+                                                    compute-cluster-launch-rate-limiter cook-pool-taint-name cook-pool-taint-prefix cook-pool-label-name cook-pool-label-prefix
                                                     ; Vector instead of seq for O(1) access.
                                                     (with-meta (vec (repeatedly lock-shard-count #(ReentrantLock.)))
                                                                {:json-value (str "<count of " lock-shard-count " ReentrantLocks>")}))]

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -611,7 +611,10 @@
         (.setKey taint "foo-taint-probably-broken-TODO")
         (.setValue taint pool)
         (.setEffect taint "NoSchedule")
-        (-> spec (.addTaintsItem taint))))
+        (-> spec (.addTaintsItem taint))
+        ; "l-p" is the label name as used in test-generate-offers
+        (-> metadata (.setLabels {"l-p" pool}))))
+
     (.setStatus node status)
     (.setName metadata node-name)
     (.setMetadata node metadata)
@@ -651,4 +654,5 @@
                                     "some-random-taint-A"
                                     "taint-prefix-1"
                                     "some-random-label-A"
+                                    "some-random-label-val-B"
                                     (repeatedly 16 #(ReentrantLock.)))))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -77,7 +77,7 @@
                                                               {:kind :static :namespace "cook"} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
                                                               {} (atom :running) (atom false) false
-                                                              cook.rate-limit/AllowAllRateLimiter "t-a" "p-a" "l-a" (repeatedly 16 #(ReentrantLock.)))
+                                                              cook.rate-limit/AllowAllRateLimiter "t-a" "p-a" "l-p" "l-v1" (repeatedly 16 #(ReentrantLock.)))
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -98,7 +98,7 @@
                                                               {:kind :per-user} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
                                                               {} (atom :running) (atom false) false
-                                                              cook.rate-limit/AllowAllRateLimiter "t-b" "p-b" "l-b" (repeatedly 16 #(ReentrantLock.)))
+                                                              cook.rate-limit/AllowAllRateLimiter "t-b" "p-b" "l-p" "l-v2" (repeatedly 16 #(ReentrantLock.)))
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -127,7 +127,7 @@
                                                             {:kind :static :namespace "cook"} nil 3 nil nil
                                                             (Executors/newSingleThreadExecutor)
                                                             {} (atom :running) (atom false) false
-                                                            cook.rate-limit/AllowAllRateLimiter "t-c" "p-c" "l-c" (repeatedly 16 #(ReentrantLock.)))
+                                                            cook.rate-limit/AllowAllRateLimiter "t-c" "p-c" "l-p" "l-c2" (repeatedly 16 #(ReentrantLock.)))
             node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 10 "nvidia-tesla-p100" nil nil)
                              "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 25 "nvidia-tesla-p100" nil nil)
                              "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil nil nil nil)


### PR DESCRIPTION
## Changes proposed in this PR

- Make Cook decide the pool based on the node label instead of taint.
- Change the CPU requirements for a couple integration tests.

## Why are we making these changes?

Labels are more visible and easier to use for node filtering.

