### PR TITLE
Optimize RAM by not storing all pod metadata in the internal maps.

### DIFF
--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -752,6 +752,8 @@
       prom/handle-pod-update-duration {:compute-cluster name}
       (timers/time!
         (metrics/timer "pod-update" name)
+        ; We don't need this and it can get pretty big, so drop it to keep it from leaking into oldgen.
+        (.setSpec new-pod nil)
         (with-process-lock
           compute-cluster
           pod-name


### PR DESCRIPTION
## Changes proposed in this PR

- Do not save all of the pod data when we're tracking kubernetes state. 

## Why are we making these changes?

If you don't save it, it doesn't clutter up RAM, and in particular, clutter up oldgen. The worst case for GC is objects that live a long time but eventually die. This hopefully cuts the rate of those objects, at least in the case of Pod data.