### PR TITLE
Submit jobs directly to Kubernetes Scheduler by pool config

### DIFF
--- a/scheduler/.gitignore
+++ b/scheduler/.gitignore
@@ -1,2 +1,3 @@
 .pytest_cache
 gclog*
+.calva/

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -91,7 +91,7 @@
                            offer-incubate-time-ms optimizer rebalancer server-port task-constraints]
                           compute-clusters curator-framework mesos-datomic-mult leadership-atom
                           pool-name->pending-jobs-atom mesos-heartbeat-chan
-                          trigger-chans kubernetes-scheduler-config]
+                          trigger-chans kubernetes-scheduler]
 
                       ; We track queue limits on all nodes, not just the leader, because
                       ; we need to check them when job submission requests come in
@@ -125,7 +125,7 @@
                                :trigger-chans trigger-chans
                                :zk-prefix mesos-leader-path
                                :api-only? (cook.config/api-only-mode?)
-                               :kubernetes-scheduler-config kubernetes-scheduler-config})
+                               :kubernetes-scheduler-config kubernetes-scheduler})
                             (catch ClassNotFoundException e
                               (log/warn e "Not loading mesos support...")
                               nil)))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -20,16 +20,23 @@
             [compojure.core :refer [routes]]
             [compojure.route :as route]
             [congestion.middleware :refer [wrap-rate-limit]]
-            [congestion.storage :as storage] ; This explicit require is needed so that mount can see the defstate defined in the cook.caches namespace.
+            [congestion.storage :as storage]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.caches namespace.
             [cook.caches]
             [cook.compute-cluster :as cc]
             [cook.config :refer [config]]
-            [cook.datomic :as datomic] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.adjustment namespace.
-            [cook.plugins.adjustment] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.completion namespace.
-            [cook.plugins.completion] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.file namespace.
-            [cook.plugins.file] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.launch namespace.
-            [cook.plugins.launch] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.pool namespace.
-            [cook.plugins.pool] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.submission namespace.
+            [cook.datomic :as datomic]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.adjustment namespace.
+            [cook.plugins.adjustment]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.completion namespace. 
+            [cook.plugins.completion]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.file namespace.
+            [cook.plugins.file]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.launch namespace.
+            [cook.plugins.launch]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.pool namespace.
+            [cook.plugins.pool]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.submission namespace.
             [cook.plugins.submission]
             [cook.pool :as pool]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.prometheus-metrics namespace.

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -16,36 +16,25 @@
   (:gen-class)
   (:require [clojure.core.async :as async]
             [clojure.core.cache :as cache]
-            [clojure.pprint :refer [pprint]]
             [clojure.tools.logging :as log]
-            [compojure.core :refer [context GET POST routes]]
+            [compojure.core :refer [routes]]
             [compojure.route :as route]
-            [congestion.middleware :refer [ip-rate-limit wrap-rate-limit]]
-            [congestion.storage :as storage]
-            ; This explicit require is needed so that mount can see the defstate defined in the cook.caches namespace.
+            [congestion.middleware :refer [wrap-rate-limit]]
+            [congestion.storage :as storage] ; This explicit require is needed so that mount can see the defstate defined in the cook.caches namespace.
             [cook.caches]
             [cook.compute-cluster :as cc]
             [cook.config :refer [config]]
-            [cook.datomic :as datomic]
-            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.adjustment namespace.
-            [cook.plugins.adjustment]
-            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.completion namespace.
-            [cook.plugins.completion]
-            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.file namespace.
-            [cook.plugins.file]
-            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.launch namespace.
-            [cook.plugins.launch]
-            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.pool namespace.
-            [cook.plugins.pool]
-            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.submission namespace.
+            [cook.datomic :as datomic] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.adjustment namespace.
+            [cook.plugins.adjustment] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.completion namespace.
+            [cook.plugins.completion] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.file namespace.
+            [cook.plugins.file] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.launch namespace.
+            [cook.plugins.launch] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.pool namespace.
+            [cook.plugins.pool] ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.submission namespace.
             [cook.plugins.submission]
             [cook.pool :as pool]
-            [cook.queue-limit :as queue-limit]
-            ; This explicit require is needed so that mount can see the defstate defined in the cook.quota namespace.
-            [cook.quota :as quota]
+            [cook.queue-limit :as queue-limit] ; This explicit require is needed so that mount can see the defstate defined in the cook.quota namespace.
             [cook.rate-limit]
             [cook.rest.cors :as cors]
-            [cook.rest.impersonation :refer [impersonation-authorized-wrapper]]
             [cook.util :as util]
             [datomic.api :as d]
             [fork.metrics-clojure.metrics.jvm.core :as metrics-jvm]
@@ -56,8 +45,7 @@
             [ring.middleware.cookies :refer [wrap-cookies]]
             [ring.middleware.params :refer [wrap-params]]
             [ring.middleware.stacktrace :refer [wrap-stacktrace]]
-            [ring.util.mime-type]
-            [ring.util.response :refer [response]])
+            [ring.util.mime-type])
   (:import (clojure.core.async.impl.channels ManyToManyChannel)
            (java.io IOException)
            (java.security Principal)
@@ -67,8 +55,8 @@
            (org.apache.curator.framework.state ConnectionStateListener)
            (org.apache.curator.retry BoundedExponentialBackoffRetry)
            (org.eclipse.jetty.security DefaultUserIdentity UserAuthentication)
-           (org.eclipse.jetty.server.handler HandlerCollection RequestLogHandler)
-           (org.eclipse.jetty.server NCSARequestLog Request)))
+           (org.eclipse.jetty.server NCSARequestLog Request)
+           (org.eclipse.jetty.server.handler HandlerCollection RequestLogHandler)))
 
 (defn wrap-no-cache
   [handler]
@@ -103,7 +91,7 @@
                            offer-incubate-time-ms optimizer rebalancer server-port task-constraints]
                           compute-clusters curator-framework mesos-datomic-mult leadership-atom
                           pool-name->pending-jobs-atom mesos-heartbeat-chan
-                          trigger-chans]
+                          trigger-chans kubernetes-scheduler-config]
 
                       ; We track queue limits on all nodes, not just the leader, because
                       ; we need to check them when job submission requests come in
@@ -136,7 +124,8 @@
                                :task-constraints task-constraints
                                :trigger-chans trigger-chans
                                :zk-prefix mesos-leader-path
-                               :api-only? (cook.config/api-only-mode?)})
+                               :api-only? (cook.config/api-only-mode?)
+                               :kubernetes-scheduler-config kubernetes-scheduler-config})
                             (catch ClassNotFoundException e
                               (log/warn e "Not loading mesos support...")
                               nil)))

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -88,10 +88,10 @@
   {:mesos-scheduler (fnk [[:settings fenzo-fitness-calculator fenzo-floor-iterations-before-reset
                            fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback
                            good-enough-fitness hostname mea-culpa-failure-limit mesos-leader-path mesos-run-as-user
-                           offer-incubate-time-ms optimizer rebalancer server-port task-constraints]
+                           offer-incubate-time-ms optimizer rebalancer server-port task-constraints kubernetes-scheduler]
                           compute-clusters curator-framework mesos-datomic-mult leadership-atom
                           pool-name->pending-jobs-atom mesos-heartbeat-chan
-                          trigger-chans kubernetes-scheduler]
+                          trigger-chans]
 
                       ; We track queue limits on all nodes, not just the leader, because
                       ; we need to check them when job submission requests come in

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -187,14 +187,12 @@
         (throw (ex-info (str "Default disk type for pool-regex " pool-regex " is not listed as a valid disk type") entry))))))
 
 (defn guard-invalid-kubernetes-scheduler-config
-  "Throws if the configuration for kubernetes scheduler is not properly formatted."
+  "Throws if the configuration for using the Kubernetes Scheduler is not properly formatted."
   [kubernetes-scheduler]
   (when :kubernetes-scheduler
-    (doseq [{:keys [enabled pool-regex max-jobs-considered] :as entry} kubernetes-scheduler]
+    (doseq [{:keys [pool-regex max-jobs-considered] :as entry} kubernetes-scheduler]
       (when-not pool-regex
         (throw (ex-info (str "pool-regex key is missing from config") entry)))
-      (when-not enabled
-        (throw (ex-info (str "Enabled boolean is not defined") entry)))
       ;; TODO(alexh): TBD if we want a separate batch size per pool
       (when-not max-jobs-considered
         (throw (ex-info (str "Max jobs considered is not defined") entry))))))
@@ -550,7 +548,6 @@
                                 (guard-invalid-kubernetes-scheduler-config (:kubernetes-scheduler scheduler))
                                 (merge
                                  {:pool-regex ".*"
-                                  :enabled false
                                   :max-considerable 1000}
                                  (:kubernetes-scheduler scheduler))) 
      :offer-matching (fnk [[:config {offer-matching {}}]]
@@ -759,6 +756,6 @@
   (-> config :settings :constraint-attribute->transformation))
 
 (defn kubernetes-scheduler
-  "Returns configuration for using Kubernetes Scheduler."
+  "Returns configuration for using Kubernetes Scheduler"
   []
-  (-> config :settings :scheduler :kubernetes-scheduler))
+  (-> config :settings :kubernetes-scheduler))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -544,12 +544,12 @@
                                     telemetry-tags-key-invalid-char-pattern
                                     (assoc :telemetry-tags-key-invalid-char-pattern
                                            (re-pattern telemetry-tags-key-invalid-char-pattern))))))
