### PR TITLE
Use pools & submit pools in /jobs list endpoint

### DIFF
--- a/scheduler/src/cook/pool.clj
+++ b/scheduler/src/cook/pool.clj
@@ -3,6 +3,7 @@
             [cook.config :as config]
             [datomic.api :as d]))
 
+; this is used in share and quota applications that look at per-pool resources
 (defn check-pool
   "Returns true if requesting-default-pool? and the entity does not have a pool
    or the entity has a pool named pool-name"
@@ -16,6 +17,8 @@
 
 (def nil-pool "nil-pool")
 
+; this is used in job submission applications where users are primarily concerned
+; with submit-pool
 (defn check-pool-and-submit-pool
   "Returns true if requesting-default-pool? and the entity does not have a pool
    or the entity has either a pool or a submit-pool named pool-name"

--- a/scheduler/src/cook/pool.clj
+++ b/scheduler/src/cook/pool.clj
@@ -16,6 +16,17 @@
 
 (def nil-pool "nil-pool")
 
+(defn check-pool-and-submit-pool
+  "Returns true if requesting-default-pool? and the entity does not have a pool
+   or the entity has either a pool or a submit-pool named pool-name"
+  ([ent entity->pool pool-name requesting-default-pool?]
+   (let [pool (entity->pool ent)
+         submit-pool (:job/submit-pool-name ent)]
+     (or (and (nil? pool)
+              requesting-default-pool?)
+         (= pool-name (:pool/name pool))
+         (= pool-name submit-pool)))))
+
 (defn check-pool-for-listing
   "Returns true if either the provided pool-name is the 'nil' pool, or if
   pool/check-pool returns true. This allows us to return jobs in all pools when the user
@@ -23,7 +34,7 @@
   ([entity entity->pool pool-name default-pool?]
    (or
      (= nil-pool pool-name)
-     (cook.pool/check-pool entity entity->pool pool-name default-pool?)))
+     (cook.pool/check-pool-and-submit-pool entity entity->pool pool-name default-pool?)))
   ([source eid entity->pool pool-name default-pool?]
    (check-pool-for-listing (d/entity source eid) entity->pool pool-name default-pool?)))
 

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -233,7 +233,7 @@
   "Return the entity id for the created dummy job."
   [conn & {:keys [command committed? container custom-executor? datasets disable-mea-culpa-retries env executor gpus disk group
                   job-state max-runtime memory name ncpus pool priority retry-count submit-time under-investigation user
-                  uuid expected-runtime]
+                  uuid expected-runtime submit-pool-name]
            :or {command "dummy command"
                 committed? true
                 disable-mea-culpa-retries false
@@ -278,6 +278,8 @@
                         (when group {:group/_job group})
                         (when pool
                           {:job/pool (d/entid (d/db conn) [:pool/name pool])})
+                        (when submit-pool-name
+                          {:job/submit-pool-name submit-pool-name})
                         (when expected-runtime
                           {:job/expected-runtime expected-runtime}))
         job-info (if gpus

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -402,7 +402,6 @@
           entid-end (d/entid-at db :db.part/user expanded-end)
           default-pool? (pool/default-pool? pool-name)
           pool-name' (or pool-name pool/nil-pool)
-          submit-pool ()
           job-user-entid (d/entid db :job/user)
           start-ms (.getTime start)
           end-ms (.getTime end)

--- a/scheduler/src/cook/tools.clj
+++ b/scheduler/src/cook/tools.clj
@@ -402,6 +402,7 @@
           entid-end (d/entid-at db :db.part/user expanded-end)
           default-pool? (pool/default-pool? pool-name)
           pool-name' (or pool-name pool/nil-pool)
+          submit-pool ()
           job-user-entid (d/entid db :job/user)
           start-ms (.getTime start)
           end-ms (.getTime end)

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2250,6 +2250,7 @@
                                     :submit-pool-name "foo")]
         (is (= 1 (count (list-jobs-fn "foo-1"))))
         (is (= 1 (count (list-jobs-fn "foo-2"))))
+        ; Should be 3 to account for the previously submitted jobs
         (is (= 3 (count (list-jobs-fn "foo"))))))))
 
 (deftest test-name-filter-str->name-filter-pattern

--- a/scheduler/test/cook/test/rest/api.clj
+++ b/scheduler/test/cook/test/rest/api.clj
@@ -2599,21 +2599,14 @@
                 job-uuid (-> request :body-params :jobs first :uuid)
                 {:keys [status] :as response} (handler request)]
             (is (= 201 status) (str response))
-            (is (= "small-job-pool" (-> conn d/db (d/entity [:job/uuid job-uuid]) cached-queries/job->pool-name)))
-            (let [job (-> conn d/db (d/entity [:job/uuid job-uuid]))]
-              (do
-                (cook.pool/check-pool-and-submit-pool job :job/pool "large-job-pool" false))))
+            (is (= "small-job-pool" (-> conn d/db (d/entity [:job/uuid job-uuid]) cached-queries/job->pool-name))))
           (let [request (-> (new-request)
                             (assoc-in [:body-params :pool] "@by-size")
                             (assoc-in [:body-params :jobs] [(assoc (minimal-job) :cpus 1.1)]))
                 job-uuid (-> request :body-params :jobs first :uuid)
                 {:keys [status] :as response} (handler request)]
             (is (= 201 status) (str response))
-            (is (= "large-job-pool" (-> conn d/db (d/entity [:job/uuid job-uuid]) cached-queries/job->pool-name)))
-            (let [job (-> conn d/db (d/entity [:job/uuid job-uuid]))]
-              (do
-                (cook.pool/check-pool-and-submit-pool job :job/pool "large-job-pool" false)))
-            ))))))
+            (is (= "large-job-pool" (-> conn d/db (d/entity [:job/uuid job-uuid]) cached-queries/job->pool-name)))))))))
 
 (deftest test-match-default-containers
   (let [default-containers


### PR DESCRIPTION
## Changes proposed in this PR

- Filter on both `:job/pool :pool-name` and `:job/submit-pool-name` in the `/jobs` API endpoint

## Why are we making these changes?
The job routing changes makes it harder for users to track where their jobs start if the `/jobs` endpoint only looks at the effective pool name. This change allows users to use the same pool for creating and looking up jobs while Cook handles the routing logic behind the scenese.

