### PR TITLE
Moving global kill-lock to be per cc

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -21,8 +21,7 @@
             [cook.util :as util]
             [datomic.api :as d]
             [metrics.timers :as timers]
-            [plumbing.core :refer [map-from-keys map-from-vals map-vals]])
-  (:import (java.util.concurrent.locks ReentrantReadWriteLock)))
+            [plumbing.core :refer [map-from-keys map-from-vals map-vals]]))
 
 (defprotocol ComputeCluster
   (launch-tasks [this pool-name matches process-task-post-launch-fn]
@@ -77,34 +76,33 @@
   (launch-rate-limiter [this]
     "Return the RateLimiter that should be used to limit launches to this compute cluster")
 
+  ; There's an ugly race where the core cook scheduler can kill a job before it tries to launch it.
+  ; What happens is:
+  ;   1. In launch-matched-tasks, we write instance objects to datomic for everything that matches,
+  ;      we have not submitted these to the compute cluster backends yet.
+  ;   2. A kill command arrives to kill the job. The job is put into completed.
+  ;   3. The monitor-tx-queue happens to notice the job just completed. It sees the instance written in step 1.
+  ;   4. We submit a kill-task to the compute cluster backend.
+  ;   5. Kill task processes. There's not much to do, as there's no task to kill.
+  ;   6. launch-matched-tasks now visits the task and submits it to the compute cluster backend.
+  ;   7. Task executes and is not killed.
+  ;
+  ; At the core the bug is an atomicity bug. The intermediate state of written-to-datomic but not yet sent (via launch-task)
+  ; to the backend. We work around this race by having a lock around of all launch-matched-tasks that contains the database
+  ; update and the submit to kubernetes. We re-use the same lock to wrap kill-task to force an ordering relationship, so
+  ; that kill-task must happen after the write-to-datomic and launch-task have been invoked.
+  ;
+  ; ComputeCluster/kill-task cannot be invoked before we write the task to datomic. If it is invoked after the write to
+  ; datomic, the lock ensures that it won't be acted upon until after launch-task has been invoked on the compute cluster.
+  ;
+  ; So, we must grab this lock before calling kill-task in the compute cluster API. As all of our invocations to it are via
+  ; safe-kill-task, we add the lock there.
+  ;
+  ; We use a ReaderWriterLock where launch tasks grab the readers, so multiple pools can launch at the same time, and a writer lock
+  ; here so that kills are blocked until nobody is in the middle of launching. Note that we don't actually need to hold this lock while
+  ; we kill, just to delay the kill until after any task-id written in the database is also guaranteed to be into the backend.
   (kill-lock-object [this]
-    "Returns the cluster's read-write lock used for ordering launch and kill operations"
-    ; There's an ugly race where the core cook scheduler can kill a job before it tries to launch it.
-    ; What happens is:
-    ;   1. In launch-matched-tasks, we write instance objects to datomic for everything that matches,
-    ;      we have not submitted these to the compute cluster backends yet.
-    ;   2. A kill command arrives to kill the job. The job is put into completed.
-    ;   3. The monitor-tx-queue happens to notice the job just completed. It sees the instance written in step 1.
-    ;   4. We submit a kill-task to the compute cluster backend.
-    ;   5. Kill task processes. There's not much to do, as there's no task to kill.
-    ;   6. launch-matched-tasks now visits the task and submits it to the compute cluster backend.
-    ;   7. Task executes and is not killed.
-    ;
-    ; At the core the bug is an atomicity bug. The intermediate state of written-to-datomic but not yet sent (via launch-task)
-    ; to the backend. We work around this race by having a lock around of all launch-matched-tasks that contains the database
-    ; update and the submit to kubernetes. We re-use the same lock to wrap kill-task to force an ordering relationship, so
-    ; that kill-task must happen after the write-to-datomic and launch-task have been invoked.
-    ;
-    ; ComputeCluster/kill-task cannot be invoked before we write the task to datomic. If it is invoked after the write to
-    ; datomic, the lock ensures that it won't be acted upon until after launch-task has been invoked on the compute cluster.
-    ;
-    ; So, we must grab this lock before calling kill-task in the compute cluster API. As all of our invocations to it are via
-    ; safe-kill-task, we add the lock there.
-    ;
-    ; We use a ReaderWriterLock where launch tasks grab the readers, so multiple pools can launch at the same time, and a writer lock
-    ; here so that kills are blocked until nobody is in the middle of launching. Note that we don't actually need to hold this lock while
-    ; we kill, just to delay the kill until after any task-id written in the database is also guaranteed to be into the backend.
-    (ReentrantReadWriteLock. true)))
+    "Returns the cluster's read-write lock used for ordering launch and kill operations"))
 
 (def kill-lock-timer-for-kill (timers/timer ["cook-mesos" "scheduler" "kill-lock-acquire-for-kill"]))
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -865,7 +865,7 @@
     matches-kept))
 
 (defn handle-launch-task-metrics
-  [matches task-txns pool-name]
+  [matches count-txns pool-name compute-cluster-name]
   (let [offers-matched (->> matches
                             (mapcat :leases)
                             (map :offer))
@@ -878,34 +878,39 @@
                             (map (comp cached-queries/job-ent->user :job :task-request))
                             frequencies)]
     (log-structured/info "Launching matched tasks"
-                         {:number-offers-matched num-offers-matched
-                          :number-tasks (count task-txns)
+                         {:compute-cluster compute-cluster-name
+                          :number-offers-matched num-offers-matched
+                          :number-tasks count-txns
                           :number-jobs-per-user (print-str user->num-jobs) ; don't treat the map as json
                           :pool pool-name})
     (meters/mark! scheduler-offer-matched num-offers-matched)
-    (histograms/update! number-offers-matched num-offers-matched))
-  (meters/mark! (meters/meter (metric-title "matched-tasks" pool-name)) (count task-txns)))
+    (histograms/update! number-offers-matched num-offers-matched)
+    (meters/mark! (meters/meter (metric-title "matched-tasks" pool-name)) count-txns)
+    (meters/mark! (meters/meter (metric-title "matched-tasks" pool-name compute-cluster-name)) count-txns)))
 
 (def kill-lock-timer-for-launch (timers/timer ["cook-mesos" "scheduler" "kill-lock-acquire-for-launch"]))
 