-     :kubernetes-scheduler (fnk [[:config {scheduler {}}]]
-                                (guard-invalid-kubernetes-scheduler-config (:kubernetes-scheduler scheduler))
+     :kubernetes-scheduler (fnk [[:config {kubernetes-scheduler {}}]]
+                                (guard-invalid-kubernetes-scheduler-config (:kubernetes-scheduler kubernetes-scheduler))
                                 (merge
                                  {:pool-regex "$^"
                                   :max-considerable 1000}
-                                 (:kubernetes-scheduler scheduler)))
+                                 (:kubernetes-scheduler kubernetes-scheduler)))
      :offer-matching (fnk [[:config {offer-matching {}}]]
                        (merge {:considerable-job-threshold-to-collect-job-match-statistics 20
                                :global-min-match-interval-millis 100

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -547,9 +547,9 @@
      :kubernetes-scheduler (fnk [[:config {scheduler nil}]]
                                 (guard-invalid-kubernetes-scheduler-config (:kubernetes-scheduler scheduler))
                                 (merge
-                                 {:pool-regex ".*"
+                                 {:pool-regex "$^"
                                   :max-considerable 1000}
-                                 (:kubernetes-scheduler scheduler))) 
+                                 (:kubernetes-scheduler scheduler)))
      :offer-matching (fnk [[:config {offer-matching {}}]]
                        (merge {:considerable-job-threshold-to-collect-job-match-statistics 20
                                :global-min-match-interval-millis 100

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -536,7 +536,8 @@
      :kubernetes-scheduler (fnk [[:config {kubernetes-scheduler {}}]]
                                 (merge
                                  {:pool-regex "$^"
-                                  :max-considerable 1000}
+                                  :max-considerable 1000
+                                  :pod-condition-unschedulable-seconds 900}
                                  kubernetes-scheduler))
      :offer-matching (fnk [[:config {offer-matching {}}]]
                        (merge {:considerable-job-threshold-to-collect-job-match-statistics 20
@@ -752,3 +753,11 @@
   "Returns configuration for using Kubernetes Scheduler"
   []
   (-> config :settings :kubernetes-scheduler))
+
+(defn is-kubernetes-scheduler-pool?
+  "Check if a given pool uses the Kubernetes Scheduler."
+  [kubernetes-scheduler-config pool-name]
+  (let [pools-pattern (-> kubernetes-scheduler-config
+                          :pool-regex
+                          re-pattern)]
+    (not (nil? (re-find pools-pattern pool-name)))))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -186,17 +186,6 @@
       (when-not (contains? valid-types default-type)
         (throw (ex-info (str "Default disk type for pool-regex " pool-regex " is not listed as a valid disk type") entry))))))
 
-(defn guard-invalid-kubernetes-scheduler-config
-  "Throws if the configuration for using the Kubernetes Scheduler is not properly formatted."
-  [kubernetes-scheduler]
-  (when kubernetes-scheduler
-    (doseq [{:keys [pool-regex max-jobs-considered] :as entry} kubernetes-scheduler]
-      (when-not pool-regex
-        (throw (ex-info (str "pool-regex key is missing from config") entry)))
-      ;; TODO(alexh): TBD if we want a separate batch size per pool
-      (when-not max-jobs-considered
-        (throw (ex-info (str "Max jobs considered is not defined") entry))))))
-
 (def config-settings
   "Parses the settings out of a config file"
   (graph/eager-compile
@@ -545,7 +534,6 @@
                                     (assoc :telemetry-tags-key-invalid-char-pattern
                                            (re-pattern telemetry-tags-key-invalid-char-pattern))))))
      :kubernetes-scheduler (fnk [[:config {kubernetes-scheduler {}}]]
-                                (guard-invalid-kubernetes-scheduler-config kubernetes-scheduler)
                                 (merge
                                  {:pool-regex "$^"
                                   :max-considerable 1000}

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -189,7 +189,7 @@
 (defn guard-invalid-kubernetes-scheduler-config
   "Throws if the configuration for using the Kubernetes Scheduler is not properly formatted."
   [kubernetes-scheduler]
-  (when :kubernetes-scheduler
+  (when kubernetes-scheduler
     (doseq [{:keys [pool-regex max-jobs-considered] :as entry} kubernetes-scheduler]
       (when-not pool-regex
         (throw (ex-info (str "pool-regex key is missing from config") entry)))
@@ -545,11 +545,11 @@
                                     (assoc :telemetry-tags-key-invalid-char-pattern
                                            (re-pattern telemetry-tags-key-invalid-char-pattern))))))
      :kubernetes-scheduler (fnk [[:config {kubernetes-scheduler {}}]]
-                                (guard-invalid-kubernetes-scheduler-config (:kubernetes-scheduler kubernetes-scheduler))
+                                (guard-invalid-kubernetes-scheduler-config kubernetes-scheduler)
                                 (merge
                                  {:pool-regex "$^"
                                   :max-considerable 1000}
-                                 (:kubernetes-scheduler kubernetes-scheduler)))
+                                 kubernetes-scheduler))
      :offer-matching (fnk [[:config {offer-matching {}}]]
                        (merge {:considerable-job-threshold-to-collect-job-match-statistics 20
                                :global-min-match-interval-millis 100

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -544,7 +544,7 @@
                                     telemetry-tags-key-invalid-char-pattern
                                     (assoc :telemetry-tags-key-invalid-char-pattern
                                            (re-pattern telemetry-tags-key-invalid-char-pattern))))))
-     :kubernetes-scheduler (fnk [[:config {scheduler nil}]]
+     :kubernetes-scheduler (fnk [[:config {scheduler {}}]]
                                 (guard-invalid-kubernetes-scheduler-config (:kubernetes-scheduler scheduler))
                                 (merge
                                  {:pool-regex "$^"

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -457,7 +457,6 @@
      :pools (fnk [[:config {pools nil}]]
                  (guard-invalid-gpu-config (:valid-gpu-models pools))
                  (guard-invalid-disk-config (:disk pools))
-                 (guard-invalid-kubernetes-scheduler-config (:kubernetes-scheduler pools))
                  (cond-> pools
                    (:job-resource-adjustment pools)
                    (update :job-resource-adjustment
@@ -468,9 +467,7 @@
                    (not (:default-env pools))
                    (assoc :default-env [])
                    (not (:quotas pools))
-                   (assoc :quotas [])
-                   (not (:kubernetes-scheduler pools))
-                   (assoc :kubernetes-scheduler []))) 
+                   (assoc :quotas []))) 
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
      :cache-working-set-size (fnk [[:config {cache-working-set-size 1000000}]]
@@ -549,6 +546,13 @@
                                     telemetry-tags-key-invalid-char-pattern
                                     (assoc :telemetry-tags-key-invalid-char-pattern
                                            (re-pattern telemetry-tags-key-invalid-char-pattern))))))
