### PR TITLE
Use non-deprecated Tenacity API

### DIFF
--- a/cli/cook/querying.py
+++ b/cli/cook/querying.py
@@ -271,7 +271,7 @@ def query_unique_and_run(clusters, entity_ref, command_fn, wait=False):
                               retry=tenacity.retry_if_exception_type(CookRetriableException),
                               stop=tenacity.stop_after_delay(one_day_in_seconds),
                               reraise=True)
-        r.call(query_unique_and_run)
+        r.__call__(query_unique_and_run)
     else:
         query_unique_and_run()
 


### PR DESCRIPTION
## Changes proposed in this PR

- Use `__call__()` instead of the deprecated `call()` API from tenacity which was removed in In jd/tenacity#307 but was still used in the CLI

## Why are we making these changes?

The deprecated call was removed and this will no longer work with newer Tenacity versions.
