### PR TITLE
Updating unit tests to handle inactive pools with 0 quota better

### DIFF
--- a/integration/tests/cook/test_basic.py
+++ b/integration/tests/cook/test_basic.py
@@ -2423,7 +2423,9 @@ class CookTest(util.CookTest):
                 job = util.load_job(self.cook_url, job_uuid)
                 self.assertEqual(pool_name, job['pool'])
             else:
-                self.assertEqual(resp.status_code, 400, msg=resp.content)
+                # We expect a 400 when submitting to a disabled pool, but it's also possible that
+                # the quota for the pool was to 0, in which case we'd get a 422
+                self.assertTrue(resp.status_code in [400, 422], msg=resp.content)
 
         # Try submitting to a pool that doesn't exist
         job_uuid, resp = util.submit_job(self.cook_url, pool=str(util.make_temporal_uuid()))

--- a/integration/tests/cook/test_cli.py
+++ b/integration/tests/cook/test_cli.py
@@ -2278,7 +2278,15 @@ if __name__ == '__main__':
                 self.assertEqual(pool_name, jobs[0]['pool'])
             else:
                 self.assertEqual(1, cp.returncode, cp.stderr)
-                self.assertIn(f'{pool_name} is not accepting job submissions', cli.stderr(cp))
+                stderr = cli.stderr(cp)
+                if f'{pool_name} is not accepting job submissions' in stderr:
+                    # Typically we get a message that the pool is not accepting jobs
+                    pass
+                elif "exceeds quota" in stderr:
+                    # It's possible the user quota for the pool was set to 0, in which case we get a different message
+                    pass
+                else:
+                    self.fail(f"Got unexpected error: {stderr}")
         # Try submitting to a pool that doesn't exist
         cp, uuids = cli.submit('ls', self.cook_url, submit_flags=f'--pool {util.make_temporal_uuid()}')
         self.assertEqual(1, cp.returncode, cp.stderr)


### PR DESCRIPTION
## Changes proposed in this PR
- Updating unit tests to handle inactive pools with 0 quota better instead. 

## Why are we making these changes?
Right now if a pool is inactive, the unit tests expect a specific error code and message. But if the user quota in the pool is 0, a different error code and message is returned. This change updates the unit tests to handle that case better.