+     :kubernetes-scheduler (fnk [[:config {scheduler nil}]]
+                                (guard-invalid-kubernetes-scheduler-config (:kubernetes-scheduler scheduler))
+                                (merge
+                                 {:pool-regex ".*"
+                                  :enabled false
+                                  :max-considerable 1000}
+                                 (:kubernetes-scheduler scheduler))) 
      :offer-matching (fnk [[:config {offer-matching {}}]]
                        (merge {:considerable-job-threshold-to-collect-job-match-statistics 20
                                :global-min-match-interval-millis 100
@@ -754,7 +758,7 @@
   []
   (-> config :settings :constraint-attribute->transformation))
 
-(defn kubernetes-scheduler-pools
-  "Returns configuration for kubernetes scheduler pools."
+(defn kubernetes-scheduler
+  "Returns configuration for using Kubernetes Scheduler."
   []
-  (-> config :settings :pools :kubernetes-scheduler))
+  (-> config :settings :scheduler :kubernetes-scheduler))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -470,7 +470,7 @@
                    (not (:quotas pools))
                    (assoc :quotas [])
                    (not (:kubernetes-scheduler pools))
-                   (assoc :kubernetes-scheduler [{:pool-regex ".*" :enabled true :max-jobs-considered 1000}]))) 
+                   (assoc :kubernetes-scheduler []))) 
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
      :cache-working-set-size (fnk [[:config {cache-working-set-size 1000000}]]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -195,6 +195,7 @@
         (throw (ex-info (str "pool-regex key is missing from config") entry)))
       (when-not enabled
         (throw (ex-info (str "Enabled boolean is not defined") entry)))
+      ;; TODO(alexh): TBD if we want a separate batch size per pool
       (when-not max-jobs-considered
         (throw (ex-info (str "Max jobs considered is not defined") entry))))))
 
@@ -469,7 +470,7 @@
                    (not (:quotas pools))
                    (assoc :quotas [])
                    (not (:kubernetes-scheduler pools))
-                   (assoc :kubernetes-scheduler []))) 
+                   (assoc :kubernetes-scheduler [{:pool-regex ".*" :enabled true :max-jobs-considered 1000}]))) 
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
      :cache-working-set-size (fnk [[:config {cache-working-set-size 1000000}]]

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -1816,7 +1816,7 @@
   (let [{:keys [pod-condition-unschedulable-seconds
                 synthetic-pod-condition-unschedulable-seconds]}
         (config/kubernetes)
-        {:keys [kubernetes-scheduler-pod-condition-unschedulable-seconds]}
+        {kubernetes-scheduler-pod-condition-unschedulable-seconds :pod-condition-unschedulable-seconds}
         (config/kubernetes-scheduler)
         unschedulable-seconds
         (if (some-> pod-name synthetic-pod?)

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -104,6 +104,17 @@
        :user user}
       instance-uuid (assoc :instance-uuid instance-uuid))))
 
+;; TODO(alexh): should we use another method to determine this? Label?
+(defn kubernetes-scheduler-pod?
+  "Given a pod name, returns true if its scheduling is handled by Kubernetes."
+  [pod-name]
+  (let [instance-uuid (pod-name->instance-uuid pod-name)
+        job-uuid (or (pod-name->job-uuid pod-name)
+                     (cached-queries/instance-uuid->job-uuid-cache-lookup instance-uuid))
+        job (cached-queries/job-uuid->job-map-cache-lookup job-uuid)
+        pool-name (cached-queries/job->pool-name job)]
+    (config/is-kubernetes-scheduler-pool? (config/kubernetes-scheduler) pool-name)))
+
 ; DeletionCandidateTaint is a soft taint that k8s uses to mark unneeded
 ; nodes as preferably unschedulable. This taint is added as soon as the
 ; autoscaler detects that nodes are under-utilized and all pods could be
@@ -1805,22 +1816,26 @@
   (let [{:keys [pod-condition-unschedulable-seconds
                 synthetic-pod-condition-unschedulable-seconds]}
         (config/kubernetes)
+        {:keys [kubernetes-scheduler-pod-condition-unschedulable-seconds]}
+        (config/kubernetes-scheduler)
         unschedulable-seconds
         (if (some-> pod-name synthetic-pod?)
           synthetic-pod-condition-unschedulable-seconds
-          pod-condition-unschedulable-seconds)]
+          (if (some-> pod-name kubernetes-scheduler-pod?)
+            kubernetes-scheduler-pod-condition-unschedulable-seconds
+            pod-condition-unschedulable-seconds))]
     (some->> pod-status
              .getConditions
              (some
-               (fn pod-condition-unschedulable?
-                 [^V1PodCondition condition]
-                 (and (-> condition .getType (= "PodScheduled"))
-                      (-> condition .getStatus (= "False"))
-                      (-> condition .getReason (= "Unschedulable"))
-                      (-> condition
-                          .getLastTransitionTime
-                          (t/plus (t/seconds unschedulable-seconds))
-                          (t/before? (t/now)))))))))
+              (fn pod-condition-unschedulable?
+                [^V1PodCondition condition]
+                (and (-> condition .getType (= "PodScheduled"))
+                     (-> condition .getStatus (= "False"))
+                     (-> condition .getReason (= "Unschedulable"))
+                     (-> condition
+                         .getLastTransitionTime
+                         (t/plus (t/seconds unschedulable-seconds))
+                         (t/before? (t/now)))))))))
 
 (defn pod-has-stuck-condition?
   "Returns true if the given pod status has a pod condition that is deemed stuck,

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -108,6 +108,7 @@
 
     (log-structured/info "Generating offers"
                          {:compute-cluster compute-cluster-name
+                          :pool pool-name
                           :number-nodes-not-schedulable (- number-nodes-total number-nodes-schedulable)
                           :number-nodes-schedulable number-nodes-schedulable
                           :number-nodes-total number-nodes-total

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -411,7 +411,7 @@
   "Record the pod's hostname in Datomic."
   [pod-name {:keys [^V1Pod pod]}]
   (log-structured/debug "nyc-record-hostname1" {:k8s-pod (api/kubernetes-scheduler-pod? pod-name)})
-  (when-not (api/kubernetes-scheduler-pod? pod-name)
+  (when (api/kubernetes-scheduler-pod? pod-name)
     (let [task-id (-> pod .getMetadata .getName)
           hostname (api/pod->node-name pod)]
         (log-structured/debug "nyc-record-hostname2" {:hostname hostname :task-id task-id})

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -172,7 +172,7 @@
    fenzo-config                  -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details
    kubernetes-scheduler-config   -- map, config for using Kubernetes Scheduler
    sandbox-syncer-state          -- map, representing the sandbox syncer object
-   api-only?                     -- bool, true if this instance should not actually join the leader selection" 
+   api-only?                     -- bool, true if this instance should not actually join the leader selection"
   [{:keys [curator-framework fenzo-config mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult
            mesos-heartbeat-chan leadership-atom pool-name->pending-jobs-atom mesos-run-as-user
            offer-incubate-time-ms optimizer-config rebalancer-config server-config task-constraints trigger-chans

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -30,10 +30,9 @@
             [cook.scheduler.scheduler :as sched]
             [cook.tools :as tools]
             [cook.util :as util]
-            [datomic.api :as d :refer [q]]
+            [datomic.api :as d]
             [mesomatic.scheduler]
             [mesomatic.types]
-            [metatransaction.core :refer [db]]
             [metatransaction.utils :as dutils]
             [metrics.counters :as counters]
             [plumbing.core :refer [map-from-keys]]
@@ -171,12 +170,13 @@
    progress-config               -- map, config for progress publishing. See scheduler/docs/configuration.adoc
    framework-id                  -- str, the Mesos framework id from the cook settings
    fenzo-config                  -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details
+   kubernetes-scheduler-config   -- map, config for using Kubernetes Scheduler
    sandbox-syncer-state          -- map, representing the sandbox syncer object
-   api-only?                     -- bool, true if this instance should not actually join the leader selection"
+   api-only?                     -- bool, true if this instance should not actually join the leader selection" 
   [{:keys [curator-framework fenzo-config mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult
            mesos-heartbeat-chan leadership-atom pool-name->pending-jobs-atom mesos-run-as-user
            offer-incubate-time-ms optimizer-config rebalancer-config server-config task-constraints trigger-chans
-           zk-prefix api-only?]}]
+           zk-prefix api-only? kubernetes-scheduler-config]}]
   (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
                 fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness]} fenzo-config
         {:keys [cancelled-task-trigger-chan lingering-task-trigger-chan optimizer-trigger-chan
@@ -223,7 +223,8 @@
                                        :pool-name->pending-jobs-atom pool-name->pending-jobs-atom
                                        :rebalancer-reservation-atom rebalancer-reservation-atom
                                        :task-constraints task-constraints
-                                       :trigger-chans trigger-chans})]
+                                       :trigger-chans trigger-chans
+                                       :kubernetes-scheduler-config kubernetes-scheduler-config})]
                                 ; we need to make sure to initialize cc/pool-name->fenzo-state-atom before we take leadership
                                 ; after we take leadership, we should be able to create dynamic clusters, so cc/pool-name->fenzo-state-atom
                                 ; needs to be set

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2271,12 +2271,12 @@
                using-pools? (not (nil? (config/default-pool)))
                user->quota (quota/create-user->quota-fn (d/db conn) (if using-pools? pool-name nil))
                pending-jobs (get @pool-name->pending-jobs-atom pool-name)]
