### PR TITLE
version bump to 3.9.5 and bugfix action-default cluster logic

### DIFF
--- a/cli/.cs.json
+++ b/cli/.cs.json
@@ -4,8 +4,7 @@
       "mem": 128,
       "cpus": 1,
       "max-retries": 1,
-      "cluster": "dev1",
-      "pool-name": "a-pool"
+      "cluster": "dev1"
     }
   },
   "clusters": [

--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -77,8 +77,8 @@ def run(args, plugins):
     action = args.pop('action')
     config_path = args.pop('config')
     cluster = args.pop('cluster')
-    pool_name = args.get('pool-name')
     url = args.pop('url')
+    pool_name = args.get('pool-name')
 
     if action is None:
         parser.print_help()
@@ -94,16 +94,18 @@ def run(args, plugins):
             defaults = config_map.get('defaults')
             action_defaults = (defaults.get(action) if defaults else None) or {}
             # load_target_clusters needs to be aware if there are any action-specific cluster defaults
-            # We want to treat cluster & pool as a pair here, so if either is specified on the cli,
+            # We want to treat cluster, pool and url as a tuple here, so if any are specified on the cli,
             # we will override the defaults.
             # Additionally, we must `pop` to remove the disallowed 'cluster' key, regardless of
             # whether we use the action_defaults or the cli flags
             if action_defaults:
                 action_default_cluster = action_defaults.pop("cluster", None)
-                if cluster or pool_name:
+                action_default_url = action_defaults.pop("url", None)
+                if cluster or pool_name or url:
                     action_defaults.pop("pool-name", None)
                 else:
                     cluster = action_default_cluster
+                    url = action_default_url
             clusters = load_target_clusters(config_map, url=url, cluster=cluster)
             logging.debug('going to execute % action' % action)
             result = actions[action](clusters, deep_merge(action_defaults, args), config_path)

--- a/cli/cook/cli.py
+++ b/cli/cook/cli.py
@@ -77,6 +77,7 @@ def run(args, plugins):
     action = args.pop('action')
     config_path = args.pop('config')
     cluster = args.pop('cluster')
+    pool_name = args.get('pool-name')
     url = args.pop('url')
 
     if action is None:
@@ -93,10 +94,16 @@ def run(args, plugins):
             defaults = config_map.get('defaults')
             action_defaults = (defaults.get(action) if defaults else None) or {}
             # load_target_clusters needs to be aware if there are any action-specific cluster defaults
+            # We want to treat cluster & pool as a pair here, so if either is specified on the cli,
+            # we will override the defaults.
+            # Additionally, we must `pop` to remove the disallowed 'cluster' key, regardless of
+            # whether we use the action_defaults or the cli flags
             if action_defaults:
-                # coalesce the defaults with cli flags overriding action config defaults
-                # using `pop` to remove the disallowed 'cluster' key
-                cluster = cluster or action_defaults.pop("cluster", None)
+                action_default_cluster = action_defaults.pop("cluster", None)
+                if cluster or pool_name:
+                    action_defaults.pop("pool-name", None)
+                else:
+                    cluster = action_default_cluster
             clusters = load_target_clusters(config_map, url=url, cluster=cluster)
             logging.debug('going to execute % action' % action)
             result = actions[action](clusters, deep_merge(action_defaults, args), config_path)

--- a/cli/cook/version.py
+++ b/cli/cook/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.9.4'
+VERSION = '3.9.5'

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -1729,7 +1729,8 @@ if __name__ == '__main__':
         self.assertEqual(1, len(groups))
 
     def test_entity_refs_case_insensitive(self):
-        config = {'clusters': [{'name': 'Foo', 'url': self.cook_url}]}
+        config = {'clusters': [{'name': 'Foo', 'url': self.cook_url}],
+                  'defaults': {'submit': {'cluster': '', 'pool-name': '', 'url': ''}}}
         with cli.temp_config_file(config) as path:
             flags = f'--config {path}'
             cp, uuids = cli.submit('ls', flags=flags)
@@ -1775,7 +1776,8 @@ if __name__ == '__main__':
         self.assertIn(instance_uuid_2, (i['task_id'] for i, _ in instance_job_pairs))
 
     def test_entity_refs_trailing_slash_on_cluster(self):
-        config = {'clusters': [{'name': 'Foo', 'url': f'{self.cook_url}/'}]}
+        config = {'clusters': [{'name': 'Foo', 'url': self.cook_url}],
+                  'defaults': {'submit': {'cluster': '', 'pool-name': '', 'url': ''}}}
         with cli.temp_config_file(config) as path:
             flags = f'--config {path}'
             cp, uuids = cli.submit('ls', flags=flags)
@@ -2228,7 +2230,8 @@ if __name__ == '__main__':
         self.assertEqual(0, cp.returncode, cp.stderr)
         user = util.get_user(self.cook_url, uuids[0])
         config = {'clusters': [{'name': 'foo', 'url': self.cook_url},
-                               {'name': 'bar', 'url': 'http://localhost:65535'}]}
+                               {'name': 'bar', 'url': 'http://localhost:65535'}],
+                  'defaults': {'submit': {'cluster': '', 'pool-name': '', 'url': ''}}}
         with cli.temp_config_file(config) as path:
             flags = f'--config {path}'
             cp, jobs = cli.jobs_json(flags=flags, jobs_flags=f'--name {name} --all --user {user}')

--- a/integration/tests/cook/test_cli_multi_cluster.py
+++ b/integration/tests/cook/test_cli_multi_cluster.py
@@ -29,7 +29,8 @@ class MultiCookCliTest(unittest.TestCase):
 
     def __two_cluster_config(self):
         return {'clusters': [{'name': 'cook1', 'url': self.cook_url_1},
-                             {'name': 'cook2', 'url': self.cook_url_2}]}
+                             {'name': 'cook2', 'url': self.cook_url_2}],
+                'default': {'submit': {'cluster': '', 'pool-name': '', 'url': ''}}}
 
     def test_federated_show(self):
         # Submit to cluster #1
@@ -147,7 +148,8 @@ class MultiCookCliTest(unittest.TestCase):
     def test_no_matching_data_error_shows_only_cluster_of_interest(self):
         name = uuid.uuid4()
         config = {'clusters': [{'name': 'FOO', 'url': f'{self.cook_url_1}'},
-                               {'name': 'BAR', 'url': f'{self.cook_url_2}'}]}
+                               {'name': 'BAR', 'url': f'{self.cook_url_2}'}],
+                  'defaults': {'submit': {'cluster': '', 'pool-name': '', 'url': ''}}}
         with cli.temp_config_file(config) as path:
             flags = f'--config {path}'
             cp, uuids = cli.submit('ls', flags=flags, submit_flags=f'--name {name}')


### PR DESCRIPTION
## Changes proposed in this PR

- Bugfix for default cluster & pool per action

## Why are we making these changes?
Previous logic did not allow us to specify a cluster and a default at the same time! Also, we want to explicitly allow any cluster or pool CLI flag to override the default.

