### PR TITLE
Release v1.61.2

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.61.2] - 2022-07-12
+### Changed
+- Add more opentracing spans to the match cycle, @samincheva
+
+### Fixed
+- Disabled pools integration tests handle 0 quota better, from @samincheva
+
 ## [1.61.1] - 2022-07-28
 ### Added 
 - Opentracing for the match cycle logic, from @samincheva

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.61.2"
+(defproject cook "1.61.3-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.61.2-SNAPSHOT"
+(defproject cook "1.61.2"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]


### PR DESCRIPTION
## Changes proposed in this PR
- Updating changelog and version for v1.61.2.

## Why are we making these changes?
To release Cook scheduler.

## Please `Rebase and merge` to preserve commit history.

