### PR TITLE
Container status to failure reason selects fields from pod object

### DIFF
--- a/scheduler/test/cook/test/kubernetes/controller.clj
+++ b/scheduler/test/cook/test/kubernetes/controller.clj
@@ -24,12 +24,11 @@
 (deftest test-container-status->failure-reason
   (testing "no container status + out-of-cpu pod status"
     (let [pod-status (V1PodStatus.)
-          container-status nil
           pod (tu/pod-helper "12345" "hostA" {:cpus 1.0 :mem 100.0})]
       (.setReason pod-status "OutOfcpu")
+      (.setStatus pod pod-status)
       (is (= :reason-invalid-offers
-             (controller/container-status->failure-reason {:name "test-cluster"} pod-status
-                                                          pod container-status))))))
+             (controller/container-status->failure-reason {:name "test-cluster"} pod))))))
 (deftest test-process
   (tu/setup)
   (with-redefs [cached-queries/instance-uuid->job-uuid-datomic-query (constantly (java.util.UUID/randomUUID))
@@ -294,7 +293,7 @@
             reason (atom nil)]
         (.setStatus pod (V1PodStatus.))
         (with-redefs [controller/write-status-to-datomic (fn [_ status] (reset! reason (:reason status)))
-                      controller/container-status->failure-reason (fn [_ _ _ _ _]
+                      controller/container-status->failure-reason (fn [_ _]
                                                                     (throw (ex-info "Shouldn't get called" {})))]
           (controller/handle-pod-completed nil "podA" {:pod pod :synthesized-state {:state :pod/failed}}
                                            :reason :reason-task-invalid))
@@ -306,7 +305,7 @@
         (.setStatus pod (V1PodStatus.))
         (with-redefs [cc/compute-cluster-name (constantly "compute-cluster-name")
                       controller/write-status-to-datomic (fn [_ status] (reset! reason (:reason status)))
-                      controller/container-status->failure-reason (fn [_ _ _ _ _]
+                      controller/container-status->failure-reason (fn [_ _]
                                                                     (throw (ex-info "Got Exception" {})))]
           (controller/handle-pod-completed nil "podA" {:pod pod :synthesized-state {:state :pod/failed}})
           (is (= :reason-task-unknown @reason)))))


### PR DESCRIPTION
## Changes proposed in this PR

- Pull `pod-status` and `container-status` from the pod object in `container-status->failure-reason`, instead of passing them in with the pod.

## Why are we making these changes?

- Follow-up feedback from #2150 
