### PR TITLE
Synthetic pods

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.62.4] - 2022-08-12
+### Added
+- Add new JobSubmissionModifier and refactor JobRouter, from @laurameng
+
+### Changed
+- Prometheus metrics
+  - Updated match cycle metric logic for 0 considerable case, from @samincheva
+  - Added prometheus metric for synthetic pods count, from @samincheva
+- Use a factory fn for creating (future) different types of pool handlers, from @ahaysx
+
 ## [1.62.3] - 2022-08-03
 ### Changed
 - Configured the /metrics endpoint to have a separate rate limit, from @samincheva

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.62.4-SNAPSHOT"
+(defproject cook "1.62.4"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.62.4"
+(defproject cook "1.62.5-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -101,9 +101,7 @@
                    (route/not-found "<h1>Not a valid route</h1>")))})
 
 (def mesos-scheduler
-  {:mesos-scheduler (fnk [[:settings fenzo-fitness-calculator fenzo-floor-iterations-before-reset
-                           fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback
-                           good-enough-fitness hostname mea-culpa-failure-limit mesos-leader-path mesos-run-as-user
+  {:mesos-scheduler (fnk [[:settings hostname mea-culpa-failure-limit mesos-leader-path mesos-run-as-user
                            offer-incubate-time-ms optimizer rebalancer server-port task-constraints]
                           compute-clusters curator-framework mesos-datomic-mult leadership-atom
                           pool-name->pending-jobs-atom mesos-heartbeat-chan
@@ -119,12 +117,6 @@
                             (Class/forName "org.apache.mesos.Scheduler")
                             ((util/lazy-load-var 'cook.mesos/start-leader-selector)
                               {:curator-framework curator-framework
-                               :fenzo-config {:fenzo-max-jobs-considered fenzo-max-jobs-considered
-                                              :fenzo-scaleback fenzo-scaleback
-                                              :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn
-                                              :fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-reset
-                                              :fenzo-fitness-calculator fenzo-fitness-calculator
-                                              :good-enough-fitness good-enough-fitness}
                                :mea-culpa-failure-limit mea-culpa-failure-limit
                                :mesos-datomic-conn datomic/conn
                                :mesos-datomic-mult mesos-datomic-mult

--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -33,6 +33,8 @@
             [cook.plugins.completion]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.file namespace.
             [cook.plugins.file]
+            ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.job-submission-modifier namespace.
+            [cook.plugins.job-submission-modifier]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.launch namespace.
             [cook.plugins.launch]
             ; This explicit require is needed so that mount can see the defstate defined in the cook.plugins.pool namespace.

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -50,6 +50,12 @@
   (restore-offers [this pool-name offers]
     "Called when offers are not processed to ensure they're still available.")
 
+  (get-outstanding-synthetic-pods [this pool-name]
+    "Returns a list of outstanding synthetic pods in the pool.")
+
+  (set-synthetic-pods-counters [this pool-name num-synthetic-pods]
+    "Sets the counter metrics for number of and max synthetic pods.")
+
   (autoscaling? [this pool-name]
     "Returns true if this compute cluster should autoscale the provided pool to satisfy pending jobs")
 

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -480,7 +480,7 @@
                                         (merge {:agent-start-grace-period-mins 10}
                                                estimated-completion-constraint))
      :plugins (fnk [[:config {plugins {}}]]
-                (let [{:keys [job-launch-filter job-routing job-submission-validator pool-selection]} plugins]
+                (let [{:keys [job-launch-filter job-routing job-submission-validator pool-selection job-submission-modifier]} plugins]
                   (merge plugins
                          {:job-launch-filter
                           (merge
@@ -510,7 +510,9 @@
                           :pool-selection
                           (merge {:attribute-name "cook-pool"
                                   :default-pool "no-pool"}
-                                 pool-selection)})))
+                                 pool-selection)
+                          :job-submission-modifier
+                          job-submission-modifier})))
      :quota-grouping (fnk [[:config {quota-grouping {}}]]
                        quota-grouping)
      :pg-config (fnk [[:config {pg-config nil}]]
@@ -750,6 +752,11 @@
 (defn job-routing
   []
   (-> config :settings :plugins :job-routing))
+
+(defn job-routing-pool-name?
+  "Returns truthy if the given pool name is a job-routing pool name"
+  [pool-name-from-submission]
+  (get (job-routing) pool-name-from-submission))
 
 (defn constraint-attribute->transformation
   []

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -13,6 +13,7 @@
             [cook.log-structured :as log-structured]
             [cook.monitor :as monitor]
             [cook.passport :as passport]
+            [cook.prometheus-metrics :as prom]
             [cook.regexp-tools :as regexp-tools]
             [cook.rest.api :as api]
             [cook.scheduler.constraints :as constraints]
@@ -194,7 +195,7 @@
     reconnecting the watch. This function is called at the start of watch processing (with one
     metric name) and between watch events (with a different metric name). In both cases, we
     update the last-watch-response-or-connect timestamp."
-    [compute-cluster-name watch-object-type metric-name log?]
+    [compute-cluster-name watch-object-type metric-name prom-metric-name log?]
     (when-let [last-watch-response-or-connect-millis
                (get-in
                  @last-watch-response-or-connect-millis-atom
@@ -203,6 +204,7 @@
             metric-name (str (name watch-object-type) "-" metric-name)]
         (histograms/update!
           (metrics/histogram metric-name compute-cluster-name) millis)
+        (prom/observe prom-metric-name {:compute-cluster compute-cluster-name :object (name watch-object-type)} millis)
         (when log?
           (log-structured/info
             "Marked watch gap"
@@ -219,12 +221,12 @@
 (defn mark-watch-gap!
   "Updates the watch-gap-millis metric."
   [compute-cluster-name watch-object-type]
-  (update-watch-gap-metric! compute-cluster-name watch-object-type "watch-gap-millis" false))
+  (update-watch-gap-metric! compute-cluster-name watch-object-type "watch-gap-millis" prom/watch-gap false))
 
 (defn mark-disconnected-watch-gap!
   "Updates the disconnected-watch-gap-millis metric."
   [compute-cluster-name watch-object-type]
-  (update-watch-gap-metric! compute-cluster-name watch-object-type "disconnected-watch-gap-millis" true))
+  (update-watch-gap-metric! compute-cluster-name watch-object-type "disconnected-watch-gap-millis" prom/disconnected-watch-gap true))
 
 (defn handle-watch-updates
   "When a watch update occurs (for pods or nodes) update both the state atom as well as
@@ -293,9 +295,11 @@
                  :number-pods-so-far (count all-pods)
                  :resource-version resource-version-string})
       (let [{:keys [continue pods resource-version]}
-            (timers/time!
-              (metrics/timer "get-all-pods-single-chunk" compute-cluster-name)
-              (list-pods-for-all-namespaces api continue-string limit))
+            (prom/with-duration
+              prom/list-pods-chunk-duration {:compute-cluster compute-cluster-name}
+              (timers/time!
+                (metrics/timer "get-all-pods-single-chunk" compute-cluster-name)
+                (list-pods-for-all-namespaces api continue-string limit)))
             new-all-pods (concat all-pods pods)]
 
         ; Note that the resourceVersion of the list remains constant across each request,
@@ -331,10 +335,12 @@
 (defn get-all-pods-in-kubernetes
   "Get all pods in kubernetes."
   [api-client compute-cluster-name limit]
-  (timers/time! (metrics/timer "get-all-pods" compute-cluster-name)
-    (let [{:keys [pods resource-version]} (list-pods api-client compute-cluster-name limit)
-          namespaced-pod-name->pod (pc/map-from-vals get-pod-namespaced-key pods)]
-      [resource-version namespaced-pod-name->pod])))
+  (prom/with-duration
+    prom/list-pods-duration {:compute-cluster compute-cluster-name}
+    (timers/time! (metrics/timer "get-all-pods" compute-cluster-name)
+                  (let [{:keys [pods resource-version]} (list-pods api-client compute-cluster-name limit)
+                        namespaced-pod-name->pod (pc/map-from-vals get-pod-namespaced-key pods)]
+                    [resource-version namespaced-pod-name->pod]))))
 
 (defn try-forever-get-all-pods-in-kubernetes
   "Try forever to get all pods in kubernetes. Used when starting a cluster up."
@@ -421,8 +427,11 @@
             get-pod-namespaced-key
             callbacks
             (fn []
+              (prom/set prom/total-pods {:compute-cluster compute-cluster-name} (-> @all-pods-atom keys count))
               (set-metric-counter "total-pods" (-> @all-pods-atom keys count) compute-cluster-name)
-              (when max-total-pods (set-metric-counter "max-total-pods" max-total-pods compute-cluster-name)))
+              (when max-total-pods
+                  (prom/set prom/max-pods {:compute-cluster compute-cluster-name} max-total-pods)
+                  (set-metric-counter "max-total-pods" max-total-pods compute-cluster-name)))
             compute-cluster-name
             :pod)
           (catch Exception e
@@ -481,19 +490,21 @@
     compute-cluster-name :name {:keys [max-total-nodes]} :synthetic-pods-config :as compute-cluster}]
   (let [api (CoreV1Api. api-client)
         ^V1NodeList current-nodes-raw
-        (timers/time! (metrics/timer "get-all-nodes" compute-cluster-name)
-                      (.listNode api
-                                 nil ; pretty
-                                 nil ; allowWatchBookmarks
-                                 nil ; continue
-                                 nil ; fieldSelector
-                                 nil ; labelSelector
-                                 nil ; limit
-                                 nil ; resourceVersion
-                                 nil ; resourceVersionMatch
-                                 nil ; timeoutSeconds
-                                 nil ; watch
-                                 ))
+        (prom/with-duration
+          prom/list-nodes-duration {:compute-cluster compute-cluster-name}
+          (timers/time! (metrics/timer "get-all-nodes" compute-cluster-name)
+                        (.listNode api
+                                   nil ; pretty
+                                   nil ; allowWatchBookmarks
+                                   nil ; continue
+                                   nil ; fieldSelector
+                                   nil ; labelSelector
+                                   nil ; limit
+                                   nil ; resourceVersion
+                                   nil ; resourceVersionMatch
+                                   nil ; timeoutSeconds
+                                   nil ; watch
+                                   )))
         current-nodes (pc/map-from-vals node->node-name (.getItems current-nodes-raw))
         callbacks
         [(tools/make-atom-updater current-nodes-atom) ; Update the set of all pods.
@@ -532,8 +543,11 @@
             node->node-name
             callbacks ; Update the set of all nodes.
             (fn []
-              (set-metric-counter "total-nodes" (-> @current-nodes-atom keys count) compute-cluster-name)
-              (when max-total-nodes (set-metric-counter "max-total-nodes" max-total-nodes compute-cluster-name)))
+              (prom/set prom/total-nodes {:compute-cluster compute-cluster-name} (-> @current-nodes-atom keys count))
+              (set-metric-counter "total-nodes"  (-> @current-nodes-atom keys count) compute-cluster-name)
+              (when max-total-nodes
+                  (prom/set prom/max-nodes {:compute-cluster compute-cluster-name} max-total-nodes)
+                  (set-metric-counter "max-total-nodes" max-total-nodes compute-cluster-name)))
             compute-cluster-name
             :node)
           (catch Exception e
@@ -2029,38 +2043,42 @@
         pod-namespace (-> pod .getMetadata .getNamespace)]
     ; TODO: This likes to noisily throw NotFound multiple times as we delete away from kubernetes.
     ; I suspect our predicate of k8s-actual-state-equivalent needs tweaking.
-    (timers/time! (metrics/timer "delete-pod" compute-cluster-name)
-      (try
-        (.deleteNamespacedPod
-          api
-          pod-name
-          pod-namespace
-          nil ; pretty
-          nil ; dryRun
-          nil ; gracePeriodSeconds
-          nil ; orphanDependents
-          nil ; propagationPolicy
-          deleteOptions
-          )
-        (catch JsonSyntaxException e
-          ; Silently gobble this exception.
-          ;
-          ; The java API can throw a a JsonSyntaxException parsing the kubernetes reply!
-          ; https://github.com/kubernetes-client/java/issues/252
-          ; https://github.com/kubernetes-client/java/issues/86
-          ;
-          ; They actually advise catching the exception and moving on!
-          ;
-          (log-structured/info "Caught the https://github.com/kubernetes-client/java/issues/252 exception deleting pod"
-                               {:pod-name pod-name :compute-cluster compute-cluster-name}))
-        (catch ApiException e
-          (meters/mark! (metrics/meter "delete-pod-errors" compute-cluster-name))
-          (let [code (.getCode e)
-                already-deleted? (contains? #{404} code)]
-            (if already-deleted?
-              (log-structured/info "Pod was already deleted"
-                                   {:pod-name pod-name :compute-cluster compute-cluster-name})
-              (throw e))))))))
+    (prom/with-duration
+      prom/delete-pod-duration {:compute-cluster compute-cluster-name}
+      (timers/time!
+        (metrics/timer "delete-pod" compute-cluster-name)
+        (try
+          (.deleteNamespacedPod
+            api
+            pod-name
+            pod-namespace
+            nil ; pretty
+            nil ; dryRun
+            nil ; gracePeriodSeconds
+            nil ; orphanDependents
+            nil ; propagationPolicy
+            deleteOptions
+            )
+          (catch JsonSyntaxException e
+            ; Silently gobble this exception.
+            ;
+            ; The java API can throw a a JsonSyntaxException parsing the kubernetes reply!
+            ; https://github.com/kubernetes-client/java/issues/252
+            ; https://github.com/kubernetes-client/java/issues/86
+            ;
+            ; They actually advise catching the exception and moving on!
+            ;
+            (log-structured/info "Caught the https://github.com/kubernetes-client/java/issues/252 exception deleting pod"
+                                 {:pod-name pod-name :compute-cluster compute-cluster-name}))
+          (catch ApiException e
+            (prom/inc prom/delete-pod-errors {:compute-cluster compute-cluster-name})
+            (meters/mark! (metrics/meter "delete-pod-errors" compute-cluster-name))
+            (let [code (.getCode e)
+                  already-deleted? (contains? #{404} code)]
+              (if already-deleted?
+                (log-structured/info "Pod was already deleted"
+                                     {:pod-name pod-name :compute-cluster compute-cluster-name})
+                (throw e)))))))))
 
 (defn delete-collect-results-finalizer
   "Delete the finalizer that collects the results of a pod completion state once the pod has a
@@ -2078,36 +2096,43 @@
     (when (and pod-deletion-timestamp (some #(= FinalizerHelper/collectResultsFinalizer %) finalizers))
       (log-structured/info "Deleting finalizer for pod"
                            {:pod-name pod-name :compute-cluster compute-cluster-name})
-      (timers/time! (metrics/timer "delete-finalizer" compute-cluster-name)
-        (try
-          (FinalizerHelper/removeFinalizer api-client pod)
-          (catch ApiException e
-            (let [code (.getCode e)]
-              ; There can be races here. Whenever we hit the state machine, we will run this code
-              ; and may try to delete the finalizer twice. The second invocation can see the pod
-              ; already deleted or it can see an unprocesssable entity as we try to delete a finalizer
-              ; that's already gone.
-              (case code
-                404
-                (do
-                  (meters/mark! (metrics/meter "delete-finalizer-expected-errors" compute-cluster-name))
-                  (log-structured/info "Not Found error deleting finalizer for pod"
-                                       {:pod-name pod-name :compute-cluster compute-cluster-name}))
-                422
-                (do
-                  (meters/mark! (metrics/meter "delete-finalizer-expected-errors" compute-cluster-name))
-                  (log-structured/info "Unprocessable Entity error deleting finalizer for pod"
-                            {:pod-name pod-name :compute-cluster compute-cluster-name}))
-                (do
-                  (meters/mark! (metrics/meter "delete-finalizer-unexpected-errors" compute-cluster-name))
-                  (log-structured/error "Error deleting finalizer for pod"
-                             {:pod-name pod-name :compute-cluster compute-cluster-name}
-                             e)))))
-          (catch Exception e
-            (meters/mark! (metrics/meter "delete-finalizer-unexpected-errors" compute-cluster-name))
-            (log-structured/error "Error deleting finalizer for pod"
-                                  {:pod-name pod-name :compute-cluster compute-cluster-name}
-                                  e)))))))
+      (prom/with-duration
+        prom/delete-finalizer-duration {:compute-cluster compute-cluster-name}
+        (timers/time!
+          (metrics/timer "delete-finalizer" compute-cluster-name)
+          (try
+            (FinalizerHelper/removeFinalizer api-client pod)
+            (catch ApiException e
+              (let [code (.getCode e)]
+                ; There can be races here. Whenever we hit the state machine, we will run this code
+                ; and may try to delete the finalizer twice. The second invocation can see the pod
+                ; already deleted or it can see an unprocesssable entity as we try to delete a finalizer
+                ; that's already gone.
+                (case code
+                  404
+                  (do
+                    (prom/inc prom/delete-finalizer-errors {:compute-cluster compute-cluster-name :type "expected"})
+                    (meters/mark! (metrics/meter "delete-finalizer-expected-errors" compute-cluster-name))
+                    (log-structured/info "Not Found error deleting finalizer for pod"
+                                         {:pod-name pod-name :compute-cluster compute-cluster-name}))
+                  422
+                  (do
+                    (prom/inc prom/delete-finalizer-errors {:compute-cluster compute-cluster-name :type "expected"})
+                    (meters/mark! (metrics/meter "delete-finalizer-expected-errors" compute-cluster-name))
+                    (log-structured/info "Unprocessable Entity error deleting finalizer for pod"
+                                         {:pod-name pod-name :compute-cluster compute-cluster-name}))
+                  (do
+                    (prom/inc prom/delete-finalizer-errors {:compute-cluster compute-cluster-name :type "unexpected"})
+                    (meters/mark! (metrics/meter "delete-finalizer-unexpected-errors" compute-cluster-name))
+                    (log-structured/error "Error deleting finalizer for pod"
+                                          {:pod-name pod-name :compute-cluster compute-cluster-name}
+                                          e)))))
+            (catch Exception e
+              (prom/inc prom/delete-finalizer-errors {:compute-cluster compute-cluster-name :type "unexpected"})
+              (meters/mark! (metrics/meter "delete-finalizer-unexpected-errors" compute-cluster-name))
+              (log-structured/error "Error deleting finalizer for pod"
+                                    {:pod-name pod-name :compute-cluster compute-cluster-name}
+                                    e))))))))
 
 
 
@@ -2147,8 +2172,11 @@
                               :pod-json (print-str (.serialize json pod))
                               :pod-namespace namespace})
         (try
-          (timers/time! (metrics/timer "launch-pod" compute-cluster-name)
-            (create-namespaced-pod api namespace pod))
+          (prom/with-duration
+            prom/launch-pod-duration {:compute-cluster compute-cluster-name}
+            (timers/time!
+              (metrics/timer "launch-pod" compute-cluster-name)
+              (create-namespaced-pod api namespace pod)))
           (passport/log-event
             (merge
               passport-base-map
@@ -2195,8 +2223,12 @@
                          :terminal-failure? terminal-failure?}
                         e)
               (if bad-pod-spec?
-                (meters/mark! (metrics/meter "launch-pod-bad-spec-errors" compute-cluster-name))
-                (meters/mark! (metrics/meter "launch-pod-good-spec-errors" compute-cluster-name)))
+                (do
+                  (prom/inc prom/launch-pod-errors {:compute-cluster compute-cluster-name :bad-spec "true"})
+                  (meters/mark! (metrics/meter "launch-pod-bad-spec-errors" compute-cluster-name)))
+                (do
+                  (prom/inc prom/launch-pod-errors {:compute-cluster compute-cluster-name :bad-spec "false"})
+                  (meters/mark! (metrics/meter "launch-pod-good-spec-errors" compute-cluster-name))))
               {:failure-reason failure-reason
                :terminal-failure? terminal-failure?}))))
       (do

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -17,6 +17,7 @@
             [cook.log-structured :as log-structured]
             [cook.monitor :as monitor]
             [cook.pool]
+            [cook.prometheus-metrics :as prom]
             [cook.scheduler.constraints :as constraints]
             [cook.tools :as tools]
             [cook.util :as util]
@@ -514,6 +515,8 @@
 
             (set-counter-fn "total-synthetic-pods" num-synthetic-pods)
             (set-counter-fn "max-total-synthetic-pods" max-pods-outstanding)
+            (prom/set prom/total-synthetic-pods {:pool pool-name :compute-cluster name} num-synthetic-pods)
+            (prom/set prom/max-synthetic-pods {:pool pool-name :compute-cluster name} max-pods-outstanding)
 
             (let [max-launchable (min (- max-pods-outstanding num-synthetic-pods)
                                       (- max-total-nodes total-nodes)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -109,6 +109,7 @@
 
     (log-structured/info "Generating offers"
                          {:compute-cluster compute-cluster-name
+                          :pool pool-name
                           :number-nodes-not-schedulable (- number-nodes-total number-nodes-schedulable)
                           :number-nodes-schedulable number-nodes-schedulable
                           :number-nodes-total number-nodes-total

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -168,7 +168,9 @@
                    :executor-ids []
                    :compute-cluster compute-cluster
                    :reject-after-match-attempt true
-                   :offer-match-timer (timers/start (ccmetrics/timer "offer-match-timer" compute-cluster-name))}))))))
+                   ; TODO: add a timer here when we add it to mesos as well
+                   :offer-match-timer (timers/start (ccmetrics/timer "offer-match-timer" compute-cluster-name))
+                   :offer-match-timer-prom-stop-fn (prom/start-timer prom/offer-match-timer {:compute-cluster compute-cluster-name})}))))))
 
 (defn taskids-to-scan
   "Determine all task ids to scan by union-ing task id's from cook expected state and existing task id maps. "
@@ -302,6 +304,7 @@
   launches the task by pumping it into the k8s state machine"
   [{:keys [name namespace-config] :as compute-cluster} task-metadata]
   (let [timer-context (timers/start (metrics/timer "cc-launch-tasks" name))
+        prom-stop-fn (prom/start-timer prom/launch-task-duration {:compute-cluster name})
         pod-namespace (get-namespace-from-task-metadata namespace-config task-metadata)
         pod-name (:task-id task-metadata)
         ^V1Pod pod (api/task-metadata->pod pod-namespace compute-cluster task-metadata)
@@ -317,6 +320,7 @@
     (try
       (controller/update-cook-expected-state compute-cluster pod-name new-cook-expected-state-dict)
       (.stop timer-context)
+      (prom-stop-fn)
       (catch Exception e
         (log-structured/error "Encountered exception launching task"
                               {:pod-name pod-name
@@ -385,9 +389,11 @@
                               {:compute-cluster name :task-id task-id})
         ; Note we can't use timer/time! because it wraps the body in a Callable, which rebinds 'this' to another 'this'
         ; causing breakage.
-        (let [timer-context (timers/start (metrics/timer "cc-kill-tasks" name))]
+        (let [timer-context (timers/start (metrics/timer "cc-kill-tasks" name))
+              prom-stop-fn (prom/start-timer prom/kill-task-duration {:compute-cluster name})]
           (controller/update-cook-expected-state this task-id {:cook-expected-state :cook-expected-state/killed})
-          (.stop timer-context)))))
+          (.stop timer-context)
+          (prom-stop-fn)))))
 
   (decline-offers [this offer-ids]
     (log/debug "Rejecting offer ids" offer-ids))
