### PR TITLE
Adding prometheus metrics for user resource usage and count

### DIFF
--- a/scheduler/src/cook/monitor.clj
+++ b/scheduler/src/cook/monitor.clj
@@ -165,7 +165,7 @@
   (do (-> [state "users" (str "pool-" pool-name)]
         counters/counter
         (set-counter! value))
-        (prometheus/set (prometheus/user-state-count state) {:pool pool-name :state state} value)))
+        (prometheus/set prometheus/user-state-count {:pool pool-name :state state} value)))
 
 (defn set-stats-counters!
   "Queries the database for running and waiting jobs per user, and sets

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -131,27 +131,27 @@
       ;; Resource usage stats -----------------------------------------------------------------------------------
       ;; We set these up using a map so we can access them easily by resource type when we set the metric.
       (prometheus/gauge (resource-metric-map :mem)
-                        {:description "Current memory by state"}
-                        :labels [:pool :user :state])
+                        {:description "Current memory by state"
+                        :labels [:pool :user :state]})
       (prometheus/gauge (resource-metric-map :cpus)
-                        {:description "Current cpu count by state"}
-                        :labels [:pool :user :state])
+                        {:description "Current cpu count by state"
+                        :labels [:pool :user :state]})
       (prometheus/gauge (resource-metric-map :gpus)
-                        {:description "Current gpu count by state"}
-                        :labels [:pool :user :state])
+                        {:description "Current gpu count by state"
+                        :labels [:pool :user :state]})
       (prometheus/gauge (resource-metric-map :jobs)
-                        {:description "Current jobs count by state"}
-                        :labels [:pool :user :state])
+                        {:description "Current jobs count by state"
+                        :labels [:pool :user :state]})
       (prometheus/gauge (resource-metric-map :launch-rate-saved)
-                        {:description "Current launch-rate-saved count by state"}
-                        :labels [:pool :user :state])
+                        {:description "Current launch-rate-saved count by state"
+                        :labels [:pool :user :state]})
       (prometheus/gauge (resource-metric-map :launch-rate-per-minute)
-                        {:description "Current launch-rate-per-minute count by state"}
-                        :labels [:pool :user :state])
+                        {:description "Current launch-rate-per-minute count by state"
+                        :labels [:pool :user :state]})
       ;; Metrics for user resource allocation counts
       (prometheus/gauge user-state-count
-                        {:description "Current user count by state"}
-                        :labels [:pool :state]))))
+                        {:description "Current user count by state"
+                         :labels [:pool :state]}))))
 
 ;; A global registry for all metrics reported by Cook.
 ;; All metrics must be registered before they can be recorded.