-           (if (not kubernetes-pool?)
-             (handle-kubernetes-scheduler-pool conn pending-jobs pool-name->pending-jobs-atom
-                                               pool-name compute-clusters job->acceptable-compute-clusters-fn
-                                               user->quota user->usage-future 
-                                               (get-max-considerable-for-kubernetes-pool (config/kubernetes-scheduler-pools) pool-name) 
-                                               mesos-run-as-user)
+           (if kubernetes-pool?
+            (handle-kubernetes-scheduler-pool conn pending-jobs pool-name->pending-jobs-atom
+                                              pool-name compute-clusters job->acceptable-compute-clusters-fn
+                                              user->quota user->usage-future
+                                              (get-max-considerable-for-kubernetes-pool (config/kubernetes-scheduler-pools) pool-name)
+                                              mesos-run-as-user)
              (handle-fenzo-pool conn fenzo fenzo-state resources-atom
                                 pending-jobs pool-name->pending-jobs-atom agent-attributes-cache fenzo-max-jobs-considered
                                 scaleback floor-iterations-before-warn floor-iterations-before-reset

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2150,7 +2150,7 @@
                  (.getTime ^Date last-waiting-start-time))))]))
 
 (defn- kubernetes-pool->zip-job-metadata
-  "For each compute cluster, zip its considerble jobs and generated task-metadata-seq."
+  "For each compute cluster, zip its considerble jobs and newly generated task-metadata-seq."
   [compute-cluster->jobs jobs->task-id mesos-run-as-user]
   (zipmap (keys compute-cluster->jobs)
           (for [[compute-cluster jobs-for-cluster] compute-cluster->jobs

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2122,7 +2122,8 @@
   [conn fenzo fenzo-state resources-atom pending-jobs pool-name->pending-jobs-atom agent-attributes-cache max-considerable
    scaleback floor-iterations-before-warn floor-iterations-before-reset rebalancer-reservation-atom
    mesos-run-as-user pool-name compute-clusters job->acceptable-compute-clusters-fn
-   user->quota user->usage-future]
+   user->quota user->usage-future] 
+  (log-structured/info "Creating handler for Fenzo pool" {:pool pool-name})
   (let [num-considerable @fenzo-num-considerable-atom
         next-considerable
         (try
@@ -2250,6 +2251,7 @@
   [conn pending-jobs pool-name->pending-jobs-atom
    pool-name compute-clusters job->acceptable-compute-clusters-fn
    user->quota user->usage-future num-considerable mesos-run-as-user]
+  (log-structured/info "Creating handler for Kubernetes Scheduler pool" {:pool pool-name})
   (try
     (let [user->usage (tracing/with-span [s {:name "scheduler.kubernetes-handler.resolve-user-to-usage-future"
                                              :tags {:pool pool-name :component tracing-component-tag}}]
@@ -2346,6 +2348,7 @@
    floor-iterations-before-warn floor-iterations-before-reset trigger-chan rebalancer-reservation-atom
    mesos-run-as-user pool-name cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn
    kubernetes-scheduler-config]
+  (log-structured/info (print-str "Kubernetes scheduler config:" kubernetes-scheduler-config " " (is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)) {:pool pool-name})
   (let [fenzo (:fenzo fenzo-state)
         resources-atom (atom (view-incubating-offers fenzo))
         kubernetes-scheduler-pool? (is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)]

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2262,6 +2262,7 @@
     (let [user->usage (tracing/with-span [s {:name "scheduler.kubernetes-handler.resolve-user-to-usage-future"
                                              :tags {:pool pool-name :component tracing-component-tag}}]
                         @user->usage-future)
+          db (db conn)
           ;; We need to filter pending jobs based on quota so that we don't
           ;; submit beyond what users have quota to actually run.
           jobs (prometheus/with-duration

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2211,18 +2211,21 @@
      ;; NB we set any job with an instance in a non-terminal
      ;; state to running to prevent scheduling the same job
      ;; twice; see schema definition for state machine
+     ;; TODO(alexh): reconsider state machine for Kubernetes Scheduler jobs.
      [:db/add job-ref :job/state :job.state/running]
      (cond->
       {:db/id (d/tempid :db.part/user)
        :job/_instance job-ref
        :instance/executor executor
        :instance/executor-id task-id ;; NB command executor uses the task-id as the executor-id
+       ;; TODO(alexh): update this once scheduled on a node.
        :instance/hostname "Unknown"
        :instance/ports 9876
        :instance/preempted? false
        :instance/progress 0
        :instance/slave-id "Unknown"
        :instance/start-time instance-start-time
+       ;; TODO(alexh): reconsider state machine for Kubernetes Scheduler jobs.
        :instance/status :instance.status/unknown
        :instance/task-id task-id
        :instance/compute-cluster (cc/db-id compute-cluster)}
@@ -2238,7 +2241,6 @@
     (for [{:keys [job/name job/user job/uuid job/environment] :as job} jobs]
       (let [pool-specific-resources
             ((adjust-job-resources-for-pool-fn pool-name) job (tools/job-ent->resources job))]
-        ;; TODO(alexh): is this everything needed to launch a real task?
         (merge
          (task/job->task-metadata compute-cluster mesos-run-as-user
                                   job (jobs->task-id job))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2343,7 +2343,8 @@
                                                           compute-cluster-launch-rate-limiter (cc/launch-rate-limiter compute-cluster)
                                                           token-key (quota/pool+user->token-key pool-name user)]
                                                       (ratelimit/spend! quota/per-user-per-pool-launch-rate-limiter token-key 1)
-                                                      (ratelimit/spend! compute-cluster-launch-rate-limiter ratelimit/compute-cluster-launch-rate-limiter-key 1))))))
+                                                      (ratelimit/spend! compute-cluster-launch-rate-limiter ratelimit/compute-cluster-launch-rate-limiter-key 1))
+                                                    (prom/inc prom/scheduler-jobs-launched {:pool pool-name :compute-cluster (cc/compute-cluster-name compute-cluster)})))))
                         (finally
                           (.. kill-lock-object readLock unlock))))))
                  doall

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2250,10 +2250,7 @@
         job-ref [:job/uuid uuid]
         instance-start-time (now)]
     [[:job/allowed-to-start? job-ref]
-     ;; NB we set any job with an instance in a non-terminal
-     ;; state to running to prevent scheduling the same job
-     ;; twice; see schema definition for state machine
-     ;; TODO(alexh): reconsider state machine for Kubernetes Scheduler jobs.
+     ;; The job will remain waiting until the instance is running.
      [:db/add job-ref :job/state :job.state/waiting]
      (cond->
       {:db/id (d/tempid :db.part/user)
@@ -2267,7 +2264,6 @@
        :instance/progress 0
        :instance/slave-id "Unknown"
        :instance/start-time instance-start-time
-       ;; TODO(alexh): reconsider state machine for Kubernetes Scheduler jobs.
        :instance/status :instance.status/unknown
        :instance/task-id task-id
        :instance/compute-cluster (cc/db-id compute-cluster)}

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1138,7 +1138,7 @@
 (defn handle-resource-offers!
   "Gets a list of offers from mesos. Decides what to do with them all--they should all
    be accepted or rejected at the end of the function."
-  [conn fenzo-state pool-name->pending-jobs-atom mesos-run-as-user
+  [conn fenzo-state pending-jobs pool-name->pending-jobs-atom mesos-run-as-user
    user->usage user->quota num-considerable offers rebalancer-reservation-atom pool-name compute-clusters
    job->acceptable-compute-clusters-fn]
   (log-structured/debug "Invoked handle-resource-offers!" {:pool pool-name})
@@ -1150,7 +1150,7 @@
         (timers/timer (metric-title "handle-resource-offer!-duration" pool-name))
         (try
           (let [db (db conn)
-                pending-jobs (get @pool-name->pending-jobs-atom pool-name)
+                
                 considerable-jobs (timers/time!
                                     (timers/timer (metric-title "handle-resource-offer!-considerable-jobs-duration" pool-name))
                                     (pending-jobs->considerable-jobs
@@ -2067,7 +2067,7 @@
                 user->usage (tracing/with-span [s {:name "scheduler.offer-handler.resolve-user-to-usage-future"
                                                    :tags {:pool pool-name :component tracing-component-tag}}]
                               @user->usage-future)
-                matched-head? (handle-resource-offers! conn fenzo-state pool-name->pending-jobs-atom
+                matched-head? (handle-resource-offers! conn fenzo-state pending-jobs pool-name->pending-jobs-atom
                                                        mesos-run-as-user user->usage user->quota
                                                        num-considerable offers
                                                        rebalancer-reservation-atom pool-name compute-clusters
@@ -2114,6 +2114,133 @@
                 max-considerable)
               next-considerable))))
 
+(defn- kubernetes-pool->task-txns
+  "Converts jobs and metadata to task transactions."
+  [compute-cluster->zip-job-metadata]
+  (for [[compute-cluster zip-job-metadata] compute-cluster->zip-job-metadata
+        {:keys [jobs task-metadata-seq]} zip-job-metadata
+        [job task-metadata] (map vector jobs task-metadata-seq)
+        :let [{:keys [job/last-waiting-start-time job/uuid]} job
+              {:keys [executor task-id]} task-metadata
+              job-ref [:job/uuid uuid]
+              instance-start-time (now)]]
+    [[:job/allowed-to-start? job-ref]
+     ;; NB we set any job with an instance in a non-terminal
+     ;; state to running to prevent scheduling the same job
+     ;; twice; see schema definition for state machine
+     [:db/add job-ref :job/state :job.state/running]
+     (cond->
+      {:db/id (d/tempid :db.part/user)
+       :job/_instance job-ref
+       :instance/executor executor
+       :instance/executor-id task-id ;; NB command executor uses the task-id as the executor-id
+       :instance/hostname "fake-hostname"
+       :instance/ports "fake-ports"
+       :instance/preempted? false
+       :instance/progress 0
+       :instance/slave-id "fake-slave-id"
+       :instance/start-time instance-start-time
+       :instance/status :instance.status/unknown
+       :instance/task-id task-id
+       :instance/compute-cluster (cc/db-id compute-cluster)}
+       last-waiting-start-time
+       (assoc :instance/queue-time
+              (- (.getTime instance-start-time)
+                 (.getTime ^Date last-waiting-start-time))))]))
+
+(defn- kubernetes-pool->zip-job-metadata
+  "For each compute cluster, zip its considerble jobs and generated task-metadata-seq."
+  [compute-cluster->jobs jobs->task-id mesos-run-as-user]
+  (zipmap (keys compute-cluster->jobs)
+          (for [[compute-cluster jobs-for-cluster] compute-cluster->jobs
+                :let [task-metadata-seq (map
+                                         (fn [job]
+                                           (task/job->task-metadata compute-cluster mesos-run-as-user job (jobs->task-id job))) jobs-for-cluster)]]
+            {:jobs jobs-for-cluster
+             :task-metadata-seq task-metadata-seq})))
+
+(defn handle-kubernetes-pool
+  "Handle scheduling pending jobs onto Kubernetes compute clusters."
+  [conn pending-jobs pool-name->pending-jobs-atom
+   pool-name compute-clusters job->acceptable-compute-clusters-fn
+   user->quota user->usage-future num-considerable mesos-run-as-user]
+  (try
+    (let [user->usage (tracing/with-span [s {:name "scheduler.kubernetes-handler.resolve-user-to-usage-future"
+                                             :tags {:pool pool-name :component tracing-component-tag}}]
+                        @user->usage-future)
+          ;; We need to filter pending jobs based on quota so that we don't
+          ;; submit beyond what users have quota to actually run.
+          considerable-jobs (tracing/with-span [s {:name "scheduler.handle-kubernetes-pool.generate-considerable-jobs"
+                                                   :tags {:pool pool-name :component tracing-component-tag}}]
+                              (->> pool-name
+                                   pending-jobs
+                                   (tools/filter-pending-jobs-for-quota pool-name (atom {}) (atom {})
+                                                                        user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name))
+                                   (take num-considerable)
+                                   (doall)))
+          ;; TODO(alexh): really filter considerable-jobs for launch rate limit
+          jobs (take 3 considerable-jobs)
+          job-uuids (set (map :job/uuid jobs))]
+      (if (seq jobs)
+        (do
+          (swap! pool-name->pending-jobs-atom
+                 remove-matched-jobs-from-pending-jobs
+                 job-uuids pool-name)
+          (log-structured/debug (print-str "Updated pool-name->pending-jobs-atom:" @pool-name->pending-jobs-atom)
+                                {:pool pool-name})
+          (let [autoscaling-compute-clusters (filter #(cc/autoscaling? % pool-name) compute-clusters)
+                ;; First, distribute each job to a compute cluster
+                ;; TODO(alexh): confirm this is random
+                compute-cluster->jobs (distribute-jobs-to-compute-clusters
+                                       jobs pool-name autoscaling-compute-clusters
+                                       job->acceptable-compute-clusters-fn)
+                ;; Get a task-id (instance) for each job
+                jobs->task-id (plumbing.core/map-from-keys (fn [_] (str (d/squuid))) jobs)
+
+                ;; Combine jobs for each cluster with a fake task-metadata-seq
+                ;; This will be used to generate all db txns and then to launch the tasks.
+                compute-cluster->zip-job-metadata (kubernetes-pool->zip-job-metadata compute-cluster->jobs jobs->task-id mesos-run-as-user)
+
+                ;; Get sequence of db txns which update all jobs across compute-clusters. 
+                task-txns (kubernetes-pool->task-txns compute-cluster->zip-job-metadata)]
+            (log-structured/info "Started launching directly to Kubernetes" {:pool pool-name})
+            (->> compute-cluster->zip-job-metadata
+                 (map
+                  (fn [[compute-cluster zip-job-metadata]]
+                    (let [kill-lock-object (cc/kill-lock-object compute-cluster)]
+                      (try
+                        (.. kill-lock-object readLock lock)
+                        (timers/time!
+                         (timers/timer (metric-title "handle-kubernetes-pool-transact-task-duration" pool-name))
+                         (datomic/transact
+                          conn
+                          (reduce into [] task-txns)
+                          (fn [e]
+                            (log-structured/warn "Transaction timed out, so these tasks might be present"
+                                                 "in Datomic without actually having been launched in compute cluster"
+                                                 {:compute-cluster compute-cluster
+                                                  :pool pool-name}
+                                                 e)
+                            (throw e))))
+                        (timers/time!
+                         (timers/timer (metric-title "handle-kubernetes-pool-submit-duration" pool-name))
+                         (do
+                           (log-structured/info "Launching tasks for kubernetes ompute cluster"
+                                                {:pool pool-name :compute-cluster compute-cluster})
+                           (future (cc/launch-tasks compute-cluster
+                                                    pool-name
+                                                    [{:task-metadata-seq (:task-metadata-seq zip-job-metadata)}]
+                                             ;; TODO(alexh): any post processing such as updating launch rate limiting?
+                                                    (fn [_])))))
+                        (finally
+                          (.. kill-lock-object readLock unlock))))))
+                 doall
+                 (run! deref))
+            (log-structured/info "Done launching directly to Kubernetes" {:pool pool-name})))
+        (log-structured/info "No considerable jobs launched this cycle" {:pool pool-name})))
+    (catch Exception e
+      (log-structured/error "Kubernetes handler encountered exception; continuing" {:pool pool-name} e))))
+
 (defn make-pool-handler
   "Make the configured handler for the pool to do scheduling."
   [conn fenzo-state pool-name->pending-jobs-atom agent-attributes-cache max-considerable scaleback
@@ -2134,21 +2261,15 @@
                using-pools? (not (nil? (config/default-pool)))
                user->quota (quota/create-user->quota-fn (d/db conn) (if using-pools? pool-name nil))
                pending-jobs (get @pool-name->pending-jobs-atom pool-name)]
-           (handle-fenzo-pool conn fenzo fenzo-state resources-atom
-                              pending-jobs pool-name->pending-jobs-atom agent-attributes-cache max-considerable
-                              scaleback floor-iterations-before-warn floor-iterations-before-reset
-                              rebalancer-reservation-atom mesos-run-as-user pool-name compute-clusters
-                              job->acceptable-compute-clusters-fn user->quota user->usage-future)
-                ;; (if is-fenzo-pool?
-                ;;   (handle-fenzo-pool conn fenzo fenzo-state resources-atom
-                ;;                      pending-jobs pool-name->pending-jobs-atom agent-attributes-cache max-considerable
-                ;;                      scaleback floor-iterations-before-warn floor-iterations-before-reset
-                ;;                      rebalancer-reservation-atom mesos-run-as-user pool-name compute-clusters
-                ;;                      job->acceptable-compute-clusters-fn user->quota user->usage-future)
-                ;;   (handle-kubernetes-pool conn pending-jobs pool-name->pending-jobs-atom
-                ;;                           pool-name compute-clusters job->acceptable-compute-clusters-fn
-                ;;                           user->quota user->usage-future max-considerable mesos-run-as-user)))
-           )
+           (if is-fenzo-pool?
+             (handle-fenzo-pool conn fenzo fenzo-state resources-atom
+                                pending-jobs pool-name->pending-jobs-atom agent-attributes-cache max-considerable
+                                scaleback floor-iterations-before-warn floor-iterations-before-reset
+                                rebalancer-reservation-atom mesos-run-as-user pool-name compute-clusters
+                                job->acceptable-compute-clusters-fn user->quota user->usage-future)
+             (handle-kubernetes-pool conn pending-jobs pool-name->pending-jobs-atom
+                                     pool-name compute-clusters job->acceptable-compute-clusters-fn
+                                     user->quota user->usage-future max-considerable mesos-run-as-user)))
          (catch Exception e
            (log-structured/error "Pool handler encountered exception; continuing" {:pool pool-name} e))))
      {:error-handler (fn [ex] (log-structured/error "Error occurred in pool handler" {:pool pool-name} ex))})
@@ -2190,13 +2311,6 @@
                                  fenzo-floor-iterations-before-reset (get pool->match-trigger-chan name)
                                  rebalancer-reservation-atom mesos-run-as-user name
                                  cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn)))]
