### PR TITLE
Fix the parallel watch

### DIFF
--- a/scheduler/java/com/twosigma/cook/kubernetes/ParallelWatchQueue.java
+++ b/scheduler/java/com/twosigma/cook/kubernetes/ParallelWatchQueue.java
@@ -97,7 +97,7 @@ public class ParallelWatchQueue {
                     var event = deque.removeFirst();
                     // Mark event as dequeed so we release any backpressure.
                     queueSlotsLeft.release();
-                    executor.submit(event);
+                    event.run();
                 }
             } finally {
                 lock.unlock();


### PR DESCRIPTION
## Changes proposed in this PR

- Fix a bug in the newly added parallel watch thread.
- We are supposed to be processing the event, not adding it back into the executor queue.

## Why are we making these changes?


