### PR TITLE
Add special version of add-starting-pods-reverse

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -293,6 +293,14 @@
   (let [starting-pods (controller/starting-namespaced-pod-name->pod compute-cluster)]
     (-> pods (merge starting-pods) vals)))
 
+(defn add-starting-pods-reverse
+  "Weird offshoot of add-starting-pods-reverse that is run when determining node capacity.
+  (We want to add the smaller set onto the bigger set. In this context, the bigger set is
+  the set of starting pods.)"
+  [compute-cluster pods]
+  (let [starting-pods (controller/starting-namespaced-pod-name->pod compute-cluster)]
+    (vals (into starting-pods pods))))
+
 (defn synthetic-pod->job-uuid
   "If the given pod is a synthetic pod for autoscaling, returns the job uuid
   that the pod corresponds to (stored in a pod label). Otherwise, returns nil."
@@ -630,7 +638,7 @@
 
   (num-tasks-on-host [this hostname]
     (->> (get @node-name->pod-name->pod hostname {})
-         (add-starting-pods this)
+         (add-starting-pods-reverse this)
          (api/num-pods-on-node hostname)))
 
   (retrieve-sandbox-url-path

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -5,6 +5,7 @@
             [cook.config :as config]
             [cook.kubernetes.api :as api]
             [cook.kubernetes.compute-cluster :as kcc]
+            [cook.kubernetes.controller :as controller]
             [cook.mesos.task :as task]
             [cook.test.postgres]
             [cook.scheduler.scheduler :as sched]


### PR DESCRIPTION
## Changes proposed in this PR

- Add special version of add-starting-pods-reverse

## Why are we making these changes?

It is more efficient to add the smaller set to the larger set. In other contexts, we want to add the starting pods to the set of all pods. But in the specific context of calculating pods on a machine, the number of pods on the machine is the smaller set.
