### PR TITLE
Fixing compute_cluster value in metric to use :name

### DIFF
--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -124,8 +124,8 @@
     (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :pool pool-name :resource "nodes"} number-nodes-total)
     (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :pool pool-name :resource "cpu"} total-cpus-capacity)
     (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :pool pool-name :resource "mem"} total-mem-capacity)
-    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :pool pool-name :resource "cpu"} total-cpus-consumption)
-    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :pool pool-name :resource "mem"} total-mem-consumption)
+    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :resource "cpu"} total-cpus-consumption)
+    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :resource "mem"} total-mem-consumption)
     (monitor/set-counter! (metrics/counter "capacity-cpus" compute-cluster-name) total-cpus-capacity)
     (monitor/set-counter! (metrics/counter "capacity-mem" compute-cluster-name) total-mem-capacity)
     (monitor/set-counter! (metrics/counter "consumption-cpus" compute-cluster-name) total-cpus-consumption)
@@ -138,7 +138,7 @@
       (monitor/set-counter! (metrics/counter (str "capacity-gpu-" gpu-model) compute-cluster-name)
                             (get gpu-model->total-capacity gpu-model))
       (prom/set prom/resource-consumption
-                {:compute-cluster compute-cluster-name :pool pool-name :resource "gpu" :resource-subtype gpu-model}
+                {:compute-cluster compute-cluster-name :resource "gpu" :resource-subtype gpu-model}
                 (get gpu-model->total-consumed gpu-model 0))
       (monitor/set-counter! (metrics/counter (str "consumption-gpu-" gpu-model) compute-cluster-name)
                             (get gpu-model->total-consumed gpu-model 0)))
@@ -149,7 +149,7 @@
       (monitor/set-counter! (metrics/counter (str "capacity-disk-" disk-type) compute-cluster-name)
                             (get disk-type->total-capacity disk-type))
       (prom/set prom/resource-consumption
-                {:compute-cluster compute-cluster-name :pool pool-name :resource "disk" :resource-subtype disk-type}
+                {:compute-cluster compute-cluster-name :resource "disk" :resource-subtype disk-type}
                 (get disk-type->total-consumed disk-type 0))
       (monitor/set-counter! (metrics/counter (str "consumption-disk-" disk-type) compute-cluster-name)
                             (get disk-type->total-consumed disk-type 0)))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -121,10 +121,11 @@
                           :first-ten-capacity (print-str (take 10 node-name->capacity))
                           :first-ten-consumed (print-str (take 10 node-name->consumed))})
 
-    (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :resource "cpu"} total-cpus-capacity)
-    (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :resource "mem"} total-mem-capacity)
-    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :resource "cpu"} total-cpus-consumption)
-    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :resource "mem"} total-mem-consumption)
+    (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :pool pool-name :resource "nodes"} number-nodes-total)
+    (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :pool pool-name :resource "cpu"} total-cpus-capacity)
+    (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :pool pool-name :resource "mem"} total-mem-capacity)
+    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :pool pool-name :resource "cpu"} total-cpus-consumption)
+    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :pool pool-name :resource "mem"} total-mem-consumption)
     (monitor/set-counter! (metrics/counter "capacity-cpus" compute-cluster-name) total-cpus-capacity)
     (monitor/set-counter! (metrics/counter "capacity-mem" compute-cluster-name) total-mem-capacity)
     (monitor/set-counter! (metrics/counter "consumption-cpus" compute-cluster-name) total-cpus-consumption)
@@ -132,23 +133,23 @@
 
     (doseq [gpu-model gpu-models]
       (prom/set prom/resource-capacity
-                {:compute-cluster compute-cluster-name :resource "gpu" :resource-subtype gpu-model}
+                {:compute-cluster compute-cluster-name :pool pool-name :resource "gpu" :resource-subtype gpu-model}
                 (get gpu-model->total-capacity gpu-model))
       (monitor/set-counter! (metrics/counter (str "capacity-gpu-" gpu-model) compute-cluster-name)
                             (get gpu-model->total-capacity gpu-model))
       (prom/set prom/resource-consumption
-                {:compute-cluster compute-cluster-name :resource "gpu" :resource-subtype gpu-model}
+                {:compute-cluster compute-cluster-name :pool pool-name :resource "gpu" :resource-subtype gpu-model}
                 (get gpu-model->total-consumed gpu-model 0))
       (monitor/set-counter! (metrics/counter (str "consumption-gpu-" gpu-model) compute-cluster-name)
                             (get gpu-model->total-consumed gpu-model 0)))
     (doseq [disk-type disk-types]
       (prom/set prom/resource-capacity
-                {:compute-cluster compute-cluster-name :resource "disk" :resource-subtype disk-type}
+                {:compute-cluster compute-cluster-name :pool pool-name :resource "disk" :resource-subtype disk-type}
                 (get disk-type->total-capacity disk-type))
       (monitor/set-counter! (metrics/counter (str "capacity-disk-" disk-type) compute-cluster-name)
                             (get disk-type->total-capacity disk-type))
       (prom/set prom/resource-consumption
-                {:compute-cluster compute-cluster-name :resource "disk" :resource-subtype disk-type}
+                {:compute-cluster compute-cluster-name :pool pool-name :resource "disk" :resource-subtype disk-type}
                 (get disk-type->total-consumed disk-type 0))
       (monitor/set-counter! (metrics/counter (str "consumption-disk-" disk-type) compute-cluster-name)
                             (get disk-type->total-consumed disk-type 0)))

