### PR TITLE
Delazy some of the list generation; do it at rank

### DIFF
--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -464,6 +464,8 @@
                 (not (:schedulers pools))
                 (assoc :schedulers [{:pool-regex ".*"
                                      :scheduler-config default-fenzo-scheduler-config}])))
+     :rank (fnk [[:config {rank {:number-to-force 1000}}]]
+             rank)
      :api-only? (fnk [[:config {api-only? false}]]
                   api-only?)
      :cache-working-set-size (fnk [[:config {cache-working-set-size 1000000}]]

--- a/scheduler/test/cook/test/benchmark.clj
+++ b/scheduler/test/cook/test/benchmark.clj
@@ -49,12 +49,12 @@
             offensive-jobs-ch (sched/make-offensive-job-stifler conn)
             offensive-job-filter (partial sched/filter-offensive-jobs task-constraints offensive-jobs-ch)]
         (println "============ rank-jobs timing ============")
-        (cc/quick-bench (sched/rank-jobs db offensive-job-filter))))
+        (cc/quick-bench (sched/rank-jobs db offensive-job-filter 0))))
     (testing "rank-jobs minus offensive-job-filter"
       (let [db (d/db conn)
             offensive-job-filter identity]
         (println "============ rank-jobs minus offensive-job-filter timing ============")
-        (cc/quick-bench (sched/rank-jobs db offensive-job-filter))))
+        (cc/quick-bench (sched/rank-jobs db offensive-job-filter 0))))
     (testing "sort-jobs-by-dru-helper"
       (let [db (d/db conn)
             pending-task-ents (->> (queries/get-pending-job-ents db)

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -873,7 +873,7 @@
         offensive-job-filter (partial sched/filter-offensive-jobs constraints offensive-jobs-ch)]
     (testing "enough offers for all normal jobs."
       (is (= {"no-pool" (list (tools/job-ent->map job-entity))}
-             (sched/rank-jobs test-db offensive-job-filter))))))
+             (sched/rank-jobs test-db offensive-job-filter 5))))))
 
 (deftest test-mesos-virtual-machine-lease-adapter
   ;; ensure that the VirtualMachineLeaseAdapter can successfully handle an offer from Mesomatic.


### PR DESCRIPTION
## Changes proposed in this PR

- Delazy some of the list generation; do it at rank time to overlap generation with launch.

## Why are we making these changes?
This slows down rank time by forcing the lazy list then, but should speed up the first one or two match cycles, and help parallelize the delazy'ing the ranked jobs and launching.