-                                ;;  (make-offer-handler
-                                ;;    conn (get pool-name->fenzo-state name)
-                                ;;    pool-name->pending-jobs-atom agent-attributes-cache
-                                ;;    fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn
-                                ;;    fenzo-floor-iterations-before-reset (get pool->match-trigger-chan name)
-                                ;;    rebalancer-reservation-atom mesos-run-as-user name
-                                ;;    cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn)))]
     (prepare-match-trigger-chan match-trigger-chan pools')
     (async/go-loop []
       (when-let [x (async/<! match-trigger-chan)]

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2251,7 +2251,7 @@
   [conn pending-jobs pool-name->pending-jobs-atom
    pool-name compute-clusters job->acceptable-compute-clusters-fn
    user->quota user->usage-future num-considerable mesos-run-as-user]
-  (log-structured/info "Creating handler for Kubernetes Scheduler pool" {:pool pool-name})
+  (log-structured/info "Running handler for Kubernetes Scheduler pool" {:pool pool-name})
   (try
     (let [user->usage (tracing/with-span [s {:name "scheduler.kubernetes-handler.resolve-user-to-usage-future"
                                              :tags {:pool pool-name :component tracing-component-tag}}]
@@ -2263,7 +2263,8 @@
                               (->> pool-name
                                    pending-jobs
                                    (tools/filter-pending-jobs-for-quota pool-name (atom {}) (atom {})
-                                                                        user->quota user->usage (tools/global-pool-quota (config/pool-quotas) pool-name))
+                                                                        user->quota user->usage 
+                                                                        (tools/global-pool-quota pool-name))
                                    (take num-considerable)
                                    (doall)))
           ;; TODO(alexh): really filter considerable-jobs for launch rate limit
@@ -2348,7 +2349,7 @@
    floor-iterations-before-warn floor-iterations-before-reset trigger-chan rebalancer-reservation-atom
    mesos-run-as-user pool-name cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn
    kubernetes-scheduler-config]
-  (log-structured/info (print-str "Kubernetes scheduler config:" kubernetes-scheduler-config " " (is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)) {:pool pool-name})
+  (log-structured/info (print-str "Kubernetes scheduler config in make-pool-handler:" kubernetes-scheduler-config " " (is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)) {:pool pool-name})
   (let [fenzo (:fenzo fenzo-state)
         resources-atom (atom (view-incubating-offers fenzo))
         kubernetes-scheduler-pool? (is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)]

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2253,7 +2253,7 @@
        :instance/executor executor
        :instance/executor-id task-id ;; NB command executor uses the task-id as the executor-id
        :instance/hostname "fake-hostname"
-       :instance/ports "fake-ports"
+       :instance/ports 9876
        :instance/preempted? false
        :instance/progress 0
        :instance/slave-id "fake-slave-id"
@@ -2396,11 +2396,6 @@
                           :pool-regex
                           re-pattern)]
     (not (nil? (re-find pools-pattern pool-name)))))
-
-(defn max-considerable-for-kubernetes-scheduler-pool
-  "Get max considerable value for a Kubernetes Scheduler pool."
-  [kubernetes-scheduler-pools pool-name]
-  (regexp-tools/match-based-on-pool-name kubernetes-scheduler-pools pool-name :max-considerable))
 
 (defn make-pool-handler
   "Make the configured handler for the pool to do scheduling."

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2247,7 +2247,7 @@
   [kubernetes-scheduler-config pool-name]
   (let [pools-pattern (-> kubernetes-scheduler-config
                           :pool-regex
-                                     re-pattern)]
+                          re-pattern)]
     (re-find pools-pattern pool-name)))
 
 (defn max-considerable-for-kubernetes-scheduler-pool
@@ -2263,7 +2263,7 @@
    kubernetes-scheduler-config]
   (let [fenzo (:fenzo fenzo-state)
         resources-atom (atom (view-incubating-offers fenzo))
-        kubernetes-scheduler-pool? (not (is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name))]
+        kubernetes-scheduler-pool? (is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)]
     (reset! fenzo-num-considerable-atom fenzo-max-jobs-considered)
     (tools/chime-at-ch
      trigger-chan

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2335,7 +2335,7 @@
   (let [pools-pattern (-> kubernetes-scheduler-config
                           :pool-regex
                           re-pattern)]
-    (re-find pools-pattern pool-name)))
+    (not (nil? (re-find pools-pattern pool-name)))))
 
 (defn max-considerable-for-kubernetes-scheduler-pool
   "Get max considerable value for a Kubernetes Scheduler pool."

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2234,7 +2234,7 @@
      ;; state to running to prevent scheduling the same job
      ;; twice; see schema definition for state machine
      ;; TODO(alexh): reconsider state machine for Kubernetes Scheduler jobs.
-     [:db/add job-ref :job/state :job.state/running]
+     [:db/add job-ref :job/state :job.state/waiting]
      (cond->
       {:db/id (d/tempid :db.part/user)
        :job/_instance job-ref

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2252,11 +2252,11 @@
        :job/_instance job-ref
        :instance/executor executor
        :instance/executor-id task-id ;; NB command executor uses the task-id as the executor-id
-       :instance/hostname "fake-hostname"
+       :instance/hostname "Unknown"
        :instance/ports 9876
        :instance/preempted? false
        :instance/progress 0
-       :instance/slave-id "fake-slave-id"
+       :instance/slave-id "Unknown"
        :instance/start-time instance-start-time
        :instance/status :instance.status/unknown
        :instance/task-id task-id
@@ -2389,14 +2389,6 @@
     (catch Exception e
       (log-structured/error "Kubernetes handler encountered exception; continuing" {:pool pool-name} e))))
 
-(defn is-kubernetes-scheduler-pool?
-  "Check if a given pool uses the Kubernetes Scheduler."
-  [kubernetes-scheduler-config pool-name]
-  (let [pools-pattern (-> kubernetes-scheduler-config
-                          :pool-regex
-                          re-pattern)]
-    (not (nil? (re-find pools-pattern pool-name)))))
-
 (defn make-pool-handler
   "Make the configured handler for the pool to do scheduling."
   [conn fenzo-state pool-name->pending-jobs-atom agent-attributes-cache fenzo-max-jobs-considered scaleback
@@ -2408,7 +2400,7 @@
   (let [fenzo (:fenzo fenzo-state)
         resources-atom (atom (view-incubating-offers fenzo))
         using-pools? (not (nil? (config/default-pool)))
-        kubernetes-scheduler-pool? (is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)]
+        kubernetes-scheduler-pool? (config/is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)]
     (reset! fenzo-num-considerable-atom fenzo-max-jobs-considered)
     (tools/chime-at-ch
      trigger-chan

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2115,7 +2115,7 @@
                 max-considerable)
               next-considerable))))
 