--- a/scheduler/src/cook/kubernetes/compute_cluster.clj
+++ b/scheduler/src/cook/kubernetes/compute_cluster.clj
@@ -106,7 +106,11 @@
                                                                  %)
                                        node-name->available)
         number-nodes-schedulable (count node-name->schedulable)
-        number-nodes-total (count node-name->node)]
+        number-nodes-total (count node-name->node)
+        total-cpus-capacity (total-resource node-name->capacity :cpus)
+        total-mem-capacity (total-resource node-name->capacity :mem)
+        total-cpus-consumption (total-resource node-name->consumed :cpus)
+        total-mem-consumption (total-resource node-name->consumed :mem)]
 
     (log-structured/info "Generating offers"
                          {:compute-cluster compute-cluster-name
@@ -117,23 +121,35 @@
                           :first-ten-capacity (print-str (take 10 node-name->capacity))
                           :first-ten-consumed (print-str (take 10 node-name->consumed))})
 
-    (monitor/set-counter! (metrics/counter "capacity-cpus" compute-cluster-name)
-                          (total-resource node-name->capacity :cpus))
-    (monitor/set-counter! (metrics/counter "capacity-mem" compute-cluster-name)
-                          (total-resource node-name->capacity :mem))
-    (monitor/set-counter! (metrics/counter "consumption-cpus" compute-cluster-name)
-                          (total-resource node-name->consumed :cpus))
-    (monitor/set-counter! (metrics/counter "consumption-mem" compute-cluster-name)
-                          (total-resource node-name->consumed :mem))
+    (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :resource "cpu"} total-cpus-capacity)
+    (prom/set prom/resource-capacity {:compute-cluster compute-cluster-name :resource "mem"} total-mem-capacity)
+    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :resource "cpu"} total-cpus-consumption)
+    (prom/set prom/resource-consumption {:compute-cluster compute-cluster-name :resource "mem"} total-mem-consumption)
+    (monitor/set-counter! (metrics/counter "capacity-cpus" compute-cluster-name) total-cpus-capacity)
+    (monitor/set-counter! (metrics/counter "capacity-mem" compute-cluster-name) total-mem-capacity)
+    (monitor/set-counter! (metrics/counter "consumption-cpus" compute-cluster-name) total-cpus-consumption)
+    (monitor/set-counter! (metrics/counter "consumption-mem" compute-cluster-name) total-mem-consumption)
 
     (doseq [gpu-model gpu-models]
+      (prom/set prom/resource-capacity
+                {:compute-cluster compute-cluster-name :resource "gpu" :resource-subtype gpu-model}
+                (get gpu-model->total-capacity gpu-model))
       (monitor/set-counter! (metrics/counter (str "capacity-gpu-" gpu-model) compute-cluster-name)
                             (get gpu-model->total-capacity gpu-model))
+      (prom/set prom/resource-consumption
+                {:compute-cluster compute-cluster-name :resource "gpu" :resource-subtype gpu-model}
+                (get gpu-model->total-consumed gpu-model 0))
       (monitor/set-counter! (metrics/counter (str "consumption-gpu-" gpu-model) compute-cluster-name)
                             (get gpu-model->total-consumed gpu-model 0)))
     (doseq [disk-type disk-types]
+      (prom/set prom/resource-capacity
+                {:compute-cluster compute-cluster-name :resource "disk" :resource-subtype disk-type}
+                (get disk-type->total-capacity disk-type))
       (monitor/set-counter! (metrics/counter (str "capacity-disk-" disk-type) compute-cluster-name)
                             (get disk-type->total-capacity disk-type))
+      (prom/set prom/resource-consumption
+                {:compute-cluster compute-cluster-name :resource "disk" :resource-subtype disk-type}
+                (get disk-type->total-consumed disk-type 0))
       (monitor/set-counter! (metrics/counter (str "consumption-disk-" disk-type) compute-cluster-name)
                             (get disk-type->total-consumed disk-type 0)))
 
@@ -169,7 +185,6 @@
                    :executor-ids []
                    :compute-cluster compute-cluster
                    :reject-after-match-attempt true
-                   ; TODO: add a timer here when we add it to mesos as well
                    :offer-match-timer (timers/start (ccmetrics/timer "offer-match-timer" compute-cluster-name))
                    :offer-match-timer-prom-stop-fn (prom/start-timer prom/offer-match-timer {:compute-cluster compute-cluster-name})}))))))
 

