### PR TITLE
Adding prometheus metric for synthetic pods count

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -17,6 +17,7 @@
             [cook.log-structured :as log-structured]
             [cook.monitor :as monitor]
             [cook.pool]
+            [cook.prometheus-metrics :as prom]
             [cook.scheduler.constraints :as constraints]
             [cook.tools :as tools]
             [cook.util :as util]
@@ -514,6 +515,8 @@
 
             (set-counter-fn "total-synthetic-pods" num-synthetic-pods)
             (set-counter-fn "max-total-synthetic-pods" max-pods-outstanding)
+            (prom/set prom/total-synthetic-pods {:pool pool-name :compute-cluster name} num-synthetic-pods)
+            (prom/set prom/max-synthetic-pods {:pool pool-name :compute-cluster name} max-pods-outstanding)
 
             (let [max-launchable (min (- max-pods-outstanding num-synthetic-pods)
                                       (- max-total-nodes total-nodes)

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -60,6 +60,8 @@
    :gpus :cook/scheduler-users-gpu-count
    :launch-rate-saved :cook/scheduler-users-launch-rate-saved
    :launch-rate-per-minute :cook/scheduler-users-launch-rate-per-minute})
+(def total-synthetic-pods :cook/scheduler-kubernetes-synthetic-pods-count)
+(def max-synthetic-pods :cook/scheduler-kubernethes-max-synthetic-pods)
 
 
 (defn create-registry
@@ -177,7 +179,16 @@
       ;; Metrics for user resource allocation counts
       (prometheus/gauge user-state-count
                         {:description "Current user count by state"
-                         :labels [:pool :state]}))))
+                         :labels [:pool :state]})
+      ;; Resource usage stats -----------------------------------------------------------------------------------
+
+      ;; Other metrics -------------------------------------------------------------------------------------------
+      (prometheus/gauge total-synthetic-pods
+                        {:description "Total current number of synthetic pods per pool and compute cluster"
+                         :labels [:pool :compute-cluster]})
+      (prometheus/gauge max-synthetic-pods
+                        {:description "Max number of synthetic pods per pool and compute cluster"
+                         :labels [:pool :compute-cluster]}))))
 
 ;; A global registry for all metrics reported by Cook.
 ;; All metrics must be registered before they can be recorded.


### PR DESCRIPTION
## Changes proposed in this PR
- Adds prometheus metrics for current and total synthetic pods count.

## Why are we making these changes?
Ongoing migration to prometheus.

