### PR TITLE
Release Cook Scheduler v1.61.0

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.61.0] - 2022-06-22
+### Changed
+- Moved the global launch/kill ordering lock to be per compute-cluster, from @laurameng
+
 ## [1.60.2] - 2022-06-15
 ### Fixed
 - Fix bug in api-only flag that would fail operations requiring a connection to the leader, from @samincheva

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.60.3-SNAPSHOT"
+(defproject cook "1.61.0"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.61.0"
+(defproject cook "1.61.1-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]


### PR DESCRIPTION
### Please `Rebase and merge` to preserve the two commits
## Changes proposed in this PR
- updating changelog
- updating version

## Why are we making these changes?

To release Cook scheduler.