### PR TITLE
Add support for specifying a default Cook cluster per Cook CLI action

### DIFF
--- a/cli/.cs.json
+++ b/cli/.cs.json
@@ -3,7 +3,9 @@
     "submit": {
       "mem": 128,
       "cpus": 1,
-      "max-retries": 1
+      "max-retries": 1,
+      "cluster": "dev1",
+      "pool-name": "a-pool"
     }
   },
   "clusters": [

--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -95,8 +95,8 @@ def run(args, plugins):
             # load_target_clusters needs to be aware if there are any action-specific cluster defaults
             if action_defaults:
                 # coalesce the defaults with cli flags overriding action config defaults
-                url = url or action_defaults.get("url", None)
-                cluster = cluster or action_defaults.get("cluster", None)
+                # using `pop` to remove the disallowed 'cluster' key
+                cluster = cluster or action_defaults.pop("cluster", None)
             clusters = load_target_clusters(config_map, url=url, cluster=cluster)
             logging.debug('going to execute % action' % action)
             result = actions[action](clusters, deep_merge(action_defaults, args), config_path)


### PR DESCRIPTION
## Changes proposed in this PR

- Add functionality to specify cluster or url action defaults for Cook's CLI

## Why are we making these changes?
This change allows us to be more flexible when assigning defaults. Specifically, if we desire different defaults per action.

