### PR TITLE
Calculate the number of pods a node more efficiently.

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -766,8 +766,9 @@
 (defn num-pods-on-node
   "Returns the number of pods assigned to the given node"
   [node-name pods]
-  (let [node-name->pods (group-by pod->node-name pods)]
-    (-> node-name->pods (get node-name []) count)))
+  (->> pods
+       (filter #(= (pod->node-name %) node-name))
+       count))
 
 (defn node->resource-map
   "Given a node, returns the resource map used internally by Cook"

--- a/scheduler/test/cook/test/kubernetes/api.clj
+++ b/scheduler/test/cook/test/kubernetes/api.clj
@@ -1244,3 +1244,18 @@
             (is (contains? pod-labels "SAMPLE_DEFAULT_POD_LABEL_KEY"))
             ; test unmatched pool
             (is (not (contains? pod-labels "org.foo/application")))))))))
+
+(deftest test-num-pods-on-node
+  (with-redefs [api/pod->node-name :node-name]
+    (let [pods [{:pod 1 :node-name "a"}
+                {:pod 2 :node-name "a"}
+                {:pod 3 :node-name nil}
+                {:pod 4 :node-name nil}
+                {:pod 5 :node-name "c"}]]
+    (is (= 2 (api/num-pods-on-node "a" pods)))
+    (is (= 2 (api/num-pods-on-node nil pods)))
+    (is (= 1 (api/num-pods-on-node "c" pods)))
+    (is (= 0 (api/num-pods-on-node "d" pods)))
+    (is (= 0 (api/num-pods-on-node "a" {})))
+    (is (= 0 (api/num-pods-on-node nil {})))
+    (is (= 0 (api/num-pods-on-node "c" {}))))))


### PR DESCRIPTION
## Changes proposed in this PR

- Compute the number of pods on a node more efficiently.

## Why are we making these changes?
This should make matching take less time and generate less garbage. 