-(defn- kubernetes-pool->task-txns
+(defn kubernetes-pool->task-txns
   "Converts jobs and metadata to task transactions."
   [compute-cluster->zip-job-metadata]
   (for [[compute-cluster zip-job-metadata] compute-cluster->zip-job-metadata
@@ -2149,7 +2149,7 @@
               (- (.getTime instance-start-time)
                  (.getTime ^Date last-waiting-start-time))))]))
 
-(defn- kubernetes-pool->zip-job-metadata
+(defn kubernetes-pool->zip-job-metadata
   "For each compute cluster, zip its considerble jobs and newly generated task-metadata-seq."
   [compute-cluster->jobs jobs->task-id mesos-run-as-user]
   (zipmap (keys compute-cluster->jobs)

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2260,8 +2260,7 @@
           ;; submit beyond what users have quota to actually run.
           considerable-jobs (tracing/with-span [s {:name "scheduler.handle-kubernetes-pool.generate-considerable-jobs"
                                                    :tags {:pool pool-name :component tracing-component-tag}}]
-                              (->> pool-name
-                                   pending-jobs
+                              (->> pending-jobs
                                    (tools/filter-pending-jobs-for-quota pool-name (atom {}) (atom {})
                                                                         user->quota user->usage 
                                                                         (tools/global-pool-quota pool-name))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2396,7 +2396,7 @@
    mesos-run-as-user pool-name cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn
    kubernetes-scheduler-config]
   ;; TODO(alexh): remove after testing
-  (log-structured/info (print-str "Kubernetes scheduler config in make-pool-handler:" kubernetes-scheduler-config " " (is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)) {:pool pool-name})
+  (log-structured/info (print-str "Kubernetes scheduler config in make-pool-handler:" kubernetes-scheduler-config " " (config/is-kubernetes-scheduler-pool? kubernetes-scheduler-config pool-name)) {:pool pool-name})
   (let [fenzo (:fenzo fenzo-state)
         resources-atom (atom (view-incubating-offers fenzo))
         using-pools? (not (nil? (config/default-pool)))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -2323,7 +2323,7 @@
                         @user->usage-future)
           ;; We need to filter pending jobs based on quota so that we don't
           ;; submit beyond what users have quota to actually run.
-          considerable-jobs (tracing/with-span [s {:name "scheduler.handle-kubernetes-pool.generate-considerable-jobs"
+          considerable-jobs (tracing/with-span [s {:name "scheduler.kubernetes-handler.generate-considerable-jobs"
                                                    :tags {:pool pool-name :component tracing-component-tag}}]
                               (->> pending-jobs
                                    (tools/filter-pending-jobs-for-quota pool-name (atom {}) (atom {})
@@ -2362,7 +2362,7 @@
                                              {:pool pool-name :compute-cluster compute-cluster :task-metadata-seq task-metadata-seq})
                         (.. kill-lock-object readLock lock)
                         (timers/time!
-                         (timers/timer (metric-title "handle-kubernetes-pool-transact-task-duration" pool-name))
+                         (timers/timer (metric-title "kubernetes-handler-transact-task-duration" pool-name))
                          (datomic/transact
                           conn
                           (reduce into [] task-txns)
@@ -2374,7 +2374,7 @@
                                                  e)
                             (throw e))))
                         (timers/time!
-                         (timers/timer (metric-title "handle-kubernetes-pool-submit-duration" pool-name))
+                         (timers/timer (metric-title "kubernetes-handler-launch-duration" pool-name))
                          (future (cc/launch-tasks compute-cluster
                                                   pool-name
                                                   [{:task-metadata-seq task-metadata-seq}]

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -20,7 +20,6 @@
             [clj-time.core :as t]
             [clojure.core.async :as async]
             [clojure.core.cache :as cache]
-            [clojure.pprint :as pprint]
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
@@ -2608,13 +2607,13 @@
           ;; TODOL count(jobs) == count(metadata)
           ;; TODO: for each job, get metadata where (metadata :environment "COOK_JOB_UUID" == (job (str uuid)))
 
-          (println "@ALEX@")
+          ;; (println "@ALEX@")
 
-          (pprint/pprint (sched/kubernetes-pool->zip-job-metadata
-                          compute-cluster->jobs
-                          jobs->task-id
-                          mesos-run-as-user
-                          "test-pool"))
+          ;; (pprint/pprint (sched/kubernetes-pool->zip-job-metadata
+          ;;                 compute-cluster->jobs
+          ;;                 jobs->task-id
+          ;;                 mesos-run-as-user
+          ;;                 "test-pool"))
 
 
 

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2288,12 +2288,12 @@
                        {:pool/name "old pool"
                         :pool/state :pool.state/inactive}])
                     sched/make-fenzo-state (fn [_ _ _])
-                    sched/make-pool-handler (fn [_ _ _ _ _ _ _ _ trigger-chan _ _ pool-name _ _]
-                                               (tools/chime-at-ch
-                                                 trigger-chan
-                                                 (fn []
-                                                   (swap! output-atom conj pool-name)
-                                                   (async/>!! send-next-chime-chan :next))))
+                    sched/make-pool-handler (fn [_ _ _ _ _ _ _ _ trigger-chan _ _ pool-name _ _ _]
+                                              (tools/chime-at-ch
+                                               trigger-chan
+                                               (fn []
+                                                 (swap! output-atom conj pool-name)
+                                                 (async/>!! send-next-chime-chan :next))))
                     sched/start-jobs-prioritizer! (fn [_ _ _ _])
                     sched/prepare-match-trigger-chan (fn [_ _])]
         (sched/create-datomic-scheduler {:trigger-chans {:match-trigger-chan match-trigger-chan}})

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1804,7 +1804,7 @@
                                           user->quota (or user-quota {test-user {:count 10, :cpus 70, :mem 32768, :gpus 10}})
                                           mesos-run-as-user nil
                                           result (sched/handle-resource-offers!
-                                                   conn fenzo-state pool-name->pending-jobs-atom mesos-run-as-user
+                                                   conn fenzo-state (pool->pending-jobs pool) pool-name->pending-jobs-atom mesos-run-as-user
                                                    user->usage user->quota num-considerable offers
                                                    rebalancer-reservation-atom pool nil
                                                    sched/job->acceptable-compute-clusters)]

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1897,7 +1897,7 @@
                                           user->quota (or user-quota {test-user {:count 10, :cpus 70, :mem 32768, :gpus 10}})
                                           mesos-run-as-user nil
                                           result (sched/handle-resource-offers!
-                                                   conn fenzo-state (pool->pending-jobs pool) pool-name->pending-jobs-atom mesos-run-as-user
+                                                   conn fenzo-state pool-name->pending-jobs-atom mesos-run-as-user
                                                    user->usage user->quota num-considerable offers
                                                    rebalancer-reservation-atom pool nil
                                                    sched/job->acceptable-compute-clusters)]

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -20,6 +20,7 @@
             [clj-time.core :as t]
             [clojure.core.async :as async]
             [clojure.core.cache :as cache]
+            [clojure.pprint :as pprint]
             [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.tools.logging :as log]
@@ -2494,15 +2495,19 @@
       compute-cluster-3 {:cluster-definition
                          {:config {:location location-a}}
                          :name compute-cluster-3-name}
-      instance-first {:instance/compute-cluster
+      instance-1 {:instance/compute-cluster
                       {:compute-cluster/cluster-name
                        compute-cluster-2-name}
                       :instance/start-time 1}
-      instance-second {:instance/compute-cluster
+      instance-2 {:instance/compute-cluster
                        {:compute-cluster/cluster-name
                         compute-cluster-1-name}
                        :instance/start-time 2}
-      instances [instance-second instance-first]]
+      instance-3 {:instance/compute-cluster
+                       {:compute-cluster/cluster-name
+                        compute-cluster-1-name}
+                       :instance/start-time 2}
+      instances [instance-1 instance-2]]
 
   (deftest test-job->preferred-compute-clusters
     (reset! cook.compute-cluster/cluster-name->compute-cluster-atom
@@ -2520,7 +2525,7 @@
     (is (= [compute-cluster-2]
            (sched/job->acceptable-compute-clusters
             {:job/checkpoint true
-             :job/instance [instance-first]}
+             :job/instance [instance-1]}
             [compute-cluster-1
              compute-cluster-2
              compute-cluster-3])))
@@ -2584,27 +2589,31 @@
         {compute-cluster-1-name compute-cluster-1
          compute-cluster-2-name compute-cluster-2
          compute-cluster-3-name compute-cluster-3})
-    (let [base-job {:job/checkpoint true}]
-      (let [job1 (assoc base-job :job/uuid (UUID/randomUUID))
-            job2 (assoc base-job :job/uuid (UUID/randomUUID))
-            job3 (assoc base-job :job/uuid (UUID/randomUUID))
-            jobs [job1 job2 job3]
-            compute-cluster->jobs (sched/distribute-jobs-to-compute-clusters
-                                   jobs
-                                   "test-pool"
-                                   [compute-cluster-1
-                                    compute-cluster-2
-                                    compute-cluster-3]
-                                   sched/job->acceptable-compute-clusters)
-            jobs->task-id (plumbing.core/map-from-keys (fn [_] (str (d/squuid))) jobs)
-            mesos-run-as-user "user"]
-        
-        (println "@ALEX@")
-        
-        (println (sched/kubernetes-pool->zip-job-metadata
-                  compute-cluster->jobs
-                  jobs->task-id
-                  mesos-run-as-user))
+    (with-redefs [cc/use-cook-executor? (fn [_] false)]
+      (let [base-job {:job/checkpoint true}]
+        (let [job1 (assoc base-job :job/uuid (UUID/randomUUID))
+              job2 (assoc base-job :job/uuid (UUID/randomUUID))
+              job3 (assoc base-job :job/uuid (UUID/randomUUID))
+              jobs [job1 job2 job3]
+              compute-cluster->jobs (sched/distribute-jobs-to-compute-clusters
+                                     jobs
+                                     "test-pool"
+                                     [compute-cluster-1
+                                      compute-cluster-2
+                                      compute-cluster-3]
+                                     sched/job->acceptable-compute-clusters)
+              jobs->task-id (plumbing.core/map-from-keys (fn [_] (str (d/squuid))) jobs)
+              mesos-run-as-user "user"]
+          
+          ;; TODOL count(jobs) == count(metadata)
+          ;; TODO: for each job, get metadata where (metadata :environment "COOK_JOB_UUID" == (job (str uuid)))
+
+          (println "@ALEX@")
+
+          (pprint/pprint (sched/kubernetes-pool->zip-job-metadata
+                    compute-cluster->jobs
+                    jobs->task-id
+                    mesos-run-as-user))
 
 
 
@@ -2617,6 +2626,9 @@
         ;;                compute-cluster-2
         ;;                compute-cluster-3]
         ;;               sched/job->acceptable-compute-clusters))))
-        ))
+          ))
+      
+    )
+    
     
     ))

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -28,23 +28,22 @@
             [cook.config :as config]
             [cook.datomic :as datomic]
             [cook.kubernetes.api :as kapi]
