### PR TITLE
Require pyzmq < 24.0.0

### DIFF
--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,5 +1,6 @@
 beakerx==1.3.0
 tornado==6.1.0
+pyzmq < 24.0.0
 jupyter_client==7.1.0
 nbconvert==6.3.0
 nbformat==5.1.3


### PR DESCRIPTION
## Changes proposed in this PR

- Limit version of pyzmq to < 24.0.0

## Why are we making these changes?
We have a transitive dependency on pyzmq through jupyter. pyzmq 24.0.0 has a known build bug.

