### PR TITLE
Add new JobSubmissionModifier and refactor JobRouter

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -33,6 +33,8 @@
             [cook.plugins.completion]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.file namespace.
             [cook.plugins.file]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.job-expander namespace.
+            [cook.plugins.job-expander]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.launch namespace.
             [cook.plugins.launch]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.pool namespace.

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -33,8 +33,8 @@
             [cook.plugins.completion]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.file namespace.
             [cook.plugins.file]
-            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.job-expander namespace.
-            [cook.plugins.job-expander]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.job-submission-modifier namespace.
+            [cook.plugins.job-submission-modifier]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.launch namespace.
             [cook.plugins.launch]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.pool namespace.

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -753,6 +753,11 @@
   []
   (-> config :settings :plugins :job-routing))
 
+(defn job-routing-pool-name?
+  "Returns truthy if the given pool name is a job-routing pool name"
+  [pool-name-from-submission]
+  (get (job-routing) pool-name-from-submission))
+
 (defn constraint-attribute->transformation
   []
   (-> config :settings :constraint-attribute->transformation))

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -480,7 +480,7 @@
                                         (merge {:agent-start-grace-period-mins 10}
                                                estimated-completion-constraint))
      :plugins (fnk [[:config {plugins {}}]]
-                (let [{:keys [job-launch-filter job-routing job-submission-validator pool-selection]} plugins]
+                (let [{:keys [job-launch-filter job-routing job-submission-validator pool-selection job-expander]} plugins]
                   (merge plugins
                          {:job-launch-filter
                           (merge
@@ -510,7 +510,9 @@
                           :pool-selection
                           (merge {:attribute-name "cook-pool"
                                   :default-pool "no-pool"}
-                                 pool-selection)})))
+                                 pool-selection)
+                          :job-expander
+                          job-expander})))
      :quota-grouping (fnk [[:config {quota-grouping {}}]]
                        quota-grouping)
      :pg-config (fnk [[:config {pg-config nil}]]

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -480,7 +480,7 @@
                                         (merge {:agent-start-grace-period-mins 10}
                                                estimated-completion-constraint))
      :plugins (fnk [[:config {plugins {}}]]
-                (let [{:keys [job-launch-filter job-routing job-submission-validator pool-selection job-expander]} plugins]
+                (let [{:keys [job-launch-filter job-routing job-submission-validator pool-selection job-submission-modifier]} plugins]
                   (merge plugins
                          {:job-launch-filter
                           (merge
@@ -511,8 +511,8 @@
                           (merge {:attribute-name "cook-pool"
                                   :default-pool "no-pool"}
                                  pool-selection)
-                          :job-expander
-                          job-expander})))
+                          :job-submission-modifier
+                          job-submission-modifier})))
      :quota-grouping (fnk [[:config {quota-grouping {}}]]
                        quota-grouping)
      :pg-config (fnk [[:config {pg-config nil}]]

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -61,9 +61,11 @@
 (defprotocol JobRouter
   (choose-pool-for-job [this job]
     ; Note that job may have a nil pool. But Cook will route based on the default pool
-    "Given a job submission, returns the initial pool selection for the job"))
+    "Given a job submission, returns the initial pool selection for the job.
+    JobRouter is expected to be called from within JobSubmissionModifier."))
 
 (defprotocol JobSubmissionModifier
   (modify-job [this job pool-name]
     "Given a job submission and pool-name, returns a modified job definition with pool selection for downstream use.
-     JobSubmissionModifier may raise an exception if it cannot return a valid job definition."))
+     JobSubmissionModifier may raise an exception if it cannot return a valid job definition.
+     An exception will cause the job submission to fail with the error message being included in the response."))

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -64,6 +64,6 @@
     "Given a job submission, returns the initial pool selection for the job"))
 
 (defprotocol JobSubmissionModifier
-  (modify-job [this job]
-    "Given a job submission, returns a modified job definition for downstream use.
+  (modify-job [this job pool-name]
+    "Given a job submission and pool-name, returns a modified job definition with pool selection for downstream use.
      JobSubmissionModifier may raise an exception if it cannot return a valid job definition."))

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -62,3 +62,7 @@
   (choose-pool-for-job [this job]
     ; Note that job may have a nil pool. But Cook will route based on the default pool
     "Given a job submission, returns the initial pool selection for the job"))
+
+(defprotocol JobExpander
+  (expand-job [this job]
+    "Given a api job submission, returns an expanded job definition for downstream use"))

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -65,4 +65,6 @@
 
 (defprotocol JobExpander
   (expand-job [this job]
-    "Given a api job submission, returns an expanded job definition for downstream use"))
+    ; Note that each job in a multi-job submission request will be acted on separately
+    "Given an api job submission, returns an expanded job definition for downstream use.
+     JobExpander may raise exception if it cannot return a valid job definition."))

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -63,8 +63,7 @@
     ; Note that job may have a nil pool. But Cook will route based on the default pool
     "Given a job submission, returns the initial pool selection for the job"))
 
-(defprotocol JobExpander
-  (expand-job [this job]
-    ; Note that each job in a multi-job submission request will be acted on separately
-    "Given an api job submission, returns an expanded job definition for downstream use.
-     JobExpander may raise exception if it cannot return a valid job definition."))
+(defprotocol JobSubmissionModifier
+  (modify-job [this job]
+    "Given a job submission, returns a modified job definition for downstream use.
+     JobSubmissionModifier may raise an exception if it cannot return a valid job definition."))

--- a/scheduler/src/cook/plugins/job_expander.clj
+++ b/scheduler/src/cook/plugins/job_expander.clj
@@ -21,14 +21,14 @@
             [cook.plugins.util]
             [mount.core :as mount]))
 
-(defrecord SimpleJobExpander []
+(defrecord IdentityJobExpander []
   JobExpander
-  ;The SimpleJobExpander doesn't make any changes to what users submit
+  ;The IdentityJobExpander doesn't make any changes to what users submit
   (expand-job [this job]
     job))
 
 (defn create-plugin-object
-  "Returns the configured JobExpander, or a SimpleJobExpander if none is defined."
+  "Returns the configured JobExpander, or a IdentityJobExpander if none is defined."
   [config]
   (let [factory-fn (get-in config [:settings :plugins :job-expander :factory-fn])]
     (if factory-fn
@@ -37,12 +37,12 @@
         (if-let [resolved-fn (cook.plugins.util/resolve-symbol (symbol factory-fn))]
           (resolved-fn config)
           (throw (ex-info (str "Unable to resolve factory fn " factory-fn) {}))))
-      (SimpleJobExpander.))))
+      (IdentityJobExpander.))))
 
 (mount/defstate plugin
                 :start (create-plugin-object config/config))
 
 (defn apply-job-expander-plugins
-  "Apply any modifications to user-submitted raw job"
+  "Modify a user-submitted job before passing it further down the submission pipeline."
   [raw-job]
   (expand-job plugin raw-job))

