### PR TITLE
Updating synthetic pods counters even if we don't autoscale in that match cycle

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -50,10 +50,7 @@
   (restore-offers [this pool-name offers]
     "Called when offers are not processed to ensure they're still available.")
 
-  (get-outstanding-synthetic-pods [this pool-name]
-    "Returns a list of outstanding synthetic pods in the pool.")
-
-  (set-synthetic-pods-counters [this pool-name num-synthetic-pods]
+  (set-synthetic-pods-counters [this pool-name]
     "Sets the counter metrics for number of and max synthetic pods.")
 
   (autoscaling? [this pool-name]

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -50,6 +50,12 @@
   (restore-offers [this pool-name offers]
     "Called when offers are not processed to ensure they're still available.")
 
+  (get-outstanding-synthetic-pods [this pool-name]
+    "Returns a list of outstanding synthetic pods in the pool.")
+
+  (set-synthetic-pods-counters [this pool-name num-synthetic-pods]
+    "Sets the counter metrics for number of and max synthetic pods.")
+
   (autoscaling? [this pool-name]
     "Returns true if this compute cluster should autoscale the provided pool to satisfy pending jobs")
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -342,6 +342,35 @@
        (map #(get @node-name->pod-name->pod % {}))
        (reduce into {})))
 
+(defn get-outstanding-synthetic-pods
+  "Get the current synthetic pods in a cluster."
+  [compute-cluster pool-name]
+  (->> (get-pods-in-pool compute-cluster pool-name)
+       (add-starting-pods compute-cluster)
+       (filter synthetic-pod->job-uuid)))
+
+(defn set-synthetic-pods-counters-helper
+  "Helper for setting the synthetic pod counters."
+  ; This is the "external call" case; we need a synthetic-pods-config to extract the max-pods-outstanding metric,
+  ; and we calculate the current number of synthetic pods explicitly.
+  ([compute-cluster pool-name synthetic-pods-config]
+   (let [num-synthetic-pods (count (get-outstanding-synthetic-pods compute-cluster pool-name))
+         {:keys [max-pods-outstanding]} synthetic-pods-config]
+     (set-synthetic-pods-counters-helper compute-cluster pool-name num-synthetic-pods max-pods-outstanding)))
+  ; This is the "internal" case, in which we already have the number of synthetic pods and the max-pods-outstanding,
+  ; so we just set the values as they are given to us.
+  ([compute-cluster pool-name num-synthetic-pods max-pods-outstanding]
+   (let [name (cc/compute-cluster-name compute-cluster)]
+     (monitor/set-counter!
+       (counters/counter ["cook-k8s" "total-synthetic-pods" (str "compute-cluster-" name) (str "pool-" pool-name)])
+       num-synthetic-pods)
+     (monitor/set-counter!
+       (counters/counter ["cook-k8s" "max-total-synthetic-pods" (str "compute-cluster-" name) (str "pool-" pool-name)])
+       max-pods-outstanding)
+     (prom/set prom/total-synthetic-pods {:pool pool-name :compute-cluster name} num-synthetic-pods)
+     (prom/set prom/max-synthetic-pods {:pool pool-name :compute-cluster name} max-pods-outstanding))))
+
+
 (defrecord KubernetesComputeCluster [^ApiClient api-client name entity-id exit-code-syncer-state
                                      all-pods-atom current-nodes-atom pool->node-name->node
                                      node-name->pod-name->pod cook-expected-state-map cook-starting-pods k8s-actual-state-map
@@ -479,21 +508,8 @@
 
   (restore-offers [this pool-name offers])
 
-  (get-outstanding-synthetic-pods [this pool-name]
-    (->> (get-pods-in-pool this pool-name)
-         (add-starting-pods this)
-         (filter synthetic-pod->job-uuid)))
-
-  (set-synthetic-pods-counters [_ pool-name num-synthetic-pods]
-    (let [{:keys [max-pods-outstanding]} synthetic-pods-config]
-      (monitor/set-counter!
-        (counters/counter ["cook-k8s" "total-synthetic-pods" (str "compute-cluster-" name) (str "pool-" pool-name)])
-        num-synthetic-pods)
-      (monitor/set-counter!
-        (counters/counter ["cook-k8s" "max-total-synthetic-pods" (str "compute-cluster-" name) (str "pool-" pool-name)])
-        max-pods-outstanding)
-      (prom/set prom/total-synthetic-pods {:pool pool-name :compute-cluster name} num-synthetic-pods)
-      (prom/set prom/max-synthetic-pods {:pool pool-name :compute-cluster name} max-pods-outstanding)))
+  (set-synthetic-pods-counters [this pool-name]
+    (set-synthetic-pods-counters-helper this pool-name synthetic-pods-config))
 
   (autoscaling? [_ pool-name]
     (and (-> synthetic-pods-config :pools (contains? pool-name))
@@ -510,7 +526,7 @@
                   (str "In " name " compute cluster, request to autoscale despite invalid / missing config"))
           (let [timer-context-autoscale (timers/start (metrics/timer "cc-synthetic-pod-autoscale" name))
                 prom-stop-fn (prom/start-timer prom/autoscale-duration {:compute-cluster name})
-                outstanding-synthetic-pods (cc/get-outstanding-synthetic-pods this pool-name)
+                outstanding-synthetic-pods (get-outstanding-synthetic-pods this pool-name)
                 num-synthetic-pods (count outstanding-synthetic-pods)
                 total-pods (-> @all-pods-atom keys count)
                 total-nodes (-> @current-nodes-atom keys count)
@@ -533,7 +549,7 @@
                                     :number-max-synthetic-pods max-pods-outstanding
                                     :number-synthetic-pods num-synthetic-pods}))
 
-            (cc/set-synthetic-pods-counters this pool-name num-synthetic-pods)
+            (set-synthetic-pods-counters-helper this pool-name num-synthetic-pods max-pods-outstanding)
 
             (let [max-launchable (min (- max-pods-outstanding num-synthetic-pods)
                                       (- max-total-nodes total-nodes)

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -310,6 +310,10 @@
     (async/go
       (async/>! (pool->offers-chan pool-name) offers)))
 
+  (get-outstanding-synthetic-pods [_ _] nil)
+
+  (set-synthetic-pods-counters [_ _ _])
+
   (autoscaling? [_ _] false)
 
   (autoscale! [_ _ _ _])

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -310,9 +310,7 @@
     (async/go
       (async/>! (pool->offers-chan pool-name) offers)))
 
-  (get-outstanding-synthetic-pods [_ _] nil)
-
-  (set-synthetic-pods-counters [_ _ _])
+  (set-synthetic-pods-counters [_ _ ])
 
   (autoscaling? [_ _] false)
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1093,8 +1093,7 @@
               (do
                 ; Update the synthetic pod counters even if we're not autoscaling, so we have accurate metrics
                 (doseq [compute-cluster autoscaling-compute-clusters]
-                  (let [outstanding-synthetic-pods (cc/get-outstanding-synthetic-pods compute-cluster pool-name)]
-                    (cc/set-synthetic-pods-counters compute-cluster pool-name (count outstanding-synthetic-pods)))))))
+                  (cc/set-synthetic-pods-counters compute-cluster pool-name)))))
           (catch Throwable e
             (log-structured/error "Encountered error while triggering autoscaling" {:pool pool-name} e)))))))
 

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1092,7 +1092,7 @@
                 (log-structured/info "Done autoscaling" {:pool pool-name}))
               (do
                 ; Update the synthetic pod counters even if we're not autoscaling, so we have accurate metrics
-                (doseq [compute-cluster [autoscaling-compute-clusters]]
+                (doseq [compute-cluster autoscaling-compute-clusters]
                   (let [outstanding-synthetic-pods (cc/get-outstanding-synthetic-pods compute-cluster pool-name)]
                     (cc/set-synthetic-pods-counters compute-cluster pool-name (count outstanding-synthetic-pods)))))))
           (catch Throwable e

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1090,10 +1090,9 @@
                        doall
                        (run! deref)))
                 (log-structured/info "Done autoscaling" {:pool pool-name}))
-              (do
-                ; Update the synthetic pod counters even if we're not autoscaling, so we have accurate metrics
-                (doseq [compute-cluster autoscaling-compute-clusters]
-                  (cc/set-synthetic-pods-counters compute-cluster pool-name)))))
+              ; Update the synthetic pod counters even if we're not autoscaling, so we have accurate metrics
+              (doseq [compute-cluster autoscaling-compute-clusters]
+                (cc/set-synthetic-pods-counters compute-cluster pool-name))))
           (catch Throwable e
             (log-structured/error "Encountered error while triggering autoscaling" {:pool pool-name} e)))))))
 


### PR DESCRIPTION
## Changes proposed in this PR
- Updates the logic to set the synthetic pods metric counters to happen even if that match cycle is not autoscaling.

## Why are we making these changes?
This makes the metric more accurate when we're matching at 100%.
