### PR TITLE
Adding :pool tag to top-most match cycle span

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1390,7 +1390,7 @@
         (timers/time!
           (timers/timer (metric-title "match-jobs-event" pool-name))
           (tracing/with-span [s {:name "scheduler.offer-handler.match-jobs"
-                                 :tags {:component tracing-component-tag}}]
+                                 :tags {:pool pool-name :component tracing-component-tag}}]
             (let [num-considerable @fenzo-num-considerable-atom
                   next-considerable
                   (try


### PR DESCRIPTION
## Changes proposed in this PR
- Add missing `:pool` tag to top-most match cycle tracing span. 

## Why are we making these changes?
This allows us to filter traces by pool.