+(defn format-matches-for-structured-logging
+  [matches]
+  (for [{:keys [task-metadata-seq]} matches
+        {:keys [task-id task-request]} task-metadata-seq]
+    {:job-uuid (-> task-request (get-in [:job :job/uuid]) str)
+     :task-id task-id}))
+
 (defn launch-tasks-for-cluster
-  [matches compute-cluster pool-name conn fenzo]
+  [compute-cluster matches pool-name conn fenzo]
   (let [compute-cluster-name (cc/compute-cluster-name compute-cluster)
         task-txns (matches->task-txns matches)
+        count-txns (count task-txns)
         kill-lock-object (cc/kill-lock-object compute-cluster)
-        kill-lock-timer-context (timers/start kill-lock-timer-for-launch)]
+        kill-lock-timer-context (timers/start kill-lock-timer-for-launch)
+        matches-for-logging (format-matches-for-structured-logging matches)]
     (log-structured/info "Writing tasks"
                          ; use print-str for the first 10 tasks so that we don't treat the map as json
-                         {:first-ten-tasks (print-str
-                                             (take
-                                               10
-                                               (for [{:keys [task-metadata-seq]} matches
-                                                     {:keys [task-id task-request]} task-metadata-seq]
-                                                 {:job-uuid (-> task-request (get-in [:job :job/uuid]) str)
-                                                  :task-id task-id})))
+                         {:first-ten-tasks (print-str (take 10 matches-for-logging))
                           :compute-cluster compute-cluster-name
                           :pool pool-name
-                          :number-tasks (count task-txns)})
+                          :number-tasks count-txns})
     (timers/time!
       (timers/timer (metric-title "launch-matched-tasks-all-duration" pool-name))
       ; Avoids a race. See docs for kill-lock-object.
@@ -923,32 +928,29 @@
             conn
             (reduce into [] task-txns)
             (fn [e]
-              (log/warn e "In" pool-name ", transaction timed out, so these tasks might be present"
-                        "in Datomic without actually having been launched in Mesos" matches)
+              (log-structured/warn e "Transaction timed out, so these tasks might be present"
+                        "in Datomic without actually having been launched in the compute cluster"
+                                   {:pool-name pool-name
+                                    :task-ids (print-str
+                                                (for [{:keys [task-id]} matches-for-logging]
+                                                  [task-id]))})
               (throw e))))
 