--- a/scheduler/src/cook/plugins/job_expander.clj
+++ b/scheduler/src/cook/plugins/job_expander.clj
@@ -1,0 +1,48 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+(ns cook.plugins.job-expander
+  (:require [clojure.tools.logging :as log]
+            [cook.config :as config]
+            [cook.plugins.definitions :refer [expand-job JobExpander]]
+            [cook.plugins.util]
+            [mount.core :as mount]))
+
+(defrecord SimpleJobExpander []
+  JobExpander
+  ;The SimpleJobExpander doesn't make any changes to what users submit
+  (expand-job [this job]
+    job))
+
+(defn create-plugin-object
+  "Returns the configured JobExpander, or a SimpleJobExpander if none is defined."
+  [config]
+  (let [factory-fn (get-in config [:settings :plugins :job-expander :factory-fn])]
+    (if factory-fn
+      (do
+        (log/info "Creating job expansion plugin with" factory-fn)
+        (if-let [resolved-fn (cook.plugins.util/resolve-symbol (symbol factory-fn))]
+          (resolved-fn config)
+          (throw (ex-info (str "Unable to resolve factory fn " factory-fn) {}))))
+      (SimpleJobExpander.))))
+
+(mount/defstate plugin
+                :start (create-plugin-object config/config))
+
+(defn apply-job-expander-plugins
+  "Apply any modifications to user-submitted raw job"
+  [raw-job]
+  (expand-job plugin raw-job))

--- a/scheduler/src/cook/plugins/job_submission_modifier.clj
+++ b/scheduler/src/cook/plugins/job_submission_modifier.clj
@@ -14,35 +14,35 @@
 ;; limitations under the License.
 ;;
 
