### PR TITLE
Fixing bug when running in api-only mode

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -108,44 +108,39 @@
                       ; We track queue limits on all nodes, not just the leader, because
                       ; we need to check them when job submission requests come in
                       (queue-limit/start-updating-queue-lengths)
-
-                      (if (cook.config/api-only-mode?)
-                        (if curator-framework
-                          (throw (ex-info "This node is configured for API-only mode, but also has a curator configured"
-                                          {:curator-framework curator-framework}))
-                          (log/info "This node is in API-only mode, and will not participate in scheduling"))
-                        (if curator-framework
-                          (do
-                            (log/info "Initializing mesos scheduler")
-                            (try
-                              (Class/forName "org.apache.mesos.Scheduler")
-                              ((util/lazy-load-var 'cook.mesos/start-leader-selector)
-                                {:curator-framework curator-framework
-                                 :fenzo-config {:fenzo-max-jobs-considered fenzo-max-jobs-considered
-                                                :fenzo-scaleback fenzo-scaleback
-                                                :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn
-                                                :fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-reset
-                                                :fenzo-fitness-calculator fenzo-fitness-calculator
-                                                :good-enough-fitness good-enough-fitness}
-                                 :mea-culpa-failure-limit mea-culpa-failure-limit
-                                 :mesos-datomic-conn datomic/conn
-                                 :mesos-datomic-mult mesos-datomic-mult
-                                 :mesos-heartbeat-chan mesos-heartbeat-chan
-                                 :leadership-atom leadership-atom
-                                 :pool-name->pending-jobs-atom pool-name->pending-jobs-atom
-                                 :mesos-run-as-user mesos-run-as-user
-                                 :offer-incubate-time-ms offer-incubate-time-ms
-                                 :optimizer-config optimizer
-                                 :rebalancer-config rebalancer
-                                 :server-config {:hostname hostname
-                                                 :server-port server-port}
-                                 :task-constraints task-constraints
-                                 :trigger-chans trigger-chans
-                                 :zk-prefix mesos-leader-path})
-                              (catch ClassNotFoundException e
-                                (log/warn e "Not loading mesos support...")
-                                nil)))
-                          (throw (ex-info "This node does not have a curator configured" {})))))})
+                      (if curator-framework
+                        (do
+                          (log/info "Initializing mesos scheduler")
+                          (try
+                            (Class/forName "org.apache.mesos.Scheduler")
+                            ((util/lazy-load-var 'cook.mesos/start-leader-selector)
+                              {:curator-framework curator-framework
+                               :fenzo-config {:fenzo-max-jobs-considered fenzo-max-jobs-considered
+                                              :fenzo-scaleback fenzo-scaleback
+                                              :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn
+                                              :fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-reset
+                                              :fenzo-fitness-calculator fenzo-fitness-calculator
+                                              :good-enough-fitness good-enough-fitness}
+                               :mea-culpa-failure-limit mea-culpa-failure-limit
+                               :mesos-datomic-conn datomic/conn
+                               :mesos-datomic-mult mesos-datomic-mult
+                               :mesos-heartbeat-chan mesos-heartbeat-chan
+                               :leadership-atom leadership-atom
+                               :pool-name->pending-jobs-atom pool-name->pending-jobs-atom
+                               :mesos-run-as-user mesos-run-as-user
+                               :offer-incubate-time-ms offer-incubate-time-ms
+                               :optimizer-config optimizer
+                               :rebalancer-config rebalancer
+                               :server-config {:hostname hostname
+                                               :server-port server-port}
+                               :task-constraints task-constraints
+                               :trigger-chans trigger-chans
+                               :zk-prefix mesos-leader-path
+                               :api-only? (cook.config/api-only-mode?)})
+                            (catch ClassNotFoundException e
+                              (log/warn e "Not loading mesos support...")
+                              nil)))
+                        (throw (ex-info "This node does not have a curator configured" {}))))})
 
 (defn health-check-middleware
   "This adds /debug to return 200 OK"

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -171,11 +171,12 @@
    progress-config               -- map, config for progress publishing. See scheduler/docs/configuration.adoc
    framework-id                  -- str, the Mesos framework id from the cook settings
    fenzo-config                  -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details
-   sandbox-syncer-state          -- map, representing the sandbox syncer object"
+   sandbox-syncer-state          -- map, representing the sandbox syncer object
+   api-only?                     -- bool, true if this instance should not actually join the leader selection"
   [{:keys [curator-framework fenzo-config mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult
            mesos-heartbeat-chan leadership-atom pool-name->pending-jobs-atom mesos-run-as-user
            offer-incubate-time-ms optimizer-config rebalancer-config server-config task-constraints trigger-chans
-           zk-prefix]}]
+           zk-prefix api-only?]}]
   (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
                 fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness]} fenzo-config
         {:keys [cancelled-task-trigger-chan lingering-task-trigger-chan optimizer-trigger-chan
@@ -184,6 +185,7 @@
         datomic-report-chan (async/chan (async/sliding-buffer 4096))
         cluster-name->compute-cluster @cc/cluster-name->compute-cluster-atom
         rebalancer-reservation-atom (atom {})
+        _ (log/info "Starting leader selection" :api-only? api-only?)
         _ (log/info "Using path" zk-prefix "for leader selection")
         leader-selector (LeaderSelector.
                           curator-framework
@@ -319,11 +321,19 @@
                                  (or server-port server-https-port) \#
                                  (if server-port "http" "https") \#
                                  (java.util.UUID/randomUUID)))
-    (.autoRequeue leader-selector)
-    (.start leader-selector)
-    (log/info "Started the leader selector")
+    (if api-only?
+      ; If this is an api-only instance, we still want all the leader election configuration to be set,
+      ; without actually joing the election process.
+      ; This allows the instance to correctly forward client requests to the leader as necessary.
+      (log/info "Will not join leader election, running as api-only")
+      (do
+        (.autoRequeue leader-selector)
+        (.start leader-selector)
+        (log/info "Started the leader selector")
+        ))
     {:submitter (partial submit-to-mesos mesos-datomic-conn)
      :leader-selector leader-selector}))
+
 
 (defn kill-job
   "Kills jobs. It works by marking them completed, which will trigger the subscription

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -329,8 +329,7 @@
       (do
         (.autoRequeue leader-selector)
         (.start leader-selector)
-        (log/info "Started the leader selector")
-        ))
+        (log/info "Started the leader selector")))
     {:submitter (partial submit-to-mesos mesos-datomic-conn)
      :leader-selector leader-selector}))
 

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -182,7 +182,8 @@
             :server-config host-settings#
             :task-constraints task-constraints#
             :trigger-chans trigger-chans#
-            :zk-prefix zk-prefix#})
+            :zk-prefix zk-prefix#
+            :api-only false})
          (do ~@body))
        (finally
          (.close curator-framework#)


### PR DESCRIPTION
## Changes proposed in this PR
- Change `api-only?` instances to still configured leader election, without actually joining the selection process.

## Why are we making these changes?
Currently, `api-only?` instances fail client requests that require forwarding to the leader. This change fixes that by giving `api-only?` instances the ability to forward to the elected leader.