-        (handle-launch-task-metrics matches task-txns pool-name)
+        (handle-launch-task-metrics matches count-txns pool-name compute-cluster-name)
 
         ;; Launching the matched tasks MUST happen after the above transaction in
         ;; order to allow a transaction failure (due to failed preconditions)
         ;; to block the launch
         (timers/time!
           (timers/timer (metric-title "handle-resource-offer!-mesos-submit-duration" pool-name))
-          (->> {compute-cluster matches}
-               (map
-                 (fn [[compute-cluster matches-in-compute-cluster]]
-                   (let [_ (log-structured/info "Launching matched tasks for compute cluster"
-                                                {:pool pool-name :compute-cluster compute-cluster-name})
-                         launch-matches-in-compute-cluster!
-                         #(launch-matches! compute-cluster pool-name
-                                           matches-in-compute-cluster fenzo)]
-                     (doseq [match matches-in-compute-cluster]
-                       (timers/stop (-> match :leases first :offer :offer-match-timer)))
-                     (if (:mesos-config compute-cluster)
-                       (launch-matches-in-compute-cluster!)
-                       (future (launch-matches-in-compute-cluster!))))))
-               doall
-               (run! #(when (future? %) (deref %)))))
+          (let [_ (log-structured/info "Launching matched tasks for compute cluster"
+                                       {:pool pool-name :compute-cluster compute-cluster-name})
+                launch-matches-in-compute-cluster!
+                #(launch-matches! compute-cluster pool-name
+                                  matches fenzo)]
+            (doseq [match matches]
+              (timers/stop (-> match :leases first :offer :offer-match-timer)))
+            (launch-matches-in-compute-cluster!)))
         (finally
           (.. kill-lock-object readLock unlock)))))
   )
@@ -958,10 +960,12 @@
   [matches conn db fenzo mesos-run-as-user pool-name]
   (let [matches (map #(update-match-with-task-metadata-seq % db mesos-run-as-user) matches)
         compute-cluster-to-matches-map (group-by match->compute-cluster matches)]
-    (map (fn [[compute-cluster matches-in-compute-cluster]]
-           (println (cc/compute-cluster-name compute-cluster) " has these matches " matches-in-compute-cluster)
-           (launch-tasks-for-cluster matches-in-compute-cluster compute-cluster pool-name conn fenzo))
-         compute-cluster-to-matches-map)))
+    (->> compute-cluster-to-matches-map
+         (map
+           (fn [[compute-cluster matches-in-compute-cluster]]
+             (future (launch-tasks-for-cluster compute-cluster matches-in-compute-cluster pool-name conn fenzo))))
+         doall
+         (run! #(when (future? %) (deref %))))))
 
 (defn launch-matched-tasks!-old
   "Updates the state of matched tasks in the database and then launches them."

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -904,8 +904,7 @@
         task-txns (matches->task-txns matches)
         count-txns (count task-txns)
         matches-for-logging (format-matches-for-structured-logging matches)
-        kill-lock-object (cc/kill-lock-object compute-cluster)
-        kill-lock-timer-context (timers/start kill-lock-timer-for-launch)]
+        kill-lock-object (cc/kill-lock-object compute-cluster)]
     (log-structured/info "Writing tasks"
                          ; use print-str for the first 10 tasks so that we don't treat the map as json
                          {:first-ten-tasks (print-str (take 10 matches-for-logging))
@@ -914,11 +913,9 @@
                           :number-tasks count-txns})
     (timers/time!
       (timers/timer (metric-title "launch-matched-tasks-all-duration" pool-name))
-      ; Avoids a race. See docs for kill-lock-object.
       (try
+        ; Avoids a race between launching tasks and killing tasks. See kill-lock-object docs for more info.
         (.. kill-lock-object readLock lock)
-        ;; Determine lock acquisition time.
-        (.stop kill-lock-timer-context)
         ;; Note that this transaction can fail if a job was scheduled
         ;; during a race. If that happens, then other jobs that should
         ;; be scheduled will not be eligible for rescheduling until
@@ -945,13 +942,10 @@
         (timers/time!
           (timers/timer (metric-title "handle-resource-offer!-mesos-submit-duration" pool-name))
           (let [_ (log-structured/info "Launching matched tasks for compute cluster"
-                                       {:pool pool-name :compute-cluster compute-cluster-name})
-                launch-matches-in-compute-cluster!
-                #(launch-matches! compute-cluster pool-name
-                                  matches fenzo)]
+                                       {:pool pool-name :compute-cluster compute-cluster-name})]
             (doseq [match matches]
               (timers/stop (-> match :leases first :offer :offer-match-timer)))
-            (launch-matches-in-compute-cluster!)))
+            (#(launch-matches! compute-cluster pool-name matches fenzo))))
         (finally
           (.. kill-lock-object readLock unlock)))))
   )