-(ns cook.plugins.job-expander
+(ns cook.plugins.job-submission-modifier
   (:require [clojure.tools.logging :as log]
             [cook.config :as config]
-            [cook.plugins.definitions :refer [expand-job JobExpander]]
+            [cook.plugins.definitions :refer [modify-job JobSubmissionModifier]]
             [cook.plugins.util]
             [mount.core :as mount]))
 
-(defrecord IdentityJobExpander []
-  JobExpander
-  ;The IdentityJobExpander doesn't make any changes to what users submit
-  (expand-job [this job]
+(defrecord IdentityJobSubmissionModifier []
+  JobSubmissionModifier
+  ;The IdentityJobSubmissionModifier doesn't make any changes to what users submit
+  (modify-job [this job]
     job))
 
 (defn create-plugin-object
-  "Returns the configured JobExpander, or a IdentityJobExpander if none is defined."
+  "Returns the configured JobSubmissionModifier, or a IdentityJobSubmissionModifier if none is defined."
   [config]
-  (let [factory-fn (get-in config [:settings :plugins :job-expander :factory-fn])]
+  (let [factory-fn (get-in config [:settings :plugins :job-submission-modifier :factory-fn])]
     (if factory-fn
       (do
-        (log/info "Creating job expansion plugin with" factory-fn)
+        (log/info "Creating job submission modifier plugin with" factory-fn)
         (if-let [resolved-fn (cook.plugins.util/resolve-symbol (symbol factory-fn))]
           (resolved-fn config)
           (throw (ex-info (str "Unable to resolve factory fn " factory-fn) {}))))
-      (IdentityJobExpander.))))
+      (IdentityJobSubmissionModifier.))))
 
 (mount/defstate plugin
                 :start (create-plugin-object config/config))
 
-(defn apply-job-expander-plugins
+(defn apply-job-submission-modifier-plugins
   "Modify a user-submitted job before passing it further down the submission pipeline."
   [raw-job]
-  (expand-job plugin raw-job))
+  (modify-job plugin raw-job))

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -39,6 +39,7 @@
             [cook.mesos.reason :as reason]
             [cook.passport :as passport]
             [cook.plugins.adjustment :as adjustment]
+            [cook.plugins.job-expander :as job-expander-plugin]
             [cook.plugins.definitions :as plugins]
             [cook.plugins.file :as file-plugin]
             [cook.plugins.submission :as submission-plugin]
@@ -2222,9 +2223,10 @@
                          (let [groups (mapv #(validate-and-munge-group db %) groups)
                                job-pool-name-maps
                                (mapv
-                                 (fn [job]
-                                   (let [effective-pool-name
-                                         (pool-name->effective-pool-name pool-name job)
+                                 (fn [raw-job]
+                                   (let [effective-job (job-expander-plugin/apply-job-expander-plugins raw-job)
+                                         effective-pool-name
+                                         (pool-name->effective-pool-name pool-name raw-job)
                                          validated-and-munged-job
                                          (validate-and-munge-job
                                            db
@@ -2233,7 +2235,7 @@
                                            task-constraints
                                            gpu-enabled?
                                            (set (map :uuid groups))
-                                           job
+                                           effective-job
                                            :override-group-immutability?
                                            override-group-immutability?)]
                                      {:job validated-and-munged-job

--- a/scheduler/src/cook/rest/api.clj
+++ b/scheduler/src/cook/rest/api.clj
@@ -39,7 +39,7 @@
             [cook.mesos.reason :as reason]
             [cook.passport :as passport]
             [cook.plugins.adjustment :as adjustment]
-            [cook.plugins.job-expander :as job-expander-plugin]
+            [cook.plugins.job-submission-modifier :as job-submission-plugin]
             [cook.plugins.definitions :as plugins]
             [cook.plugins.file :as file-plugin]
             [cook.plugins.submission :as submission-plugin]
@@ -2224,7 +2224,8 @@
                                job-pool-name-maps
                                (mapv
                                  (fn [raw-job]
-                                   (let [effective-job (job-expander-plugin/apply-job-expander-plugins raw-job)
+                                   (let [effective-job
+                                         (job-submission-plugin/apply-job-submission-modifier-plugins raw-job)
                                          effective-pool-name
                                          (pool-name->effective-pool-name pool-name raw-job)
                                          validated-and-munged-job

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -128,6 +128,7 @@
                          #'cook.config/config
                          #'cook.plugins.adjustment/plugin
                          #'cook.plugins.file/plugin
+                         #'cook.plugins.job-expander/plugin
                          #'cook.plugins.launch/job-launch-cache
                          #'cook.plugins.launch/plugin-object
                          #'cook.plugins.pool/plugin

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -128,7 +128,7 @@
                          #'cook.config/config
                          #'cook.plugins.adjustment/plugin
                          #'cook.plugins.file/plugin
-                         #'cook.plugins.job-expander/plugin
+                         #'cook.plugins.job-submission-modifier/plugin
                          #'cook.plugins.launch/job-launch-cache
                          #'cook.plugins.launch/plugin-object
                          #'cook.plugins.pool/plugin

--- a/scheduler/test/cook/test/plugins/job_submission_modifier.clj
+++ b/scheduler/test/cook/test/plugins/job_submission_modifier.clj
@@ -1,0 +1,21 @@
+(ns cook.test.plugins.job-submission-modifier
+  (:require [clojure.test :refer :all]
+            [cook.plugins.definitions :as plugins]
+            [cook.plugins.job-submission-modifier :as job-mod]))
+
+(deftest test-identity-add-pool
+  (let [mod-plugin (job-mod/->IdentityJobSubmissionModifier)
+        job {}
+        pool-name "my-pool"]
+    (is (= "my-pool" (get (plugins/modify-job mod-plugin job pool-name) :pool) ))))
+
+(defrecord TestJobModifier []
+  plugins/JobSubmissionModifier
+  (modify-job [this job pool-name]
+    (throw (IllegalArgumentException. "TestJobModifier always throws"))))
+
+(deftest test-raise-exception
+  ; On its own, this test has little value. We are more interested in the overall
+  ; behavior when a real job is submitted and the plugin raises an exception.
+  (let [mod-plugin (TestJobModifier.)]
+    (is (thrown? IllegalArgumentException (plugins/modify-job mod-plugin nil nil)))))


### PR DESCRIPTION
## Changes proposed in this PR

- Add the JobSubmissionModifier plugin location and default, IdentityJobSubmissionModifier
- Refactors JobRouter logic to be applied inside the Job Submission Modifier

## Why are we making these changes?
We want to create the ability to modify user jobs based on what they submit (e.g. for routing or constraints)
