### PR TITLE
Optimizing total pod count metric

### DIFF
--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -549,8 +549,9 @@
             node->node-name
             callbacks ; Update the set of all nodes.
             (fn []
-              (prom/set prom/total-nodes {:compute-cluster compute-cluster-name} (-> @current-nodes-atom keys count))
-              (set-metric-counter "total-nodes"  (-> @current-nodes-atom keys count) compute-cluster-name)
+              (let [current-nodes (count @current-nodes-atom)]
+                (prom/set prom/total-nodes {:compute-cluster compute-cluster-name} current-nodes)
+                (set-metric-counter "total-nodes"  current-nodes compute-cluster-name))
               (when max-total-nodes
                   (prom/set prom/max-nodes {:compute-cluster compute-cluster-name} max-total-nodes)
                   (set-metric-counter "max-total-nodes" max-total-nodes compute-cluster-name)))

--- a/scheduler/src/cook/kubernetes/api.clj
+++ b/scheduler/src/cook/kubernetes/api.clj
@@ -432,8 +432,9 @@
             get-pod-namespaced-key
             callbacks
             (fn []
-              (prom/set prom/total-pods {:compute-cluster compute-cluster-name} (-> @all-pods-atom keys count))
-              (set-metric-counter "total-pods" (-> @all-pods-atom keys count) compute-cluster-name)
+              (let [total-pods (count @all-pods-atom)]
+                (prom/set prom/total-pods {:compute-cluster compute-cluster-name} total-pods)
+                (set-metric-counter "total-pods" total-pods compute-cluster-name))
               (when max-total-pods
                   (prom/set prom/max-pods {:compute-cluster compute-cluster-name} max-total-pods)
                   (set-metric-counter "max-total-pods" max-total-pods compute-cluster-name)))

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -240,10 +240,10 @@
       ;; Kubernetes metrics --------------------------------------------------------------------------------------------
       (prometheus/gauge total-pods
                         {:description "Total current number of pods per compute cluster"
-                         :labels [:pool]})
+                         :labels [:compute-cluster]})
       (prometheus/gauge max-pods
                         {:description "Max number of pods per compute cluster"
-                         :labels [:pool]})
+                         :labels [:compute-cluster]})
       (prometheus/gauge total-synthetic-pods
                         {:description "Total current number of synthetic pods per pool and compute cluster"
                          :labels [:pool :compute-cluster]})
@@ -255,10 +255,10 @@
                          :labels [:compute-cluster]})
       (prometheus/gauge total-nodes
                         {:description "Total current number of nodes per compute cluster"
-                         :labels [:pool]})
+                         :labels [:compute-cluster]})
       (prometheus/gauge max-nodes
                         {:description "Max number of nodes per compute cluster"
-                         :labels [:pool]})
+                         :labels [:compute-cluster]})
       (prometheus/summary watch-gap
                           {:description "Latency distribution of the gap between last watch response and current response"
                            :labels [:compute-cluster :object]


### PR DESCRIPTION
## Changes proposed in this PR
- Updates the calculation for the pod count metric to avoid unnecessary operations.

## Why are we making these changes?
Improved runtime and reduced memory footprint.