@@ -964,91 +958,13 @@
     (->> compute-cluster-to-matches-map
          (map
            (fn [[compute-cluster matches-in-compute-cluster]]
-             (future (launch-tasks-for-cluster compute-cluster matches-in-compute-cluster pool-name conn fenzo))))
+             ; vary behavior based on compute cluster type. Mesos clusters are single-threaded and
+             ; should not be launched with futures
+             (if (:mesos-config compute-cluster)
+               (launch-tasks-for-cluster compute-cluster matches-in-compute-cluster pool-name conn fenzo)
+               (future (launch-tasks-for-cluster compute-cluster matches-in-compute-cluster pool-name conn fenzo)))))
          doall
          (run! #(when (future? %) (deref %))))))
-
-(defn launch-matched-tasks!-old
-  "Updates the state of matched tasks in the database and then launches them."
-  [matches conn db fenzo mesos-run-as-user pool-name]
-  (let [matches (map #(update-match-with-task-metadata-seq % db mesos-run-as-user) matches)
-        task-txns (matches->task-txns matches)
-        kill-lock-timer-context (timers/start kill-lock-timer-for-launch)]
-    (log-structured/info "Writing tasks"
-                         ; use print-str for the first 10 tasks so that we don't treat the map as json
-                         {:first-ten-tasks (print-str
-                                             (take
-                                               10
-                                               (for [{:keys [task-metadata-seq]} matches
-                                                     {:keys [task-id task-request]} task-metadata-seq]
-                                                 {:job-uuid (-> task-request (get-in [:job :job/uuid]) str)
-                                                  :task-id task-id})))
-                          :pool pool-name
-                          :number-tasks (count task-txns)})
-    (timers/time!
-      (timers/timer (metric-title "launch-matched-tasks-all-duration" pool-name))
-      ; Avoids a race. See docs for kill-lock-object.
-      (try
-        (.. cc/kill-lock-object readLock lock)
-        ;; Determine lock acquisition time.
-        (.stop kill-lock-timer-context)
-        ;; Note that this transaction can fail if a job was scheduled
-        ;; during a race. If that happens, then other jobs that should
-        ;; be scheduled will not be eligible for rescheduling until
-        ;; the pending-jobs atom is repopulated
-        (timers/time!
-          (timers/timer (metric-title "handle-resource-offer!-transact-task-duration" pool-name))
-          (datomic/transact
-            conn
-            (reduce into [] task-txns)
-            (fn [e]
-              (log/warn e "In" pool-name ", transaction timed out, so these tasks might be present"
-                        "in Datomic without actually having been launched in Mesos" matches)
-              (throw e))))
-
-        (let [offers-matched (->> matches
-                                  (mapcat :leases)
-                                  (map :offer))
-              num-offers-matched (->> offers-matched
-                                      (map (comp :value :id))
-                                      distinct
-                                      count)
-              user->num-jobs (->> matches
-                                  (mapcat :task-metadata-seq)
-                                  (map (comp cached-queries/job-ent->user :job :task-request))
-                                  frequencies)]
-          (log-structured/info "Launching matched tasks"
-                               {:number-offers-matched num-offers-matched
-                                :number-tasks (count task-txns)
-                                :number-jobs-per-user (print-str user->num-jobs) ; don't treat the map as json
-                                :pool pool-name})
-          (meters/mark! scheduler-offer-matched num-offers-matched)
-          (histograms/update! number-offers-matched num-offers-matched))
-        (meters/mark! (meters/meter (metric-title "matched-tasks" pool-name)) (count task-txns))
-
-        ;; Launching the matched tasks MUST happen after the above transaction in
-        ;; order to allow a transaction failure (due to failed preconditions)
-        ;; to block the launch
-        (timers/time!
-          (timers/timer (metric-title "handle-resource-offer!-mesos-submit-duration" pool-name))
-          (->> (group-by match->compute-cluster matches)
-               (map
-                 (fn [[compute-cluster matches-in-compute-cluster]]
-                   (let [compute-cluster-name (cc/compute-cluster-name compute-cluster)
-                         _ (log-structured/info "Launching matched tasks for compute cluster"
-                                                {:pool pool-name :compute-cluster compute-cluster-name})
-                         launch-matches-in-compute-cluster!
-                         #(launch-matches! compute-cluster pool-name
-                                           matches-in-compute-cluster fenzo)]
-                     (doseq [match matches-in-compute-cluster]
-                       (timers/stop (-> match :leases first :offer :offer-match-timer)))
-                     (if (:mesos-config compute-cluster)
-                       (launch-matches-in-compute-cluster!)
-                       (future (launch-matches-in-compute-cluster!))))))
-               doall
-               (run! #(when (future? %) (deref %)))))
-        (finally
-          (.. cc/kill-lock-object readLock unlock))))))
 
 (defn update-host-reservations!
   "Updates the rebalancer-reservation-atom with the result of the match cycle.

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -935,8 +935,6 @@
                                    {:compute-cluster compute-cluster-name
                                     :pool pool-name}
                                    e)
-              ;(log/warn e "In" pool-name ", transaction timed out, so these tasks might be present"
-              ;          "in Datomic without actually having been launched in compute cluster" matches)
               (throw e))))
 
         (handle-launch-task-metrics matches count-txns pool-name compute-cluster)

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -46,7 +46,7 @@
            (io.kubernetes.client.custom Quantity Quantity$Format)
            (io.kubernetes.client.openapi.models V1Container V1Node V1NodeSpec V1NodeStatus V1ObjectMeta V1Pod V1PodSpec V1ResourceRequirements V1Taint)
            (java.util.concurrent Executors TimeUnit)
-           (java.util.concurrent.locks ReentrantLock)
+           (java.util.concurrent.locks ReentrantLock ReentrantReadWriteLock)
            (java.util UUID)
            (org.apache.log4j ConsoleAppender Logger PatternLayout)))
 