@@ -447,6 +453,7 @@
               (do
                 (log-structured/info "Looking for offers for pool" {:compute-cluster name :pool pool-name})
                 (let [timer (timers/start (metrics/timer "cc-pending-offers-compute" name))
+                      prom-stop-fn (prom/start-timer prom/compute-pending-offers-duration {:compute-cluster name})
                       pods (add-starting-pods this @all-pods-atom)
                       nodes @current-nodes-atom
                       offers-this-pool (generate-offers this (or node-name->node {})
@@ -467,6 +474,7 @@
                                         :number-total-pods-in-compute-cluster (count pods)
                                         :first-ten-offers-this-pool (print-str offers-this-pool-for-logging)})
                   (timers/stop timer)
+                  (prom-stop-fn)
                   offers-this-pool))))))))
 
   (restore-offers [this pool-name offers])
@@ -485,6 +493,7 @@
           (assert (cc/autoscaling? this pool-name)
                   (str "In " name " compute cluster, request to autoscale despite invalid / missing config"))
           (let [timer-context-autoscale (timers/start (metrics/timer "cc-synthetic-pod-autoscale" name))
+                prom-stop-fn (prom/start-timer prom/autoscale-duration {:compute-cluster name})
                 outstanding-synthetic-pods (->> (get-pods-in-pool this pool-name)
                                                 (add-starting-pods this)
                                                 (filter synthetic-pod->job-uuid))
@@ -591,18 +600,22 @@
                                                     ; Need to pass in resources to task-metadata->pod for gpu count
                                                     :resources pool-specific-resources}}))))
                       num-synthetic-pods-to-launch (count task-metadata-seq)]
