### PR TITLE
Enabling JVM metrics in prometheus

### DIFF
--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -108,6 +108,7 @@
                                                             org.clojure/clojure io.netty/netty]]
                  [opentracing-clj "0.2.2"]
                  [clj-commons/iapetos "0.1.12"]
+                 [io.prometheus/simpleclient_hotspot "0.16.0"]
 
                  ;;External system integrations
                  [org.clojure/tools.nrepl "0.2.3"]

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -17,7 +17,8 @@
 ;; Declares prometheus metrics for cook scheduler.
 
 (ns cook.prometheus-metrics
-  (:require [iapetos.core :as prometheus]
+  (:require [iapetos.collector.jvm :as jvm]
+            [iapetos.core :as prometheus]
             [iapetos.export :as prometheus-export]
             [mount.core :as mount]))
 
@@ -194,6 +195,8 @@
 (defn create-registry
   []
   (-> (prometheus/collector-registry)
+    ;; Initialize default JVM metrics
+    (jvm/initialize)
     (prometheus/register
       ;; Scheduler metrics ---------------------------------------------------------------------------------------------
       ;; Note that we choose to use a summary instead of a histogram for the latency metrics because we only have


### PR DESCRIPTION
## Changes proposed in this PR
- Enables the default JVM instrumentation available with the prometheus module.

## Why are we making these changes?
Ongoing migration to prometheus.