@@ -69,7 +69,8 @@
                                {}
                                {"no-pool" (async/chan 100)}
                                {}
-                               rate-limit/AllowAllRateLimiter)))
+                               rate-limit/AllowAllRateLimiter
+                               (ReentrantReadWriteLock. true))))
 
 (defn fake-test-compute-cluster-with-driver
   "Create a test compute cluster with associated driver attached to it. Returns the compute cluster."
@@ -655,4 +656,5 @@
                                     "taint-prefix-1"
                                     "some-random-label-A"
                                     "some-random-label-val-B"
-                                    (repeatedly 16 #(ReentrantLock.)))))
+                                    (repeatedly 16 #(ReentrantLock.))
+                                    (ReentrantReadWriteLock. true))))

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -13,7 +13,7 @@
   (:import (clojure.lang ExceptionInfo)
            (io.kubernetes.client.openapi.models V1NodeSelectorRequirement V1Pod V1PodSecurityContext)
            (java.util.concurrent Executors)
-           (java.util.concurrent.locks ReentrantLock)
+           (java.util.concurrent.locks ReentrantLock ReentrantReadWriteLock)
            (java.util UUID)))
 
 (use-fixtures :once cook.test.postgres/with-pg-db)
@@ -77,7 +77,9 @@
                                                               {:kind :static :namespace "cook"} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
                                                               {} (atom :running) (atom false) false
