### PR TITLE
Better version of add-starting-pods

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -291,7 +291,7 @@
   list of those pods with currently starting pods in the compute cluster added in"
   [compute-cluster pods]
   (let [starting-pods (controller/starting-namespaced-pod-name->pod compute-cluster)]
-    (-> pods (merge starting-pods) vals)))
+    (vals (into pods starting-pods))))
 
 (defn add-starting-pods-reverse
   "Weird offshoot of add-starting-pods-reverse that is run when determining node capacity.

--- a/scheduler/test/cook/test/kubernetes/compute_cluster.clj
+++ b/scheduler/test/cook/test/kubernetes/compute_cluster.clj
@@ -433,6 +433,21 @@
   (testing "gracefully handles missing resource"
     (= 3 (kcc/total-resource {"node-a" {:cpus 1} "node-b" {} "node-c" {:cpus 2}} :cpus))))
 
+(deftest test-add-starting-pods
+  (with-redefs [controller/starting-namespaced-pod-name->pod
+                (constantly
+                  {{:namespace "ns" :name "name1"} "pod1"
+                   {:namespace "ns" :name "name2"} "pod2"})]
+    (let [pods {{:namespace "ns" :name "name2"} "pod2b"
+                {:namespace "ns" :name "name3"} "pod3"}]
+      (is (= #{"pod1" "pod2" "pod3"} (into #{} (kcc/add-starting-pods nil pods))))
+      (is (= #{"pod1" "pod2"} (into #{} (kcc/add-starting-pods nil {}))))))
+  (with-redefs [controller/starting-namespaced-pod-name->pod (constantly {})]
+    (let [pods {{:namespace "ns" :name "name2"} "pod2b"
+                {:namespace "ns" :name "name3"} "pod3"}]
+      (is (= #{"pod2b" "pod3"} (into #{} (kcc/add-starting-pods nil pods))))
+      (is (= #{} (into #{} (kcc/add-starting-pods nil {})))))))
+
 
 (deftest test-add-starting-pods-reverse
   (with-redefs [controller/starting-namespaced-pod-name->pod


### PR DESCRIPTION
## Changes proposed in this PR

- Use 'into' instead of 'merge' for merging maps.

## Why are we making these changes?
Using `into` here lets clojure use a more optimized codepath where it doesn't make persistent collections for the intermediate states. This means less copying and less garbage. (See docs on `persistent!` and `transient`)