+                  (prom/set prom/synthetic-pods-submitted {:compute-cluster name} num-synthetic-pods-to-launch)
                   (meters/mark! (metrics/meter "cc-synthetic-pod-submit-rate" name) num-synthetic-pods-to-launch)
                   (log-structured/info "Launching synthetic pod(s) in pool"
                                        {:compute-cluster name
                                         :pool synthetic-task-pool-name
                                         :number-synthetic-pods-to-launch num-synthetic-pods-to-launch})
-                  (let [timer-context-launch-tasks (timers/start (metrics/timer "cc-synthetic-pod-launch-tasks" name))]
+                  (let [timer-context-launch-tasks (timers/start (metrics/timer "cc-synthetic-pod-launch-tasks" name))
+                        prom-stop-fn (prom/start-timer prom/launch-synthetic-tasks-duration {:compute-cluster name})]
                     (cc/launch-tasks this
                                      synthetic-task-pool-name
                                      [{:task-metadata-seq task-metadata-seq}]
                                      (fn [_]))
-                    (.stop timer-context-launch-tasks)))))
-            (.stop timer-context-autoscale))
+                    (.stop timer-context-launch-tasks)
+                    (prom-stop-fn)))))
+            (.stop timer-context-autoscale)
+            (prom-stop-fn))
           (catch Throwable e
             (log-structured/error "Encountered error launching synthetic pod(s)" {:compute-cluster name :pool pool-name} e))))))
 

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -170,16 +170,13 @@
    rebalancer-config             -- map, config for rebalancer. See scheduler/docs/rebalancer-config.adoc for details
    progress-config               -- map, config for progress publishing. See scheduler/docs/configuration.adoc
    framework-id                  -- str, the Mesos framework id from the cook settings
-   fenzo-config                  -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details
    sandbox-syncer-state          -- map, representing the sandbox syncer object
    api-only?                     -- bool, true if this instance should not actually join the leader selection"
