### PR TITLE
Use backpressure of scheduling pods to moderate launching new pods for real jobs

### DIFF
--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -57,7 +57,7 @@
     "Returns true if this compute cluster should autoscale the provided pool to satisfy pending jobs")
   
   (max-launchable [this pool-name]
-    "Returns the maximum number of launchable jobs in the pool by considering current pending pods.")
+    "Returns the maximum number of launchable jobs in the pool by considering current scheduling pods.")
 
   (autoscale! [this pool-name jobs adjust-job-resources-for-pool-fn]
     "Autoscales the provided pool to satisfy the provided pending jobs")

--- a/scheduler/src/cook/compute_cluster.clj
+++ b/scheduler/src/cook/compute_cluster.clj
@@ -55,6 +55,9 @@
 
   (autoscaling? [this pool-name]
     "Returns true if this compute cluster should autoscale the provided pool to satisfy pending jobs")
+  
+  (max-launchable [this pool-name]
+    "Returns the maximum number of launchable jobs in the pool by considering current pending pods.")
 
   (autoscale! [this pool-name jobs adjust-job-resources-for-pool-fn]
     "Autoscales the provided pool to satisfy the provided pending jobs")

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -115,7 +115,8 @@
                                      :fenzo-floor-iterations-before-warn 10
                                      :fenzo-floor-iterations-before-reset 1000})
 (def default-kubernetes-scheduler-config {:scheduler "kubernetes"
-                                          :max-jobs-considered 1000})
+                                          :max-jobs-considered 500
+                                          :minimum-scheduling-capacity-threshold 50})
 (def default-schedulers-config [{:pool-regex ".*"
                                  :scheduler-config default-fenzo-scheduler-config}])
 

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -116,7 +116,8 @@
                                      :fenzo-floor-iterations-before-reset 1000})
 (def default-kubernetes-scheduler-config {:scheduler "kubernetes"
                                           :max-jobs-considered 500
-                                          :minimum-scheduling-capacity-threshold 50})
+                                          :minimum-scheduling-capacity-threshold 50
+                                          :scheduling-pause-time-ms 3000})
 (def default-schedulers-config [{:pool-regex ".*"
                                  :scheduler-config default-fenzo-scheduler-config}])
 

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -379,11 +379,20 @@
      (prom/set prom/max-synthetic-pods {:pool pool-name :compute-cluster name} max-pods-outstanding))))
 
 (defn get-scheduling-pods
-  "Get the pods that are still being scheduled by Kubernetes. We consider pods
-   not yet bound to a node when filtering for this state. Pods with 'Pending' 
-   status are not considered, since this phase includes time spent pulling images
-   onto the host. Depending on that status would not acurately reflect the pressure
-   inside the Kubernetes Scheduler."
+  "Get the pods that are still being scheduled by Kubernetes. This is 
+   done by filtering pods not yet bound to a node from the set of 
+   pods Cook thinks is running.
+
+   This is particularly useful when utilizing the Kubernetes Scheduler
+   to bin pack jobs. Pressure inside the scheduler is measured and then
+   reduced by only having so many outstanding, unscheduled pods at any 
+   given time.
+
+   Filtering for node assignments is the best approximation of this 
+   pressure. Depending on pods with 'Pending' status is problematic. 
+   It includes time spent pulling images onto nodes, after they have 
+   been assigned by the scheduler. This status does not accurately 
+   reflect the pressure inside the Kubernetes Scheduler."
   [compute-cluster pool-name]
   (->> (get-pods-in-pool compute-cluster pool-name)
        (add-starting-pods compute-cluster)

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -552,8 +552,7 @@
          ; pods in the compute cluster. This configuration, set on the compute cluster
          ; template, will be refactored in the future to more generally define autoscaling 
          ; parameters once synthetic pods are decommissioned.
-         {:keys [max-pods-outstanding max-total-pods max-total-nodes]
-          :or {max-total-pods 32000 max-total-nodes 1000}} synthetic-pods-config]
+         {:keys [max-pods-outstanding max-total-pods max-total-nodes]} synthetic-pods-config]
 
      (when (>= total-pods max-total-pods)
        (log-structured/warn "Total pods are maxed out"
@@ -858,10 +857,12 @@
   [compute-cluster-name synthetic-pods-config]
   (when synthetic-pods-config
     (when-not (and
-                (-> synthetic-pods-config :image count pos?)
-                (-> synthetic-pods-config :max-pods-outstanding pos?)
-                (-> synthetic-pods-config :pools set?)
-                (-> synthetic-pods-config :pools count pos?))
+               (-> synthetic-pods-config :image count pos?)
+               (-> synthetic-pods-config :max-pods-outstanding pos?)
+               (-> synthetic-pods-config :max-total-pods pos?)
+               (-> synthetic-pods-config :max-total-nodes pos?)
+               (-> synthetic-pods-config :pools set?)
+               (-> synthetic-pods-config :pools count pos?))
       (throw (ex-info (str "In " compute-cluster-name " compute cluster, invalid synthetic pods config")
                       synthetic-pods-config)))))
 

