### PR TITLE
Releasing Cook v1.6.2

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.62.2] - 2022-08-02
+### Added
+- Prometheus, from @samincheva
+- Adding match cycle metrics to prometheus, from @samincheva
+- Adding prometheus metric for jobs launch count, from @samincheva
+
+### Fixed
+- Use pools & submit pools in /jobs list endpoint, from @laurameng
+
 ## [1.62.1] - 2022-07-27
 ### Added
 - Add support for pool quotas across pools, from @scrosby

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.62.2"
+(defproject cook "1.62.3-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.62.2-SNAPSHOT"
+(defproject cook "1.62.2"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]


### PR DESCRIPTION
## Please rebase and merge to preserve the double-commit
# Changes proposed in this PR
- Updates changelog and version of v1.62.1.

# Why are we making these changes?
To release cook scheduler.