@@ -168,9 +168,9 @@
   "Sets the value of the given metric."
   {:arglists '([name amount] [name labels amount])}
   ([name amount]
-   `(prometheus/set (registry ~name) ~amount))
+   `(prometheus/set registry ~name ~amount))
   ([name labels amount]
-   `(prometheus/set (registry ~name ~labels) ~amount)))
+   `(prometheus/set registry ~name ~labels ~amount)))
 
 (defn export []
   "Returns the current values of all registered metrics in plain text format."

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -168,9 +168,9 @@
   "Sets the value of the given metric."
   {:arglists '([name amount] [name labels amount])}
   ([name amount]
-   `(prometheus/set registry ~name ~amount))
+   `(prometheus/set (registry ~name) ~amount))
   ([name labels amount]
-   `(prometheus/set registry ~name ~labels ~amount)))
+   `(prometheus/set (registry ~name ~labels) ~amount)))
 
 (defn export []
   "Returns the current values of all registered metrics in plain text format."

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -44,39 +44,16 @@
 (def scheduler-filter-offensive-jobs-duration :cook/scheduler-filter-offensive-jobs-duration-seconds)
 (def scheduler-handle-status-update-duaration :cook/scheduler-handle-status-update-duaration-seconds)
 (def scheduler-handle-framework-message-duration :cook/scheduler-handle-framework-message-duration-seconds)
-;; For user resource metrics, we access them by state + resource type at runtime, so it is
+(def user-state-count :cook/scheduler-users-state-count)
+;; For user resource metrics, we access them by resource type at runtime, so it is
 ;; easier to define them all in a map instead of separate vars.
-(def user-state-count-metric-map
-  {"total" :cook/scheduler-users-total-count
-   "starved" :cook/scheduler-users-starved-count
-   "waiting-under-quota" :cook/scheduler-users-waiting-under-quota-count
-   "hungry" :cook/scheduler-users-hungry-count
-   "satisfied" :cook/scheduler-users-satisfied-count})
 (def resource-metric-map
-  {"running" {:cpus :cook/scheduler-running-cpu-count
-              :mem :cook/scheduler-running-mem-mebibytes
-              :jobs :cook/scheduler-running-jobs-count
-              :gpus :cook/scheduler-running-gpu-count
-              :launch-rate-saved :cook/scheduler-running-launch-rate-saved
-              :launch-rate-per-minute :cook/scheduler-running-launch-rate-per-minute}
-   "waiting" {:cpus :cook/scheduler-waiting-cpu-count
-              :mem :cook/scheduler-waiting-mem-mebibytes
-              :jobs :cook/scheduler-waiting-jobs-count
-              :gpus :cook/scheduler-waiting-gpu-count
-              :launch-rate-saved :cook/scheduler-waiting-launch-rate-saved
-              :launch-rate-per-minute :cook/scheduler-waiting-launch-rate-per-minute}
-   "starved" {:cpus :cook/scheduler-starved-cpu-count
-              :mem :cook/scheduler-starved-mem-mebibytes
-              :jobs :cook/scheduler-starved-jobs-count
-              :gpus :cook/scheduler-starved-gpu-count
-              :launch-rate-saved :cook/scheduler-starved-launch-rate-saved
-              :launch-rate-per-minute :cook/scheduler-starved-launch-rate-per-minute}
-   "waiting-under-quota" {:cpus :cook/scheduler-waiting-under-quota-cpu-count
-                          :mem :cook/scheduler-waiting-under-quota-mem-mebibytes
-                          :jobs :cook/scheduler-waiting-under-quota-jobs-count
-                          :gpus :cook/scheduler-waiting-under-quota-gpu-count
-                          :launch-rate-saved :cook/scheduler-waiting-under-quota-launch-rate-saved
-                          :launch-rate-per-minute :cook/scheduler-waiting-under-quota-launch-rate-per-minute}})
+  {:cpus :cook/scheduler-users-cpu-count
+   :mem :cook/scheduler-users-memory-mebibytes
+   :jobs :cook/scheduler-users-jobs-count
+   :gpus :cook/scheduler-users-gpu-count
+   :launch-rate-saved :cook/scheduler-users-launch-rate-saved
+   :launch-rate-per-minute :cook/scheduler-users-launch-rate-per-minute})
 
 
 (defn create-registry
@@ -151,102 +128,30 @@
       (prometheus/summary scheduler-handle-framework-message-duration
                           {:description "Distribution of handle framework message latency"
                            :quantiles default-summary-quantiles})
-      ;; Reosurce usage stats -----------------------------------------------------------------------------------
-      ;; We set these up using a map so we can break them down easily by state and resource type.
-      ;; Memory
-      (prometheus/gauge ((resource-metric-map "running") :mem)
-                        {:description "Current running memory"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting") :mem)
-                        {:description "Current waiting memory"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "starved") :mem)
-                        {:description "Current starved memory"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :mem)
-                        {:description "Current waiting-under-quota memory"}
-                        :labels [:pool :user])
-      ;; CPU
-      (prometheus/gauge ((resource-metric-map "running") :cpus)
-                        {:description "Current running cpu count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting") :cpus)
-                        {:description "Current waiting cpu count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "starved") :cpus)
-                        {:description "Current starved cpu count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :cpus)
-                        {:description "Current waiting-under-quota cpu count"}
-                        :labels [:pool :user])
-      ;; GPU
-      (prometheus/gauge ((resource-metric-map "running") :gpus)
-                        {:description "Current running gpu count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting") :gpus)
-                        {:description "Current waiting gpu count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "starved") :gpus)
-                        {:description "Current starved gpu count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :gpus)
-                        {:description "Current waiting-under-quota gpu count"}
-                        :labels [:pool :user])
-      ;; Job instances
-      (prometheus/gauge ((resource-metric-map "running") :jobs)
-                        {:description "Current running jobs count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting") :jobs)
-                        {:description "Current waiting jobs count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "starved") :jobs)
-                        {:description "Current starved jobs count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :jobs)
-                        {:description "Current waiting-under-quota jobs count"}
-                        :labels [:pool :user])
-      ;; Launch rate saved
-      (prometheus/gauge ((resource-metric-map "running") :launch-rate-saved)
-                        {:description "Current running launch-rate-saved count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting") :launch-rate-saved)
-                        {:description "Current waiting launch-rate-saved count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "starved") :launch-rate-saved)
-                        {:description "Current starved launch-rate-saved count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :launch-rate-saved)
-                        {:description "Current waiting-under-quota launch-rate-saved count"}
-                        :labels [:pool :user])
-      ;; Launch rate per minute
-      (prometheus/gauge ((resource-metric-map "running") :launch-rate-per-minute)
-                        {:description "Current running launch-rate-per-minute count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting") :launch-rate-per-minute)
-                        {:description "Current waiting launch-rate-per-minute count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "starved") :launch-rate-per-minute)
-                        {:description "Current starved launch-rate-per-minute count"}
-                        :labels [:pool :user])
-      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :launch-rate-per-minute)
-                        {:description "Current waiting-under-quota launch-rate-per-minute count"}
-                        :labels [:pool :user])
+      ;; Resource usage stats -----------------------------------------------------------------------------------
+      ;; We set these up using a map so we can access them easily by resource type when we set the metric.
+      (prometheus/gauge (resource-metric-map :mem)
+                        {:description "Current memory by state"}
+                        :labels [:pool :user :state])
+      (prometheus/gauge (resource-metric-map :cpus)
+                        {:description "Current cpu count by state"}
+                        :labels [:pool :user :state])
+      (prometheus/gauge (resource-metric-map :gpus)
+                        {:description "Current gpu count by state"}
+                        :labels [:pool :user :state])
+      (prometheus/gauge (resource-metric-map :jobs)
+                        {:description "Current jobs count by state"}
+                        :labels [:pool :user :state])
+      (prometheus/gauge (resource-metric-map :launch-rate-saved)
+                        {:description "Current launch-rate-saved count by state"}
+                        :labels [:pool :user :state])
+      (prometheus/gauge (resource-metric-map :launch-rate-per-minute)
+                        {:description "Current launch-rate-per-minute count by state"}
+                        :labels [:pool :user :state])
       ;; Metrics for user resource allocation counts
-      (prometheus/gauge (user-state-count-metric-map "total")
-                        {:description "Current total user count"}
-                        :labels [:pool])
-      (prometheus/gauge (user-state-count-metric-map "starved")
-                        {:description "Current starved user count"}
-                        :labels [:pool])
-      (prometheus/gauge (user-state-count-metric-map "waiting-under-quota")
-                        {:description "Current waiting under quota user count"}
-                        :labels [:pool])
-      (prometheus/gauge (user-state-count-metric-map "hungry")
-                        {:description "Current hungry user count"}
-                        :labels [:pool])
-      (prometheus/gauge (user-state-count-metric-map "satisfied")
-                        {:description "Current satisfied user count"}
-                        :labels [:pool]))))
+      (prometheus/gauge user-state-count
+                        {:description "Current user count by state"}
+                        :labels [:pool :state]))))
 
 ;; A global registry for all metrics reported by Cook.
 ;; All metrics must be registered before they can be recorded.

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -44,6 +44,40 @@
 (def scheduler-filter-offensive-jobs-duration :cook/scheduler-filter-offensive-jobs-duration-seconds)
 (def scheduler-handle-status-update-duaration :cook/scheduler-handle-status-update-duaration-seconds)
 (def scheduler-handle-framework-message-duration :cook/scheduler-handle-framework-message-duration-seconds)
