### PR TITLE
Version bump cli to 3.9.5

### DIFF
--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.9.4'
+VERSION = '3.9.5'


### PR DESCRIPTION
## Changes proposed in this PR

- Bump cook-client cli version post-release

## Why are we making these changes?
To release cook-client