-            [cook.kubernetes.compute-cluster :as kcc]
-            [cook.log-structured :as log-structured]
             [cook.mesos.task :as task]
             [cook.plugins.completion :as completion]
             [cook.plugins.definitions :as pd]
             [cook.plugins.launch :as launch-plugin]
             [cook.pool :as pool]
-            [cook.test.postgres]
             [cook.progress :as progress]
             [cook.quota :as quota]
             [cook.rate-limit :as rate-limit]
             [cook.scheduler.offer :as offer]
             [cook.scheduler.scheduler :as sched]
             [cook.scheduler.share :as share]
+            [cook.test.postgres]
             [cook.test.testutil :as testutil
-             :refer [create-dummy-group create-dummy-instance create-dummy-job create-dummy-job-with-instances create-pool
-                     init-agent-attributes-cache poll-until restore-fresh-database! setup wait-for]]
+             :refer [create-dummy-group create-dummy-instance create-dummy-job
+                     create-dummy-job-with-instances create-pool
+                     restore-fresh-database! setup wait-for]]
             [cook.tools :as tools]
             [criterium.core :as crit]
             [datomic.api :as d :refer [db q]]
@@ -52,8 +51,12 @@
             [mesomatic.types :as mtypes]
             [metrics.timers :as timers]
             [plumbing.core :as pc])