-  [{:keys [curator-framework fenzo-config mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult
+  [{:keys [curator-framework mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult
            mesos-heartbeat-chan leadership-atom pool-name->pending-jobs-atom mesos-run-as-user
            offer-incubate-time-ms optimizer-config rebalancer-config server-config task-constraints trigger-chans
            zk-prefix api-only?]}]
-  (let [{:keys [fenzo-fitness-calculator fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-warn
-                fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness]} fenzo-config
-        {:keys [cancelled-task-trigger-chan lingering-task-trigger-chan optimizer-trigger-chan
+  (let [{:keys [cancelled-task-trigger-chan lingering-task-trigger-chan optimizer-trigger-chan
                 rebalancer-trigger-chan straggler-trigger-chan]} trigger-chans
         {:keys [hostname server-port server-https-port]} server-config
         datomic-report-chan (async/chan (async/sliding-buffer 4096))
@@ -210,12 +207,6 @@
                                     (sched/create-datomic-scheduler
                                       {:conn mesos-datomic-conn
                                        :cluster-name->compute-cluster-atom cook.compute-cluster/cluster-name->compute-cluster-atom
-                                       :fenzo-fitness-calculator fenzo-fitness-calculator
-                                       :fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-reset
-                                       :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn
-                                       :fenzo-max-jobs-considered fenzo-max-jobs-considered
-                                       :fenzo-scaleback fenzo-scaleback
-                                       :good-enough-fitness good-enough-fitness
                                        :mea-culpa-failure-limit mea-culpa-failure-limit
                                        :mesos-run-as-user mesos-run-as-user
                                        :agent-attributes-cache agent-attributes-cache

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -310,6 +310,10 @@
     (async/go
       (async/>! (pool->offers-chan pool-name) offers)))
 
+  (get-outstanding-synthetic-pods [_ _] nil)
+
+  (set-synthetic-pods-counters [_ _ _])
+
   (autoscaling? [_ _] false)
 
   (autoscale! [_ _ _ _])

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -28,6 +28,7 @@
             [cook.plugins.pool :as pool-plugin]
             [cook.pool :as pool]
             [cook.progress :as progress]
+            [cook.prometheus-metrics :as prom]
             [cook.scheduler.scheduler :as sched]
             [cook.tools :as tools]
             [datomic.api :as d]
@@ -164,7 +165,8 @@
         [this driver raw-offers]
         (log/debug "Got offers:" raw-offers)
         (let [offers (map #(assoc % :compute-cluster compute-cluster
-                                    :offer-match-timer (timers/start (ccmetrics/timer "offer-match-timer" (cc/compute-cluster-name compute-cluster))))
+                                    :offer-match-timer (timers/start (ccmetrics/timer "offer-match-timer" (cc/compute-cluster-name compute-cluster)))
+                                    :offer-match-timer-prom-stop-fn (prom/start-timer prom/offer-match-timer {:compute-cluster compute-cluster}))
                           raw-offers)
               pool->offers (group-by (fn [o] (plugins/select-pool pool-plugin/plugin o)) offers)
               using-pools? (config/default-pool)]

--- a/scheduler/src/cook/mesos/mesos_mock.clj
+++ b/scheduler/src/cook/mesos/mesos_mock.clj
@@ -437,7 +437,8 @@
                                         (when (seq new-offers)
                                           (->>
                                             (.resourceOffers scheduler driver (mapv (partial mesos-type/->pb :Offer) new-offers))
-                                            (map #(assoc % :offer-match-timer (timers/start (timers/timer "mock-mesos"))))))
+                                            (map #(assoc % :offer-match-timer (timers/start (timers/timer "mock-mesos"))
+                                                           :offer-match-timer-prom-stop-fn (fn [] (constantly nil))))))
                                         (tools/close-when-ch! v)
                                         state')
                    complete-trigger-chan (let [state' (complete-tasks! (assoc state :now (t/now)) scheduler driver)]

--- a/scheduler/src/cook/plugins/definitions.clj
+++ b/scheduler/src/cook/plugins/definitions.clj
@@ -61,4 +61,11 @@
 (defprotocol JobRouter
   (choose-pool-for-job [this job]
     ; Note that job may have a nil pool. But Cook will route based on the default pool
-    "Given a job submission, returns the initial pool selection for the job"))
+    "Given a job submission, returns the initial pool selection for the job.
+    JobRouter is expected to be called from within JobSubmissionModifier."))
+
+(defprotocol JobSubmissionModifier
+  (modify-job [this job pool-name]
+    "Given a job submission and pool-name, returns a modified job definition with pool selection for downstream use.
+     JobSubmissionModifier may raise an exception if it cannot return a valid job definition.
+     An exception will cause the job submission to fail with the error message being included in the response."))

--- a/scheduler/src/cook/plugins/job_submission_modifier.clj
+++ b/scheduler/src/cook/plugins/job_submission_modifier.clj
@@ -1,0 +1,57 @@
+;;
+;; Copyright (c) Two Sigma Open Source, LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;  http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+(ns cook.plugins.job-submission-modifier
+  (:require [clojure.tools.logging :as log]
+            [cook.config :as config]
+            [cook.plugins.definitions :refer [choose-pool-for-job modify-job JobRouter JobSubmissionModifier]]
+            [cook.plugins.util]
+            [mount.core :as mount]))
+
+(defn pool-name->effective-pool-name
+  "Given a pool name and job from a submission returns the effective pool name"
+  [pool-name-from-submission job]
+  (if-let [job-router (config/job-routing-pool-name? pool-name-from-submission)]
+    (choose-pool-for-job job-router job)
+    (or pool-name-from-submission (config/default-pool))))
+
+(defrecord IdentityJobSubmissionModifier []
+  JobSubmissionModifier
+  ; The IdentityJobSubmissionModifier doesn't make any changes to what users submit except
+  ; to add the calculated pool
+  (modify-job [this job pool-name]
+    (let [effective-pool-name (pool-name->effective-pool-name pool-name job)]
+      (assoc job :pool effective-pool-name))))
+
+(defn create-plugin-object
+  "Returns the configured JobSubmissionModifier, or a IdentityJobSubmissionModifier if none is defined."
+  [config]
+  (let [factory-fn (get-in config [:settings :plugins :job-submission-modifier :factory-fn])]
+    (if factory-fn
+      (do
+        (log/info "Creating job submission modifier plugin with" factory-fn)
+        (if-let [resolved-fn (cook.plugins.util/resolve-symbol (symbol factory-fn))]
+          (resolved-fn config)
+          (throw (ex-info (str "Unable to resolve factory fn " factory-fn) {}))))
+      (IdentityJobSubmissionModifier.))))
+
+(mount/defstate plugin
+                :start (create-plugin-object config/config))
+
+(defn apply-job-submission-modifier-plugins
+  "Modify a user-submitted job before passing it further down the submission pipeline."
+  [raw-job pool-name]
+  (modify-job plugin raw-job pool-name))

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -60,6 +60,8 @@
    :gpus :cook/scheduler-users-gpu-count
    :launch-rate-saved :cook/scheduler-users-launch-rate-saved
    :launch-rate-per-minute :cook/scheduler-users-launch-rate-per-minute})
+(def total-synthetic-pods :cook/scheduler-kubernetes-synthetic-pods-count)
+(def max-synthetic-pods :cook/scheduler-kubernethes-max-synthetic-pods)
 
 
 (defn create-registry
@@ -177,7 +179,16 @@
       ;; Metrics for user resource allocation counts
       (prometheus/gauge user-state-count
                         {:description "Current user count by state"
-                         :labels [:pool :state]}))))
+                         :labels [:pool :state]})
+      ;; Resource usage stats -----------------------------------------------------------------------------------
+
+      ;; Other metrics -------------------------------------------------------------------------------------------
+      (prometheus/gauge total-synthetic-pods
+                        {:description "Total current number of synthetic pods per pool and compute cluster"
+                         :labels [:pool :compute-cluster]})
+      (prometheus/gauge max-synthetic-pods
+                        {:description "Max number of synthetic pods per pool and compute cluster"
+                         :labels [:pool :compute-cluster]}))))
 
 ;; A global registry for all metrics reported by Cook.
 ;; All metrics must be registered before they can be recorded.

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1423,128 +1423,94 @@
 (meters/defmeter [cook-mesos scheduler fenzo-abandon-and-reset-meter])
 (counters/defcounter [cook-mesos scheduler offer-chan-depth])
 
-(defn make-offer-handler
-  "Make the core scheduling loop for a pool"
-  [conn fenzo-state pool-name->pending-jobs-atom agent-attributes-cache max-considerable scaleback
-   floor-iterations-before-warn floor-iterations-before-reset trigger-chan rebalancer-reservation-atom
-   mesos-run-as-user pool-name cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn]
-  (let [fenzo (:fenzo fenzo-state)
-        resources-atom (atom (view-incubating-offers fenzo))]
-    (reset! fenzo-num-considerable-atom max-considerable)
-    (tools/chime-at-ch
-      trigger-chan
-      (fn match-jobs-event []
-        (log-structured/info "Starting offer matching" {:pool pool-name})
-        (prom/with-duration
-          prom/scheduler-match-cycle-duration {:pool pool-name}
-          (timers/time!
-            (timers/timer (metric-title "match-jobs-event" pool-name))
-            (tracing/with-span
-              [s {:name "scheduler.offer-handler.match-jobs" :tags {:pool pool-name :component tracing-component-tag}}]
-              (let [num-considerable @fenzo-num-considerable-atom
-                    next-considerable
-                    (try
-                      (let [
-                            ;; There are implications to generating the user->usage here:
-                            ;;  1. Currently cook has two oddities in state changes.
-                            ;;  We plan to correct both of these but are important for the time being.
-                            ;;    a. Cook doesn't mark as a job as running when it schedules a job.
-                            ;;       While this is technically correct, it confuses some process.
-                            ;;       For example, it will mean that the user->usage generated here
-                            ;;       may not include jobs that have been scheduled but haven't started.
-                            ;;       Since we do the filter for quota first, this is ok because those jobs
-                            ;;       show up in the queue. However, it is important to know about
-                            ;;    b. Cook doesn't update the job state when cook hears from mesos about the
-                            ;;       state of an instance. Cook waits until it hears from datomic about the
-                            ;;       instance state change to change the state of the job. This means that it
-                            ;;       is possible to have large delays between when an instance changes status
-                            ;;       and the job reflects that change
-                            ;;  2. Once the above two items are addressed, user->usage should always correctly
-                            ;;     reflect *Cook*'s understanding of the state of the world at this point.
-                            ;;     When this happens, users should never exceed their quota
-                            user->usage-future (future (tracing/with-span [s1 {:from s :finish? false}] ; NOTE: finish? is set to false to prevent early finishing of the span
-                                                                          (generate-user-usage-map (d/db conn) pool-name)))
-                            ;; Try to clear the channel
-                            ;; Merge the pending offers from all compute clusters.
-                            compute-clusters (vals @cook.compute-cluster/cluster-name->compute-cluster-atom)
-                            offers (tracing/with-span
-                                     [s {:name "scheduler.offer-handler.generate-offers" :tags {:pool pool-name :component tracing-component-tag}}]
-                                     (apply concat (map (fn [compute-cluster]
-                                                          (try
-                                                            (cc/pending-offers compute-cluster pool-name)
-                                                            (catch Throwable t
-                                                              (log-structured/error "Error getting pending offers"
-                                                                                    {:pool pool-name
-                                                                                     :compute-cluster (cc/compute-cluster-name compute-cluster)}
-                                                                                    t)
-                                                              (list))))
-                                                        compute-clusters)))
-                            _ (tracing/with-span
-                                [s {:name "scheduler.offer-handler.cache-offers-for-rebalancer" :tags {:pool pool-name :component tracing-component-tag}}]
-                                (doseq [offer offers
-                                        :let [slave-id (-> offer :slave-id :value)]]
-                                  ; Cache offers for rebalancer so it can use job constraints when doing preemption decisions.
-                                  ; Computing get-offer-attr-map is pretty expensive because it includes calculating
-                                  ; currently running pods, so we have to union the set of pods k8s says are there and
-                                  ; the set of pods we're trying to put on the node. Even though it's not used by
-                                  ; rebalancer (and not needed). So it's OK if it's stale, so we do not need to refresh
-                                  ; and only store if it is a new node.
-                                  (when-not (ccache/get-if-present agent-attributes-cache identity slave-id)
-                                    (ccache/put-cache! agent-attributes-cache identity slave-id (offer/get-offer-attr-map offer)))))
-                            using-pools? (not (nil? (config/default-pool)))
-                            user->quota (quota/create-user->quota-fn (d/db conn) (if using-pools? pool-name nil))
-                            user->usage (tracing/with-span [s {:name "scheduler.offer-handler.resolve-user-to-usage-future"
-                                                               :tags {:pool pool-name :component tracing-component-tag}}]
-                                                           @user->usage-future)
-                            matched-head? (handle-resource-offers! conn fenzo-state pool-name->pending-jobs-atom
-                                                                   mesos-run-as-user user->usage user->quota
-                                                                   num-considerable offers
-                                                                   rebalancer-reservation-atom pool-name compute-clusters
-                                                                   job->acceptable-compute-clusters-fn)]
-                        (when (seq offers)
-                          (reset! resources-atom (view-incubating-offers fenzo)))
-                        ;; This check ensures that, although we value Fenzo's optimizations,
-                        ;; we also value Cook's sensibility of fairness when deciding which jobs
-                        ;; to schedule.  If Fenzo produces a set of matches that doesn't include
-                        ;; Cook's highest-priority job, on the next cycle, we give Fenzo it less
-                        ;; freedom in the form of fewer jobs to consider.
-                        (if matched-head?
-                          max-considerable
-                          (let [new-considerable (max 1 (long (* scaleback num-considerable)))] ;; With max=1000 and 1 iter/sec, this will take 88 seconds to reach 1
-                            (log-structured/info "Failed to match head, reducing number of considerable jobs"
-                                                 {:prev-considerable num-considerable
-                                                  :new-considerable new-considerable
-                                                  :pool pool-name})
-                            new-considerable)))
-                      (catch Exception e
-                        (log-structured/error "Offer handler encountered exception; continuing" {:pool pool-name} e)
-                        max-considerable))]
+(defn handle-fenzo-pool
+  "Handle scheduling pending jobs using the Fenzo Scheduler."
+  [conn fenzo fenzo-state resources-atom pool-name->pending-jobs-atom agent-attributes-cache max-considerable
+   scaleback floor-iterations-before-warn floor-iterations-before-reset rebalancer-reservation-atom
+   mesos-run-as-user pool-name compute-clusters job->acceptable-compute-clusters-fn
+   user->quota user->usage-future]
+  (log-structured/info "Creating handler for Fenzo pool" {:pool pool-name})
+  (timers/time!
+   (timers/timer (metric-title "match-jobs-event" pool-name))
+   (tracing/with-span [s {:name "scheduler.offer-handler.match-jobs" :tags {:pool pool-name :component tracing-component-tag}}]
+     (let [num-considerable @fenzo-num-considerable-atom
+           next-considerable
+           (try
+             (let [;; Try to clear the channel
+                   ;; Merge the pending offers from all compute clusters.
+                   offers (tracing/with-span [s {:name "scheduler.offer-handler.generate-offers"
+                                                 :tags {:pool pool-name :component tracing-component-tag}}]
+                            (apply concat (map (fn [compute-cluster]
+                                                 (try
+                                                   (cc/pending-offers compute-cluster pool-name)
+                                                   (catch Throwable t
+                                                     (log-structured/error "Error getting pending offers"
+                                                                           {:pool pool-name
+                                                                            :compute-cluster (cc/compute-cluster-name compute-cluster)}
+                                                                           t)
+                                                     (list))))
+                                               compute-clusters)))
+                   _ (tracing/with-span [s {:name "scheduler.offer-handler.cache-offers-for-rebalancer"
+                                            :tags {:pool pool-name :component tracing-component-tag}}]
+                       (doseq [offer offers
+                               :let [slave-id (-> offer :slave-id :value)]]
+                      ; Cache offers for rebalancer so it can use job constraints when doing preemption decisions.
+                      ; Computing get-offer-attr-map is pretty expensive because it includes calculating
+                      ; currently running pods, so we have to union the set of pods k8s says are there and
+                      ; the set of pods we're trying to put on the node. Even though it's not used by
+                      ; rebalancer (and not needed). So it's OK if it's stale, so we do not need to refresh
+                      ; and only store if it is a new node.
+                         (when-not (ccache/get-if-present agent-attributes-cache identity slave-id)
+                           (ccache/put-cache! agent-attributes-cache identity slave-id (offer/get-offer-attr-map offer)))))
+                   user->usage (tracing/with-span [s {:name "scheduler.offer-handler.resolve-user-to-usage-future"
+                                                      :tags {:pool pool-name :component tracing-component-tag}}]
+                                 @user->usage-future)
+                   matched-head? (handle-resource-offers! conn fenzo-state pool-name->pending-jobs-atom
+                                                          mesos-run-as-user user->usage user->quota
+                                                          num-considerable offers
+                                                          rebalancer-reservation-atom pool-name compute-clusters
+                                                          job->acceptable-compute-clusters-fn)]
+               (when (seq offers)
+                 (reset! resources-atom (view-incubating-offers fenzo)))
+            ;; This check ensures that, although we value Fenzo's optimizations,
+            ;; we also value Cook's sensibility of fairness when deciding which jobs
+            ;; to schedule.  If Fenzo produces a set of matches that doesn't include
+            ;; Cook's highest-priority job, on the next cycle, we give Fenzo it less
+            ;; freedom in the form of fewer jobs to consider.
+               (if matched-head?
+                 max-considerable
+                 (let [new-considerable (max 1 (long (* scaleback num-considerable)))] ;; With max=1000 and 1 iter/sec, this will take 88 seconds to reach 1
+                   (log-structured/info "Failed to match head, reducing number of considerable jobs"
+                                        {:prev-considerable num-considerable
+                                         :new-considerable new-considerable
+                                         :pool pool-name})
+                   new-considerable)))
+             (catch Exception e
+               (log-structured/error "Offer handler encountered exception; continuing" {:pool pool-name} e)
+               max-considerable))]
 
-                (if (= next-considerable 1)
-                  (counters/inc! iterations-at-fenzo-floor)
-                  (counters/clear! iterations-at-fenzo-floor))
+       (if (= next-considerable 1)
+         (counters/inc! iterations-at-fenzo-floor)
+         (counters/clear! iterations-at-fenzo-floor))
 
-                (if (>= (counters/value iterations-at-fenzo-floor) floor-iterations-before-warn)
-                  (log-structured/warn (print-str "Offer handler has been showing Fenzo only 1 job for" (counters/value iterations-at-fenzo-floor) "iterations")
-                                       {:pool pool-name
-                                        :iterations-count (counters/value iterations-at-fenzo-floor)}))
+       (if (>= (counters/value iterations-at-fenzo-floor) floor-iterations-before-warn)
+         (log-structured/warn (print-str "Offer handler has been showing Fenzo only 1 job for" (counters/value iterations-at-fenzo-floor) "iterations")
+                              {:pool pool-name
+                               :iterations-count (counters/value iterations-at-fenzo-floor)}))
 
-                (reset! fenzo-num-considerable-atom
-                        (if (>= (counters/value iterations-at-fenzo-floor) floor-iterations-before-reset)
-                          (do
-                            (log-structured/error (print-str "FENZO CANNOT MATCH THE MOST IMPORTANT JOB."
-                                                             "Fenzo has seen only 1 job for" (counters/value iterations-at-fenzo-floor)
-                                                             "iterations, and still hasn't matched it.  Cook is now giving up and will "
-                                                             "now give Fenzo" max-considerable "jobs to look at.")
-                                                  {:pool pool-name
-                                                   :iterations-count (counters/value iterations-at-fenzo-floor)
-                                                   :number-max-considerable max-considerable})
-                            (meters/mark! fenzo-abandon-and-reset-meter)
-                            max-considerable)
-                          next-considerable))))))
-        (log-structured/info "Done with offer matching" {:pool pool-name}))
-      {:error-handler (fn [ex] (log-structured/error "Error occurred in match" {:pool pool-name} ex))})
-    resources-atom))
+       (reset! fenzo-num-considerable-atom
+               (if (>= (counters/value iterations-at-fenzo-floor) floor-iterations-before-reset)
+                 (do
+                   (log-structured/error (print-str "FENZO CANNOT MATCH THE MOST IMPORTANT JOB."
+                                                    "Fenzo has seen only 1 job for" (counters/value iterations-at-fenzo-floor)
+                                                    "iterations, and still hasn't matched it.  Cook is now giving up and will "
+                                                    "now give Fenzo" max-considerable "jobs to look at.")
+                                         {:pool pool-name
+                                          :iterations-count (counters/value iterations-at-fenzo-floor)
+                                          :number-max-considerable max-considerable})
+                   (meters/mark! fenzo-abandon-and-reset-meter)
+                   max-considerable)
+                 next-considerable))))))
 
 (defn reconcile-jobs
   "Ensure all jobs saw their final state change"
@@ -2133,6 +2099,54 @@
                 "schedule each pool less often than the desired setting of every " target-per-pool-match-interval-millis " ms."))
     (async/pipe (chime-ch (util/time-seq (time/now) (time/millis match-interval-millis))) match-trigger-chan)))
 
+(defn make-pool-handler
+  "Make the configured handler for the pool to do scheduling."
+  [conn fenzo-state pool-name->pending-jobs-atom agent-attributes-cache fenzo-max-jobs-considered scaleback
+   floor-iterations-before-warn floor-iterations-before-reset trigger-chan rebalancer-reservation-atom
+   mesos-run-as-user pool-name cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn]
+  (let [fenzo (:fenzo fenzo-state)
+        resources-atom (atom (view-incubating-offers fenzo))
+        using-pools? (not (nil? (config/default-pool)))]
+    (reset! fenzo-num-considerable-atom fenzo-max-jobs-considered)
+    (tools/chime-at-ch
+     trigger-chan
+     (fn pool-schedule-event []
+       (log-structured/info "Starting pool handler" {:pool pool-name})
+       (prom/with-duration
+         prom/scheduler-match-cycle-duration {:pool pool-name}
+         (tracing/with-span [s {:name "scheduler.pool-handler" :tags {:pool pool-name :component tracing-component-tag}}]
+           (try
+             (let [;; There are implications to generating the user->usage here:
+                   ;;  1. Currently cook has two oddities in state changes.
+                   ;;  We plan to correct both of these but are important for the time being.
+                   ;;    a. Cook doesn't mark as a job as running when it schedules a job.
+                   ;;       While this is technically correct, it confuses some process.
+                   ;;       For example, it will mean that the user->usage generated here
+                   ;;       may not include jobs that have been scheduled but haven't started.
+                   ;;       Since we do the filter for quota first, this is ok because those jobs
+                   ;;       show up in the queue. However, it is important to know about
+                   ;;    b. Cook doesn't update the job state when cook hears from mesos about the
+                   ;;       state of an instance. Cook waits until it hears from datomic about the
+                   ;;       instance state change to change the state of the job. This means that it
+                   ;;       is possible to have large delays between when an instance changes status
+                   ;;       and the job reflects that change
+                   ;;  2. Once the above two items are addressed, user->usage should always correctly
+                   ;;     reflect *Cook*'s understanding of the state of the world at this point.
+                   ;;     When this happens, users should never exceed their quota
+                   user->usage-future (future (tracing/with-span [s1 {:from s :finish? false}] ; NOTE: finish? is set to false to prevent early finishing of the span 
+                                                (generate-user-usage-map (d/db conn) pool-name)))
+                   compute-clusters (vals @cook.compute-cluster/cluster-name->compute-cluster-atom)
+                   user->quota (quota/create-user->quota-fn (d/db conn) (if using-pools? pool-name nil))]
+               (handle-fenzo-pool conn fenzo fenzo-state resources-atom pool-name->pending-jobs-atom agent-attributes-cache fenzo-max-jobs-considered
+                                  scaleback floor-iterations-before-warn floor-iterations-before-reset
+                                  rebalancer-reservation-atom mesos-run-as-user pool-name compute-clusters
+                                  job->acceptable-compute-clusters-fn user->quota user->usage-future))
+             (catch Exception e
+               (log-structured/error "Pool handler encountered exception; continuing" {:pool pool-name} e)))))
+       (log-structured/info "Done with pool handler" {:pool pool-name}))
+     {:error-handler (fn [ex] (log-structured/error "Error occurred in pool handler" {:pool pool-name} ex))})
+    resources-atom))
+
 (defn create-datomic-scheduler
   [{:keys [conn cluster-name->compute-cluster-atom fenzo-fitness-calculator fenzo-floor-iterations-before-reset
            fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness
@@ -2157,15 +2171,15 @@
           (util/lazy-load-var fn-name-from-config)
           job->acceptable-compute-clusters)
         pool->resources-atom (pool-map
-                               pools'
-                               (fn [{:keys [pool/name]}]
-                                 (make-offer-handler
-                                   conn (get pool-name->fenzo-state name)
-                                   pool-name->pending-jobs-atom agent-attributes-cache
-                                   fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn
-                                   fenzo-floor-iterations-before-reset (get pool->match-trigger-chan name)
-                                   rebalancer-reservation-atom mesos-run-as-user name
-                                   cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn)))]
+                              pools'
+                              (fn [{:keys [pool/name]}]
+                                (make-pool-handler
+                                 conn (get pool-name->fenzo-state name)
+                                 pool-name->pending-jobs-atom agent-attributes-cache
+                                 fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn
+                                 fenzo-floor-iterations-before-reset (get pool->match-trigger-chan name)
+                                 rebalancer-reservation-atom mesos-run-as-user name
+                                 cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn)))]
     (prepare-match-trigger-chan match-trigger-chan pools')
     (async/go-loop []
       (when-let [x (async/<! match-trigger-chan)]

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -983,7 +983,8 @@
                 (let [_ (log-structured/info "Launching matched tasks for compute cluster"
                                              {:pool pool-name :compute-cluster compute-cluster-name})]
                   (doseq [match matches]
-                    (timers/stop (-> match :leases first :offer :offer-match-timer)))
+                    (timers/stop (-> match :leases first :offer :offer-match-timer))
+                    (-> match :leases first :offer :offer-match-timer-prom-stop-fn))
                   (#(launch-matches! compute-cluster pool-name matches fenzo)))))
             (finally
               (.. kill-lock-object readLock unlock))))))))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -42,6 +42,7 @@
             [cook.queries :as queries]
             [cook.quota :as quota]
             [cook.rate-limit :as ratelimit]
