### PR TITLE
Refactor: Make util/global-pool-quota simpler to use.

### DIFF
--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -2401,7 +2401,7 @@
                                                (util/filter-pending-jobs-for-quota
                                                  pool-name (atom {}) (atom {}) (pool->user->quota pool-name)
                                                  (pool->user->usage pool-name)
-                                                 (util/global-pool-quota (config/pool-quotas) pool-name))
+                                                 (util/global-pool-quota pool-name))
                                                (take (::limit ctx)))))))))
 
 ;;

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -713,7 +713,7 @@
           (->> pending-jobs
                (tools/filter-pending-jobs-for-quota pool-name user->rate-limit-count user->passed-count
                                                     user->quota user->usage
-                                                    (tools/global-pool-quota (config/pool-quotas) pool-name))
+                                                    (tools/global-pool-quota pool-name))
                (filter (fn [job] (tools/job-allowed-to-start? db job)))
                (filter launch-plugin/filter-job-launches)
                (take num-considerable)
@@ -1319,7 +1319,7 @@
                                                        (->> pool-name
                                                             (get @pool-name->pending-jobs-atom)
                                                             (tools/filter-pending-jobs-for-quota pool-name (atom {}) (atom {})
-                                                                                                 user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name))
+                                                                                                 user->quota user->usage (tools/global-pool-quota pool-name))
                                                             (take max-jobs-for-autoscaling-scaled)
                                                             (doall)))
                   filtered-autoscalable-jobs (remove #(.getIfPresent caches/recent-synthetic-pod-job-uuids (:job/uuid %)) autoscalable-jobs)]

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -869,8 +869,8 @@
 
 (defn global-pool-quota
   "Given a pool name, determine the global quota for that pool across all users."
-  [quotas effective-pool-name]
-  (regexp-tools/match-based-on-pool-name quotas effective-pool-name :quota))
+  [effective-pool-name]
+  (regexp-tools/match-based-on-pool-name (config/pool-quotas) effective-pool-name :quota))
 
 (defn filter-based-on-user-quota
   "Lazily filters jobs for which the sum of running jobs and jobs earlier in the queue exceeds one of the constraints,


### PR DESCRIPTION
## Changes proposed in this PR

- A cleanup to simplify util/global-pool-quota invocation.

## Why are we making these changes?
Split off from the joint quota work.