-  (:import (clojure.lang ExceptionInfo)
-           (com.netflix.fenzo SchedulingResult SimpleAssignmentResult TaskAssignmentResult TaskRequest TaskScheduler)
+  (:import (com.netflix.fenzo
+             SchedulingResult
+             SimpleAssignmentResult
+             TaskAssignmentResult
+             TaskRequest
+             TaskScheduler)
            (com.netflix.fenzo.plugins BinPackingFitnessCalculators)
            (cook.compute_cluster ComputeCluster)
            (java.util UUID)
@@ -2285,7 +2288,7 @@
                        {:pool/name "old pool"
                         :pool/state :pool.state/inactive}])
                     sched/make-fenzo-state (fn [_ _ _])
-                    sched/make-offer-handler (fn [_ _ _ _ _ _ _ _ trigger-chan _ _ pool-name _ _]
+                    sched/make-pool-handler (fn [_ _ _ _ _ _ _ _ trigger-chan _ _ pool-name _ _]
                                                (tools/chime-at-ch
                                                  trigger-chan
                                                  (fn []

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2611,9 +2611,10 @@
           (println "@ALEX@")
 
           (pprint/pprint (sched/kubernetes-pool->zip-job-metadata
-                    compute-cluster->jobs
-                    jobs->task-id
-                    mesos-run-as-user))
+                          compute-cluster->jobs
+                          jobs->task-id
+                          mesos-run-as-user
+                          "test-pool"))
 
 
 

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -90,7 +90,7 @@
                                :memory-gb 140
                                :cpus 40
                                :retry-limit 5})
-(def default-kubernetes-scheduler-config {:pools-regex "$^"
+(def default-kubernetes-scheduler-config {:pool-regex "$^"
                                           :max-considerable 1000})
 
 (defmacro with-cook-scheduler


### PR DESCRIPTION
This change adds a proof of concept for configuring pools to bypass Fenzo and submit their considerable jobs directly to Kubernetes. These jobs are scheduled by a new Kubernetes handler, which respects quota and rate limits. Pools not configured for this new handler are sent to Fenzo in the same way Cook does presently. Because of the new feature flag, this change should be deployable with no change in behavior.

* New: `make-pool-handler` calls new `handle-fenzo-pool`, which is identical to old `make-offer-handler` except with some common variables refactored into the handler factory.
* New: `handle-kubernetes-pool` and associated helper functions added and tested manually on-prem.
* New: config to optionally have a pool be managed by the new Kubernetes handler.
* New: some testing for helper functions supporting the Kubernetes handler.

Future work 
* Address TODOs.
* Keep instance in Waiting state until it is initializing on a node
* Update instance hostname after being scheduled by Kubernetes
* Add any missing metrics needed for experiment measurements
* Implement backpressure mechanism