--- a/scheduler/src/cook/mesos/mesos_compute_cluster.clj
+++ b/scheduler/src/cook/mesos/mesos_compute_cluster.clj
@@ -314,6 +314,8 @@
 
   (autoscaling? [_ _] false)
 
+  (max-launchable [_ _])
+
   (autoscale! [_ _ _ _])
 
   (use-cook-executor? [_] true)

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1743,6 +1743,8 @@
                                                    :number-pending-jobs (count pending-jobs)})
           (if (seq considerable-jobs)
             (do
+              ; Remove the considerable jobs from consideration from matching,
+              ; until we do a rank cycle again.
               (swap! pool-name->pending-jobs-atom
                      remove-matched-jobs-from-pending-jobs
                      considerable-job-uuids pool-name)

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1118,11 +1118,7 @@
                     acceptable-compute-clusters)]
                (if (empty? available-compute-clusters)
                  :no-acceptable-compute-cluster
-                 (let [assigned-compute-cluster
-                       (nth available-compute-clusters
-                            (-> uuid
-                                hash
-                                (mod (count available-compute-clusters))))]
+                 (let [assigned-compute-cluster (rand-nth available-compute-clusters)]
                    (swap! compute-cluster->available-scheduling-capacity-atom
                           decrement-scheduling-capacity-counter assigned-compute-cluster)
                    assigned-compute-cluster))))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1650,6 +1650,7 @@
          (log-structured/info "Launching jobs in Kubernetes" {:pool pool-name})
          (distribute-and-launch-jobs considerable-jobs pool-name compute-clusters-for-pool
                                      job->acceptable-compute-clusters-fn launch-distributed-job-fn)
+         ; TODO: change count to actual launched
          (log-structured/info "Launched jobs in Kubernetes" {:pool pool-name :number-launched-jobs (count considerable-jobs)}))))))
 
 (defn handle-kubernetes-scheduler-pool

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1108,7 +1108,6 @@
                     (fn [compute-cluster]
                       (let [capacity (get @compute-cluster->available-scheduling-capacity-atom
                                           compute-cluster)]
-
                         (if (some? capacity)
                           (pos? capacity)
                           (do

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1117,7 +1117,8 @@
                      :no-acceptable-compute-cluster
                      (let [assigned-compute-cluster (nth available-compute-clusters
                                                          (-> uuid hash (mod (count available-compute-clusters))))]
-                       (swap! capacity-counter-atom assigned-compute-cluster)
+                       (swap! capacity-counter-atom 
+                              decrement-scheduling-capacity-counter assigned-compute-cluster)
                        assigned-compute-cluster))))
                autoscalable-jobs)]
           (when-let [jobs (:no-acceptable-compute-cluster compute-cluster->jobs)]

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1084,6 +1084,11 @@
                               :first-ten-jobs (print-str (->> jobs (take 10) (map :job/uuid) (map str)))}))
       (dissoc compute-cluster->jobs :no-acceptable-compute-cluster))))
 