-                                                              cook.rate-limit/AllowAllRateLimiter "t-a" "p-a" "l-p" "l-v1" (repeatedly 16 #(ReentrantLock.)))
+                                                              cook.rate-limit/AllowAllRateLimiter "t-a" "p-a" "l-p" "l-v1"
+                                                              (repeatedly 16 #(ReentrantLock.))
+                                                              (ReentrantReadWriteLock. true))
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -98,7 +100,9 @@
                                                               {:kind :per-user} nil nil nil nil
                                                               (Executors/newSingleThreadExecutor)
                                                               {} (atom :running) (atom false) false
-                                                              cook.rate-limit/AllowAllRateLimiter "t-b" "p-b" "l-p" "l-v2" (repeatedly 16 #(ReentrantLock.)))
+                                                              cook.rate-limit/AllowAllRateLimiter "t-b" "p-b" "l-p" "l-v2"
+                                                              (repeatedly 16 #(ReentrantLock.))
+                                                              (ReentrantReadWriteLock. true))
               task-metadata (task/TaskAssignmentResult->task-metadata (d/db conn)
                                                                       nil
                                                                       compute-cluster
@@ -127,7 +131,9 @@
                                                             {:kind :static :namespace "cook"} nil 3 nil nil
                                                             (Executors/newSingleThreadExecutor)
                                                             {} (atom :running) (atom false) false
-                                                            cook.rate-limit/AllowAllRateLimiter "t-c" "p-c" "l-p" "l-c2" (repeatedly 16 #(ReentrantLock.)))
+                                                            cook.rate-limit/AllowAllRateLimiter "t-c" "p-c" "l-p" "l-c2"
+                                                            (repeatedly 16 #(ReentrantLock.))
+                                                            (ReentrantReadWriteLock. true))
             node-name->node {"nodeA" (tu/node-helper "nodeA" 1.0 1000.0 10 "nvidia-tesla-p100" nil nil)
                              "nodeB" (tu/node-helper "nodeB" 1.0 1000.0 25 "nvidia-tesla-p100" nil nil)
                              "nodeC" (tu/node-helper "nodeC" 1.0 1000.0 nil nil nil nil)

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2161,7 +2161,8 @@
           job-id (create-dummy-job conn)
           job (d/entity (d/db conn) job-id)
           ^TaskRequest task-request (sched/make-task-request (d/db conn) job nil)
-          matches [{:tasks [(SimpleAssignmentResult. [] nil task-request)]}]]
+          matches [{:tasks [(SimpleAssignmentResult. [] nil task-request)]
+                    :leases {:offer {:compute-cluster "kubernetes"}}}]]
       (with-redefs [cc/db-id (constantly -1) ; So we don't throw prematurely when trying to create the task structure.
                     d/transact (fn [_ _]
                                  (throw timeout-exception))

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -57,9 +57,9 @@
            (com.netflix.fenzo.plugins BinPackingFitnessCalculators)
            (cook.compute_cluster ComputeCluster)
            (java.util UUID)
+           (java.util.concurrent ExecutionException)
            (java.util.concurrent.locks ReentrantReadWriteLock)
-           (org.mockito Mockito)
-           (java.util.concurrent ExecutionException)))
+           (org.mockito Mockito)))
 
 
 (use-fixtures :once cook.test.postgres/with-pg-db)

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -32,6 +32,7 @@
             [datomic.api :as d]
             [plumbing.core :refer [map-from-vals map-keys map-vals]])
   (:import (java.util Date)
+           (java.util.concurrent.locks ReentrantReadWriteLock)
            (org.apache.curator.framework CuratorFrameworkFactory)
            (org.apache.curator.framework.state ConnectionStateListener)
            (org.apache.curator.retry BoundedExponentialBackoffRetry)
@@ -147,7 +148,8 @@
                                                               {}
                                                               {"no-pool" (async/chan 100)}
                                                               {}
-                                                              cook.rate-limit/AllowAllRateLimiter))
+                                                              cook.rate-limit/AllowAllRateLimiter
+                                                              (ReentrantReadWriteLock. true)))
          prepare-match-trigger-chan-orig# ~sched/prepare-match-trigger-chan]
      (try
        (with-redefs [executor-config (constantly executor-config#)


### PR DESCRIPTION
## Changes proposed in this PR

- Moves the previously global kill/launch sequencing lock to be per compute cluster rather than per Cook cluster

## Why are we making these changes?
A global kill lock forces all compute clusters to wait behind the slowest. Switching to a per-cluster design breaks that bottleneck, but trades for another. Instead, we may end up with different pools waiting for the same compute cluster.

Long term goal is to remove the lock by removing the requirement that kill signals process strictly after the relevant task was launched.