+            [cook.regexp-tools :as regexp-tools]
             [cook.scheduler.constraints :as constraints]
             [cook.scheduler.dru :as dru]
             [cook.scheduler.fenzo-utils :as fenzo]
@@ -1426,15 +1427,17 @@
 
 (defn handle-fenzo-pool
   "Handle scheduling pending jobs using the Fenzo Scheduler."
-  [conn fenzo fenzo-state resources-atom pool-name->pending-jobs-atom agent-attributes-cache max-considerable
-   scaleback floor-iterations-before-warn floor-iterations-before-reset rebalancer-reservation-atom
-   mesos-run-as-user pool-name compute-clusters job->acceptable-compute-clusters-fn
-   user->quota user->usage-future]
+  [conn fenzo fenzo-state resources-atom pool-name->pending-jobs-atom agent-attributes-cache 
+   scheduler-config rebalancer-reservation-atom mesos-run-as-user pool-name compute-clusters 
+   job->acceptable-compute-clusters-fn user->quota user->usage-future]
   (log-structured/info "Creating handler for Fenzo pool" {:pool pool-name})
   (timers/time!
    (timers/timer (metric-title "match-jobs-event" pool-name))
    (tracing/with-span [s {:name "scheduler.offer-handler.match-jobs" :tags {:pool pool-name :component tracing-component-tag}}]
-     (let [num-considerable @fenzo-num-considerable-atom
+     (let [{max-considerable :fenzo-max-jobs-considered scaleback :fenzo-scaleback
+            floor-iterations-before-warn :fenzo-floor-iterations-before-warn 
+            floor-iterations-before-reset :fenzo-floor-iterations-before-reset} scheduler-config
+           num-considerable @fenzo-num-considerable-atom
            next-considerable
            (try
              (let [;; Try to clear the channel
@@ -1473,11 +1476,11 @@
                                                           job->acceptable-compute-clusters-fn)]
                (when (seq offers)
                  (reset! resources-atom (view-incubating-offers fenzo)))
-            ;; This check ensures that, although we value Fenzo's optimizations,
-            ;; we also value Cook's sensibility of fairness when deciding which jobs
-            ;; to schedule.  If Fenzo produces a set of matches that doesn't include
-            ;; Cook's highest-priority job, on the next cycle, we give Fenzo it less
-            ;; freedom in the form of fewer jobs to consider.
+               ;; This check ensures that, although we value Fenzo's optimizations,
+               ;; we also value Cook's sensibility of fairness when deciding which jobs
+               ;; to schedule.  If Fenzo produces a set of matches that doesn't include
+               ;; Cook's highest-priority job, on the next cycle, we give Fenzo it less
+               ;; freedom in the form of fewer jobs to consider.
                (if matched-head?
                  max-considerable
                  (let [new-considerable (max 1 (long (* scaleback num-considerable)))] ;; With max=1000 and 1 iter/sec, this will take 88 seconds to reach 1
@@ -1494,7 +1497,7 @@
          (counters/inc! iterations-at-fenzo-floor)
          (counters/clear! iterations-at-fenzo-floor))
 
-       (if (>= (counters/value iterations-at-fenzo-floor) floor-iterations-before-warn)
+       (when (>= (counters/value iterations-at-fenzo-floor) floor-iterations-before-warn)
          (log-structured/warn (print-str "Offer handler has been showing Fenzo only 1 job for" (counters/value iterations-at-fenzo-floor) "iterations")
                               {:pool pool-name
                                :iterations-count (counters/value iterations-at-fenzo-floor)}))
@@ -2100,19 +2103,35 @@
                 "schedule each pool less often than the desired setting of every " target-per-pool-match-interval-millis " ms."))
     (async/pipe (chime-ch (util/time-seq (time/now) (time/millis match-interval-millis))) match-trigger-chan)))
 
+(defn kubernetes-scheduler?
+  "Return true if the scheduler is Kubernetes Scheduler."
+  [scheduler-name]
+  (= "kubernetes" scheduler-name))
+
+(defn pool-scheduler-config
+  "Get the scheduler config for a pool."
+  [schedulers pool-name]
+  (regexp-tools/match-based-on-pool-name
+   schedulers
+   pool-name
+   :scheduler-config))
+
 (defn make-pool-handler
   "Make the configured handler for the pool to do scheduling."
-  [conn fenzo-state pool-name->pending-jobs-atom agent-attributes-cache fenzo-max-jobs-considered scaleback
-   floor-iterations-before-warn floor-iterations-before-reset trigger-chan rebalancer-reservation-atom
-   mesos-run-as-user pool-name cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn]
+  [conn fenzo-state pool-name->pending-jobs-atom agent-attributes-cache scheduler-config trigger-chan
+   rebalancer-reservation-atom mesos-run-as-user pool-name cluster-name->compute-cluster-atom
+   job->acceptable-compute-clusters-fn]
   (let [fenzo (:fenzo fenzo-state)
         resources-atom (atom (view-incubating-offers fenzo))
-        using-pools? (not (nil? (config/default-pool)))]
-    (reset! fenzo-num-considerable-atom fenzo-max-jobs-considered)
+        using-pools? (not (nil? (config/default-pool)))
+        scheduler-name (:scheduler scheduler-config)
+        using-kubernetes-scheduler? (kubernetes-scheduler? scheduler-name)]
+    (when-not using-kubernetes-scheduler?
+      (reset! fenzo-num-considerable-atom (:fenzo-max-jobs-considered scheduler-config)))
     (tools/chime-at-ch
      trigger-chan
      (fn pool-schedule-event []
-       (log-structured/info "Starting pool handler" {:pool pool-name})
+       (log-structured/info "Starting pool handler" {:pool pool-name :scheduler-name scheduler-name})
        (prom/with-duration
          prom/scheduler-match-cycle-duration {:pool pool-name}
          (tracing/with-span [s {:name "scheduler.pool-handler" :tags {:pool pool-name :component tracing-component-tag}}]
@@ -2138,9 +2157,8 @@
                                                 (generate-user-usage-map (d/db conn) pool-name)))
                    compute-clusters (vals @cook.compute-cluster/cluster-name->compute-cluster-atom)
                    user->quota (quota/create-user->quota-fn (d/db conn) (if using-pools? pool-name nil))]
-               (handle-fenzo-pool conn fenzo fenzo-state resources-atom pool-name->pending-jobs-atom agent-attributes-cache fenzo-max-jobs-considered
-                                  scaleback floor-iterations-before-warn floor-iterations-before-reset
-                                  rebalancer-reservation-atom mesos-run-as-user pool-name compute-clusters
+               (handle-fenzo-pool conn fenzo fenzo-state resources-atom pool-name->pending-jobs-atom agent-attributes-cache 
+                                  scheduler-config rebalancer-reservation-atom mesos-run-as-user pool-name compute-clusters
                                   job->acceptable-compute-clusters-fn user->quota user->usage-future))
              (catch Exception e
                (log-structured/error "Pool handler encountered exception; continuing" {:pool pool-name} e)))))
@@ -2149,11 +2167,10 @@
     resources-atom))
 
 (defn create-datomic-scheduler
-  [{:keys [conn cluster-name->compute-cluster-atom fenzo-fitness-calculator fenzo-floor-iterations-before-reset
-           fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback good-enough-fitness
-           mea-culpa-failure-limit mesos-run-as-user agent-attributes-cache offer-incubate-time-ms
-           pool-name->pending-jobs-atom rebalancer-reservation-atom task-constraints
-           trigger-chans]}]
+  [{:keys [conn cluster-name->compute-cluster-atom mea-culpa-failure-limit 
+           mesos-run-as-user agent-attributes-cache offer-incubate-time-ms
+           pool-name->pending-jobs-atom rebalancer-reservation-atom 
+           task-constraints trigger-chans]}]
 
   (persist-mea-culpa-failure-limit! conn mea-culpa-failure-limit)
 
@@ -2162,8 +2179,11 @@
         pools' (if (-> pools count pos?)
                  pools
                  [{:pool/name "no-pool"}])
-        pool-name->fenzo-state (pool-map pools' (fn [_] (make-fenzo-state offer-incubate-time-ms
-                                                                          fenzo-fitness-calculator good-enough-fitness)))
+        pool->scheduler-config (pool-map pools' (fn [{:keys [pool/name]}]
+                                                 (pool-scheduler-config (config/pool-schedulers) name)))
+        pool-name->fenzo-state (pool-map pools' (fn [{:keys [pool/name]}]
+                                                  (let [{:keys [fenzo-fitness-calculator good-enough-fitness]} (pool->scheduler-config name)]
+                                                    (make-fenzo-state offer-incubate-time-ms fenzo-fitness-calculator good-enough-fitness))))
         pool->match-trigger-chan (pool-map pools' (fn [_] (async/chan (async/sliding-buffer 1))))
         pool-names-linked-list (LinkedList. (map :pool/name pools'))
         job->acceptable-compute-clusters-fn
@@ -2177,8 +2197,7 @@
                                 (make-pool-handler
                                  conn (get pool-name->fenzo-state name)
                                  pool-name->pending-jobs-atom agent-attributes-cache
-                                 fenzo-max-jobs-considered fenzo-scaleback fenzo-floor-iterations-before-warn
-                                 fenzo-floor-iterations-before-reset (get pool->match-trigger-chan name)
+                                 (pool->scheduler-config name) (pool->match-trigger-chan name)
                                  rebalancer-reservation-atom mesos-run-as-user name
                                  cluster-name->compute-cluster-atom job->acceptable-compute-clusters-fn)))]
     (prepare-match-trigger-chan match-trigger-chan pools')

--- a/scheduler/src/cook/test/testutil.clj
+++ b/scheduler/src/cook/test/testutil.clj
@@ -128,6 +128,7 @@
                          #'cook.config/config
                          #'cook.plugins.adjustment/plugin
                          #'cook.plugins.file/plugin
+                         #'cook.plugins.job-submission-modifier/plugin
                          #'cook.plugins.launch/job-launch-cache
                          #'cook.plugins.launch/plugin-object
                          #'cook.plugins.pool/plugin

--- a/scheduler/test/cook/test/mesos/mesos_mock.clj
+++ b/scheduler/test/cook/test/mesos/mesos_mock.clj
@@ -678,7 +678,7 @@
           make-mesos-driver-fn (fn [config scheduler framework-id] ;; _ is framework-id
                                  (mm/mesos-mock hosts offer-trigger-chan scheduler))]
       (with-cook-scheduler
-        mesos-datomic-conn make-mesos-driver-fn {} true
+        mesos-datomic-conn make-mesos-driver-fn {} true []
         (share/set-share! mesos-datomic-conn "default" nil "new cluster settings"
                           :mem mem :cpus cpus :gpus 1.0)
         ;; Note these two vars are lazy, need to realize to put them in db.

--- a/scheduler/test/cook/test/plugins/job_submission_modifier.clj
+++ b/scheduler/test/cook/test/plugins/job_submission_modifier.clj
@@ -1,0 +1,21 @@
+(ns cook.test.plugins.job-submission-modifier
+  (:require [clojure.test :refer :all]
+            [cook.plugins.definitions :as plugins]
+            [cook.plugins.job-submission-modifier :as job-mod]))
+
+(deftest test-identity-add-pool
+  (let [mod-plugin (job-mod/->IdentityJobSubmissionModifier)
+        job {}
+        pool-name "my-pool"]
+    (is (= "my-pool" (get (plugins/modify-job mod-plugin job pool-name) :pool) ))))
+
+(defrecord TestJobModifier []
+  plugins/JobSubmissionModifier
+  (modify-job [this job pool-name]
+    (throw (IllegalArgumentException. "TestJobModifier always throws"))))
+
+(deftest test-raise-exception
+  ; On its own, this test has little value. We are more interested in the overall
+  ; behavior when a real job is submitted and the plugin raises an exception.
+  (let [mod-plugin (TestJobModifier.)]
+    (is (thrown? IllegalArgumentException (plugins/modify-job mod-plugin nil nil)))))

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -1811,7 +1811,9 @@
                            :slave-id {:value (str "slave-" (UUID/randomUUID))}
                            :hostname (str "host-" (UUID/randomUUID))
                            :compute-cluster compute-cluster
-                           :offer-match-timer (timers/start (timers/timer "noop-timer-offer"))})
+                           :offer-match-timer (timers/start (timers/timer "noop-timer-offer"))
+                           ; We just want a no-op function here
+                           :offer-match-timer-prom-stop-fn (fn [] (constantly nil))})
       offers-chan (async/chan (async/buffer 10))
       run-handle-resource-offers! (fn [num-considerable offers pool & {:keys [user-quota user->usage rebalancer-reservation-atom job-name->uuid]
                                                                        :or {rebalancer-reservation-atom (atom {})

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2380,7 +2380,7 @@
                        {:pool/name "old pool"
                         :pool/state :pool.state/inactive}])
                     sched/make-fenzo-state (fn [_ _ _])
-                    sched/make-pool-handler (fn [_ _ _ _ _ _ _ _ trigger-chan _ _ pool-name _ _]
+                    sched/make-pool-handler (fn [_ _ _ _ _ trigger-chan _ _ pool-name _ _]
                                               (tools/chime-at-ch
                                                trigger-chan
                                                (fn []

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2378,12 +2378,12 @@
                        {:pool/name "old pool"
                         :pool/state :pool.state/inactive}])
                     sched/make-fenzo-state (fn [_ _ _])
-                    sched/make-offer-handler (fn [_ _ _ _ _ _ _ _ trigger-chan _ _ pool-name _ _]
-                                               (tools/chime-at-ch
-                                                 trigger-chan
-                                                 (fn []
-                                                   (swap! output-atom conj pool-name)
-                                                   (async/>!! send-next-chime-chan :next))))
+                    sched/make-pool-handler (fn [_ _ _ _ _ _ _ _ trigger-chan _ _ pool-name _ _]
+                                              (tools/chime-at-ch
+                                               trigger-chan
+                                               (fn []
+                                                 (swap! output-atom conj pool-name)
+                                                 (async/>!! send-next-chime-chan :next))))
                     sched/start-jobs-prioritizer! (fn [_ _ _ _])
                     sched/prepare-match-trigger-chan (fn [_ _])]
         (sched/create-datomic-scheduler {:trigger-chans {:match-trigger-chan match-trigger-chan}})
@@ -2509,36 +2509,36 @@
     (is (= [compute-cluster-1
             compute-cluster-3]
            (sched/job->acceptable-compute-clusters
-             {:job/checkpoint true
-              :job/instance instances}
-             [compute-cluster-1
-              compute-cluster-2
-              compute-cluster-3])))
+            {:job/checkpoint true
+             :job/instance instances}
+            [compute-cluster-1
+             compute-cluster-2
+             compute-cluster-3])))
     (is (= [compute-cluster-2]
            (sched/job->acceptable-compute-clusters
-             {:job/checkpoint true
+            {:job/checkpoint true
               :job/instance [instance-first]}
-             [compute-cluster-1
-              compute-cluster-2
-              compute-cluster-3])))
+            [compute-cluster-1
+             compute-cluster-2
+             compute-cluster-3])))
     (is (= [compute-cluster-1
             compute-cluster-2
             compute-cluster-3]
            (sched/job->acceptable-compute-clusters
-             {:job/checkpoint true
-              :job/instance []}
-             [compute-cluster-1
-              compute-cluster-2
-              compute-cluster-3])))
+            {:job/checkpoint true
+             :job/instance []}
+            [compute-cluster-1
+             compute-cluster-2
+             compute-cluster-3])))
     (is (= [compute-cluster-1
             compute-cluster-2
             compute-cluster-3]
            (sched/job->acceptable-compute-clusters
-             {:job/checkpoint false
-              :job/instance instances}
-             [compute-cluster-1
-              compute-cluster-2
-              compute-cluster-3]))))
+            {:job/checkpoint false
+             :job/instance instances}
+            [compute-cluster-1
+             compute-cluster-2
+             compute-cluster-3]))))
 
   (deftest test-distribute-jobs-to-compute-clusters
     (testutil/setup)
@@ -2552,26 +2552,26 @@
             job1 (assoc base-job :job/uuid uuid)]
         (is (= (list [job1])
                (vals (sched/distribute-jobs-to-compute-clusters
-                       [job1]
-                       "test-pool"
-                       [compute-cluster-1
-                        compute-cluster-2
-                        compute-cluster-3]
-                       sched/job->acceptable-compute-clusters)))))
+                      [job1]
+                      "test-pool"
+                      [compute-cluster-1
+                       compute-cluster-2
+                       compute-cluster-3]
+                      sched/job->acceptable-compute-clusters)))))
       (testing "max-jobs-for-autoscaling=0"
         (let [job (assoc base-job :job/uuid (UUID/randomUUID))]
           (is (= {}
                  (sched/distribute-jobs-to-compute-clusters
-                   []
-                   "test-pool"
-                   [compute-cluster-1
-                    compute-cluster-2
-                    compute-cluster-3]
-                   sched/job->acceptable-compute-clusters)))))
+                  []
+                  "test-pool"
+                  [compute-cluster-1
+                   compute-cluster-2
+                   compute-cluster-3]
+                  sched/job->acceptable-compute-clusters)))))
       (let [job (assoc base-job :job/uuid (UUID/randomUUID))]
         (is (= {}
                (sched/distribute-jobs-to-compute-clusters
-                 [(assoc job :job/uuid (UUID/randomUUID))]
-                 "test-pool"
-                 [compute-cluster-2]
+                [(assoc job :job/uuid (UUID/randomUUID))]
+                "test-pool"
+                [compute-cluster-2]
                  sched/job->acceptable-compute-clusters)))))))

