### PR TITLE
Build user usage map async

### DIFF
--- a/scheduler/CHANGELOG.md
+++ b/scheduler/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.63.4] - 2022-09-21
+### Fixed
+- Fixed bug in parallelized Kubernetes watch processing, from @scrosby
+### Changed
+- Make prometheus JVM metrics use compute cluster name, from @samincheva
+
 ## [1.63.3] - 2022-09-13
 ### Changed
 - Parallelize Kubernetes watch processing, from @scrosby

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.63.4-SNAPSHOT"
+(defproject cook "1.63.4"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/project.clj
+++ b/scheduler/project.clj
@@ -13,7 +13,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 ;;
-(defproject cook "1.63.4"
+(defproject cook "1.63.5-SNAPSHOT"
   :description "This launches jobs on a Mesos cluster with fair sharing and preemption"
   :license {:name "Apache License, Version 2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -102,6 +102,7 @@
     (cond->
         {:cancelled-task-trigger-chan (prepare-trigger-chan (time/seconds 3))
          :lingering-task-trigger-chan (prepare-trigger-chan (time/minutes timeout-interval-minutes))
+         :generate-pool-user-usage-map-trigger-chan (prepare-trigger-chan (time/minutes 1))
          :match-trigger-chan (async/chan (async/sliding-buffer 1))
          :optimizer-trigger-chan (prepare-trigger-chan (time/seconds (:optimizer-interval-seconds optimizer-config 10)))
          :progress-updater-trigger-chan (prepare-trigger-chan (time/millis (:publish-interval-ms progress-config)))

--- a/scheduler/src/cook/scheduler/scheduler.clj
+++ b/scheduler/src/cook/scheduler/scheduler.clj
@@ -731,7 +731,7 @@
                                                             (reduce (partial merge-with +)))))))))))))
 (defn update-pool-user-usage-map
   []
-  (reset! cached-user-usage-map-atom (generate-pool-user-usage-map datomic/conn)))
+  (reset! cached-user-usage-map-atom (generate-pool-user-usage-map (d/db datomic/conn))))
 
 (defn generate-user-usage-map
   "Returns a mapping from user to usage stats from cached data"

--- a/scheduler/test/cook/test/mesos/mesos_mock.clj
+++ b/scheduler/test/cook/test/mesos/mesos_mock.clj
@@ -604,7 +604,8 @@
 
 (deftest mesos-mock-kill
   ;; Mock this out with a stub string, as the compute cluster shouldn't be used anywhere.
-  (with-redefs [cc/compute-cluster-name->ComputeCluster "mesos-mock-kill"]
+  (with-redefs [cc/compute-cluster-name->ComputeCluster "mesos-mock-kill"
+                cook.scheduler.scheduler/update-pool-user-usage-map (fn [])]
     (testing "kill task"
       (let [registered-atom (atom false)
             offer-atom (atom [])

--- a/scheduler/test/cook/test/scheduler/scheduler.clj
+++ b/scheduler/test/cook/test/scheduler/scheduler.clj
@@ -2400,6 +2400,7 @@
           output-atom (atom [])]
       (with-redefs [sched/persist-mea-culpa-failure-limit! (fn [_ _])
                     d/db (fn [_])
+                    sched/update-pool-user-usage-map (fn [])
                     pool/all-pools
                     (fn [_]
                       [{:pool/name "pool 1"


### PR DESCRIPTION
## Changes proposed in this PR

- Build the user-usage map asynchronoutsly outside of the match loop.

## Why are we making these changes?
This is more efficient as we do it once for all pools, not n times for each pool. In addition, we take it out of the critical latency path.