+;; For user resource metrics, we access them by state + resource type at runtime, so it is
+;; easier to define them all in a map instead of separate vars.
+(def user-state-count-metric-map
+  {"total" :cook/scheduler-users-total-count
+   "starved" :cook/scheduler-users-starved-count
+   "waiting-under-quota" :cook/scheduler-users-waiting-under-quota-count
+   "hungry" :cook/scheduler-users-hungry-count
+   "satisfied" :cook/scheduler-users-satisfied-count})
+(def resource-metric-map
+  {"running" {:cpus :cook/scheduler-running-cpu-count
+              :mem :cook/scheduler-running-mem-mebibytes
+              :jobs :cook/scheduler-running-jobs-count
+              :gpus :cook/scheduler-running-gpu-count
+              :launch-rate-saved :cook/scheduler-running-launch-rate-saved
+              :launch-rate-per-minute :cook/scheduler-running-launch-rate-per-minute}
+   "waiting" {:cpus :cook/scheduler-waiting-cpu-count
+              :mem :cook/scheduler-waiting-mem-mebibytes
+              :jobs :cook/scheduler-waiting-jobs-count
+              :gpus :cook/scheduler-waiting-gpu-count
+              :launch-rate-saved :cook/scheduler-waiting-launch-rate-saved
+              :launch-rate-per-minute :cook/scheduler-waiting-launch-rate-per-minute}
+   "starved" {:cpus :cook/scheduler-starved-cpu-count
+              :mem :cook/scheduler-starved-mem-mebibytes
+              :jobs :cook/scheduler-starved-jobs-count
+              :gpus :cook/scheduler-starved-gpu-count
+              :launch-rate-saved :cook/scheduler-starved-launch-rate-saved
+              :launch-rate-per-minute :cook/scheduler-starved-launch-rate-per-minute}
+   "waiting-under-quota" {:cpus :cook/scheduler-waiting-under-quota-cpu-count
+                          :mem :cook/scheduler-waiting-under-quota-mem-mebibytes
+                          :jobs :cook/scheduler-waiting-under-quota-jobs-count
+                          :gpus :cook/scheduler-waiting-under-quota-gpu-count
+                          :launch-rate-saved :cook/scheduler-waiting-under-quota-launch-rate-saved
+                          :launch-rate-per-minute :cook/scheduler-waiting-under-quota-launch-rate-per-minute}})
+
 
 (defn create-registry
   []
@@ -116,7 +150,103 @@
                            :quantiles default-summary-quantiles})
       (prometheus/summary scheduler-handle-framework-message-duration
                           {:description "Distribution of handle framework message latency"
-                           :quantiles default-summary-quantiles}))))
+                           :quantiles default-summary-quantiles})
+      ;; Reosurce usage stats -----------------------------------------------------------------------------------
+      ;; We set these up using a map so we can break them down easily by state and resource type.
+      ;; Memory
+      (prometheus/gauge ((resource-metric-map "running") :mem)
+                        {:description "Current running memory"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting") :mem)
+                        {:description "Current waiting memory"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "starved") :mem)
+                        {:description "Current starved memory"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :mem)
+                        {:description "Current waiting-under-quota memory"}
+                        :labels [:pool :user])
+      ;; CPU
+      (prometheus/gauge ((resource-metric-map "running") :cpus)
+                        {:description "Current running cpu count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting") :cpus)
+                        {:description "Current waiting cpu count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "starved") :cpus)
+                        {:description "Current starved cpu count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :cpus)
+                        {:description "Current waiting-under-quota cpu count"}
+                        :labels [:pool :user])
+      ;; GPU
+      (prometheus/gauge ((resource-metric-map "running") :gpus)
+                        {:description "Current running gpu count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting") :gpus)
+                        {:description "Current waiting gpu count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "starved") :gpus)
+                        {:description "Current starved gpu count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :gpus)
+                        {:description "Current waiting-under-quota gpu count"}
+                        :labels [:pool :user])
+      ;; Job instances
+      (prometheus/gauge ((resource-metric-map "running") :jobs)
+                        {:description "Current running jobs count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting") :jobs)
+                        {:description "Current waiting jobs count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "starved") :jobs)
+                        {:description "Current starved jobs count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :jobs)
+                        {:description "Current waiting-under-quota jobs count"}
+                        :labels [:pool :user])
+      ;; Launch rate saved
+      (prometheus/gauge ((resource-metric-map "running") :launch-rate-saved)
+                        {:description "Current running launch-rate-saved count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting") :launch-rate-saved)
+                        {:description "Current waiting launch-rate-saved count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "starved") :launch-rate-saved)
+                        {:description "Current starved launch-rate-saved count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :launch-rate-saved)
+                        {:description "Current waiting-under-quota launch-rate-saved count"}
+                        :labels [:pool :user])
+      ;; Launch rate per minute
+      (prometheus/gauge ((resource-metric-map "running") :launch-rate-per-minute)
+                        {:description "Current running launch-rate-per-minute count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting") :launch-rate-per-minute)
+                        {:description "Current waiting launch-rate-per-minute count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "starved") :launch-rate-per-minute)
+                        {:description "Current starved launch-rate-per-minute count"}
+                        :labels [:pool :user])
+      (prometheus/gauge ((resource-metric-map "waiting-under-quota") :launch-rate-per-minute)
+                        {:description "Current waiting-under-quota launch-rate-per-minute count"}
+                        :labels [:pool :user])
+      ;; Metrics for user resource allocation counts
+      (prometheus/gauge (user-state-count-metric-map "total")
+                        {:description "Current total user count"}
+                        :labels [:pool])
+      (prometheus/gauge (user-state-count-metric-map "starved")
+                        {:description "Current starved user count"}
+                        :labels [:pool])
+      (prometheus/gauge (user-state-count-metric-map "waiting-under-quota")
+                        {:description "Current waiting under quota user count"}
+                        :labels [:pool])
+      (prometheus/gauge (user-state-count-metric-map "hungry")
+                        {:description "Current hungry user count"}
+                        :labels [:pool])
+      (prometheus/gauge (user-state-count-metric-map "satisfied")
+                        {:description "Current satisfied user count"}
+                        :labels [:pool]))))
 
 ;; A global registry for all metrics reported by Cook.
 ;; All metrics must be registered before they can be recorded.
@@ -128,6 +258,14 @@
   {:arglists '([name labels & body])}
   [name labels & body]
   `(prometheus/with-duration (registry ~name ~labels) ~@body))
+
+(defmacro set
+  "Sets the value of the given metric."
+  {:arglists '([name amount] [name labels amount])}
+  ([name amount]
+   `(prometheus/set registry ~name ~amount))
+  ([name labels amount]
+   `(prometheus/set registry ~name ~labels ~amount)))
 
 (defn export []
   "Returns the current values of all registered metrics in plain text format."


### PR DESCRIPTION
## Changes proposed in this PR
- Adding prometheus metrics to `monitor.clj`, which contains user resource usage and count metrics.

## Why are we making these changes?
Ongoing migration to prometheus.