--- a/scheduler/test/cook/test/zz_simulator.clj
+++ b/scheduler/test/cook/test/zz_simulator.clj
@@ -17,7 +17,7 @@
             [clojure.tools.logging :as log]
             [clojure.walk :refer [keywordize-keys]]
             [com.rpl.specter :refer [ALL FIRST MAP-KEYS MAP-VALS select transform]]
-            [cook.config :refer [executor-config init-logger]]
+            [cook.config :refer [default-fitness-calculator executor-config init-logger pool-schedulers]]
             [cook.datomic :as datomic]
             [cook.mesos :as c]
             [cook.mesos.mesos-compute-cluster :as mcc]
@@ -79,11 +79,14 @@
                                 :max-preemption 100.0
                                 :pool-regex ".*"})
 
-(def default-fenzo-config {:fenzo-max-jobs-considered 2000
-                           :fenzo-scaleback 0.95
-                           :fenzo-floor-iterations-before-warn 10
-                           :fenzo-floor-iterations-before-reset 1000
-                           :good-enough-fitness 1.0})
+(def default-schedulers-config [{:pool-regex ".*"
+                                 :scheduler-config {:scheduler "fenzo"
+                                                    :good-enough-fitness 1.0
+                                                    :fenzo-fitness-calculator default-fitness-calculator
+                                                    :fenzo-max-jobs-considered 2000
+                                                    :fenzo-scaleback 0.95
+                                                    :fenzo-floor-iterations-before-warn 10
+                                                    :fenzo-floor-iterations-before-reset 1000}}])
 
 (def default-task-constraints {:timeout-hours 1
                                :timeout-interval-minutes 1
@@ -92,7 +95,7 @@
                                :retry-limit 5})
 
 (defmacro with-cook-scheduler
-  [conn make-mesos-driver-fn scheduler-config trigger-matching? & body]
+  [conn make-mesos-driver-fn scheduler-config trigger-matching? schedulers-config & body]
   `(let [conn# ~conn
          [zookeeper-server# curator-framework#] (setup-test-curator-framework)
          mesos-mult# (or (:mesos-datomic-mult ~scheduler-config)
@@ -126,7 +129,6 @@
          sandbox-syncer-state# {:task-id->sandbox-agent (agent {})}
          host-settings# {:server-port 12321 :hostname "localhost"}
          leadership-atom# (atom false)
-         fenzo-config# (merge default-fenzo-config (:fenzo-config ~scheduler-config))
          optimizer-config# (or (:optimizer-config ~scheduler-config)
                                {})
          trigger-chans# (or (:trigger-chans ~scheduler-config)
@@ -162,7 +164,10 @@
                      sched/prepare-match-trigger-chan (fn [match-trigger-chan# pools#]
                                                         (when
                                                           ~trigger-matching?
-                                                          (prepare-match-trigger-chan-orig# match-trigger-chan# pools#)))]
+                                                          (prepare-match-trigger-chan-orig# match-trigger-chan# pools#)))
+                     pool-schedulers (constantly (if (empty? ~schedulers-config)
+                                                          default-schedulers-config
+                                                          ~schedulers-config))]
          (testutil/fake-test-compute-cluster-with-driver conn#
                                                          testutil/fake-test-compute-cluster-name
                                                          nil ; no dummy driver - simulator is going to call initialize
@@ -170,7 +175,6 @@
                                                          framework-id#)
          (c/start-leader-selector
            {:curator-framework curator-framework#
-            :fenzo-config fenzo-config#
             :mea-culpa-failure-limit mea-culpa-failure-limit#
             :mesos-datomic-conn conn#
             :mesos-datomic-mult mesos-mult#
@@ -355,7 +359,7 @@
    The start simulation time is the min submit time in the trace.
 
    Returns a list of the task entities run"
-  [mesos-hosts trace cycle-step-ms config temp-out-trace-file]
+  [mesos-hosts trace cycle-step-ms config schedulers-config temp-out-trace-file]
   (let [simulation-time (-> trace first :submit-time-ms)
         mesos-datomic-conn (restore-fresh-database! (get config :datomic-url "datomic:mem://mock-mesos"))
         offer-trigger-chan (async/chan)
@@ -424,6 +428,7 @@
       make-mesos-driver-fn
       scheduler-config
       false
+      schedulers-config
       (try
         (doseq [{:keys [user mem cpus gpus]} (:shares config)]
           (share/set-share! mesos-datomic-conn user nil "simulation" :mem mem :cpus cpus :gpus gpus))
@@ -600,8 +605,8 @@
                      ;; This is needed because we want the roles to be strings
                      (transform [ALL :resources MAP-VALS MAP-KEYS] name))
           config (if config-file
-                   (edn/read-string (slurp config-file))
-                   {})
+                        (edn/read-string (slurp config-file))
+                        {})
           cycle-step-ms (or cycle-step-ms (:cycle-step-ms config))
           _ (when-not cycle-step-ms
               (throw (ex-info "Must configure cycle-step-ms on command line or config file" {})))
@@ -609,6 +614,7 @@
                               (cheshire/parse-stream (clojure.java.io/reader trace-file) true)
                               cycle-step-ms
                               config
+                              (get-in config [:settings :pools :schedulers])
                               (str out-trace-file ".temp-" (System/nanoTime)))]
       (println "tasks run: " (count task-ents))
       (dump-jobs-to-csv task-ents out-trace-file)
@@ -736,10 +742,17 @@
                 (trace-host i host-mem host-cpus))
         cycle-step-ms 30000
         config {:shares [{:cpus (/ host-cpus 10) :gpus 1.0 :mem (/ host-mem 10) :user "default"}]
-                :scheduler-config {:rebalancer-config {:max-preemption 1.0}
-                                   :fenzo-config {:fenzo-max-jobs-considered 200}}}
-        out-trace-a (simulate hosts jobs cycle-step-ms config nil)
-        out-trace-b (simulate hosts jobs cycle-step-ms config nil)]
+                :scheduler-config {:rebalancer-config {:max-preemption 1.0}}}
+        schedulers-config [{:pool-regex ".*"
+                            :scheduler-config {:scheduler "fenzo"
+                                               :good-enough-fitness 1.0
+                                               :fenzo-fitness-calculator default-fitness-calculator
+                                               :fenzo-max-jobs-considered 200
+                                               :fenzo-scaleback 0.95
+                                               :fenzo-floor-iterations-before-warn 10
+                                               :fenzo-floor-iterations-before-reset 1000}}]
+        out-trace-a (simulate hosts jobs cycle-step-ms config schedulers-config nil)
+        out-trace-b (simulate hosts jobs cycle-step-ms config schedulers-config nil)]
     (is (> (count out-trace-a) 0))
     (is (> (count out-trace-b) 0))
     (is (traces-equivalent? out-trace-a out-trace-b)


### PR DESCRIPTION
## Changes proposed in this PR
- Updates the logic to set the synthetic pods metric counters to happen even if that match cycle is not autoscaling.

## Why are we making these changes?
This makes the metric more accurate when we're matching at 100%.