+(defn decrement-scheduling-capacity-counter
+  "Decrement capacity for compute cluster in the counter."
+  [capacity-counter compute-cluster]
+  (update-in capacity-counter [compute-cluster] dec))
+
 (defn create-scheduling-capacity-constrained-job-distributor
   "Create a job distributor function that only assigns jobs to compute clusters
    with available scheduling capacity. Assignments are tracked and the given
@@ -1112,8 +1117,7 @@
                      :no-acceptable-compute-cluster
                      (let [assigned-compute-cluster (nth available-compute-clusters
                                                          (-> uuid hash (mod (count available-compute-clusters))))]
-                       (swap! compute-cluster->scheduling-capacity
-                              (update-in compute-cluster->scheduling-capacity [assigned-compute-cluster] dec))
+                       (swap! capacity-counter-atom assigned-compute-cluster)
                        assigned-compute-cluster))))
                autoscalable-jobs)]
           (when-let [jobs (:no-acceptable-compute-cluster compute-cluster->jobs)]

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -1102,13 +1102,11 @@
                        available-compute-clusters
                        (filter
                         (fn [compute-cluster]
-                          (if (-> @capacity-counter-atom compute-cluster pos?)
-                            true
-                            (do
-                              (log-structured/error "Compute cluster given to distributor is not tracking scheduling capacity"
-                                                    {:pool-name pool-name
-                                                     :compute-cluster compute-cluster})
-                              false)))
+                          (let [capacity (get @capacity-counter-atom compute-cluster)]
+                            (when (nil? capacity)
+                              (throw (ex-info "Compute cluster given to distributor is not tracking scheduling capacity" 
+                                              {:pool-name pool-name :compute-cluster compute-cluster})))
+                            (pos? capacity)))
                         acceptable-compute-clusters)]
                    (if (empty? available-compute-clusters)
                      :no-acceptable-compute-cluster

--- a/scheduler/test/cook/test/config.clj
+++ b/scheduler/test/cook/test/config.clj
@@ -136,7 +136,8 @@
       (is (= actual
              [{:pool-regex "test-pool"
                :scheduler-config {:scheduler "kubernetes"
-                                  :max-jobs-considered 1000}}])))))
+                                  :max-jobs-considered 500
+                                  :minimum-scheduling-capacity-threshold 50}}])))))
 
 (deftest test-valid-schedulers-config
   (testing "empty valid-schedulers-config"

--- a/scheduler/test/cook/test/config.clj
+++ b/scheduler/test/cook/test/config.clj
@@ -137,7 +137,8 @@
              [{:pool-regex "test-pool"
                :scheduler-config {:scheduler "kubernetes"
                                   :max-jobs-considered 500
-                                  :minimum-scheduling-capacity-threshold 50}}])))))
+                                  :minimum-scheduling-capacity-threshold 50
+                                  :scheduling-pause-time-ms 3000}}])))))
 
 (deftest test-valid-schedulers-config
   (testing "empty valid-schedulers-config"

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2670,6 +2670,46 @@
                   [compute-cluster-1
                    compute-cluster-2
                    compute-cluster-3]
+                  sched/job->acceptable-compute-clusters)))))
+      (testing "no-available-capacity"
+        (let [job1 (assoc base-job :job/uuid (UUID/randomUUID))
+              compute-cluster->scheduling-capacity
+              {compute-cluster-1 0
+               compute-cluster-2 0
+               compute-cluster-3 0}]
+          (is (= {}
+                 (sched/scheduling-capacity-constrained-job-distributor
+                  compute-cluster->scheduling-capacity
+                  [job1]
+                  "test-pool"
+                  [compute-cluster-1
+                   compute-cluster-2
+                   compute-cluster-3]
+                  sched/job->acceptable-compute-clusters)))))
+      (testing "schedules-with-remaining-capacity"
+        (let [job1 (assoc base-job :job/uuid (UUID/randomUUID))
+              job2 (assoc base-job :job/uuid (UUID/randomUUID))
+              compute-cluster->scheduling-capacity
+              {compute-cluster-1 4}]
+          (is (= {compute-cluster-1 [job1 job2]}
+                 (sched/scheduling-capacity-constrained-job-distributor
+                  compute-cluster->scheduling-capacity
+                  [job1 job2]
+                  "test-pool"
+                  [compute-cluster-1]
+                  sched/job->acceptable-compute-clusters)))))
+      (testing "no-compute-clusters"
+        (let [job1 (assoc base-job :job/uuid (UUID/randomUUID))
+              job2 (assoc base-job :job/uuid (UUID/randomUUID))
+              compute-cluster->scheduling-capacity
+              {compute-cluster-1 2
+               compute-cluster-2 2}]
+          (is (= {}
+                 (sched/scheduling-capacity-constrained-job-distributor
+                  compute-cluster->scheduling-capacity
+                  [job1 job2]
+                  "test-pool"
+                  []
                   sched/job->acceptable-compute-clusters))))))))
 
 (deftest test-write-sandbox-url-to-datomic


### PR DESCRIPTION
## Changes proposed in this PR

- The Kenzo loop will now account for available scheduling capacity before "assigning" a job to an acceptable compute cluster. This is done via  `pos?` filter in the distribution function.
- Kubernetes compute clusters now report their "max launchable" stat, which is a measurement of pods without assigned nodes. This is our best approximation for pressure inside the Kubernetes Scheduler.
- The Kenzo handler will not try scheduling more jobs than total available scheduling capacity across all compute clusters. This reduces expensive work for jobs that would be filtered out at distribution stage.
- The Kenzo handler will short-circuit and then delay the next scheduling loop if there isn't sufficient scheduling capacity (configurable). This will prevent incurring expensive cycle overhead for a small number of considerable jobs.

## Why are we making these changes?
- This is a backpressure mechanism needed to efficiently use the Kubernetes Scheduler for real job pods.

## Newly Identified Future Work
- Move synthetic pod config on cc-template to new "autoscaling" block, in addition to max-outstanding, etc.