### PR TITLE
Release Cook v1.62.4

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.62.4] - 2022-08-12
+### Added
+- Add new JobSubmissionModifier and refactor JobRouter, from @laurameng
+
+### Changed
+- Prometheus metrics
+  - Updated match cycle metric logic for 0 considerable case, from @samincheva
+  - Added prometheus metric for synthetic pods count, from @samincheva
+- Use a factory fn for creating (future) different types of pool handlers, from @ahaysx
+
 ## [1.62.3] - 2022-08-03
 ### Changed
 - Configured the /metrics endpoint to have a separate rate limit, from @samincheva

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.62.4-SNAPSHOT"
+(defproject cook "1.62.4"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.62.4"
+(defproject cook "1.62.5-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]


### PR DESCRIPTION
## Please rebase and merge to preserve the double-commit
# Changes proposed in this PR
- Updates changelog and version of v1.62.4.

# Why are we making these changes?
To release cook scheduler.