--- a/scheduler/src/cook/kubernetes/controller.clj
+++ b/scheduler/src/cook/kubernetes/controller.clj
@@ -41,7 +41,7 @@
                  "process-lock-acquire"
                  (:name ~compute-cluster)))
              prom-stop-fn#
-             (prom/start-timer prom/process-lock-acquire-duration {:compute-cluster ~compute-cluster})]
+             (prom/start-timer prom/process-lock-acquire-duration {:compute-cluster (:name ~compute-cluster)})]
          (.lock lock-object#)
          (try
            (.stop timer-context#)

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -131,6 +131,8 @@
 (def pod-waiting-duration :cook/scheduler-kubernetes-pod-duration-until-waiting-seconds)
 (def pod-running-duration :cook/scheduler-kubernetes-pod-duration-until-running-seconds)
 (def offer-match-timer :cook/scheduler-kubernetes-offer-match-duration-seconds)
+(def resource-capacity :cook/scheduler-kubernetes-resource-capacity)
+(def resource-consumption :cook/scheduler-kubernetes-resource-consumption)
 
 ;; Mesos metrics
 (def mesos-heartbeats :cook/scheduler-mesos-heartbeats-count)
@@ -534,6 +536,12 @@
                           {:description "Latency distribution of matching an offer"
                            :labels [:compute-cluster]
                            :quantiles default-summary-quantiles})
+      (prometheus/gauge resource-capacity
+                        {:description "Total available capacity of the given resource per cluster"
+                         :labels [:compute-cluster :resource :resource-subtype]})
+      (prometheus/gauge resource-consumption
+                        {:description "Total consumption of the given resource per cluster"
+                         :labels [:compute-cluster :resource :resource-subtype]})
       ;; Mesos metrics -------------------------------------------------------------------------------------------------
       (prometheus/counter mesos-heartbeats
                           {:description "Count of mesos heartbeats"})

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -526,11 +526,11 @@
                            :quantiles default-summary-quantiles})
       (prometheus/summary pod-waiting-duration
                           {:description "Latency distribution of the time until a pod is waiting"
-                           :labels [:compute-cluster :synthetic]
+                           :labels [:compute-cluster :synthetic :kubernetes-scheduler-pod]
                            :quantiles default-summary-quantiles})
       (prometheus/summary pod-running-duration
                           {:description "Latency distribution of the time until a pod is running"
-                           :labels [:compute-cluster :synthetic]
+                           :labels [:compute-cluster :synthetic :kubernetes-scheduler-pod]
                            :quantiles default-summary-quantiles})
       (prometheus/summary offer-match-timer
                           {:description "Latency distribution of matching an offer"

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -538,10 +538,10 @@
                            :quantiles default-summary-quantiles})
       (prometheus/gauge resource-capacity
                         {:description "Total available capacity of the given resource per cluster and pool"
-                         :labels [:compute-cluster :resource :resource-subtype]})
+                         :labels [:compute-cluster :pool :resource :resource-subtype]})
       (prometheus/gauge resource-consumption
                         {:description "Total consumption of the given resource per cluster"
-                         :labels [:compute-cluster :pool :resource :resource-subtype]})
+                         :labels [:compute-cluster :resource :resource-subtype]})
       ;; Mesos metrics -------------------------------------------------------------------------------------------------
       (prometheus/counter mesos-heartbeats
                           {:description "Count of mesos heartbeats"})

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -538,10 +538,10 @@
                            :quantiles default-summary-quantiles})
       (prometheus/gauge resource-capacity
                         {:description "Total available capacity of the given resource per cluster"
-                         :labels [:compute-cluster :resource :resource-subtype]})
+                         :labels [:compute-cluster :pool :resource :resource-subtype]})
       (prometheus/gauge resource-consumption
                         {:description "Total consumption of the given resource per cluster"
-                         :labels [:compute-cluster :resource :resource-subtype]})
+                         :labels [:compute-cluster :pool :resource :resource-subtype]})
       ;; Mesos metrics -------------------------------------------------------------------------------------------------
       (prometheus/counter mesos-heartbeats
                           {:description "Count of mesos heartbeats"})

--- a/scheduler/src/cook/prometheus_metrics.clj
+++ b/scheduler/src/cook/prometheus_metrics.clj
@@ -537,8 +537,8 @@
                            :labels [:compute-cluster]
                            :quantiles default-summary-quantiles})
       (prometheus/gauge resource-capacity
-                        {:description "Total available capacity of the given resource per cluster"
-                         :labels [:compute-cluster :pool :resource :resource-subtype]})
+                        {:description "Total available capacity of the given resource per cluster and pool"
+                         :labels [:compute-cluster :resource :resource-subtype]})
       (prometheus/gauge resource-consumption
                         {:description "Total consumption of the given resource per cluster"
                          :labels [:compute-cluster :pool :resource :resource-subtype]})


### PR DESCRIPTION
## Changes proposed in this PR
-  Updating a prometheus metric that was recording the compute cluster incorrectly.



