### PR TITLE
Remove metatransaction filter from match.

### DIFF
--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1186,7 +1186,7 @@
         (timers/time!
           (timers/timer (metric-title "handle-resource-offer!-duration" pool-name))
           (try
-            (let [db (db conn)
+            (let [db (d/db conn)
                   pending-jobs (get @pool-name->pending-jobs-atom pool-name)
                   considerable-jobs (prom/with-duration
                                       prom/scheduler-handle-resource-offers-pending-to-considerable-duration {:pool pool-name}


### PR DESCRIPTION
## Changes proposed in this PR

- Remove metatransaction filter from match.

## Why are we making these changes?

This should make the database pathway used to load jobs from the database (at match time) more efficient. At this point, we're already filtering to jobs with a commit latch set.
